### PR TITLE
Fix pnpm 11 install gate (ERR_PNPM_IGNORED_BUILDS) breaking site-deploy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,16 @@
 packages:
   - "packages/*"
 
-# Dependencies allowed to run install scripts (pnpm 10 blocks others and errors).
-# cycletls ships prebuilt Go binaries in its tarball, so this is just to satisfy
-# pnpm's approval gate during a clean install (e.g. in the Docker build).
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
-  - cycletls
+# Dependencies allowed to run install/build scripts. pnpm 11 requires every
+# package that ships a build script to be explicitly allowed (true) or denied
+# (false); otherwise `pnpm install` aborts with ERR_PNPM_IGNORED_BUILDS.
+#   - esbuild, sharp, cycletls, workerd all ship working prebuilt binaries in
+#     their tarballs (or platform optional deps), so we let their scripts run.
+#   - spawn-sync is an unused transitive native shim for legacy Node; deny it.
+# (The CLI Docker build uses --ignore-scripts, so this gate doesn't apply there.)
+allowBuilds:
+  esbuild: true
+  sharp: true
+  cycletls: true
+  workerd: true
+  spawn-sync: false


### PR DESCRIPTION
## Problem

The `Deploy site` workflow on `main` fails at `pnpm install --frozen-lockfile`:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.7, esbuild@0.28.1, sharp@0.34.5, spawn-sync@1.0.15, workerd@1.20260617.1
```

This is **not** a lockfile-sync problem — the lockfile is up to date. It's a pnpm 11 behavior change (introduced by Renovate PRs #47/#48 bumping pnpm to v11 + action-setup v6). pnpm 11 replaced the `onlyBuiltDependencies` allow-list with `allowBuilds`, where **every** package that ships a build script must be explicitly allowed (`true`) or denied (`false`). With only the old `onlyBuiltDependencies` key present, pnpm 11 hard-errors on CI installs (pnpm 10 only warned).

## Fix

Migrate `pnpm-workspace.yaml` to `allowBuilds`:
- `esbuild`, `sharp`, `cycletls`, `workerd` → `true` (all ship working prebuilt binaries / platform optional deps)
- `spawn-sync` → `false` (unused transitive native shim for legacy Node)

The CLI Docker build is unaffected — it installs with `--ignore-scripts`, bypassing this gate entirely.

## Verification

- `pnpm install --frozen-lockfile` exits 0 under **both** pnpm 10.30 (local) and pnpm 11.9 (CI) — no re-prompt, no file rewrite.
- `pnpm build:site` completes successfully (sharp image optimization runs).