### PR TITLE
ci: automate Chrome Web Store releases

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,9 +6,6 @@ on:
       push:
         type: boolean
         default: false
-      tags:
-        type: string
-        default: ""
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/lurkloot-cli
@@ -56,36 +53,3 @@ jobs:
           name: docker-digest-${{ matrix.arch }}
           path: /tmp/digests/*
           retention-days: 1
-
-  publish:
-    if: inputs.push
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: /tmp/digests
-          pattern: docker-digest-*
-          merge-multiple: true
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish multi-architecture manifest
-        working-directory: /tmp/digests
-        env:
-          TAGS: ${{ inputs.tags }}
-        run: |
-          tag_args=()
-          while IFS= read -r tag; do
-            test -z "$tag" || tag_args+=(--tag "${IMAGE_NAME}:${tag}")
-          done <<< "$TAGS"
-          digest_args=()
-          for digest in *; do digest_args+=("${IMAGE_NAME}@sha256:${digest}"); done
-          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
-          first_tag=${TAGS%%$'\n'*}
-          docker buildx imagetools inspect "${IMAGE_NAME}:${first_tag}" | tee /tmp/manifest.txt
-          grep -q 'linux/amd64' /tmp/manifest.txt
-          grep -q 'linux/arm64' /tmp/manifest.txt

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.9.0
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.9.0
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.9.0
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.9.0
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,117 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     with:
       push: true
-      tags: ${{ needs.declaration.outputs.docker_tags }}
+
+  chrome-web-store:
+    needs: [declaration, extension, docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v8
+        with:
+          name: extension-release-assets
+          path: release-assets
+      - name: Validate staged candidate provenance
+        if: needs.declaration.outputs.prerelease == 'false'
+        env:
+          VERSION: ${{ needs.declaration.outputs.version }}
+        run: |
+          candidate="refs/tags/cws-v$VERSION-candidate"
+          git fetch origin "+$candidate:$candidate"
+          candidate_commit=$(git rev-parse "$candidate^{commit}")
+          candidate_checksum=$(git for-each-ref --format='%(contents)' "$candidate" | sed -n 's/^chrome_zip_sha256=//p')
+          test -n "$candidate_checksum" || {
+            echo "CWS candidate tag does not contain a Chrome ZIP checksum" >&2
+            exit 1
+          }
+          echo "Validated CWS candidate $candidate_commit with Chrome ZIP SHA-256 $candidate_checksum"
+          git merge-base --is-ancestor "$candidate_commit" "$GITHUB_SHA" || {
+            echo "CWS candidate $candidate_commit is not an ancestor of $GITHUB_SHA" >&2
+            exit 1
+          }
+          git diff --quiet "$candidate_commit" "$GITHUB_SHA" -- \
+            package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json \
+            packages/extension packages/core packages/shared packages/locales packages/popup-ui || {
+            echo "Extension build inputs changed after the CWS candidate was uploaded; upload and review a new candidate." >&2
+            exit 1
+          }
+      - id: prerelease
+        name: Upload mutable pre-release draft
+        if: needs.declaration.outputs.prerelease == 'true'
+        env:
+          CWS_SERVICE_ACCOUNT_JSON: ${{ secrets.CWS_SERVICE_ACCOUNT_JSON }}
+          CWS_PUBLISHER_ID: ${{ vars.CWS_PUBLISHER_ID }}
+          CWS_EXTENSION_ID: ${{ vars.CWS_EXTENSION_ID }}
+          CWS_VERSION: ${{ needs.declaration.outputs.version }}
+          CWS_PACKAGE_PATH: release-assets/lurkloot-${{ needs.declaration.outputs.version }}-chrome.zip
+        run: node scripts/cws.mjs upload-prerelease
+      - name: Record uploaded candidate commit
+        if: steps.prerelease.outputs.candidate == 'true'
+        env:
+          VERSION: ${{ needs.declaration.outputs.version }}
+        run: |
+          tag="cws-v$VERSION-candidate"
+          checksum=$(sha256sum "release-assets/lurkloot-$VERSION-chrome.zip" | awk '{print $1}')
+          git tag --force --annotate "$tag" "$GITHUB_SHA" --message "chrome_zip_sha256=$checksum"
+          git push --force origin "refs/tags/$tag"
+      - id: stable
+        name: Publish approved staged revision
+        if: needs.declaration.outputs.prerelease == 'false'
+        env:
+          CWS_SERVICE_ACCOUNT_JSON: ${{ secrets.CWS_SERVICE_ACCOUNT_JSON }}
+          CWS_PUBLISHER_ID: ${{ vars.CWS_PUBLISHER_ID }}
+          CWS_EXTENSION_ID: ${{ vars.CWS_EXTENSION_ID }}
+          CWS_VERSION: ${{ needs.declaration.outputs.version }}
+        run: node scripts/cws.mjs publish-stable
+      - name: Summarize Chrome Web Store state
+        env:
+          PRERELEASE_ACTION: ${{ steps.prerelease.outputs.action }}
+          STABLE_ACTION: ${{ steps.stable.outputs.action }}
+        run: |
+          action=${PRERELEASE_ACTION:-$STABLE_ACTION}
+          echo "### Chrome Web Store" >> "$GITHUB_STEP_SUMMARY"
+          echo "Action: **$action**" >> "$GITHUB_STEP_SUMMARY"
+
+  docker-publish:
+    needs: [declaration, docker, chrome-web-store]
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/lurkloot-cli
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: docker-digest-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish multi-architecture manifest
+        working-directory: /tmp/digests
+        env:
+          TAGS: ${{ needs.declaration.outputs.docker_tags }}
+        run: |
+          tag_args=()
+          while IFS= read -r tag; do
+            test -z "$tag" || tag_args+=(--tag "${IMAGE_NAME}:${tag}")
+          done <<< "$TAGS"
+          digest_args=()
+          for digest in *; do digest_args+=("${IMAGE_NAME}@sha256:${digest}"); done
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
+          first_tag=${TAGS%%$'\n'*}
+          docker buildx imagetools inspect "${IMAGE_NAME}:${first_tag}" | tee /tmp/manifest.txt
+          grep -q 'linux/amd64' /tmp/manifest.txt
+          grep -q 'linux/arm64' /tmp/manifest.txt
 
   publish:
-    needs: [declaration, verify, extension, docker]
+    needs: [declaration, verify, extension, docker-publish, chrome-web-store]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.9.0
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -25,9 +25,9 @@ git commit -m "chore(release): bump version to 1.5.0"
 git push -u origin release/1.5.0
 ```
 
-Open a pull request and merge it into `main`. The unified workflow creates the GitHub pre-release and attaches the Chrome CRX/ZIP, Firefox ZIP/source ZIP, and checksums. It also publishes the `VERSION`, `main`, and `sha-COMMIT` Docker tags; `latest` remains on the newest stable version.
+Open a pull request and merge it into `main`. The unified workflow creates the GitHub pre-release, attaches the Chrome CRX/ZIP, Firefox ZIP/source ZIP, and checksums, and uploads the Chrome ZIP as an unsubmitted Chrome Web Store draft. It also publishes the `VERSION`, `main`, and `sha-COMMIT` Docker tags; `latest` remains on the newest stable version.
 
-While `prerelease: true`, every subsequent successful `main` build replaces the pre-release assets, moves the version tag, and updates its mutable Docker tags.
+While `prerelease: true`, every subsequent successful `main` build replaces the pre-release assets, CWS draft, version tag, and mutable Docker tags. Once a CWS revision is submitted for review or approved for deferred publishing, later builds leave that revision frozen.
 
 ## Promote to stable
 
@@ -47,11 +47,11 @@ git commit -m "chore(release): bump version to 1.5.0"
 git push -u origin release/1.5.0-stable
 ```
 
-Open and merge the promotion pull request, then approve its waiting `stable-releases` deployment in GitHub Actions. The workflow rebuilds all assets, promotes the GitHub release, and publishes `VERSION`, `MAJOR.MINOR`, `MAJOR`, `latest`, and `sha-COMMIT` Docker tags.
+Before promotion, manually submit the CWS draft for review with automatic publishing disabled. Wait for its status to become ready to publish. Then open and merge the promotion pull request and approve its waiting `stable-releases` deployment in GitHub Actions. The workflow validates and publishes the approved CWS candidate before promoting the GitHub release and publishing `VERSION`, `MAJOR.MINOR`, `MAJOR`, `latest`, and `sha-COMMIT` Docker tags.
 
 After the workflow succeeds:
 
-1. Download the verified Chrome and Firefox artifacts from the stable GitHub Release and upload them to their stores.
+1. Confirm the Chrome Web Store and GitHub Release both show the new version, then upload the Firefox ZIP/source ZIP to AMO.
 2. Deploy the dated public changelog with `pnpm --filter @lurkloot/site cf:deploy`.
 3. Prepare the next pre-release before merging further feature changes. The stable-release guard intentionally refuses to mutate the released version.
 
@@ -61,12 +61,30 @@ The release contains Chrome CRX/ZIP, Firefox ZIP/source ZIP, and `SHA256SUMS`. C
 
 Create the GitHub environments `prereleases` and `stable-releases`; add required reviewers to `stable-releases`. `GITHUB_TOKEN` supplies scoped release and GHCR access. No registry deletion occurs during publication. The scheduled retention workflow removes only old untagged GHCR versions and keeps at least ten.
 
+Chrome Web Store automation requires repository secret `CWS_SERVICE_ACCOUNT_JSON` and repository variables `CWS_PUBLISHER_ID` and `CWS_EXTENSION_ID`. Add the service-account email to the publisher in the Chrome Developer Dashboard. Pull requests never receive the credential and never contact CWS.
+
+## Chrome Web Store lifecycle
+
+Each eligible mutable pre-release build replaces the unsubmitted CWS draft with the same declared version. A successful upload moves the automated `cws-vVERSION-candidate` tag to record its source commit and Chrome ZIP checksum. The workflow never submits a draft for review.
+
+When choosing a candidate, submit it manually in the Developer Dashboard and disable automatic publishing after approval. CWS reports `PENDING_REVIEW` during review and `STAGED` after approval; both states freeze automated draft replacement. Approved staged submissions expire after 30 days.
+
+Stable promotion requires all of the following:
+
+- CWS reports the declared version as `STAGED`, or already `PUBLISHED` during recovery.
+- The candidate tag is an ancestor of the promotion commit.
+- No extension build inputs changed after the candidate upload.
+
+The protected workflow publishes CWS first, Docker aliases second, and the GitHub stable release last. These services cannot be updated transactionally; if a later step fails, rerun the same commit. CWS publication is idempotent and the GitHub release remains a pre-release until its own publication step succeeds.
+
 ## Recovery
 
-Re-run a failed workflow after correcting credentials or transient infrastructure. Mutable pre-releases may safely be rebuilt: assets and mutable tags are replaced only after validation succeeds. A stable rebuild requires a manual workflow dispatch with `allow_stable_rebuild` and approval through `stable-releases`; use this only to recover corrupt or missing artifacts, never for code changes.
+Re-run a failed workflow after correcting credentials or transient infrastructure. Mutable pre-releases may safely be rebuilt: assets and mutable tags are replaced only after validation succeeds. Resolve CWS `REJECTED`, `CANCELLED`, warning, or takedown states in the Developer Dashboard. To replace a revision under review, cancel its review before merging another candidate build.
+
+A stable rebuild requires a manual workflow dispatch with `allow_stable_rebuild` and approval through `stable-releases`; use this only to recover corrupt or missing artifacts, never for code changes.
 
 If publication partially succeeds, rerun the same commit. The release job re-uploads the full asset set and verifies its checksums, while Docker publication recreates the multi-architecture manifest. Never manually move a stable tag to different source code.
 
 ## Store upload
 
-GitHub Releases are the canonical built artifacts, but Chrome Web Store and AMO submission remains manual. Download the verified Chrome ZIP and Firefox ZIP/source ZIP from the stable GitHub release, upload them to their stores, and deploy the site so its dated changelog is live before users update.
+GitHub Releases are the canonical built artifacts. Chrome review submission and AMO upload remain manual; approved Chrome publication is automated during stable promotion. Download the verified Firefox ZIP/source ZIP from the stable GitHub release for AMO, and deploy the site so its dated changelog is live before users update.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "privacy:gist": "scripts/update-privacy-gist.sh",
     "release:prepare": "node scripts/release.mjs prepare",
     "release:check": "node scripts/release.mjs check",
-    "verify": "pnpm -r typecheck && pnpm --filter @lurkloot/extension test && pnpm --filter @lurkloot/extension build && pnpm --filter @lurkloot/extension build:firefox"
+    "cws:test": "node --test scripts/cws.test.mjs",
+    "verify": "pnpm cws:test && pnpm -r typecheck && pnpm --filter @lurkloot/extension test && pnpm --filter @lurkloot/extension build && pnpm --filter @lurkloot/extension build:firefox"
   },
   "devDependencies": {
     "typescript": "^6.0.0"

--- a/scripts/cws.mjs
+++ b/scripts/cws.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { createSign } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+const scope = "https://www.googleapis.com/auth/chromewebstore";
+const apiOrigin = "https://chromewebstore.googleapis.com";
+
+export function revisionVersion(revision) {
+  return revision?.distributionChannels?.[0]?.crxVersion;
+}
+
+function assertHealthy(status) {
+  if (status.takenDown) throw new Error("Chrome Web Store item is taken down");
+  if (status.warned) throw new Error("Chrome Web Store item has an unresolved policy warning");
+}
+
+export function prereleaseAction(status, version) {
+  assertHealthy(status);
+  const publishedVersion = revisionVersion(status.publishedItemRevisionStatus);
+  const submitted = status.submittedItemRevisionStatus;
+  const submittedVersion = revisionVersion(submitted);
+  if (!submitted) {
+    if (publishedVersion === version) throw new Error(`${version} is already published and cannot be replaced as a pre-release draft`);
+    return "upload";
+  }
+  if (submittedVersion !== version) {
+    throw new Error(`Chrome Web Store has ${submittedVersion ?? "an unknown version"} in state ${submitted.state}; expected ${version}`);
+  }
+  if (submitted.state === "PENDING_REVIEW" || submitted.state === "STAGED") return "frozen";
+  throw new Error(`Chrome Web Store submitted revision is ${submitted.state}; resolve it in the Developer Dashboard`);
+}
+
+export function stableAction(status, version) {
+  assertHealthy(status);
+  const publishedVersion = revisionVersion(status.publishedItemRevisionStatus);
+  const submitted = status.submittedItemRevisionStatus;
+  if (!submitted) {
+    if (publishedVersion === version) return "already-published";
+    throw new Error(`Chrome Web Store has no approved staged ${version} revision`);
+  }
+  const submittedVersion = revisionVersion(submitted);
+  if (submittedVersion !== version) {
+    throw new Error(`Chrome Web Store staged version is ${submittedVersion ?? "unknown"}; expected ${version}`);
+  }
+  if (submitted.state === "STAGED") return "publish";
+  throw new Error(`Chrome Web Store revision ${version} is ${submitted.state}; expected STAGED`);
+}
+
+function encode(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+export async function serviceAccountToken(credentials, fetchImpl = fetch) {
+  const now = Math.floor(Date.now() / 1000);
+  const unsigned = `${encode({ alg: "RS256", typ: "JWT" })}.${encode({
+    iss: credentials.client_email,
+    scope,
+    aud: credentials.token_uri,
+    iat: now,
+    exp: now + 3600,
+  })}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(unsigned);
+  const assertion = `${unsigned}.${signer.sign(credentials.private_key).toString("base64url")}`;
+  const response = await fetchImpl(credentials.token_uri, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion }),
+  });
+  const body = await response.json();
+  if (!response.ok || !body.access_token) throw new Error(`Chrome Web Store token request failed (${response.status})`);
+  return body.access_token;
+}
+
+export class ChromeWebStoreClient {
+  constructor({ publisherId, extensionId, accessToken, fetchImpl = fetch }) {
+    this.item = `publishers/${publisherId}/items/${extensionId}`;
+    this.accessToken = accessToken;
+    this.fetch = fetchImpl;
+  }
+
+  async request(path, init = {}) {
+    const response = await this.fetch(`${apiOrigin}${path}`, {
+      ...init,
+      headers: { authorization: `Bearer ${this.accessToken}`, ...init.headers },
+    });
+    const body = await response.json();
+    if (!response.ok) throw new Error(`Chrome Web Store API failed (${response.status}): ${body.error?.message ?? "unknown error"}`);
+    return body;
+  }
+
+  status() {
+    return this.request(`/v2/${this.item}:fetchStatus`);
+  }
+
+  upload(packageBytes, filename) {
+    return this.request(`/upload/v2/${this.item}:upload`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/zip",
+        "x-goog-upload-protocol": "raw",
+        "x-goog-upload-file-name": filename,
+      },
+      body: packageBytes,
+    });
+  }
+
+  publishStaged() {
+    return this.request(`/v2/${this.item}:publish`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ publishType: "STAGED_PUBLISH", blockOnWarnings: true }),
+    });
+  }
+}
+
+async function waitForUpload(client, initial) {
+  if (initial.uploadState === "SUCCEEDED" || initial.uploadState === "SUCCESS") return initial;
+  if (initial.uploadState !== "UPLOAD_IN_PROGRESS" && initial.uploadState !== "IN_PROGRESS") return initial;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    const current = await client.status();
+    const state = current.lastAsyncUploadState;
+    if (state === "SUCCEEDED" || state === "SUCCESS") return { ...initial, uploadState: state };
+    if (state && state !== "UPLOAD_IN_PROGRESS" && state !== "IN_PROGRESS") return { ...initial, uploadState: state };
+  }
+  throw new Error("Chrome Web Store upload was still in progress after 60 seconds");
+}
+
+function required(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function output(values) {
+  for (const [key, value] of Object.entries(values)) console.log(`${key}=${value}`);
+  if (!process.env.GITHUB_OUTPUT) return;
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${value}`).join("\n");
+  const { appendFile } = await import("node:fs/promises");
+  await appendFile(process.env.GITHUB_OUTPUT, `${lines}\n`);
+}
+
+async function main() {
+  const command = process.argv[2];
+  if (!command || !["status", "upload-prerelease", "publish-stable"].includes(command)) {
+    throw new Error("usage: cws.mjs <status | upload-prerelease | publish-stable>");
+  }
+  const credentials = JSON.parse(required("CWS_SERVICE_ACCOUNT_JSON"));
+  const accessToken = await serviceAccountToken(credentials);
+  const client = new ChromeWebStoreClient({
+    publisherId: required("CWS_PUBLISHER_ID"),
+    extensionId: required("CWS_EXTENSION_ID"),
+    accessToken,
+  });
+  const status = await client.status();
+  const version = command === "status" ? process.env.CWS_VERSION : required("CWS_VERSION");
+  if (command === "status") {
+    await output({
+      published_version: revisionVersion(status.publishedItemRevisionStatus) ?? "none",
+      submitted_version: revisionVersion(status.submittedItemRevisionStatus) ?? "none",
+      submitted_state: status.submittedItemRevisionStatus?.state ?? "none",
+    });
+    return;
+  }
+  if (command === "upload-prerelease") {
+    const action = prereleaseAction(status, version);
+    if (action === "frozen") {
+      await output({ action, candidate: "false" });
+      return;
+    }
+    const packagePath = required("CWS_PACKAGE_PATH");
+    const result = await waitForUpload(client, await client.upload(await readFile(packagePath), packagePath.split("/").at(-1)));
+    if (result.uploadState !== "SUCCEEDED" && result.uploadState !== "SUCCESS") {
+      throw new Error(`Chrome Web Store upload did not complete: ${result.uploadState}`);
+    }
+    if (result.crxVersion && result.crxVersion !== version) throw new Error(`Chrome Web Store accepted ${result.crxVersion}; expected ${version}`);
+    const after = await client.status();
+    if (after.submittedItemRevisionStatus) throw new Error("Draft upload unexpectedly created a submitted revision");
+    await output({ action: "uploaded", candidate: "true" });
+    return;
+  }
+  const action = stableAction(status, version);
+  if (action === "publish") {
+    const result = await client.publishStaged();
+    if (result.state !== "PUBLISHED") throw new Error(`Chrome Web Store publish returned ${result.state}; expected PUBLISHED`);
+  }
+  await output({ action });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`cws: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/cws.test.mjs
+++ b/scripts/cws.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { prereleaseAction, revisionVersion, stableAction } from "./cws.mjs";
+
+const revision = (state, version) => ({ state, distributionChannels: [{ deployPercentage: 100, crxVersion: version }] });
+const status = ({ published = "1.3.0", submitted, warned = false, takenDown = false } = {}) => ({
+  publishedItemRevisionStatus: published ? revision("PUBLISHED", published) : undefined,
+  submittedItemRevisionStatus: submitted,
+  warned,
+  takenDown,
+});
+
+test("revisionVersion reads the submitted package version", () => {
+  assert.equal(revisionVersion(revision("STAGED", "1.4.0")), "1.4.0");
+});
+
+test("pre-release uploads replace an unsubmitted draft", () => {
+  assert.equal(prereleaseAction(status(), "1.4.0"), "upload");
+});
+
+test("pre-release upload freezes during review and staging", () => {
+  assert.equal(prereleaseAction(status({ submitted: revision("PENDING_REVIEW", "1.4.0") }), "1.4.0"), "frozen");
+  assert.equal(prereleaseAction(status({ submitted: revision("STAGED", "1.4.0") }), "1.4.0"), "frozen");
+});
+
+test("pre-release rejects conflicting or unhealthy store state", () => {
+  assert.throws(() => prereleaseAction(status({ submitted: revision("STAGED", "1.3.1") }), "1.4.0"), /expected 1.4.0/);
+  assert.throws(() => prereleaseAction(status({ submitted: revision("REJECTED", "1.4.0") }), "1.4.0"), /REJECTED/);
+  assert.throws(() => prereleaseAction(status({ warned: true }), "1.4.0"), /policy warning/);
+  assert.throws(() => prereleaseAction(status({ takenDown: true }), "1.4.0"), /taken down/);
+});
+
+test("stable promotion publishes only a matching staged revision", () => {
+  assert.equal(stableAction(status({ submitted: revision("STAGED", "1.4.0") }), "1.4.0"), "publish");
+  assert.throws(() => stableAction(status({ submitted: revision("PENDING_REVIEW", "1.4.0") }), "1.4.0"), /expected STAGED/);
+  assert.throws(() => stableAction(status({ submitted: revision("STAGED", "1.5.0") }), "1.4.0"), /expected 1.4.0/);
+});
+
+test("stable promotion is idempotent after CWS publication", () => {
+  assert.equal(stableAction(status({ published: "1.4.0" }), "1.4.0"), "already-published");
+});


### PR DESCRIPTION
Closes #65.

## Summary

- replace the unsubmitted Chrome Web Store draft on every mutable prerelease build
- freeze CWS uploads while a revision is pending review or staged for deferred publication
- record each uploaded candidate's source commit and Chrome ZIP checksum in an automated tag
- require matching staged version, candidate ancestry, and unchanged extension inputs before stable promotion
- publish CWS before Docker aliases and GitHub stable promotion, with idempotent recovery
- add a tested CWS V2 service-account client and document setup, review, recovery, and expiry behavior

## Safety

- pull requests never receive CWS credentials or contact CWS
- review submission remains manual
- stable publication remains behind the protected `stable-releases` environment
- CWS warning, takedown, rejected, cancelled, mismatched, or unapproved states block promotion

## Testing

- `pnpm verify` — 6 CWS tests and 283 extension tests
- Chromium and Firefox production builds
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- live read-only CWS authentication/status check
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Chrome Web Store lifecycle automation for prerelease uploads and stable staged publishing, with status checks and version/store-state validation.
  * Updated release orchestration to wait for Chrome Web Store completion before Docker publishing.
* **Bug Fixes**
  * Improved safeguards to ensure promotions only occur from the expected staged revision.
* **Documentation**
  * Expanded release workflow docs for Chrome Web Store steps, eligibility rules, and recovery behavior.
* **Tests**
  * Added Chrome Web Store lifecycle unit tests and wired them into verification.
* **Chores**
  * Bumped PNPM to 11.9.0 across workflows; adjusted Docker build workflow to stop publishing multi-arch manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->