### PR TITLE
Serialize handleTabRemoved under the state lock

### DIFF
--- a/packages/extension/src/background/controller.ts
+++ b/packages/extension/src/background/controller.ts
@@ -255,31 +255,40 @@ export function createBackgroundController(deps: BackgroundControllerDeps) {
   }
 
   async function handleTabRemoved(tabId: number): Promise<void> {
-    const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
-    const manualPlatforms = (["twitch", "kick"] as Platform[]).filter((platform) => state.manualWatch?.[platform]?.tabId === tabId);
-    if (manualPlatforms.length > 0) {
-      const manualWatch = { ...state.manualWatch };
-      for (const platform of manualPlatforms) delete manualWatch[platform];
-      await persist({
-        ...state,
-        manualWatch,
-      });
-    }
-    if (!settings.running) return;
-
-    for (const platform of ["twitch", "kick"] as Platform[]) {
-      const session = state.sessions[platform];
-      if (
-        settings.platform[platform].enabled
-        && session.status === "watching"
-        && session.tabManagedByExtension
-        && session.tabId === tabId
-      ) {
-        pendingTabEvents.push({ platform, level: "info", message: "Managed watch tab was closed; re-running scheduler" });
-        await tick();
-        return;
+    // Serialize the load-modify-persist under the state lock so it cannot race a
+    // concurrent tick()/heartbeat (both fire on a ~1-minute cadence while the
+    // user can close a tab at any moment). The trailing tick() is deferred to
+    // outside the lock because it re-acquires the lock itself — mirroring how
+    // runWatchHeartbeat returns its fallback work and ticks afterwards.
+    const shouldRerunScheduler = await withStateLock(async () => {
+      const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+      const manualPlatforms = (["twitch", "kick"] as Platform[]).filter((platform) => state.manualWatch?.[platform]?.tabId === tabId);
+      if (manualPlatforms.length > 0) {
+        const manualWatch = { ...state.manualWatch };
+        for (const platform of manualPlatforms) delete manualWatch[platform];
+        await persist({
+          ...state,
+          manualWatch,
+        });
       }
-    }
+      if (!settings.running) return false;
+
+      for (const platform of ["twitch", "kick"] as Platform[]) {
+        const session = state.sessions[platform];
+        if (
+          settings.platform[platform].enabled
+          && session.status === "watching"
+          && session.tabManagedByExtension
+          && session.tabId === tabId
+        ) {
+          pendingTabEvents.push({ platform, level: "info", message: "Managed watch tab was closed; re-running scheduler" });
+          return true;
+        }
+      }
+      return false;
+    });
+
+    if (shouldRerunScheduler) await tick();
   }
 
   function tablessWatchContext(): WatchContext {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1165,4 +1165,52 @@ describe("background controller", () => {
     expect(env.state.sessions.twitch.playback).toBeDefined();
     expect(env.state.lastTickAt).toBeDefined();
   });
+
+  it("serializes handleTabRemoved against a concurrent tick so neither write is lost", async () => {
+    const env = harness();
+    env.state.manualWatch = {
+      kick: { platform: "kick", tabId: 50, checkedAt: new Date().toISOString(), active: true },
+    };
+    env.state.sessions.twitch = {
+      platform: "twitch",
+      status: "watching",
+      offlineChecks: 0,
+      tabId: 10,
+      tabManagedByExtension: true,
+      channel: channel("twitch"),
+      campaignId: "twitch-campaign",
+      rewardId: "reward",
+    };
+
+    // Same snapshot-isolation trace as the writer-serialization test above: an
+    // unserialized handleTabRemoved would build on a stale snapshot and clobber
+    // tick()'s save (or vice versa).
+    const trace: string[] = [];
+    const originalSave = env.deps.saveState.getMockImplementation()!;
+    env.deps.loadState.mockImplementation(async () => {
+      trace.push("load");
+      return structuredClone(env.state);
+    });
+    env.deps.saveState.mockImplementation(async (next: SchedulerState) => {
+      trace.push("save");
+      await Promise.resolve();
+      await originalSave(next);
+    });
+
+    await Promise.all([
+      env.controller.handleTabRemoved(50),
+      env.controller.tick(),
+    ]);
+
+    // Serialized: every load is immediately followed by that operation's save.
+    expect(trace.length).toBeGreaterThanOrEqual(4);
+    for (let i = 0; i + 1 < trace.length; i += 2) {
+      expect(trace[i]).toBe("load");
+      expect(trace[i + 1]).toBe("save");
+    }
+    // Both writers' changes survive: the manual-watch entry is removed AND the
+    // concurrent tick committed its progress.
+    expect(env.state.manualWatch?.kick).toBeUndefined();
+    expect(env.state.lastTickAt).toBeDefined();
+  });
 });


### PR DESCRIPTION
Fixes #14.

## Problem

`handleTabRemoved` (`packages/extension/src/background/controller.ts`) performed its load-modify-`persist` of scheduler state **without** `withStateLock`, while every other state writer — `tick()` and `runWatchHeartbeat()` — is serialized through it. Because each `loadState` returns an isolated snapshot, closing a tab while a ~1-minute `tick()` was in-flight let `handleTabRemoved` build on a stale snapshot and clobber the tick's save (or vice versa) — e.g. a `manualWatch` deletion silently lost, or the tick's committed progress overwritten.

## Fix

Wrap the body of `handleTabRemoved` in `withStateLock` and defer the trailing `tick()` to **after** the lock is released (it re-acquires the lock itself), mirroring how `runWatchHeartbeat` returns its fallback work and ticks afterwards. No reentrancy.

## Test

Added a regression test (`serializes handleTabRemoved against a concurrent tick so neither write is lost`) using the same snapshot-isolation trace as the existing writer-serialization test. It **fails on `main`** (the `manualWatch` deletion is clobbered by the concurrent tick) and passes with this change.

## Verification

- `pnpm --filter @stream-autopilot/extension test` → 255 passed
- `pnpm --filter @stream-autopilot/extension typecheck` → clean