### PR TITLE
Add one-time Chrome Web Store rate/review nudge

### DIFF
--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -64,6 +64,13 @@ const controller = createBackgroundController({
 export default defineBackground(() => {
   browser.runtime.onInstalled.addListener(async () => {
     await controller.ensureAlarm();
+    // Stamp the install date once so the popup can time the rate/review nudge.
+    // Set-if-missing (rather than gating on reason === "install") also backfills
+    // a sane date for users upgrading from a pre-nudge version.
+    const state = await loadState();
+    if (!state.installedAt) {
+      await saveState({ ...state, installedAt: new Date().toISOString() });
+    }
   });
 
   browser.runtime.onStartup.addListener(async () => {

--- a/packages/extension/public/_locales/ar/messages.json
+++ b/packages/extension/public/_locales/ar/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "jamezrin على X"
   },
+  "rateNudgeTitle": {
+    "message": "هل يعجبك Lurkloot؟"
+  },
+  "rateNudgeBody": {
+    "message": "تقييم سريع على متجر Chrome يساعد كثيرًا."
+  },
+  "rateNudgeAction": {
+    "message": "قيّمه"
+  },
+  "rateNudgeDismiss": {
+    "message": "ليس الآن"
+  },
   "removeItem": {
     "message": "إزالة $1"
   }

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "jamezrin auf X"
   },
+  "rateNudgeTitle": {
+    "message": "Gefällt dir Lurkloot?"
+  },
+  "rateNudgeBody": {
+    "message": "Eine kurze Bewertung im Chrome Web Store hilft sehr."
+  },
+  "rateNudgeAction": {
+    "message": "Bewerten"
+  },
+  "rateNudgeDismiss": {
+    "message": "Nicht jetzt"
+  },
   "removeItem": {
     "message": "$1 entfernen"
   }

--- a/packages/extension/public/_locales/en/messages.json
+++ b/packages/extension/public/_locales/en/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "jamezrin on X"
   },
+  "rateNudgeTitle": {
+    "message": "Enjoying Lurkloot?"
+  },
+  "rateNudgeBody": {
+    "message": "A quick review on the Chrome Web Store helps a lot."
+  },
+  "rateNudgeAction": {
+    "message": "Rate it"
+  },
+  "rateNudgeDismiss": {
+    "message": "Not now"
+  },
   "removeItem": {
     "message": "Remove $1"
   }

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "jamezrin en X"
   },
+  "rateNudgeTitle": {
+    "message": "¿Te gusta Lurkloot?"
+  },
+  "rateNudgeBody": {
+    "message": "Una reseña rápida en Chrome Web Store ayuda mucho."
+  },
+  "rateNudgeAction": {
+    "message": "Valórala"
+  },
+  "rateNudgeDismiss": {
+    "message": "Ahora no"
+  },
   "removeItem": {
     "message": "Eliminar $1"
   }

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "jamezrin sur X"
   },
+  "rateNudgeTitle": {
+    "message": "Lurkloot vous plaît ?"
+  },
+  "rateNudgeBody": {
+    "message": "Un petit avis sur le Chrome Web Store aide beaucoup."
+  },
+  "rateNudgeAction": {
+    "message": "Noter"
+  },
+  "rateNudgeDismiss": {
+    "message": "Pas maintenant"
+  },
   "removeItem": {
     "message": "Supprimer $1"
   }

--- a/packages/extension/public/_locales/hi/messages.json
+++ b/packages/extension/public/_locales/hi/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "X पर jamezrin"
   },
+  "rateNudgeTitle": {
+    "message": "Lurkloot पसंद आया?"
+  },
+  "rateNudgeBody": {
+    "message": "Chrome Web Store पर एक छोटी समीक्षा बहुत मदद करती है।"
+  },
+  "rateNudgeAction": {
+    "message": "रेटिंग दें"
+  },
+  "rateNudgeDismiss": {
+    "message": "अभी नहीं"
+  },
   "removeItem": {
     "message": "$1 हटाएँ"
   }

--- a/packages/extension/public/_locales/it/messages.json
+++ b/packages/extension/public/_locales/it/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "jamezrin su X"
   },
+  "rateNudgeTitle": {
+    "message": "Ti piace Lurkloot?"
+  },
+  "rateNudgeBody": {
+    "message": "Una breve recensione sul Chrome Web Store aiuta molto."
+  },
+  "rateNudgeAction": {
+    "message": "Valutala"
+  },
+  "rateNudgeDismiss": {
+    "message": "Non ora"
+  },
   "removeItem": {
     "message": "Rimuovi $1"
   }

--- a/packages/extension/public/_locales/pt_BR/messages.json
+++ b/packages/extension/public/_locales/pt_BR/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "jamezrin no X"
   },
+  "rateNudgeTitle": {
+    "message": "Curtindo o Lurkloot?"
+  },
+  "rateNudgeBody": {
+    "message": "Uma avaliação rápida na Chrome Web Store ajuda muito."
+  },
+  "rateNudgeAction": {
+    "message": "Avaliar"
+  },
+  "rateNudgeDismiss": {
+    "message": "Agora não"
+  },
   "removeItem": {
     "message": "Remover $1"
   }

--- a/packages/extension/public/_locales/ru/messages.json
+++ b/packages/extension/public/_locales/ru/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "jamezrin в X"
   },
+  "rateNudgeTitle": {
+    "message": "Нравится Lurkloot?"
+  },
+  "rateNudgeBody": {
+    "message": "Короткий отзыв в Chrome Web Store очень помогает."
+  },
+  "rateNudgeAction": {
+    "message": "Оценить"
+  },
+  "rateNudgeDismiss": {
+    "message": "Не сейчас"
+  },
   "removeItem": {
     "message": "Удалить $1"
   }

--- a/packages/extension/public/_locales/zh_CN/messages.json
+++ b/packages/extension/public/_locales/zh_CN/messages.json
@@ -512,6 +512,18 @@
   "xAttribution": {
     "message": "X 上的 jamezrin"
   },
+  "rateNudgeTitle": {
+    "message": "喜欢 Lurkloot 吗？"
+  },
+  "rateNudgeBody": {
+    "message": "在 Chrome 应用商店留下简短评价会很有帮助。"
+  },
+  "rateNudgeAction": {
+    "message": "去评价"
+  },
+  "rateNudgeDismiss": {
+    "message": "暂不"
+  },
   "removeItem": {
     "message": "移除 $1"
   }

--- a/packages/extension/tests/rateNudge.test.ts
+++ b/packages/extension/tests/rateNudge.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowRateNudge } from "@lurkloot/popup-ui/rateNudge";
+
+describe("shouldShowRateNudge", () => {
+  const now = new Date("2026-06-14T12:00:00.000Z");
+  const daysAgo = (n: number) => new Date(now.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
+
+  it("hides until the extension has been installed at least minDays", () => {
+    expect(shouldShowRateNudge(daysAgo(1), "pending", now, 3)).toBe(false);
+    expect(shouldShowRateNudge(daysAgo(3), "pending", now, 3)).toBe(true);
+    expect(shouldShowRateNudge(daysAgo(10), "pending", now, 3)).toBe(true);
+  });
+
+  it("stays hidden once rated or dismissed, regardless of age", () => {
+    expect(shouldShowRateNudge(daysAgo(30), "rated", now, 3)).toBe(false);
+    expect(shouldShowRateNudge(daysAgo(30), "dismissed", now, 3)).toBe(false);
+  });
+
+  it("stays hidden when the install date is missing or unparseable", () => {
+    expect(shouldShowRateNudge(undefined, "pending", now, 3)).toBe(false);
+    expect(shouldShowRateNudge("not-a-date", "pending", now, 3)).toBe(false);
+  });
+});

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -108,6 +108,15 @@ describe("settings", () => {
       .toBe("ending_soonest");
   });
 
+  it("validates the rate nudge status", () => {
+    expect(DEFAULT_SETTINGS.rateNudgeStatus).toBe("pending");
+    expect(mergeSettings(undefined).rateNudgeStatus).toBe("pending");
+    expect(mergeSettings({ rateNudgeStatus: "rated" }).rateNudgeStatus).toBe("rated");
+    expect(mergeSettings({ rateNudgeStatus: "dismissed" }).rateNudgeStatus).toBe("dismissed");
+    expect(mergeSettings({ rateNudgeStatus: "bogus" } as unknown as Parameters<typeof mergeSettings>[0]).rateNudgeStatus)
+      .toBe("pending");
+  });
+
   it("validates the language override", () => {
     expect(mergeSettings(undefined).languageOverride).toBe("browser");
     expect(mergeSettings({ languageOverride: "es" }).languageOverride).toBe("es");

--- a/packages/popup-ui/package.json
+++ b/packages/popup-ui/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "exports": {
     ".": "./src/index.ts",
+    "./rateNudge": "./src/rateNudge.logic.ts",
     "./styles.css": "./src/styles.css"
   },
   "scripts": {

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -16,6 +16,7 @@ import { effectiveLocale, isRtlLocale, loadLocaleCatalog, translateFromCatalogs,
 import { I18nContext, PopupRuntimeContext } from "./context";
 import {
   PLATFORMS,
+  RATE_NUDGE_MIN_DAYS,
   SCREENSHOT_VARIANTS,
   SELECTED_PLATFORM_KEY,
 } from "./constants";
@@ -40,6 +41,7 @@ import {
 import { IconButton, SubTabs, cn } from "./primitives";
 import { ActivityLog } from "./activity";
 import { AttributionFooter } from "./footer";
+import { RateNudge, shouldShowRateNudge } from "./rateNudge";
 import { DropsPanel } from "./drops";
 import { WatchQueuePanel } from "./watchQueue";
 import { AutomationHero, PlatformSwitcher } from "./automation";
@@ -356,6 +358,15 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
               </motion.div>
             ) : (
               <motion.div key="main" initial={{ opacity: 0, x: -14 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -14 }} transition={{ duration: 0.18 }} className="space-y-3">
+                <AnimatePresence initial={false}>
+                  {!preview && shouldShowRateNudge(snapshot.state.installedAt, settings.rateNudgeStatus, new Date(), RATE_NUDGE_MIN_DAYS) ? (
+                    <RateNudge
+                      key="rate-nudge"
+                      onRate={() => void updateSettings({ rateNudgeStatus: "rated" })}
+                      onDismiss={() => void updateSettings({ rateNudgeStatus: "dismissed" })}
+                    />
+                  ) : null}
+                </AnimatePresence>
                 <AutomationHero platformLabel={PLATFORMS[platform].label} enabled={enabled} pending={automationPending} farmingTitle={activeCampaign?.title} farmingChannel={farmingChannel} statusMessage={resumingAutomation ? t("resumingAutomation") : session.message} onChange={setAutomation} />
                 <div className="flex items-start gap-2 rounded-xl px-2.5 py-2 text-[11px]" style={{ backgroundColor: "var(--accent-softer)" }}>
                   <Info size={13} className="mt-0.5 shrink-0" style={{ color: "var(--accent-text)" }} />

--- a/packages/popup-ui/src/constants.ts
+++ b/packages/popup-ui/src/constants.ts
@@ -10,6 +10,13 @@ export const PLATFORMS: Record<Platform, { label: string; mark: string; color: s
 export const SELECTED_PLATFORM_KEY = "popup:selectedPlatform";
 export const COLLAPSED_SETTINGS_SECTIONS_KEY = "popup:collapsedSettingsSections";
 
+// Chrome Web Store listing for the rate/review nudge. Single source of truth for
+// the store id so the reviews URL stays correct if the listing slug changes.
+export const CHROME_WEB_STORE_ID = "aobaackpofkghaejdnnmpmeaiaoibhdn";
+export const CHROME_WEB_STORE_REVIEW_URL = `https://chromewebstore.google.com/detail/${CHROME_WEB_STORE_ID}/reviews`;
+// How long after install before the one-time "rate it" nudge appears.
+export const RATE_NUDGE_MIN_DAYS = 3;
+
 export const GAME_ACCENTS = ["#2563eb", "#0891b2", "#ef4444", "#16a34a", "#9333ea", "#f59e0b"];
 
 export const CAMPAIGN_TINTS = [

--- a/packages/popup-ui/src/rateNudge.logic.ts
+++ b/packages/popup-ui/src/rateNudge.logic.ts
@@ -1,0 +1,17 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Pure trigger predicate, kept dependency-free so it can be unit-tested without
+// pulling in the React component tree. Shows the nudge only while pending and
+// once the extension has been installed for at least `minDays`. A missing or
+// unparseable `installedAt` keeps it hidden.
+export function shouldShowRateNudge(
+  installedAt: string | undefined,
+  status: string,
+  now: Date,
+  minDays: number,
+): boolean {
+  if (status !== "pending" || !installedAt) return false;
+  const installedMs = Date.parse(installedAt);
+  if (Number.isNaN(installedMs)) return false;
+  return now.getTime() - installedMs >= minDays * DAY_MS;
+}

--- a/packages/popup-ui/src/rateNudge.tsx
+++ b/packages/popup-ui/src/rateNudge.tsx
@@ -33,7 +33,7 @@ export function RateNudge({ onRate, onDismiss }: { onRate(): void; onDismiss(): 
           target="_blank"
           rel="noreferrer"
           onClick={onRate}
-          className="mt-2 inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[11px] font-semibold text-white outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+          className="mt-2 inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[11px] font-semibold text-[var(--accent-contrast)] outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
           style={{ backgroundColor: "var(--accent)" }}
         >
           <Star size={12} fill="currentColor" />

--- a/packages/popup-ui/src/rateNudge.tsx
+++ b/packages/popup-ui/src/rateNudge.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { Star, X } from "lucide-react";
+import { CHROME_WEB_STORE_REVIEW_URL } from "./constants";
+import { useT } from "./context";
+import { cn } from "./primitives";
+
+export { shouldShowRateNudge } from "./rateNudge.logic";
+
+export function RateNudge({ onRate, onDismiss }: { onRate(): void; onDismiss(): void }): React.ReactElement {
+  const t = useT();
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -6 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -6 }}
+      transition={{ duration: 0.18 }}
+      className="relative flex items-start gap-2.5 rounded-xl px-3 py-2.5"
+      style={{ backgroundColor: "var(--accent-soft)" }}
+    >
+      <span className="mt-0.5 shrink-0" style={{ color: "var(--accent-text)" }}>
+        <Star size={16} fill="currentColor" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-[13px] font-semibold leading-tight" style={{ color: "var(--accent-text)" }}>
+          {t("rateNudgeTitle")}
+        </p>
+        <p className="mt-0.5 text-[11px] leading-snug text-zinc-600 dark:text-zinc-300">
+          {t("rateNudgeBody")}
+        </p>
+        <a
+          href={CHROME_WEB_STORE_REVIEW_URL}
+          target="_blank"
+          rel="noreferrer"
+          onClick={onRate}
+          className="mt-2 inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[11px] font-semibold text-white outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+          style={{ backgroundColor: "var(--accent)" }}
+        >
+          <Star size={12} fill="currentColor" />
+          {t("rateNudgeAction")}
+        </a>
+      </div>
+      <button
+        type="button"
+        title={t("rateNudgeDismiss")}
+        aria-label={t("rateNudgeDismiss")}
+        onClick={onDismiss}
+        className={cn(
+          "flex h-6 w-6 shrink-0 items-center justify-center rounded-md outline-none transition-colors",
+          "text-zinc-400 hover:bg-black/5 hover:text-zinc-700 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:text-zinc-500 dark:hover:bg-white/5 dark:hover:text-zinc-200",
+        )}
+      >
+        <X size={13} />
+      </button>
+    </motion.div>
+  );
+}

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -6,6 +6,10 @@ export type CampaignStatus = "active" | "upcoming" | "expired" | "completed";
 
 export type RewardStatus = "locked" | "in_progress" | "claimable" | "claimed";
 
+// Lifecycle of the one-time Chrome Web Store rate/review nudge. "pending" until
+// the user either rates or dismisses it, after which it never shows again.
+export type RateNudgeStatus = "pending" | "rated" | "dismissed";
+
 export interface DropReward {
   id: string;
   name: string;
@@ -206,6 +210,7 @@ export interface ExtensionSettings {
   offlineRetryLimit: number;
   pollIntervalMinutes: number;
   enabledLogLevels: LogLevel[];
+  rateNudgeStatus: RateNudgeStatus;
 }
 
 export interface EventLogEntry {
@@ -224,6 +229,9 @@ export interface SchedulerState {
   campaigns: Record<Platform, DropCampaign[]>;
   events: EventLogEntry[];
   lastTickAt?: string;
+  // ISO timestamp recorded once by the background on install; drives the
+  // time-based rate/review nudge. Undefined means "unknown" (pre-feature state).
+  installedAt?: string;
 }
 
 export interface WatchDecision {

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -1,9 +1,10 @@
-import type { AdFocusMode, CampaignFilterKey, CategorySelection, ExtensionSettings, LanguageOverride, Platform, PlatformSettings, PriorityMode, SupportedLocale } from "./models";
+import type { AdFocusMode, CampaignFilterKey, CategorySelection, ExtensionSettings, LanguageOverride, Platform, PlatformSettings, PriorityMode, RateNudgeStatus, SupportedLocale } from "./models";
 import { LOG_LEVELS, type LogLevel } from "./logging";
 
 const AD_FOCUS_MODES: AdFocusMode[] = ["none", "tab", "window"];
 const PRIORITY_MODES: PriorityMode[] = ["ending_soonest", "lowest_availability", "priority_list_only"];
 const CAMPAIGN_FILTER_KEYS: CampaignFilterKey[] = ["notLinked", "upcoming", "expired", "excluded", "finished"];
+const RATE_NUDGE_STATUSES: RateNudgeStatus[] = ["pending", "rated", "dismissed"];
 export const SUPPORTED_LOCALES: SupportedLocale[] = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar"];
 const LANGUAGE_OVERRIDES: LanguageOverride[] = ["browser", ...SUPPORTED_LOCALES];
 
@@ -58,6 +59,7 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
   offlineRetryLimit: 3,
   pollIntervalMinutes: 1,
   enabledLogLevels: ["info", "warn", "error"],
+  rateNudgeStatus: "pending",
 };
 
 export function mergeSettings(value: Partial<ExtensionSettings> | undefined): ExtensionSettings {
@@ -105,6 +107,9 @@ export function mergeSettings(value: Partial<ExtensionSettings> | undefined): Ex
     // chrome.alarms floors periodInMinutes at 1, so sub-minute values are inert.
     pollIntervalMinutes: clampNumber(value?.pollIntervalMinutes, 1, 60, DEFAULT_SETTINGS.pollIntervalMinutes),
     enabledLogLevels: normalizeLogLevels(value),
+    rateNudgeStatus: RATE_NUDGE_STATUSES.includes(value?.rateNudgeStatus as RateNudgeStatus)
+      ? (value!.rateNudgeStatus as RateNudgeStatus)
+      : DEFAULT_SETTINGS.rateNudgeStatus,
   };
 }
 


### PR DESCRIPTION
## What

Adds a dismissible **rate/review nudge** to the popup. It appears once the extension has been installed for at least **3 days** and links to the Chrome Web Store reviews page. Once the user rates or dismisses it, it never shows again.

No third footer link is added — this is a standalone, time-gated nudge (per design discussion).

## How it works

- **Trigger:** time-based. The background stamps `installedAt` (ISO) into `SchedulerState` once on install (set-if-missing, so upgraders get a sane date too). The popup already receives the full state via `RuntimeSnapshot`, so no new messaging is needed.
- **State:** a new `rateNudgeStatus` setting (`pending` → `rated`/`dismissed`) rides the existing settings save flow, with a validating normalizer in `mergeSettings`.
- **URL:** single config constant built from the store id `aobaackpofkghaejdnnmpmeaiaoibhdn` (`CHROME_WEB_STORE_REVIEW_URL`).
- **Trigger logic** lives in a pure, dependency-free `shouldShowRateNudge` (exported via the `@lurkloot/popup-ui/rateNudge` subpath) so it's unit-testable in the node-env runner.

## i18n

Added 4 keys (`rateNudgeTitle/Body/Action/Dismiss`) to all 10 locales. The non-Latin translations (ru/zh_CN/hi/ar) are a good-faith pass and worth a native-eye review before publishing.

## Verification

- `pnpm -r typecheck` — clean across shared, popup-ui, extension
- `pnpm --filter @lurkloot/extension test` — **261 passed**, incl. new `rateNudge.test.ts` and the i18n key-consistency test
- `wxt build` — chrome-mv3 builds clean

To preview locally without waiting 3 days, set an old `installedAt` in the service-worker console and reopen the popup.