### PR TITLE
Fire "no drops left" notification only on state transition

### DIFF
--- a/packages/extension/src/background/controller.ts
+++ b/packages/extension/src/background/controller.ts
@@ -713,14 +713,20 @@ export function createBackgroundController(deps: BackgroundControllerDeps) {
     }
 
     if (settings.notifyNoDropsLeft) {
+      const isDropsExhausted = (state: SchedulerState, platform: Platform): boolean =>
+        state.sessions[platform].status === "idle"
+        && state.campaigns[platform].length > 0
+        && state.campaigns[platform].every((campaign) => !hasEarnableReward(campaign));
+
       for (const platform of ["twitch", "kick"] as Platform[]) {
-        const session = next.sessions[platform];
         if (
           settings.running
           && settings.platform[platform].enabled
-          && session.status === "idle"
-          && next.campaigns[platform].length > 0
-          && next.campaigns[platform].every((campaign) => !hasEarnableReward(campaign))
+          // Only on the transition into the exhausted state, so the
+          // notification fires once instead of re-firing every tick (~1/min)
+          // for as long as the platform stays out of earnable drops.
+          && isDropsExhausted(next, platform)
+          && !isDropsExhausted(previous, platform)
         ) {
           await safeNotify(
             settings,

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1001,6 +1001,42 @@ describe("background controller", () => {
     expect(env.deps.createNotification).not.toHaveBeenCalledWith(expect.objectContaining({ title: "Reward earned" }));
   });
 
+  it("emits the no-drops-left notification once when entering the exhausted state", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      notifyNoDropsLeft: true,
+      platform: { ...DEFAULT_SETTINGS.platform, kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false } },
+    });
+    // A fully claimed campaign is present but has nothing earnable, so the
+    // scheduler goes idle into the "no drops left" condition.
+    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimed")]);
+
+    await env.controller.tick();
+
+    expect(env.deps.createNotification).toHaveBeenCalledWith(expect.objectContaining({ title: "No drops left" }));
+  });
+
+  it("does not re-emit the no-drops-left notification while the exhausted state persists", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      notifyNoDropsLeft: true,
+      notifyRewardEarned: false,
+      platform: { ...DEFAULT_SETTINGS.platform, kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false } },
+    });
+    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimed")]);
+
+    await env.controller.tick();
+    await env.controller.tick();
+
+    // The exhausted state persists across both ticks; the notification must fire
+    // only on the transition, not once per tick. No other notifications are
+    // enabled, so the no-drops notification is the only expected call.
+    expect(env.deps.createNotification).toHaveBeenCalledWith(expect.objectContaining({ title: "No drops left" }));
+    expect(env.deps.createNotification).toHaveBeenCalledTimes(1);
+  });
+
   it("persists an error event when scheduler execution throws unexpectedly", async () => {
     const env = harness();
     vi.mocked(env.deps.createAdapters).mockImplementation(() => {


### PR DESCRIPTION
Fixes #15.

## Problem

`emitNotifications` (`packages/extension/src/background/controller.ts`) evaluated the "no drops left" condition against the `next` state alone, never comparing `previous`. Once a platform ran out of earnable drops (idle + campaigns present + none earnable), the condition stayed true on every subsequent tick, so the notification re-fired roughly once per minute until the user disabled farming. The reward-earned notification right beside it already gates on a transition (`newlyEarnedRewards`).

## Fix

Extract an `isDropsExhausted(state, platform)` helper and notify only on the **transition into** the exhausted state — `isDropsExhausted(next)` is true and `isDropsExhausted(previous)` is false.

## Tests

- `emits the no-drops-left notification once when entering the exhausted state` — fires on the transition.
- `does not re-emit the no-drops-left notification while the exhausted state persists` — **fails on `main`** (2 calls across 2 ticks); passes here (1 call). It also re-fires correctly if the state leaves and re-enters the exhausted condition.

## Verification

- `pnpm --filter @stream-autopilot/extension test` → 256 passed
- `pnpm --filter @stream-autopilot/extension typecheck` → clean