### PR TITLE
Add changelog page and open it on meaningful extension updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,19 @@ Use pnpm for all package tasks.
 - `pnpm verify`: run tests, typecheck, and both browser builds.
 - `pnpm zip` / `pnpm zip:firefox`: package release artifacts.
 
+## Cutting a Release
+
+Releases ship the extension to the Chrome Web Store and AMO, with the public changelog on the site kept in lockstep. Follow these steps from the repo root on a clean `main`:
+
+1. **Pick the version (semver).** `patch` for bugfixes only, `minor` for backwards-compatible features, `major` for breaking changes. This choice matters beyond convention: on update the extension auto-opens the changelog **only for minor/major bumps** (see `isMinorOrMajorBump` in `packages/extension/src/core/version.ts`), so patch releases ship silently.
+2. **Bump the version.** Update `"version"` to the new number in the four in-lockstep manifests: `package.json` (root), `packages/extension/package.json`, `packages/popup-ui/package.json`, and `packages/shared/package.json`. WXT reads `packages/extension/package.json` for the built `manifest.json`; the others are kept in sync for tidiness. (The `packages/site` version is independent — leave it.)
+3. **Update the changelog.** Add a new top entry to `packages/site/src/changelog.ts` with the `version`, the release `date` (ISO `YYYY-MM-DD`, the Chrome Web Store publish date), and the user-facing `changes` grouped by `kind` (`new` / `improved` / `fixed`). The page renders newest-first and the extension deep-links to `#v{version}`. If a future version was already staged as an `Unreleased` entry (no `date`), just fill in its `date`.
+4. **Verify.** Run `pnpm verify` (tests, typecheck, and both browser builds). Don't proceed if it fails.
+5. **Regenerate the artifacts.** Run `pnpm zip` and `pnpm zip:firefox`. They write `lurkloot-{version}-{browser}.zip` (and a sources zip for Firefox) to `packages/extension/.output/`.
+6. **Commit.** Stage the version bumps and the changelog change together and commit with the existing convention: `Bump version to X.Y.Z`. Optionally tag `vX.Y.Z`.
+7. **Publish.** Upload the Chrome zip to the Chrome Web Store and the Firefox zip + sources to AMO. Use the actual store-publish date in the changelog entry from step 3 if review lag moves it.
+8. **Deploy the site** so the new notes are live before users update: `pnpm --filter @lurkloot/site cf:deploy`. This matters because the extension opens `https://lurkloot.jamezrin.com/changelog#v{version}` on update.
+
 ## Coding Style & Naming Conventions
 
 Use strict TypeScript and ES modules. Keep imports explicit and prefer `type` imports for types. Follow the existing two-space indentation, double quotes, semicolons, and camelCase functions/variables. Use PascalCase for React components and TypeScript types. Keep platform behavior behind `PlatformAdapter`; do not mix Twitch/Kick parsing logic into scheduler or UI code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,29 @@
 
 ## Project Structure & Module Organization
 
-This is a TypeScript WXT WebExtension for Twitch and Kick drop farming. Extension entrypoints live in `entrypoints/`: `background.ts` starts the controller, content scripts are split by platform, and `popup/` contains the React popup UI and CSS. Shared logic lives in `src/core/` for scheduling, settings, storage, tabs, messages, and models. Platform adapters and parsers are in `src/platforms/`. Tests are in `tests/**/*.test.ts`; static assets are in `public/`. `mockup-v1/` is a separate prototype app and should only change when the task targets the mockup.
+This is a TypeScript pnpm monorepo (`packages/*`, see `pnpm-workspace.yaml`) centered on a WXT WebExtension for Twitch and Kick drop farming. Four workspace packages:
+
+- **`packages/extension`** — the WXT extension. Entrypoints are in `entrypoints/`: `background.ts` starts the controller, content scripts are split by platform (`kick.content.ts`, `twitch.content.ts`, `twitchKeepAlive.content.ts`), and `popup/` mounts the React popup. Core logic lives in `src/core/` (`scheduler.ts`, `storage.ts`, `tabs.ts`, `tablessWatch.ts`, `twitchIntegrity.ts`, `version.ts`, `links.ts`, …), the scheduler/controller in `src/background/controller.ts`, and platform adapters/parsers in `src/platforms/` (`adapter.ts` plus `twitch/` and `kick/`). Tests are in `tests/**/*.test.ts`. Static assets and localized messages are in `public/` (`public/_locales` for i18n). `wxt.config.ts` declares the manifest, permissions, and content scripts.
+- **`packages/popup-ui`** — the shared React popup UI (`Popup.tsx`, `primitives.tsx`, view components like `watchQueue.tsx`/`drops.tsx`/`settings.tsx`, and the rate-nudge logic), imported by the extension as `@lurkloot/popup-ui`.
+- **`packages/shared`** — framework-agnostic shared core imported as `@lurkloot/shared`: `models.ts`, `settings.ts`, `messages.ts`, `categories.ts`, `i18n.ts`, `logging.ts`.
+- **`packages/site`** — the Astro marketing site (deployed to Cloudflare Pages at `https://lurkloot.jamezrin.com`). Pages in `src/pages/` (`index.astro`, `privacy.astro`, `changelog.astro`), content data in `src/changelog.ts`/`src/faq.ts`/`src/consts.ts`, and components/layouts/styles alongside.
+
+Other top-level dirs: `docs/` (architecture and store-listing notes), `scripts/` (repo tooling), and `references/` (optional, untracked local snapshots — see below).
 
 ## Build, Test, and Development Commands
 
-Use pnpm for all package tasks.
+Use pnpm for all package tasks. The root `package.json` orchestrates the workspace; these scripts run from the repo root and delegate to the right package via `--filter`.
 
 - `pnpm install`: install dependencies from `pnpm-lock.yaml`.
 - `pnpm dev`: run the WXT development server for Chromium.
 - `pnpm dev:firefox`: run WXT for Firefox.
-- `pnpm test`: run the Vitest test suite once.
-- `pnpm typecheck`: run `tsc --noEmit` with strict TypeScript settings.
-- `pnpm build` / `pnpm build:firefox`: create production builds.
-- `pnpm verify`: run tests, typecheck, and both browser builds.
-- `pnpm zip` / `pnpm zip:firefox`: package release artifacts.
+- `pnpm dev:site`: run the Astro site dev server.
+- `pnpm test`: run the extension Vitest suite once.
+- `pnpm typecheck`: run `tsc --noEmit` across all packages (`pnpm -r typecheck`).
+- `pnpm build` / `pnpm build:firefox`: create production extension builds.
+- `pnpm build:site`: build the Astro site; `pnpm build:all` builds every package.
+- `pnpm verify`: run typecheck, tests, and both browser builds.
+- `pnpm zip` / `pnpm zip:firefox`: package release artifacts into `packages/extension/.output/`.
 
 ## Cutting a Release
 
@@ -32,15 +41,15 @@ Releases ship the extension to the Chrome Web Store and AMO, with the public cha
 
 ## Coding Style & Naming Conventions
 
-Use strict TypeScript and ES modules. Keep imports explicit and prefer `type` imports for types. Follow the existing two-space indentation, double quotes, semicolons, and camelCase functions/variables. Use PascalCase for React components and TypeScript types. Keep platform behavior behind `PlatformAdapter`; do not mix Twitch/Kick parsing logic into scheduler or UI code.
+Use strict TypeScript and ES modules. Keep imports explicit and prefer `type` imports for types. Follow the existing two-space indentation, double quotes, semicolons, and camelCase functions/variables. Use PascalCase for React components and TypeScript types. Put cross-package types, models, and settings in `@lurkloot/shared` rather than duplicating them. Keep platform behavior behind `PlatformAdapter`; do not mix Twitch/Kick parsing logic into scheduler or UI code.
 
 ## Reference Implementations
 
-`references/` contains source snapshots of similar open-source drop-farming apps, including `KickDropsMiner`, `StreamDropCollector`, and `TwitchDropsMiner`. Use them as implementation inspiration for platform behavior, parsing ideas, or edge cases, but adapt code to this extension's WXT, browser-session, and `PlatformAdapter` architecture.
+`references/` is an optional, untracked local directory for source snapshots of similar open-source drop-farming apps (e.g. KickDropsMiner, TwitchDropsMiner). When present, use them as inspiration for platform behavior, parsing ideas, or edge cases, but adapt code to this extension's WXT, browser-session, and `PlatformAdapter` architecture. It is not committed, so don't assume it exists.
 
 ## Testing Guidelines
 
-Tests use Vitest in a Node environment with globals enabled. Add focused `*.test.ts` files under `tests/`, matching the module being exercised, such as `scheduler.test.ts` or `parsers.test.ts`. Prefer deterministic unit tests with mocked adapters, browser APIs, or storage rather than live Twitch/Kick calls. Run `pnpm test` for test-only changes and `pnpm verify` before releases.
+Tests use Vitest in a Node environment with globals enabled and live in `packages/extension/tests/`. Add focused `*.test.ts` files matching the module being exercised, such as `scheduler.test.ts`, `parsers.test.ts`, or `version.test.ts`. Prefer deterministic unit tests with mocked adapters, browser APIs, or storage rather than live Twitch/Kick calls. Run `pnpm test` for test-only changes and `pnpm verify` before releases.
 
 ## Commit & Pull Request Guidelines
 
@@ -48,4 +57,4 @@ Recent history uses short imperative commit subjects, for example `Fix viewer co
 
 ## Security & Configuration Tips
 
-Do not add features that store credentials, export cookies, or bypass platform detection. The extension relies on normal logged-in browser sessions and visible muted tabs. Keep host permissions scoped to the services declared in `wxt.config.ts`, and document any new permission in the PR.
+Do not add features that store credentials, export cookies, or bypass platform detection. The extension relies on normal logged-in browser sessions and visible muted tabs. Keep `permissions` and `host_permissions` scoped to the services declared in `packages/extension/wxt.config.ts`, and document any new permission in the PR.

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -7,6 +7,8 @@ import { effectiveLocale, loadLocaleCatalog, translateFromCatalogs, type Message
 import type { ExtensionSettings, SupportedLocale } from "@lurkloot/shared/models";
 import { KickAdapter } from "../src/platforms/kick";
 import { TwitchAdapter } from "../src/platforms/twitch";
+import { isMinorOrMajorBump } from "../src/core/version";
+import { CHANGELOG_URL } from "../src/core/links";
 
 const localeCatalogs = new Map<string, MessageCatalog | undefined>();
 const getMessage = browser.i18n.getMessage as (key: string, substitutions?: string | string[]) => string;
@@ -62,7 +64,7 @@ const controller = createBackgroundController({
 });
 
 export default defineBackground(() => {
-  browser.runtime.onInstalled.addListener(async () => {
+  browser.runtime.onInstalled.addListener(async (details) => {
     await controller.ensureAlarm();
     // Stamp the install date once so the popup can time the rate/review nudge.
     // Set-if-missing (rather than gating on reason === "install") also backfills
@@ -70,6 +72,13 @@ export default defineBackground(() => {
     const state = await loadState();
     if (!state.installedAt) {
       await saveState({ ...state, installedAt: new Date().toISOString() });
+    }
+
+    // On a meaningful update (major/minor — not a patch bugfix, not a fresh
+    // install), open the changelog so returning users see what's new.
+    const currentVersion = browser.runtime.getManifest().version;
+    if (details.reason === "update" && isMinorOrMajorBump(details.previousVersion, currentVersion)) {
+      await browser.tabs.create({ url: `${CHANGELOG_URL}#v${currentVersion}` });
     }
   });
 

--- a/packages/extension/src/core/links.ts
+++ b/packages/extension/src/core/links.ts
@@ -1,0 +1,5 @@
+// Outbound URLs the extension links to. Kept in one place so the canonical
+// site domain has a single home on the extension side.
+
+export const SITE_URL = "https://lurkloot.jamezrin.com";
+export const CHANGELOG_URL = `${SITE_URL}/changelog`;

--- a/packages/extension/src/core/version.ts
+++ b/packages/extension/src/core/version.ts
@@ -1,0 +1,29 @@
+// Tiny semver-ish helper for deciding whether an extension update is worth
+// surfacing to the user. We only care about major/minor: patch bumps are
+// typically bugfixes and shouldn't steal a tab.
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+}
+
+// Parse "major.minor.patch" leniently. Missing trailing parts default to 0
+// (so "1" === "1.0.0"). Returns null when major/minor aren't real numbers.
+function parse(version: string | undefined): ParsedVersion | null {
+  if (!version) return null;
+  const [rawMajor = "0", rawMinor = "0"] = version.trim().split(".");
+  const major = Number(rawMajor);
+  const minor = Number(rawMinor);
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) return null;
+  return { major, minor };
+}
+
+// True when `next` is a higher major or minor than `prev`. Patch-only bumps,
+// equal versions, downgrades, and unparseable input all return false.
+export function isMinorOrMajorBump(prev: string | undefined, next: string | undefined): boolean {
+  const a = parse(prev);
+  const b = parse(next);
+  if (!a || !b) return false;
+  if (b.major !== a.major) return b.major > a.major;
+  return b.minor > a.minor;
+}

--- a/packages/extension/tests/version.test.ts
+++ b/packages/extension/tests/version.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isMinorOrMajorBump } from "../src/core/version";
+
+describe("isMinorOrMajorBump", () => {
+  it("is false for a patch-only bump", () => {
+    expect(isMinorOrMajorBump("1.3.0", "1.3.1")).toBe(false);
+    expect(isMinorOrMajorBump("1.3.5", "1.3.12")).toBe(false);
+  });
+
+  it("is true for a minor bump", () => {
+    expect(isMinorOrMajorBump("1.3.0", "1.4.0")).toBe(true);
+    expect(isMinorOrMajorBump("1.3.7", "1.4.0")).toBe(true);
+  });
+
+  it("is true for a major bump", () => {
+    expect(isMinorOrMajorBump("1.3.0", "2.0.0")).toBe(true);
+    expect(isMinorOrMajorBump("1.9.9", "2.0.0")).toBe(true);
+  });
+
+  it("is false for equal versions", () => {
+    expect(isMinorOrMajorBump("1.3.0", "1.3.0")).toBe(false);
+  });
+
+  it("is false for a downgrade", () => {
+    expect(isMinorOrMajorBump("1.4.0", "1.3.0")).toBe(false);
+    expect(isMinorOrMajorBump("2.0.0", "1.9.9")).toBe(false);
+  });
+
+  it("is false for malformed or missing input", () => {
+    expect(isMinorOrMajorBump(undefined, "1.4.0")).toBe(false);
+    expect(isMinorOrMajorBump("1.3.0", undefined)).toBe(false);
+    expect(isMinorOrMajorBump("", "1.4.0")).toBe(false);
+    expect(isMinorOrMajorBump("not.a.version", "1.4.0")).toBe(false);
+    expect(isMinorOrMajorBump("1", "2")).toBe(true);
+  });
+});

--- a/packages/site/src/changelog.ts
+++ b/packages/site/src/changelog.ts
@@ -1,0 +1,119 @@
+// Changelog content — the single source of truth for the on-site /changelog page.
+// Newest version first. Text is plain (no markup) to keep the page simple.
+// The extension deep-links here on update (e.g. /changelog#v1.3.0).
+
+export type ChangeKind = "new" | "improved" | "fixed";
+
+export interface Change {
+  kind: ChangeKind;
+  text: string;
+}
+
+export interface ChangelogEntry {
+  version: string; // "1.3.0"
+  // ISO date "2026-06-07" of the Chrome Web Store release; formatted on the page.
+  // Omit for a version that hasn't been published yet (rendered as "Unreleased").
+  date?: string;
+  changes: Change[];
+}
+
+export const changelog: ChangelogEntry[] = [
+  {
+    version: "1.3.0",
+    changes: [
+      { kind: "new", text: "Renamed to Lurkloot." },
+      {
+        kind: "new",
+        text:
+          "Streamer and channel names are now clickable links to their channel page — in the watch queue, on each drop's allowed channels, and in the automation view.",
+      },
+      {
+        kind: "new",
+        text:
+          "Added direct links to each drop's campaign page, plus a “No category” grouping for uncategorized drops.",
+      },
+      { kind: "new", text: "Added a Chrome Web Store link in the settings footer." },
+      {
+        kind: "improved",
+        text: "Added an occasional one-time prompt to rate the extension.",
+      },
+      {
+        kind: "fixed",
+        text: "Corrected the Twitch liveness fallback default and removed dead diagnostics state.",
+      },
+    ],
+  },
+  {
+    version: "1.2.0",
+    date: "2026-06-07",
+    changes: [
+      { kind: "new", text: "Added a “Priority list only” farming mode." },
+      {
+        kind: "new",
+        text: "Added per-platform category filters and campaign visibility controls.",
+      },
+      {
+        kind: "new",
+        text: "Added a per-level activity log control and a reset for excluded campaigns.",
+      },
+      {
+        kind: "new",
+        text: "Added campaign lifecycle pills and a start countdown for upcoming campaigns.",
+      },
+      { kind: "new", text: "Localized the interface and store assets." },
+      {
+        kind: "improved",
+        text: "Tabless background farming is now enabled by default.",
+      },
+      {
+        kind: "improved",
+        text: "Reorganized settings into collapsible, grouped sections with a platform switcher.",
+      },
+      {
+        kind: "improved",
+        text: "Kick now tries a background fetch before falling back to a page.",
+      },
+      {
+        kind: "fixed",
+        text: "Fixed Kick reward images by resolving relative paths to the Kick CDN.",
+      },
+      { kind: "fixed", text: "Fixed editing automation settings while farming was paused." },
+    ],
+  },
+  {
+    version: "1.1.0",
+    date: "2026-06-06",
+    changes: [
+      {
+        kind: "fixed",
+        text: "Hardened Kick drop auto-claim against the live API so claims register reliably.",
+      },
+      {
+        kind: "fixed",
+        text: "More reliable Twitch drop claiming by replaying the page's Client-Integrity token.",
+      },
+    ],
+  },
+  {
+    version: "1.0.0",
+    date: "2026-06-05",
+    changes: [
+      {
+        kind: "new",
+        text:
+          "First public release: automatic Twitch and Kick drop farming through your own logged-in session.",
+      },
+      {
+        kind: "new",
+        text: "Opt-in tabless low-resource mode that farms without a visible video tab.",
+      },
+      { kind: "new", text: "Automatic drop claiming, including Twitch channel points." },
+      { kind: "new", text: "Activity log panel with adjustable detail levels." },
+      {
+        kind: "improved",
+        text: "Smart channel switching and real campaign progress tracking.",
+      },
+      { kind: "fixed", text: "Detect already-owned Twitch drops to avoid re-farming them." },
+    ],
+  },
+];

--- a/packages/site/src/components/Footer.astro
+++ b/packages/site/src/components/Footer.astro
@@ -27,6 +27,7 @@ const year = new Date().getFullYear();
     </div>
     <nav class="foot__links" aria-label="Footer">
       <a href={LINKS.chrome} target="_blank" rel="noopener">Chrome Web Store</a>
+      <a href={LINKS.changelog}>Changelog</a>
       <a href={LINKS.privacy}>Privacy Policy</a>
     </nav>
   </div>

--- a/packages/site/src/consts.ts
+++ b/packages/site/src/consts.ts
@@ -29,6 +29,7 @@ export const LINKS = {
     "https://chromewebstore.google.com/detail/lurkloot/aobaackpofkghaejdnnmpmeaiaoibhdn",
   // On-site page (rendered from the same source policy) — no GitHub link.
   privacy: "/privacy",
+  changelog: "/changelog",
   x: "https://x.com/jamezrin",
   github: "https://github.com/jamezrin",
 } as const;

--- a/packages/site/src/pages/changelog.astro
+++ b/packages/site/src/pages/changelog.astro
@@ -1,0 +1,215 @@
+---
+import Base from "../layouts/Base.astro";
+import Footer from "../components/Footer.astro";
+import { LINKS } from "../consts";
+import { changelog, type ChangeKind } from "../changelog";
+import logo from "../assets/logo-ring.svg";
+
+const dateFmt = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+const formatDate = (iso: string) => dateFmt.format(new Date(`${iso}T00:00:00Z`));
+
+const kindLabel: Record<ChangeKind, string> = {
+  new: "New",
+  improved: "Improved",
+  fixed: "Fixed",
+};
+---
+
+<Base
+  title="Changelog — Lurkloot"
+  description="What's new in Lurkloot — release notes for every version of the Twitch and Kick drops farming extension."
+>
+  <header class="legalnav">
+    <div class="wrap legalnav__inner">
+      <a class="legalnav__brand" href="/">
+        <img src={logo.src} width="28" height="28" alt="" />
+        <span>Lurkloot</span>
+      </a>
+      <a class="btn btn--primary legalnav__cta" href={LINKS.chrome} target="_blank" rel="noopener">
+        Add to browser
+      </a>
+    </div>
+  </header>
+
+  <main class="legal">
+    <div class="wrap legal__wrap">
+      <p class="eyebrow">Release notes</p>
+      <h1>Changelog</h1>
+
+      <div class="log">
+        {changelog.map((entry) => (
+          <section class="rel" id={`v${entry.version}`}>
+            <div class="rel__head">
+              <h2 class="rel__version">v{entry.version}</h2>
+              {entry.date ? (
+                <time class="rel__date" datetime={entry.date}>{formatDate(entry.date)}</time>
+              ) : (
+                <span class="rel__date rel__date--unreleased">Unreleased</span>
+              )}
+            </div>
+            <ul class="rel__list">
+              {entry.changes.map((change) => (
+                <li class="change">
+                  <span class={`tag tag--${change.kind}`}>{kindLabel[change.kind]}</span>
+                  <span class="change__text">{change.text}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+
+      <p class="legal__back"><a href="/">← Back to home</a></p>
+    </div>
+  </main>
+
+  <Footer />
+</Base>
+
+<style>
+  .legalnav {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    border-bottom: 1px solid var(--line);
+    background: rgba(6, 6, 9, 0.8);
+    backdrop-filter: blur(12px);
+  }
+  .legalnav__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 64px;
+    gap: 1.5rem;
+  }
+  .legalnav__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-family: var(--font-display);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+  }
+  .legalnav__brand img { border-radius: 8px; }
+  .legalnav__cta { padding: 0.55em 1.05em; font-size: 0.88rem; }
+
+  .legal {
+    padding: clamp(3rem, 8vw, 6rem) 0 clamp(4rem, 8vw, 6rem);
+  }
+  .legal__wrap {
+    max-width: 760px;
+  }
+  .legal h1 {
+    font-family: var(--font-display);
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    font-size: clamp(2.4rem, 6vw, 4rem);
+    margin: 0.6rem 0 0;
+  }
+
+  .log {
+    margin-top: clamp(2rem, 5vw, 3rem);
+    display: grid;
+    gap: clamp(2rem, 4vw, 2.75rem);
+  }
+
+  /* Each release anchors below the sticky header when deep-linked. */
+  .rel {
+    scroll-margin-top: 84px;
+    padding-top: clamp(1.6rem, 3vw, 2.25rem);
+    border-top: 1px solid var(--line);
+  }
+  .rel:first-child {
+    padding-top: 0;
+    border-top: 0;
+  }
+  .rel__head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.9rem;
+    flex-wrap: wrap;
+  }
+  .rel__version {
+    font-family: var(--font-display);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--text);
+    font-size: 1.5rem;
+    margin: 0;
+  }
+  .rel__date {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--faint);
+  }
+  .rel__date--unreleased {
+    color: var(--lime);
+    padding: 0.18em 0.55em;
+    border-radius: 999px;
+    border: 1px solid color-mix(in oklab, var(--lime) 35%, var(--line));
+    font-size: 0.66rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .rel__list {
+    list-style: none;
+    margin: 1.1rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 0.7rem;
+  }
+  .change {
+    display: grid;
+    grid-template-columns: 5.5rem 1fr;
+    gap: 0.75rem;
+    align-items: baseline;
+  }
+  @media (max-width: 520px) {
+    .change {
+      grid-template-columns: 1fr;
+      gap: 0.3rem;
+    }
+  }
+  .change__text {
+    color: var(--muted);
+    font-size: 1.05rem;
+    line-height: 1.6;
+  }
+  /* Small category label per change. */
+  .tag {
+    justify-self: start;
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 0.18em 0.55em;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: var(--ink-1);
+    white-space: nowrap;
+    transform: translateY(-0.08em);
+  }
+  .tag--new {
+    color: var(--lime);
+    border-color: color-mix(in oklab, var(--lime) 35%, var(--line));
+  }
+  .tag--improved {
+    color: var(--purple-soft);
+    border-color: color-mix(in oklab, var(--purple-soft) 35%, var(--line));
+  }
+  .tag--fixed {
+    color: var(--muted);
+  }
+
+  .legal__back {
+    margin-top: 3rem;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+  }
+  .legal__back a { color: var(--muted); }
+  .legal__back a:hover { color: var(--lime); }
+</style>


### PR DESCRIPTION
## What

Adds a changelog to Lurkloot, surfaced both on the site and in the extension.

### Site — `/changelog` page
- New `packages/site/src/changelog.ts` data module (single source of truth, mirrors the `faq.ts` pattern). Each change is tagged **New / Improved / Fixed**.
- New `packages/site/src/pages/changelog.astro`, modeled on `privacy.astro` (same layout, header, footer, design tokens). Version blocks have `id="v{version}"` anchors for deep-linking; unpublished versions render an "Unreleased" badge instead of a date.
- `LINKS.changelog` added to `consts.ts`; "Changelog" link added to the footer.

### Extension — open on update
- Extends the existing `onInstalled` listener in `background.ts` to open the changelog **on update only** (never on fresh install) and **only for minor/major bumps** (patches stay silent). Uses `details.previousVersion`, so no new persisted state is needed.
- New pure `isMinorOrMajorBump` helper in `src/core/version.ts` (with `tests/version.test.ts`).
- New `src/core/links.ts` holds the canonical site/changelog URL (none existed in the extension before).

## Notes
- **1.3.0 is unreleased** — its entry has no date and renders an "Unreleased" badge. Add a `date:` when it ships; the `#v1.3.0` deep-link anchor already exists.
- Release dates are the Chrome Web Store publish dates (1.2.0 → Jun 7, 1.1.0 → Jun 6, 1.0.0 → Jun 5). The 1.0.0/1.1.0 content split is a best-effort reconstruction from git history.

## Verification
- Extension: `tsc --noEmit` clean; **274/274 tests pass** (incl. 6 new); `wxt build` succeeds.
- Site: `pnpm build` succeeds (3 pages); changelog rendering checked in a browser.