### PR TITLE
Filter non-watch Twitch rewards

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -866,7 +866,7 @@ function hasEarnableReward(campaign: DropCampaign): boolean {
     && !hasCampaignEnded(campaign)
     && campaign.accountLinked !== false
     && (!campaign.eligibility || campaign.eligibility === "eligible")
-    && campaign.rewards.some((reward) => reward.status !== "claimed" && reward.status !== "claimable" && reward.preconditionsMet !== false);
+    && campaign.rewards.some((reward) => reward.isWatchBased !== false && reward.status !== "claimed" && reward.status !== "claimable" && reward.preconditionsMet !== false);
 }
 
 function hasCampaignEnded(campaign: DropCampaign): boolean {

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -633,7 +633,10 @@ async function claimReadyRewards(
     updated.push({
       ...campaign,
       rewards,
-      status: rewards.every((reward) => reward.status === "claimed") ? "completed" : campaign.status,
+      status: rewards.some((reward) => reward.isWatchBased !== false)
+        && rewards.filter((reward) => reward.isWatchBased !== false).every((reward) => reward.status === "claimed")
+        ? "completed"
+        : campaign.status,
     });
   }
 
@@ -645,6 +648,7 @@ function isRewardRelevantNow(reward: DropReward): boolean {
 }
 
 function isRewardAvailableToEarn(reward: DropReward): boolean {
+  if (reward.isWatchBased === false) return false;
   const now = Date.now();
   const startsAt = reward.availableFrom ? Date.parse(reward.availableFrom) : undefined;
   const endsAt = reward.availableUntil ? Date.parse(reward.availableUntil) : undefined;

--- a/packages/core/src/platforms/kick/parser.ts
+++ b/packages/core/src/platforms/kick/parser.ts
@@ -175,12 +175,14 @@ export function kickRewardImageUrl(value: string | undefined): string | undefine
 }
 
 function parseKickReward(reward: KickReward): DropReward {
+  const requiredMinutes =
+    reward.required_units ?? reward.required_minutes ?? reward.minutes_required ?? reward.watch_time_required ?? 0;
   return {
     id: String(reward.id),
     name: reward.name ?? reward.title ?? `Reward ${reward.id}`,
     imageUrl: kickRewardImageUrl(reward.image_url ?? reward.image),
-    requiredMinutes:
-      reward.required_units ?? reward.required_minutes ?? reward.minutes_required ?? reward.watch_time_required ?? 0,
+    requiredMinutes,
+    isWatchBased: requiredMinutes > 0,
     watchedMinutes: 0,
     status: reward.claimed || reward.is_claimed ? "claimed" : "locked",
   };

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -93,9 +93,11 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
           : rawStatus === "expired"
           ? "expired"
           : "active";
-    const parsedRewards = (campaign.timeBasedDrops ?? []).map((drop) =>
-      parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops),
-    );
+    // Twitch includes subscription, purchase, and other action-gated rewards in
+    // timeBasedDrops. Retain them internally so an obtained reward can still be
+    // claimed, but mark them as non-watch rewards so they never drive farming.
+    const parsedRewards = (campaign.timeBasedDrops ?? [])
+      .map((drop) => parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops));
     const rewards = parsedRewards.map((reward) => ({
       ...reward,
       preconditionsMet: (reward.preconditionRewardIds ?? []).every((id) =>
@@ -103,7 +105,8 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
       ),
     }));
 
-    const finalStatus = rewards.length > 0 && rewards.every((reward) => reward.status === "claimed") ? "completed" : status;
+    const watchRewards = rewards.filter((reward) => reward.isWatchBased !== false);
+    const finalStatus = watchRewards.length > 0 && watchRewards.every((reward) => reward.status === "claimed") ? "completed" : status;
 
     return {
       id: campaign.id,
@@ -119,8 +122,8 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
       accountLinkUrl: campaign.accountLinkURL ?? undefined,
       status: finalStatus,
       url: campaign.detailsURL ?? undefined,
-      eligibility: eligibility(finalStatus, accountLinked, rewards.length),
-      eligibilityReason: eligibilityReason(finalStatus, accountLinked, rewards.length),
+      eligibility: eligibility(finalStatus, accountLinked, watchRewards.length),
+      eligibilityReason: eligibilityReason(finalStatus, accountLinked, watchRewards.length),
       allowedChannels,
       connectionUrls: allowedChannels.length > 0
         ? allowedChannels.map((login) => `https://www.twitch.tv/${login}`)
@@ -142,6 +145,7 @@ function parseTwitchReward(
 ): DropReward {
   const watchedMinutes = reward.self?.currentMinutesWatched ?? 0;
   const requiredMinutes = reward.requiredMinutesWatched ?? 0;
+  const isWatchBased = requiredMinutes > 0;
   const benefits = (reward.benefitEdges ?? [])
     .map((edge) => edge.benefit)
     .filter((benefit): benefit is NonNullable<typeof benefit> => Boolean(benefit));
@@ -156,7 +160,7 @@ function parseTwitchReward(
   // edge once the claim is released, and reconstruct it deterministically when
   // the edge is absent so a watched-complete drop is still claimable.
   const claimId = reward.self?.dropInstanceID
-    ?? (userId ? `${userId}#${campaignId}#${reward.id}` : undefined);
+    ?? (isWatchBased && userId ? `${userId}#${campaignId}#${reward.id}` : undefined);
   const preconditionRewardIds = reward.preconditionDrops?.map((drop) => drop.id) ?? [];
 
   return {
@@ -167,6 +171,7 @@ function parseTwitchReward(
     benefitType: benefits[0]?.distributionType,
     requiredMinutes,
     requiredSubs: reward.requiredSubs,
+    isWatchBased,
     watchedMinutes: isClaimed ? requiredMinutes : watchedMinutes,
     claimId,
     availableFrom: reward.startAt,
@@ -176,6 +181,8 @@ function parseTwitchReward(
     preconditionsMet: preconditionRewardIds.length === 0,
     status: isClaimed
       ? "claimed"
+      : !isWatchBased && reward.self?.dropInstanceID
+        ? "claimable"
       : watchedMinutes >= requiredMinutes && requiredMinutes > 0
         ? "claimable"
         : watchedMinutes > 0
@@ -217,7 +224,8 @@ export function mergeTwitchCampaignProgress(
       }
       return merged;
     });
-    const allClaimed = rewards.length > 0 && rewards.every((reward) => reward.status === "claimed");
+    const watchRewards = rewards.filter((reward) => reward.isWatchBased !== false);
+    const allClaimed = watchRewards.length > 0 && watchRewards.every((reward) => reward.status === "claimed");
     const next = { ...campaign, status: progress?.status ?? campaign.status, rewards };
     return allClaimed ? withCampaignStatus(next, "completed") : next;
   });
@@ -271,11 +279,12 @@ function eligibilityReason(status: DropCampaign["status"], accountLinked: boolea
 // longer lists the campaign as active) that the inventory payload can't convey.
 export function withCampaignStatus(campaign: DropCampaign, status: DropCampaign["status"]): DropCampaign {
   const accountLinked = campaign.accountLinked !== false;
+  const watchRewardCount = campaign.rewards.filter((reward) => reward.isWatchBased !== false).length;
   return {
     ...campaign,
     status,
-    eligibility: eligibility(status, accountLinked, campaign.rewards.length),
-    eligibilityReason: eligibilityReason(status, accountLinked, campaign.rewards.length),
+    eligibility: eligibility(status, accountLinked, watchRewardCount),
+    eligibilityReason: eligibilityReason(status, accountLinked, watchRewardCount),
   };
 }
 

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -27,6 +27,7 @@ describe("Kick parsers", () => {
     expect(merged[0].connectionUrls).toEqual(["https://kick.com/creator"]);
     expect(merged[0].rewards[0].status).toBe("claimable");
     expect(merged[0].rewards[0].claimId).toBe("claim-99");
+    expect(merged[0].rewards[0].isWatchBased).toBe(true);
   });
 
   it("resolves relative reward image paths to absolute ext.kick.com URLs", () => {
@@ -249,9 +250,84 @@ describe("Kick parsers", () => {
 
     expect(campaigns[0].rewards[0].requiredMinutes).toBe(90);
   });
+
+  it("marks zero-duration Kick rewards as non-watch rewards", () => {
+    const campaigns = parseKickCampaigns({
+      data: [{
+        id: "campaign",
+        rewards: [
+          { id: "missing-duration" },
+          { id: "zero-duration", required_units: 0 },
+        ],
+      }],
+    });
+
+    expect(campaigns[0].rewards.map((reward) => reward.isWatchBased)).toEqual([false, false]);
+  });
 });
 
 describe("Twitch parsers", () => {
+  it("marks subscription-only and other zero-minute rewards as non-watch rewards", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "subscription-campaign",
+      name: "Jubilee Badge",
+      timeBasedDrops: [
+        { id: "subscription", name: "Jubilee Badge", requiredMinutesWatched: 0, requiredSubs: 1 },
+        { id: "purchase", name: "Purchase Reward" },
+      ],
+    }]);
+
+    expect(campaigns[0].rewards).toHaveLength(2);
+    expect(campaigns[0].rewards.every((reward) => reward.isWatchBased === false)).toBe(true);
+    expect(campaigns[0].eligibility).toBe("no_rewards");
+  });
+
+  it("keeps only watch-based rewards in mixed campaigns", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "mixed-campaign",
+      name: "Detroit Badge Drop",
+      timeBasedDrops: [
+        { id: "subscription", name: "Detroit Blue LED", requiredMinutesWatched: 0, requiredSubs: 1 },
+        { id: "watch", name: "Android Triangle", requiredMinutesWatched: 60 },
+        { id: "combined", name: "Watch and Subscribe", requiredMinutesWatched: 60, requiredSubs: 1 },
+      ],
+    }]);
+
+    expect(campaigns[0].rewards.filter((reward) => reward.isWatchBased !== false).map((reward) => reward.id)).toEqual(["watch", "combined"]);
+    expect(campaigns[0].eligibility).toBe("eligible");
+  });
+
+  it("does not unlock a watch reward whose paid prerequisite was excluded", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "paid-prerequisite-campaign",
+      timeBasedDrops: [
+        { id: "subscription", requiredMinutesWatched: 0, requiredSubs: 1 },
+        { id: "watch", requiredMinutesWatched: 60, preconditionDrops: [{ id: "subscription" }] },
+      ],
+    }]);
+
+    expect(campaigns[0].rewards).toHaveLength(2);
+    expect(campaigns[0].rewards.find((reward) => reward.id === "watch")?.preconditionsMet).toBe(false);
+  });
+
+  it("makes an obtained subscription reward claimable only with Twitch's real instance id", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "subscription-campaign",
+      timeBasedDrops: [{
+        id: "subscription",
+        requiredMinutesWatched: 0,
+        requiredSubs: 1,
+        self: { dropInstanceID: "subscription-instance" },
+      }],
+    }]);
+
+    expect(campaigns[0].rewards[0]).toMatchObject({
+      isWatchBased: false,
+      status: "claimable",
+      claimId: "subscription-instance",
+    });
+  });
+
   it("normalizes inventory campaigns with ACL and claim ids", () => {
     const campaigns = parseTwitchInventory({
       data: {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1014,6 +1014,38 @@ describe("scheduler tick", () => {
     expect(twitch.claimReward).toHaveBeenCalledWith(ready, ready.rewards[0]);
   });
 
+  it("claims an obtained non-watch reward without selecting it for farming", async () => {
+    const actionReward = {
+      ...reward("claimable"),
+      requiredMinutes: 0,
+      watchedMinutes: 0,
+      isWatchBased: false,
+      claimId: "subscription-instance",
+    };
+    const ready = campaign("subscription-drops", {
+      eligibility: "no_rewards",
+      rewards: [actionReward],
+    });
+    const twitch = adapter("twitch", [ready], [channel("allowed")]);
+
+    const result = await runSchedulerTick(
+      {
+        sessions: {
+          twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [], kick: [] },
+        events: [],
+      },
+      settings({ platform: { twitch: { enabled: true, watchQueueChannels: [] }, kick: { enabled: false, watchQueueChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(twitch.claimReward).toHaveBeenCalledWith(ready, actionReward);
+    expect(twitch.listCandidateChannels).not.toHaveBeenCalled();
+    expect(result.state.sessions.twitch.status).toBe("idle");
+  });
+
   it("defers claiming a ready reward until the adapter reports it is claim-ready", async () => {
     const ready = campaign("drops", { rewards: [reward("claimable")] });
     const twitch = { ...adapter("twitch", [ready], [channel("allowed")]), isClaimReady: vi.fn(() => false) };

--- a/packages/popup-ui/src/viewModels.ts
+++ b/packages/popup-ui/src/viewModels.ts
@@ -125,7 +125,7 @@ export function campaignViewFromCampaign(campaign: DropCampaign, index: number, 
     thumbnail: initials(campaign.gameName ?? campaign.name),
     tint: CAMPAIGN_TINTS[index % CAMPAIGN_TINTS.length],
     imageUrl: campaign.gameImageUrl,
-    rewards: campaign.rewards.map((reward, rewardIndex) => {
+    rewards: campaign.rewards.filter((reward) => reward.isWatchBased !== false).map((reward, rewardIndex) => {
       const progress = reward.requiredMinutes > 0
         ? Math.min(100, (Math.min(reward.watchedMinutes, reward.requiredMinutes) / reward.requiredMinutes) * 100)
         : reward.status === "claimed" ? 100 : 0;

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -18,6 +18,7 @@ export interface DropReward {
   benefitType?: "UNKNOWN" | "BADGE" | "EMOTE" | "DIRECT_ENTITLEMENT" | string;
   requiredMinutes: number;
   requiredSubs?: number;
+  isWatchBased?: boolean;
   watchedMinutes: number;
   status: RewardStatus;
   claimId?: string;


### PR DESCRIPTION
## Summary

- mark subscription, purchase, and other zero-minute Twitch rewards as non-watch rewards
- exclude non-watch rewards from farming decisions, priority, and popup reward lists
- still claim action rewards after Twitch releases their real claim instance
- preserve positive-duration rewards in mixed or combined-condition campaigns

## Root cause

Twitch includes action-gated rewards in `timeBasedDrops`. LurkLoot parsed every entry as farmable, including rewards with no positive watch-time requirement. Those rewards could enter scheduler eligibility and campaign priority calculations and were also shown as zero-minute rewards in the popup.

The parser now marks only rewards with positive `requiredMinutesWatched` as watch-based. Non-watch rewards remain in internal campaign data so the auto-claim pass can claim a subscription reward when Twitch supplies its real `dropInstanceID`, but they cannot drive watch selection and are omitted from the popup. Positive-duration rewards remain farmable even if they also carry subscription metadata.

## Impact

Subscription-only campaigns now have no farmable rewards, while mixed campaigns continue farming their watch-based rewards. Users who obtain an action reward by subscribing can still have LurkLoot claim it automatically.

## Validation

- `pnpm test` (283 tests passed)
- `pnpm typecheck`
- `git diff --check`

Closes #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for distinguishing watch-based rewards from other reward types.
  * Subscription-only and zero-duration rewards are excluded from watch progress and campaign completion calculations.
  * Obtained non-watch rewards can now be claimed using their provided claim identifiers.

* **Improvements**
  * Campaign eligibility, exhaustion status, scheduling, and completion now reflect only watch-based rewards.
  * Non-watch rewards are hidden from campaign views while remaining claimable when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->