### PR TITLE
Replace update tab with popup notice

### DIFF
--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -20,7 +20,7 @@ import type { WatchTabPort } from "@lurkloot/core/adapter";
 import { createKickFetcher, KickAdapter } from "@lurkloot/core/kick";
 import { TwitchAdapter } from "@lurkloot/core/twitch";
 import { isMinorOrMajorBump } from "../src/core/version";
-import { CHANGELOG_URL } from "../src/core/links";
+import { savePendingChangelogVersion } from "../src/core/updateNotice";
 
 const localeCatalogs = new Map<string, MessageCatalog | undefined>();
 const getMessage = browser.i18n.getMessage as (key: string, substitutions?: string | string[]) => string;
@@ -145,10 +145,11 @@ export default defineBackground(() => {
     }
 
     // On a meaningful update (major/minor — not a patch bugfix, not a fresh
-    // install), open the changelog so returning users see what's new.
+    // install), queue a popup notice so returning users can choose to see
+    // what's new without an unsolicited browser tab interrupting them.
     const currentVersion = browser.runtime.getManifest().version;
     if (details.reason === "update" && isMinorOrMajorBump(details.previousVersion, currentVersion)) {
-      await browser.tabs.create({ url: `${CHANGELOG_URL}#v${currentVersion}` });
+      await savePendingChangelogVersion(currentVersion);
     }
   });
 

--- a/packages/extension/entrypoints/popup/app.tsx
+++ b/packages/extension/entrypoints/popup/app.tsx
@@ -12,6 +12,11 @@ import {
 import { SETTINGS_SESSION_PORT } from "@lurkloot/shared/messages";
 import { SUPPORTED_LOCALES } from "@lurkloot/shared/settings";
 import type { SupportedLocale } from "@lurkloot/shared/models";
+import {
+  changelogUrl,
+  dismissPendingChangelogVersion,
+  loadPendingChangelogVersion,
+} from "../../src/core/updateNotice";
 
 const URL_PARAMS = new URLSearchParams(typeof window !== "undefined" ? window.location.search : "");
 
@@ -39,6 +44,9 @@ export function createExtensionPopupAdapter(): PopupAdapter {
     },
     getMessage: (key, substitutions) => browser.i18n.getMessage(key as never, substitutions),
     getUiLanguage: () => browser.i18n.getUILanguage(),
+    getPendingChangelogVersion: loadPendingChangelogVersion,
+    dismissPendingChangelogVersion,
+    changelogUrl,
     exportCredentials: (blob) => {
       // Download the credential blob the CLI's `login --import` consumes. The
       // popup is a normal extension page, so a Blob URL + anchor works without

--- a/packages/extension/src/core/updateNotice.ts
+++ b/packages/extension/src/core/updateNotice.ts
@@ -1,0 +1,23 @@
+import { browser } from "wxt/browser";
+import { CHANGELOG_URL } from "./links";
+
+const PENDING_CHANGELOG_VERSION_KEY = "pendingChangelogVersion";
+
+export async function loadPendingChangelogVersion(): Promise<string | undefined> {
+  const stored = await browser.storage.local.get(PENDING_CHANGELOG_VERSION_KEY);
+  return typeof stored[PENDING_CHANGELOG_VERSION_KEY] === "string"
+    ? stored[PENDING_CHANGELOG_VERSION_KEY]
+    : undefined;
+}
+
+export async function savePendingChangelogVersion(version: string): Promise<void> {
+  await browser.storage.local.set({ [PENDING_CHANGELOG_VERSION_KEY]: version });
+}
+
+export async function dismissPendingChangelogVersion(): Promise<void> {
+  await browser.storage.local.remove(PENDING_CHANGELOG_VERSION_KEY);
+}
+
+export function changelogUrl(version: string): string {
+  return `${CHANGELOG_URL}#v${version}`;
+}

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "موقع Lurkloot"
   },
+  "updateNoticeTitle": { "message": "تم تحديث Lurkloot إلى الإصدار $1" },
+  "updateNoticeBody": { "message": "تعرّف على الميزات الجديدة والتغييرات." },
+  "updateNoticeAction": { "message": "عرض التغييرات" },
+  "updateNoticeDismiss": { "message": "تجاهل إشعار التحديث" },
   "rateNudgeTitle": {
     "message": "هل يعجبك Lurkloot؟"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "Lurkloot-Website"
   },
+  "updateNoticeTitle": { "message": "Lurkloot wurde auf $1 aktualisiert" },
+  "updateNoticeBody": { "message": "Sieh dir die Neuerungen und Änderungen an." },
+  "updateNoticeAction": { "message": "Änderungen ansehen" },
+  "updateNoticeDismiss": { "message": "Update-Hinweis schließen" },
   "rateNudgeTitle": {
     "message": "Gefällt dir Lurkloot?"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "Lurkloot website"
   },
+  "updateNoticeTitle": { "message": "Lurkloot was updated to $1" },
+  "updateNoticeBody": { "message": "See what's new and what changed." },
+  "updateNoticeAction": { "message": "View changes" },
+  "updateNoticeDismiss": { "message": "Dismiss update notice" },
   "rateNudgeTitle": {
     "message": "Enjoying Lurkloot?"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "Sitio web de Lurkloot"
   },
+  "updateNoticeTitle": { "message": "Lurkloot se ha actualizado a la versión $1" },
+  "updateNoticeBody": { "message": "Descubre las novedades y los cambios." },
+  "updateNoticeAction": { "message": "Ver cambios" },
+  "updateNoticeDismiss": { "message": "Descartar aviso de actualización" },
   "rateNudgeTitle": {
     "message": "¿Te gusta Lurkloot?"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "Site web de Lurkloot"
   },
+  "updateNoticeTitle": { "message": "Lurkloot a été mis à jour vers la version $1" },
+  "updateNoticeBody": { "message": "Découvrez les nouveautés et les changements." },
+  "updateNoticeAction": { "message": "Voir les changements" },
+  "updateNoticeDismiss": { "message": "Fermer l’avis de mise à jour" },
   "rateNudgeTitle": {
     "message": "Lurkloot vous plaît ?"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "Lurkloot वेबसाइट"
   },
+  "updateNoticeTitle": { "message": "Lurkloot को $1 में अपडेट किया गया" },
+  "updateNoticeBody": { "message": "नई सुविधाएँ और बदलाव देखें।" },
+  "updateNoticeAction": { "message": "बदलाव देखें" },
+  "updateNoticeDismiss": { "message": "अपडेट सूचना हटाएँ" },
   "rateNudgeTitle": {
     "message": "Lurkloot पसंद आया?"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "Sito web di Lurkloot"
   },
+  "updateNoticeTitle": { "message": "Lurkloot è stato aggiornato alla versione $1" },
+  "updateNoticeBody": { "message": "Scopri le novità e le modifiche." },
+  "updateNoticeAction": { "message": "Vedi modifiche" },
+  "updateNoticeDismiss": { "message": "Chiudi l’avviso di aggiornamento" },
   "rateNudgeTitle": {
     "message": "Ti piace Lurkloot?"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "Site da Lurkloot"
   },
+  "updateNoticeTitle": { "message": "O Lurkloot foi atualizado para a versão $1" },
+  "updateNoticeBody": { "message": "Veja as novidades e o que mudou." },
+  "updateNoticeAction": { "message": "Ver alterações" },
+  "updateNoticeDismiss": { "message": "Dispensar aviso de atualização" },
   "rateNudgeTitle": {
     "message": "Curtindo o Lurkloot?"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "Сайт Lurkloot"
   },
+  "updateNoticeTitle": { "message": "Lurkloot обновлён до версии $1" },
+  "updateNoticeBody": { "message": "Узнайте о новых функциях и изменениях." },
+  "updateNoticeAction": { "message": "Посмотреть изменения" },
+  "updateNoticeDismiss": { "message": "Закрыть уведомление об обновлении" },
   "rateNudgeTitle": {
     "message": "Нравится Lurkloot?"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -533,6 +533,10 @@
   "siteAttribution": {
     "message": "Lurkloot 网站"
   },
+  "updateNoticeTitle": { "message": "Lurkloot 已更新至 $1" },
+  "updateNoticeBody": { "message": "查看新增内容和改动。" },
+  "updateNoticeAction": { "message": "查看改动" },
+  "updateNoticeDismiss": { "message": "关闭更新通知" },
   "rateNudgeTitle": {
     "message": "喜欢 Lurkloot 吗？"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -326,6 +326,9 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
         setCampaignFocus((prev) => ({ id: activeCampaign.id, seq: (prev?.seq ?? 0) + 1 }));
       }
     : undefined;
+  const updateNotice = pendingChangelogVersion && adapter.changelogUrl
+    ? { version: pendingChangelogVersion, href: adapter.changelogUrl(pendingChangelogVersion) }
+    : undefined;
 
   return (
       <PopupRuntimeContext.Provider value={{ adapter, preview }}>
@@ -394,15 +397,15 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
             ) : (
               <motion.div key="main" initial={{ opacity: 0, x: -14 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -14 }} transition={{ duration: 0.18 }} className="space-y-3">
                 <AnimatePresence initial={false}>
-                  {pendingChangelogVersion && adapter.changelogUrl ? (
+                  {updateNotice ? (
                     <UpdateNotice
                       key="update-notice"
-                      version={pendingChangelogVersion}
-                      href={adapter.changelogUrl(pendingChangelogVersion)}
+                      version={updateNotice.version}
+                      href={updateNotice.href}
                       onDismiss={dismissUpdateNotice}
                     />
                   ) : null}
-                  {!pendingChangelogVersion && !preview && shouldShowRateNudge(snapshot.state.installedAt, settings.rateNudgeStatus, new Date(), RATE_NUDGE_MIN_DAYS) ? (
+                  {!updateNotice && !preview && shouldShowRateNudge(snapshot.state.installedAt, settings.rateNudgeStatus, new Date(), RATE_NUDGE_MIN_DAYS) ? (
                     <RateNudge
                       key="rate-nudge"
                       onRate={() => void updateSettings({ rateNudgeStatus: "rated" })}

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -43,6 +43,7 @@ import { IconButton, SubTabs, cn } from "./primitives";
 import { ActivityLog } from "./activity";
 import { AttributionFooter } from "./footer";
 import { RateNudge, shouldShowRateNudge } from "./rateNudge";
+import { UpdateNotice } from "./updateNotice";
 import { DropsPanel } from "./drops";
 import { WatchQueuePanel } from "./watchQueue";
 import { AutomationHero, PlatformSwitcher } from "./automation";
@@ -67,6 +68,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const [activityOpen, setActivityOpen] = useState(preview && initialVariant.view === "activity");
   const [refreshing, setRefreshing] = useState(false);
   const [resumingAutomation, setResumingAutomation] = useState(false);
+  const [pendingChangelogVersion, setPendingChangelogVersion] = useState<string>();
   const [pendingAutomation, setPendingAutomation] = useState<Partial<Record<Platform, boolean>>>({});
   // Request to jump to a campaign in the drops list (expand + scroll). The seq
   // counter lets repeated clicks on the same campaign re-trigger the effect.
@@ -146,6 +148,16 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
       setSnapshot(snapshotWithMergedSettings(nextSnapshot));
     });
   }, [adapter, initialVariant.platform, preview]);
+
+  useEffect(() => {
+    if (preview || !adapter.getPendingChangelogVersion) return;
+    void adapter.getPendingChangelogVersion().then(setPendingChangelogVersion);
+  }, [adapter, preview]);
+
+  function dismissUpdateNotice(): void {
+    setPendingChangelogVersion(undefined);
+    void adapter.dismissPendingChangelogVersion?.();
+  }
 
   useEffect(() => {
     if (preview || !settingsOpen || !adapter.connectSettingsSession) return;
@@ -382,7 +394,15 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
             ) : (
               <motion.div key="main" initial={{ opacity: 0, x: -14 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -14 }} transition={{ duration: 0.18 }} className="space-y-3">
                 <AnimatePresence initial={false}>
-                  {!preview && shouldShowRateNudge(snapshot.state.installedAt, settings.rateNudgeStatus, new Date(), RATE_NUDGE_MIN_DAYS) ? (
+                  {pendingChangelogVersion && adapter.changelogUrl ? (
+                    <UpdateNotice
+                      key="update-notice"
+                      version={pendingChangelogVersion}
+                      href={adapter.changelogUrl(pendingChangelogVersion)}
+                      onDismiss={dismissUpdateNotice}
+                    />
+                  ) : null}
+                  {!pendingChangelogVersion && !preview && shouldShowRateNudge(snapshot.state.installedAt, settings.rateNudgeStatus, new Date(), RATE_NUDGE_MIN_DAYS) ? (
                     <RateNudge
                       key="rate-nudge"
                       onRate={() => void updateSettings({ rateNudgeStatus: "rated" })}

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -54,6 +54,11 @@ export interface PopupAdapter {
   connectSettingsSession?(): () => void;
   getMessage(key: string, substitutions?: string | string[]): string;
   getUiLanguage(): string;
+  // Optional extension lifecycle hooks. Demo/site hosts omit these, which also
+  // keeps update notices out of screenshots and the landing-page popup demo.
+  getPendingChangelogVersion?(): Promise<string | undefined>;
+  dismissPendingChangelogVersion?(): Promise<void>;
+  changelogUrl?(version: string): string;
   // Optional: download/persist an exported credential blob for the headless CLI.
   // Only the live extension implements it (the demo omits it, hiding the action).
   exportCredentials?(blob: CliCredentialBlob): void;

--- a/packages/popup-ui/src/updateNotice.tsx
+++ b/packages/popup-ui/src/updateNotice.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { Sparkles, X } from "lucide-react";
+import { useT } from "./context";
+import { cn } from "./primitives";
+
+export function UpdateNotice({ version, href, onDismiss }: {
+  version: string;
+  href: string;
+  onDismiss(): void;
+}): React.ReactElement {
+  const t = useT();
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -6 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -6 }}
+      transition={{ duration: 0.18 }}
+      className="relative flex items-start gap-2.5 rounded-xl px-3 py-2.5"
+      style={{ backgroundColor: "var(--accent-soft)" }}
+    >
+      <span className="mt-0.5 shrink-0" style={{ color: "var(--accent-text)" }}>
+        <Sparkles size={16} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-[13px] font-semibold leading-tight" style={{ color: "var(--accent-text)" }}>
+          {t("updateNoticeTitle", version)}
+        </p>
+        <p className="mt-0.5 text-[11px] leading-snug text-zinc-600 dark:text-zinc-300">
+          {t("updateNoticeBody")}
+        </p>
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={onDismiss}
+          className="mt-2 inline-flex items-center rounded-lg px-2.5 py-1 text-[11px] font-semibold text-[var(--accent-contrast)] outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+          style={{ backgroundColor: "var(--accent)" }}
+        >
+          {t("updateNoticeAction")}
+        </a>
+      </div>
+      <button
+        type="button"
+        title={t("updateNoticeDismiss")}
+        aria-label={t("updateNoticeDismiss")}
+        onClick={onDismiss}
+        className={cn(
+          "flex h-6 w-6 shrink-0 items-center justify-center rounded-md outline-none transition-colors",
+          "text-zinc-400 hover:bg-black/5 hover:text-zinc-700 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:text-zinc-500 dark:hover:bg-white/5 dark:hover:text-zinc-200",
+        )}
+      >
+        <X size={13} />
+      </button>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary

- stop opening the changelog in an unsolicited tab after minor and major updates
- persist the latest pending changelog version and show a dismissible “What’s new” card in the popup
- link directly to the matching changelog anchor and localize the notice across all supported languages
- keep patch updates silent and prevent the review nudge from competing with an update notice

## Why

Automatically opening a browser tab during an extension update is intrusive and can interrupt unrelated browsing. The popup notice keeps release notes discoverable while letting users choose when to open them.

## Validation

- `pnpm verify`
- 277 tests passed
- Chromium production build passed
- Firefox production build passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an in-app update notice for minor and major releases.
  - Users can view the changelog or dismiss the notice from the popup.
  - Changelog notices are queued for display instead of opening a new tab automatically.
  - Added localized update-notice text across supported languages.
  - Rate prompts are hidden while an update notice is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->