### PR TITLE
ci: publish declared GitHub releases

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,91 @@
+name: Build CLI Docker image
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        type: boolean
+        default: false
+      tags:
+        type: string
+        default: ""
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/lurkloot-cli
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - if: inputs.push
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: packages/cli/Dockerfile
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          push: ${{ inputs.push }}
+          outputs: ${{ inputs.push && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.IMAGE_NAME) || 'type=cacheonly' }}
+      - if: inputs.push
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+      - if: inputs.push
+        uses: actions/upload-artifact@v7
+        with:
+          name: docker-digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  publish:
+    if: inputs.push
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: docker-digest-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish multi-architecture manifest
+        working-directory: /tmp/digests
+        env:
+          TAGS: ${{ inputs.tags }}
+        run: |
+          tag_args=()
+          while IFS= read -r tag; do
+            test -z "$tag" || tag_args+=(--tag "${IMAGE_NAME}:${tag}")
+          done <<< "$TAGS"
+          digest_args=()
+          for digest in *; do digest_args+=("${IMAGE_NAME}@sha256:${digest}"); done
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
+          first_tag=${TAGS%%$'\n'*}
+          docker buildx imagetools inspect "${IMAGE_NAME}:${first_tag}" | tee /tmp/manifest.txt
+          grep -q 'linux/amd64' /tmp/manifest.txt
+          grep -q 'linux/arm64' /tmp/manifest.txt

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,0 +1,63 @@
+name: Build extension artifacts
+
+on:
+  workflow_call:
+    inputs:
+      sign_crx:
+        type: boolean
+        default: false
+    secrets:
+      CRX_PRIVATE_KEY:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm release:check
+      - run: pnpm zip && pnpm zip:firefox
+      - name: Normalize ZIP names
+        shell: bash
+        run: |
+          version=$(node -p "require('./package.json').version")
+          output=packages/extension/.output
+          mkdir release-assets
+          chrome_zip=$(find "$output" -maxdepth 1 -name "*-$version-chrome.zip" -print -quit)
+          firefox_zip=$(find "$output" -maxdepth 1 -name "*-$version-firefox.zip" -print -quit)
+          sources_zip=$(find "$output" -maxdepth 1 -name "*-$version-sources.zip" -print -quit)
+          test -n "$chrome_zip" -a -n "$firefox_zip" -a -n "$sources_zip"
+          cp "$chrome_zip" "release-assets/lurkloot-$version-chrome.zip"
+          cp "$firefox_zip" "release-assets/lurkloot-$version-firefox.zip"
+          cp "$sources_zip" "release-assets/lurkloot-$version-firefox-sources.zip"
+      - name: Build signed CRX3
+        if: inputs.sign_crx
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          test -n "$CRX_PRIVATE_KEY" || { echo "CRX_PRIVATE_KEY is not configured" >&2; exit 1; }
+          printf '%s' "$CRX_PRIVATE_KEY" > "$RUNNER_TEMP/lurkloot.pem"
+          version=$(node -p "require('./package.json').version")
+          pnpm build
+          pnpm dlx crx3@2.0.0 -p "$RUNNER_TEMP/lurkloot.pem" -o "release-assets/lurkloot-$version-chrome.crx" -- packages/extension/.output/chrome-mv3
+          rm -f "$RUNNER_TEMP/lurkloot.pem"
+      - name: Generate checksums
+        working-directory: release-assets
+        run: sha256sum lurkloot-* > SHA256SUMS
+      - uses: actions/upload-artifact@v7
+        with:
+          name: extension-release-assets
+          path: release-assets/*
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/cli-docker.yml
+++ b/.github/workflows/cli-docker.yml
@@ -8,28 +8,9 @@ name: CLI Docker image
 #   - tags (v*.*.*):  publish semver tags.
 
 on:
-  push:
-    branches: [main]
-    tags: ['v*.*.*']
-    paths:
-      - 'packages/cli/**'
-      - 'packages/core/**'
-      - 'packages/shared/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - 'tsconfig.base.json'
-      - '.github/workflows/cli-docker.yml'
-  pull_request:
-    paths:
-      - 'packages/cli/**'
-      - 'packages/core/**'
-      - 'packages/shared/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'package.json'
-      - 'tsconfig.base.json'
-      - '.github/workflows/cli-docker.yml'
+  # Superseded by release.yml and pr-validation.yml. Retained temporarily so
+  # existing branch-protection references do not break during migration.
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/lurkloot-cli

--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -1,0 +1,21 @@
+name: GHCR retention
+
+on:
+  schedule:
+    - cron: "37 4 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  prune-untagged:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: lurkloot-cli
+          package-type: container
+          delete-only-untagged-versions: "true"
+          min-versions-to-keep: 10

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,33 @@
+name: Pull request validation
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm release:check
+      - run: pnpm verify
+
+  extension:
+    uses: ./.github/workflows/build-extension.yml
+    with:
+      sign_crx: false
+
+  docker:
+    uses: ./.github/workflows/build-docker.yml
+    with:
+      push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,165 @@
+name: Publish declared release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      allow_stable_rebuild:
+        description: Allow explicitly approved replacement of an existing stable release
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  # main can have only one active declared version; this serializes every build
+  # of that version and cancels superseded pre-release commits.
+  group: declared-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  declaration:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
+      docker_tags: ${{ steps.release.outputs.docker_tags }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm release:check
+      - id: release
+        shell: bash
+        run: |
+          version=$(awk '$1 == "version:" { print $2 }' release.yml)
+          prerelease=$(awk '$1 == "prerelease:" { print $2 }' release.yml)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          {
+            echo 'docker_tags<<EOF'
+            echo "$version"
+            echo "sha-${GITHUB_SHA::12}"
+            if [[ "$prerelease" == true ]]; then
+              echo main
+            else
+              echo "${version%.*}"
+              echo "${version%%.*}"
+              echo latest
+            fi
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Protect stable releases from mutation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+          PRERELEASE: ${{ steps.release.outputs.prerelease }}
+          OVERRIDE: ${{ inputs.allow_stable_rebuild || false }}
+        run: |
+          existing=$(gh release view "v$VERSION" --json isPrerelease --jq .isPrerelease 2>/dev/null || true)
+          if [[ "$existing" == false && "$OVERRIDE" != true ]]; then
+            echo "v$VERSION is already stable. Declare the next pre-release, or manually dispatch with the protected stable-releases environment approval and override." >&2
+            exit 1
+          fi
+          if [[ "$PRERELEASE" == true && "$existing" == false ]]; then
+            echo "A stable v$VERSION cannot be changed back to a pre-release." >&2
+            exit 1
+          fi
+
+  approval:
+    needs: declaration
+    runs-on: ubuntu-latest
+    environment: ${{ (needs.declaration.outputs.prerelease == 'false' || inputs.allow_stable_rebuild) && 'stable-releases' || 'prereleases' }}
+    steps:
+      - run: echo "Release environment approved"
+
+  verify:
+    needs: [declaration, approval]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm verify
+
+  extension:
+    needs: [declaration, verify]
+    uses: ./.github/workflows/build-extension.yml
+    with:
+      sign_crx: true
+    secrets:
+      CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+
+  docker:
+    needs: [declaration, verify]
+    uses: ./.github/workflows/build-docker.yml
+    with:
+      push: true
+      tags: ${{ needs.declaration.outputs.docker_tags }}
+
+  publish:
+    needs: [declaration, verify, extension, docker]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v8
+        with:
+          name: extension-release-assets
+          path: release-assets
+      - name: Move version tag
+        env:
+          VERSION: ${{ needs.declaration.outputs.version }}
+        run: |
+          git tag --force "v$VERSION" "$GITHUB_SHA"
+          git push --force origin "v$VERSION"
+      - name: Replace release and assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.declaration.outputs.version }}
+          PRERELEASE: ${{ needs.declaration.outputs.prerelease }}
+        run: |
+          tag="v$VERSION"
+          built_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          notes=$(printf 'Automated build of `%s` from commit `%s`, built at `%s`.' "$tag" "$GITHUB_SHA" "$built_at")
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release view "$tag" --json assets --jq '.assets[].name' | while read -r asset; do
+              gh release delete-asset "$tag" "$asset" --yes
+            done
+            args=(--title "$tag" --notes "$notes")
+            [[ "$PRERELEASE" == true ]] && args+=(--prerelease --latest=false) || args+=(--latest)
+            gh release edit "$tag" "${args[@]}"
+          else
+            args=(--title "$tag" --notes "$notes" --verify-tag)
+            [[ "$PRERELEASE" == true ]] && args+=(--prerelease --latest=false) || args+=(--latest)
+            gh release create "$tag" "${args[@]}"
+          fi
+          gh release upload "$tag" release-assets/*
+      - name: Verify downloadable assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.declaration.outputs.version }}
+        run: |
+          mkdir downloaded
+          gh release download "v$VERSION" --dir downloaded
+          cd downloaded
+          sha256sum --check SHA256SUMS
+          test "$(find . -maxdepth 1 -type f | wc -l)" -eq 5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,16 +31,7 @@ Use pnpm for all package tasks. The root `package.json` orchestrates the workspa
 
 ## Cutting a Release
 
-Releases ship the extension to the Chrome Web Store and AMO, with the public changelog on the site kept in lockstep. Follow these steps from the repo root on a clean `main`:
-
-1. **Pick the version (semver).** `patch` for bugfixes only, `minor` for backwards-compatible features, `major` for breaking changes. This choice matters beyond convention: on update the extension auto-opens the changelog **only for minor/major bumps** (see `isMinorOrMajorBump` in `packages/extension/src/core/version.ts`), so patch releases ship silently.
-2. **Bump the version.** Update `"version"` to the new number in the in-lockstep manifests: `package.json` (root), `packages/extension/package.json`, `packages/core/package.json`, `packages/cli/package.json`, `packages/locales/package.json`, `packages/popup-ui/package.json`, and `packages/shared/package.json`. WXT reads `packages/extension/package.json` for the built `manifest.json`; the others are kept in sync for tidiness. (The `packages/site` version is independent — leave it.)
-3. **Update the changelog.** Add a new top entry to `packages/site/src/changelog.ts` with the `version`, the release `date` (ISO `YYYY-MM-DD`, the Chrome Web Store publish date), and the user-facing `changes` grouped by `kind` (`new` / `improved` / `fixed`). The page renders newest-first and the extension deep-links to `#v{version}`. If a future version was already staged as an `Unreleased` entry (no `date`), just fill in its `date`.
-4. **Verify.** Run `pnpm verify` (tests, typecheck, and both browser builds). Don't proceed if it fails.
-5. **Regenerate the artifacts.** Run `pnpm zip` and `pnpm zip:firefox`. They write `lurkloot-{version}-{browser}.zip` (and a sources zip for Firefox) to `packages/extension/.output/`.
-6. **Commit.** Stage the version bumps and the changelog change together and commit as `chore(release): bump version to X.Y.Z`. Optionally tag `vX.Y.Z`.
-7. **Publish.** Upload the Chrome zip to the Chrome Web Store and the Firefox zip + sources to AMO. Use the actual store-publish date in the changelog entry from step 3 if review lag moves it.
-8. **Deploy the site** so the new notes are live before users update: `pnpm --filter @lurkloot/site cf:deploy`. This matters because the extension opens `https://lurkloot.jamezrin.com/changelog#v{version}` on update.
+`release.yml` declares the active version and pre-release/stable state. Use `pnpm release:prepare X.Y.Z --prerelease` to start a version, or `pnpm release:prepare X.Y.Z --stable --date YYYY-MM-DD` to promote it. Then fill in the changelog, run `pnpm release:check`, and commit the declaration, manifests, and changelog together as `chore(release): bump version to X.Y.Z`. Do not create or move release tags manually; the unified workflow owns tags, GitHub release assets, and Docker aliases. See `docs/releases.md` for publication, recovery, credentials, store upload, and migration details.
 
 ## Coding Style & Naming Conventions
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,42 @@
+# Releases
+
+`release.yml` is the canonical declaration of the version currently being built and whether it is mutable (`prerelease: true`) or stable. `pnpm release:check` verifies that declaration, all in-lockstep package manifests, semver, and the changelog agree.
+
+## Prepare a pre-release
+
+From a clean `main`, run:
+
+```bash
+pnpm release:prepare 1.5.0 --prerelease
+```
+
+This updates `release.yml`, synchronizes the root, extension, core, CLI, locales, popup UI, and shared package versions, and creates an empty Unreleased changelog entry when needed. Fill in its user-facing changes, run `pnpm release:check`, and merge the preparation PR. Every subsequent successful relevant `main` build replaces the assets for that GitHub pre-release and moves its version tag. Pre-release Docker tags are `VERSION`, `main`, and `sha-COMMIT`; `latest` is never changed.
+
+## Promote to stable
+
+Use the actual public/store release date:
+
+```bash
+pnpm release:prepare 1.4.0 --stable --date 2026-07-12
+pnpm release:check
+```
+
+Merge the declaration and dated changelog together. The protected `stable-releases` environment should require maintainer approval. The workflow rebuilds all assets, promotes the GitHub release, and publishes `VERSION`, `MAJOR.MINOR`, `MAJOR`, `latest`, and `sha-COMMIT` Docker tags. Later builds refuse to modify that stable version; prepare the next pre-release before merging another release-triggering change.
+
+## Artifacts and credentials
+
+The release contains Chrome CRX/ZIP, Firefox ZIP/source ZIP, and `SHA256SUMS`. CRX3 packaging uses the pinned `crx3@2.0.0` CLI and the `CRX_PRIVATE_KEY` Actions secret. Store a PEM-encoded RSA private key in that secret and preserve it permanently: replacing it changes the sideloaded extension ID. Pull requests build unsigned ZIPs and both Docker architectures, but do not receive that secret or publish anything.
+
+Create the GitHub environments `prereleases` and `stable-releases`; add required reviewers to `stable-releases`. `GITHUB_TOKEN` supplies scoped release and GHCR access. No registry deletion occurs during publication. The scheduled retention workflow removes only old untagged GHCR versions and keeps at least ten.
+
+## Recovery
+
+Re-run a failed workflow after correcting credentials or transient infrastructure. Mutable pre-releases may safely be rebuilt: assets and mutable tags are replaced only after validation succeeds. A stable rebuild requires a manual workflow dispatch with `allow_stable_rebuild` and approval through `stable-releases`; use this only to recover corrupt or missing artifacts, never for code changes.
+
+If publication partially succeeds, rerun the same commit. The release job re-uploads the full asset set and verifies its checksums, while Docker publication recreates the multi-architecture manifest. Never manually move a stable tag to different source code.
+
+## Store upload and migration
+
+GitHub Releases are the canonical built artifacts, but Chrome Web Store and AMO submission remains manual. Download the verified Chrome ZIP and Firefox ZIP/source ZIP from the stable GitHub release, upload them to their stores, and deploy the site so its dated changelog is live before users update.
+
+The initial repository migration does not mutate GitHub. A maintainer must separately backfill `v1.3.0` and its stable release at the historical release commit, configure the environments and CRX key, then run the unified workflow for declared pre-release `1.4.0`. Confirm `latest` still points to `1.3.0` until promotion.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "promo:store": "pnpm --filter @lurkloot/extension promo:store",
     "kick:inspect": "pnpm --filter @lurkloot/extension kick:inspect",
     "privacy:gist": "scripts/update-privacy-gist.sh",
+    "release:prepare": "node scripts/release.mjs prepare",
+    "release:check": "node scripts/release.mjs check",
     "verify": "pnpm -r typecheck && pnpm --filter @lurkloot/extension test && pnpm --filter @lurkloot/extension build && pnpm --filter @lurkloot/extension build:firefox"
   },
   "devDependencies": {

--- a/release.yml
+++ b/release.yml
@@ -1,0 +1,2 @@
+version: 1.4.0
+prerelease: true

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import process from "node:process";
+
+const packages = [
+  "package.json",
+  "packages/extension/package.json",
+  "packages/core/package.json",
+  "packages/cli/package.json",
+  "packages/locales/package.json",
+  "packages/popup-ui/package.json",
+  "packages/shared/package.json",
+];
+const declarationPath = "release.yml";
+const changelogPath = "packages/site/src/changelog.ts";
+const semver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const isoDate = /^\d{4}-\d{2}-\d{2}$/;
+
+function fail(message) {
+  console.error(`release: ${message}`);
+  process.exitCode = 1;
+}
+
+function declaration(source) {
+  const version = source.match(/^version:\s*([^\s#]+)\s*$/m)?.[1];
+  const rawPrerelease = source.match(/^prerelease:\s*(true|false)\s*$/m)?.[1];
+  if (!version || !rawPrerelease) throw new Error("release.yml must contain version and prerelease");
+  return { version, prerelease: rawPrerelease === "true" };
+}
+
+function changelogEntry(source, version) {
+  const marker = `version: "${version}"`;
+  const start = source.indexOf(marker);
+  if (start < 0) return undefined;
+  const next = source.indexOf("\n  {", start);
+  const text = source.slice(start, next < 0 ? source.length : next);
+  const date = text.match(/\n\s*date:\s*"([^"]+)"/)?.[1];
+  return { text, date };
+}
+
+function validDate(value) {
+  if (!isoDate.test(value ?? "")) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+async function check() {
+  let active;
+  try {
+    active = declaration(await readFile(declarationPath, "utf8"));
+  } catch (error) {
+    fail(error.message);
+    return;
+  }
+  if (!semver.test(active.version)) fail(`${active.version} is not a valid release semver`);
+  for (const path of packages) {
+    const manifest = JSON.parse(await readFile(path, "utf8"));
+    if (manifest.version !== active.version) {
+      fail(`${path} has version ${manifest.version}; expected ${active.version}`);
+    }
+  }
+  const source = await readFile(changelogPath, "utf8");
+  const entry = changelogEntry(source, active.version);
+  if (!entry) fail(`changelog has no ${active.version} entry`);
+  else if (active.prerelease && entry.date) fail(`prerelease ${active.version} must be Unreleased (no date)`);
+  else if (!active.prerelease && !validDate(entry.date)) fail(`stable ${active.version} must have a valid dated changelog entry`);
+  if (!process.exitCode) console.log(`${active.version} (${active.prerelease ? "pre-release" : "stable"}) is consistent`);
+}
+
+async function prepare(args) {
+  const [version, status, dateFlag, date] = args;
+  if (!semver.test(version ?? "")) throw new Error("usage: release:prepare VERSION (--prerelease | --stable --date YYYY-MM-DD)");
+  if (!['--prerelease', '--stable'].includes(status)) throw new Error("choose exactly one of --prerelease or --stable");
+  const prerelease = status === "--prerelease";
+  if (!prerelease && (dateFlag !== "--date" || !validDate(date))) throw new Error("stable releases require a valid --date YYYY-MM-DD");
+  if (prerelease && args.length !== 2) throw new Error("pre-releases do not accept a release date");
+
+  for (const path of packages) {
+    const manifest = JSON.parse(await readFile(path, "utf8"));
+    manifest.version = version;
+    await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`);
+  }
+  await writeFile(declarationPath, `version: ${version}\nprerelease: ${prerelease}\n`);
+
+  let source = await readFile(changelogPath, "utf8");
+  const entry = changelogEntry(source, version);
+  if (!entry) {
+    const insertion = `  {\n    version: "${version}",\n${prerelease ? "    // Unreleased — omit `date` until the public release.\n" : `    date: "${date}",\n`}    changes: [],\n  },\n`;
+    source = source.replace("export const changelog: ChangelogEntry[] = [\n", `export const changelog: ChangelogEntry[] = [\n${insertion}`);
+  } else if (prerelease) {
+    source = source.replace(entry.text, entry.text.replace(/\n\s*date:\s*"\d{4}-\d{2}-\d{2}",?/, ""));
+  } else if (entry.date) {
+    source = source.replace(entry.text, entry.text.replace(/date:\s*"\d{4}-\d{2}-\d{2}"/, `date: "${date}"`));
+  } else {
+    source = source.replace(entry.text, entry.text.replace(/(version:\s*"[^"]+",)/, `$1\n    date: "${date}",`).replace(/\n\s*\/\/ Unreleased[^\n]*/, ""));
+  }
+  await writeFile(changelogPath, source);
+  await check();
+}
+
+const [command, ...args] = process.argv.slice(2);
+try {
+  if (command === "check") await check();
+  else if (command === "prepare") await prepare(args);
+  else throw new Error("usage: release.mjs <check | prepare VERSION --prerelease | --stable --date YYYY-MM-DD>");
+} catch (error) {
+  fail(error.message);
+}


### PR DESCRIPTION
Closes #62.

## Summary

- declare the active version and prerelease status in repository-owned `release.yml`
- add `release:prepare` and `release:check` commands to synchronize manifests and validate the changelog
- add reusable extension and multi-architecture Docker build workflows
- publish signed CRX/ZIP artifacts, checksums, GitHub Releases, and the appropriate prerelease or stable Docker aliases only after verification succeeds
- protect stable releases from silent mutation and keep pull-request validation non-publishing
- move GHCR cleanup into a separate scheduled retention workflow and disable duplicate publishing in the legacy Docker workflow
- document preparation, promotion, recovery, credentials, store upload, and initial migration steps

## Testing

- `pnpm release:check`
- isolated prerelease and stable `release:prepare` checks
- `pnpm verify`
- `pnpm zip`
- `pnpm zip:firefox`
- actionlint and YAML parsing across workflows
- `git diff --check`

## Maintainer setup

Before publication, configure the stable `CRX_PRIVATE_KEY`, create the `prereleases` and protected `stable-releases` environments, backfill the historical v1.3.0 release/tag, and dispatch the declared v1.4.0 prerelease as documented in `docs/releases.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release workflows for validation, extension packaging, multi-architecture Docker publishing, and GitHub release creation.
  * Added release preparation and consistency-check commands.
  * Added scheduled cleanup of untagged container images.
  * Configured version 1.4.0 as a prerelease.

* **Documentation**
  * Added release process documentation covering preparation, promotion, artifacts, signing, and recovery procedures.
  * Simplified release instructions to use the unified automation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->