### PR TITLE
fix(twitch): validate channel campaign eligibility

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,7 +82,7 @@ Temporary page-context tabs are reference-counted per origin and removed after t
 - Campaign discovery calls `Inventory` and `ViewerDropsDashboard`, then fetches campaign details for active/upcoming connected campaigns.
 - Progress refresh re-reads `Inventory`; while watching, it also queries `DropCurrentSessionContext` to update the current reward's watched minutes.
 - Candidate discovery prefers campaign allowed-channel data. If none exists, it queries `GameDirectory` with the DropsEnabled tag and sorts by viewer count.
-- Channel validation calls `StreamInfo` with an inline public query and anonymous credentials to avoid logged-in integrity-token failures. If GraphQL fails, it falls back to parsing channel page HTML.
+- Channel validation calls `StreamInfo` with an inline public query and anonymous credentials to avoid logged-in integrity-token failures. For live category matches, it briefly caches `DropsHighlightService_AvailableDrops` results to confirm the selected campaign; unavailable or malformed confirmation data falls back to the live/category result. If `StreamInfo` fails, validation falls back to parsing channel page HTML.
 - Reward claiming calls `DropsPage_ClaimDropRewards`.
 - Channel points claiming checks `ChannelPointsContext` and submits `ClaimCommunityPoints` when a claim is available.
 - Tabless watching sends Twitch's `sendSpadeEvents` minute-watched mutation once per watch alarm while the selected stream is live.

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -206,7 +206,7 @@ async function firstValidCandidate(
 ): Promise<ChannelCandidate | undefined> {
   for (const candidate of candidates) {
     const check = await adapter.checkChannel(candidate, campaign);
-    if (check.live && check.categoryMatches) {
+    if (check.live && check.categoryMatches && check.campaignMatches !== false) {
       return channelFromCheck(candidate, check);
     }
   }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -11,6 +11,7 @@ const CURRENT_USER_QUERY = "query CurrentUser { currentUser { id } }";
 // Twitch's web Client-ID — the default identity. It is the one Twitch gates
 // behind Client-Integrity (Kasada); non-web client ids (Android/TV) are not.
 const TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
+const CHANNEL_CAMPAIGN_CACHE_TTL_MS = 60_000;
 
 export interface TwitchAdapterOptions {
   // GQL Client-ID. Defaults to the web client. A headless runtime passes a
@@ -36,6 +37,7 @@ const TWITCH_QUERIES = {
   gameDirectoryHash: "cb5dc816e139dcb8a118f14b4b677d59abc224a4b016c4bc2bb00a47fe0ddec4",
   streamInfoHash: "198492e0857f6aedead9665c81c5a06d67b25b58034649687124083ff288597d",
   currentDropHash: "4d06b702d25d652afb9ef835d2a550031f1cf762b193523a92166f40ea3d142b",
+  availableDropsHash: "782dad0f032942260171d2d80a654f88bdd0c5a9dddc392e9bc92218a0f42d20",
   channelPointsHash: "374314de591e69925fce3ddc2bcf085796f56ebb8cad67a0daa3165c03adc345",
   claimCommunityPointsHash: "46aaeebe02c99afdf4fc97c7c0cba964124bf6b0af229395f1f6d1feed05b3d0",
   claimHash: "a455deea71bdc9015b78eb49f4acfbce8baa7ccbedd28e549bb025bd0f751930",
@@ -132,6 +134,12 @@ const TWITCH_INLINE_QUERIES: Partial<Record<string, string>> = {
         dropID
         currentMinutesWatched
       }
+    }
+  }`,
+  DropsHighlightService_AvailableDrops: `query DropsHighlightService_AvailableDrops($channelID: ID!) {
+    channel(id: $channelID) {
+      id
+      viewerDropCampaigns { id }
     }
   }`,
   ChannelPointsContext: `query ChannelPointsContext($channelLogin: String!) {
@@ -240,11 +248,24 @@ interface TwitchCurrentDropData {
   };
 }
 
+interface TwitchAvailableDropsData {
+  channel?: {
+    id?: string;
+    viewerDropCampaigns?: Array<{ id?: string }> | null;
+  } | null;
+}
+
+interface CachedAvailableCampaigns {
+  campaignIds: Set<string>;
+  expiresAt: number;
+}
+
 export class TwitchAdapter implements PlatformAdapter {
   platform = "twitch" as const;
 
   private readonly clientId: string;
   private readonly userAgent?: string;
+  private readonly availableCampaignsByChannel = new Map<string, CachedAvailableCampaigns>();
 
   constructor(
     // Twitch GQL is unreachable from the twitch.tv page context (CORS / anti-
@@ -407,24 +428,72 @@ export class TwitchAdapter implements PlatformAdapter {
         "omit",
       );
       const stream = response.data?.user?.stream;
+      const channelId = response.data?.user?.id;
       const actualCategoryId = stream?.game?.id;
       const expectedCategoryId = campaign?.categoryId ?? channel.categoryId;
+      const categoryMatches = !expectedCategoryId || actualCategoryId === expectedCategoryId;
+      const campaignMatches = stream && categoryMatches && campaign && channelId
+        ? await this.checkCampaignAvailability(channelId, campaign.id, channel.username)
+        : undefined;
       return {
         live: Boolean(stream),
-        categoryMatches: !expectedCategoryId || actualCategoryId === expectedCategoryId,
-        reason: stream ? undefined : "Twitch channel is offline",
+        categoryMatches,
+        campaignMatches,
+        reason: !stream
+          ? "Twitch channel is offline"
+          : campaignMatches === false
+            ? "Twitch campaign is not available on this channel"
+            : undefined,
         candidate: {
           ...channel,
           displayName: response.data?.user?.displayName ?? channel.displayName,
           categoryId: actualCategoryId ?? channel.categoryId,
           categoryName: stream?.game?.name ?? channel.categoryName,
           viewerCount: stream?.viewersCount ?? channel.viewerCount,
-          channelId: response.data?.user?.id ?? channel.channelId,
+          channelId: channelId ?? channel.channelId,
           broadcastId: stream?.id ?? channel.broadcastId,
         },
       };
     } catch (error) {
       return this.checkChannelFromPage(channel, campaign, error);
+    }
+  }
+
+  private async checkCampaignAvailability(
+    channelId: string,
+    campaignId: string,
+    channelLogin: string,
+  ): Promise<boolean | undefined> {
+    const cached = this.availableCampaignsByChannel.get(channelId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.campaignIds.has(campaignId);
+    }
+    if (cached) this.availableCampaignsByChannel.delete(channelId);
+
+    try {
+      const response = await this.gql<TwitchAvailableDropsData>(
+        "DropsHighlightService_AvailableDrops",
+        TWITCH_QUERIES.availableDropsHash,
+        { channelID: channelId },
+      );
+      const campaigns = response.data?.channel?.viewerDropCampaigns;
+      if (!Array.isArray(campaigns)) {
+        logActivity("debug", `Twitch did not return available campaign data for ${channelLogin}; using live/category validation`, "twitch");
+        return undefined;
+      }
+
+      const campaignIds = new Set(
+        campaigns.map((campaign) => campaign.id).filter((id): id is string => Boolean(id)),
+      );
+      this.availableCampaignsByChannel.set(channelId, {
+        campaignIds,
+        expiresAt: Date.now() + CHANNEL_CAMPAIGN_CACHE_TTL_MS,
+      });
+      return campaignIds.has(campaignId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logActivity("debug", `Could not confirm available Twitch campaigns for ${channelLogin}; using live/category validation: ${message}`, "twitch");
+      return undefined;
     }
   }
 

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -145,7 +145,10 @@ function parseTwitchReward(
 ): DropReward {
   const watchedMinutes = reward.self?.currentMinutesWatched ?? 0;
   const requiredMinutes = reward.requiredMinutesWatched ?? 0;
-  const isWatchBased = requiredMinutes > 0;
+  const requiredSubs = reward.requiredSubs ?? 0;
+  // A reward that also requires subscriptions cannot be completed by watching
+  // alone. Keep it for ownership/claim tracking, but never let it drive farming.
+  const isWatchBased = requiredMinutes > 0 && requiredSubs <= 0;
   const benefits = (reward.benefitEdges ?? [])
     .map((edge) => edge.benefit)
     .filter((benefit): benefit is NonNullable<typeof benefit> => Boolean(benefit));
@@ -181,8 +184,12 @@ function parseTwitchReward(
     preconditionsMet: preconditionRewardIds.length === 0,
     status: isClaimed
       ? "claimed"
-      : !isWatchBased && reward.self?.dropInstanceID
-        ? "claimable"
+      : !isWatchBased
+        ? reward.self?.dropInstanceID
+          ? "claimable"
+          : watchedMinutes > 0
+            ? "in_progress"
+            : "locked"
       : watchedMinutes >= requiredMinutes && requiredMinutes > 0
         ? "claimable"
         : watchedMinutes > 0

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -993,6 +993,157 @@ describe("TwitchAdapter", () => {
     });
   });
 
+  it("confirms the selected campaign is available on the Twitch channel", async () => {
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { game: { id: "game", name: "Game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        expect(requestBody(init).variables).toEqual({ channelID: "channel-id" });
+        return { data: { channel: { id: "channel-id", viewerDropCampaigns: [{ id: "campaign" }] } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const adapter = new TwitchAdapter(fetcher);
+
+    await expect(adapter.checkChannel(
+      { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator", isAclMatch: true },
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    )).resolves.toMatchObject({
+      live: true,
+      categoryMatches: true,
+      campaignMatches: true,
+      candidate: { channelId: "channel-id" },
+    });
+  });
+
+  it("rejects a Twitch channel that explicitly does not offer the selected campaign", async () => {
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        return { data: { channel: { id: "channel-id", viewerDropCampaigns: [{ id: "other" }] } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const adapter = new TwitchAdapter(fetcher);
+
+    await expect(adapter.checkChannel(
+      { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    )).resolves.toMatchObject({
+      live: true,
+      categoryMatches: true,
+      campaignMatches: false,
+      reason: "Twitch campaign is not available on this channel",
+    });
+  });
+
+  it("falls back to live/category validation when Twitch campaign availability is unavailable", async () => {
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") throw new Error("availability unavailable");
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const adapter = new TwitchAdapter(fetcher);
+
+    await expect(adapter.checkChannel(
+      { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    )).resolves.toMatchObject({
+      live: true,
+      categoryMatches: true,
+      campaignMatches: undefined,
+    });
+  });
+
+  it("treats malformed Twitch campaign availability as a soft fallback", async () => {
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        return { data: { channel: { id: "channel-id" } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const adapter = new TwitchAdapter(fetcher);
+
+    await expect(adapter.checkChannel(
+      { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    )).resolves.toMatchObject({
+      live: true,
+      categoryMatches: true,
+      campaignMatches: undefined,
+    });
+  });
+
+  it("retries stale Twitch campaign availability hashes with an inline query", async () => {
+    let availabilityAttempts = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        availabilityAttempts += 1;
+        const body = requestBody(init);
+        if (!body.query) return { errors: [{ message: "PersistedQueryNotFound" }] };
+        expect(body.query).toContain("viewerDropCampaigns");
+        return { data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const adapter = new TwitchAdapter(fetcher);
+
+    await expect(adapter.checkChannel(
+      { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    )).resolves.toMatchObject({ campaignMatches: true });
+    expect(availabilityAttempts).toBe(2);
+  });
+
+  it("caches positive and negative Twitch campaign availability for a bounded time", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-07-13T12:00:00.000Z"));
+      let availabilityCalls = 0;
+      const fetcher = jsonFetcher((_url, init) => {
+        const op = operation(init);
+        if (op === "StreamInfo") {
+          return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        }
+        if (op === "DropsHighlightService_AvailableDrops") {
+          availabilityCalls += 1;
+          return { data: { channel: { viewerDropCampaigns: [{ id: "available" }] } } };
+        }
+        throw new Error(`Unexpected op ${op}`);
+      });
+      const adapter = new TwitchAdapter(fetcher);
+      const candidate = { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" } as const;
+
+      await expect(adapter.checkChannel(candidate, { id: "available", categoryId: "game" } as DropCampaign))
+        .resolves.toMatchObject({ campaignMatches: true });
+      await expect(adapter.checkChannel(candidate, { id: "missing", categoryId: "game" } as DropCampaign))
+        .resolves.toMatchObject({ campaignMatches: false });
+      expect(availabilityCalls).toBe(1);
+
+      vi.advanceTimersByTime(60_001);
+      await adapter.checkChannel(candidate, { id: "available", categoryId: "game" } as DropCampaign);
+      expect(availabilityCalls).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("lists Twitch drop-enabled streams through the slug directory query", async () => {
     const fetcher = jsonFetcher((_url, init) => {
       expect(operation(init)).toBe("DirectoryPage_Game");

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -293,8 +293,90 @@ describe("Twitch parsers", () => {
       ],
     }]);
 
-    expect(campaigns[0].rewards.filter((reward) => reward.isWatchBased !== false).map((reward) => reward.id)).toEqual(["watch", "combined"]);
+    expect(campaigns[0].rewards.filter((reward) => reward.isWatchBased !== false).map((reward) => reward.id)).toEqual(["watch"]);
+    expect(campaigns[0].rewards.find((reward) => reward.id === "combined")).toMatchObject({
+      requiredSubs: 1,
+      isWatchBased: false,
+      status: "locked",
+    });
     expect(campaigns[0].eligibility).toBe("eligible");
+  });
+
+  it("does not farm a mixed watch-and-subscription reward without a real claim instance", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "mixed-only",
+      self: { isAccountConnected: true },
+      timeBasedDrops: [{
+        id: "combined",
+        requiredMinutesWatched: 60,
+        requiredSubs: 1,
+        self: { currentMinutesWatched: 60 },
+      }],
+    }]);
+
+    expect(campaigns[0].eligibility).toBe("no_rewards");
+    expect(campaigns[0].rewards[0]).toMatchObject({
+      isWatchBased: false,
+      status: "in_progress",
+      claimId: undefined,
+    });
+  });
+
+  it("makes an obtained mixed-requirement reward claimable with Twitch's real instance id", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "mixed-obtained",
+      timeBasedDrops: [{
+        id: "combined",
+        requiredMinutesWatched: 60,
+        requiredSubs: 1,
+        self: { currentMinutesWatched: 60, dropInstanceID: "mixed-instance" },
+      }],
+    }]);
+
+    expect(campaigns[0].rewards[0]).toMatchObject({
+      isWatchBased: false,
+      status: "claimable",
+      claimId: "mixed-instance",
+    });
+  });
+
+  it("keeps linked native badge and emote watch rewards farmable", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "native-rewards",
+      self: { isAccountConnected: true },
+      timeBasedDrops: [
+        {
+          id: "badge",
+          requiredMinutesWatched: 30,
+          benefitEdges: [{ benefit: { id: "badge-benefit", distributionType: "BADGE" } }],
+        },
+        {
+          id: "emote",
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit: { id: "emote-benefit", distributionType: "EMOTE" } }],
+        },
+      ],
+    }]);
+
+    expect(campaigns[0].eligibility).toBe("eligible");
+    expect(campaigns[0].rewards).toMatchObject([
+      { benefitType: "BADGE", isWatchBased: true },
+      { benefitType: "EMOTE", isWatchBased: true },
+    ]);
+  });
+
+  it("does not bypass account linking for unconfirmed native reward payloads", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "unlinked-native",
+      self: { isAccountConnected: false },
+      timeBasedDrops: [{
+        id: "badge",
+        requiredMinutesWatched: 30,
+        benefitEdges: [{ benefit: { id: "badge-benefit", distributionType: "BADGE" } }],
+      }],
+    }]);
+
+    expect(campaigns[0].eligibility).toBe("account_not_linked");
   });
 
   it("does not unlock a watch reward whose paid prerequisite was excluded", () => {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -364,6 +364,31 @@ describe("scheduler campaign selection", () => {
     expect(checkChannel).toHaveBeenCalledTimes(3);
   });
 
+  it("skips channels that do not offer the selected campaign", async () => {
+    const unavailable = channel("unavailable", { isAclMatch: true });
+    const valid = channel("valid", { isAclMatch: false });
+    const checkChannel = vi.fn(async (candidate: ChannelCandidate) => ({
+      live: true,
+      categoryMatches: true,
+      campaignMatches: candidate.username !== "unavailable",
+      candidate,
+    }));
+
+    const decision = await chooseCampaignDecision(
+      "twitch",
+      [campaign("drops")],
+      settings(),
+      {
+        listCandidateChannels: vi.fn(async () => [unavailable, valid]),
+        checkChannel,
+      },
+    );
+
+    expect(decision.action).toBe("watch");
+    expect(decision.channel?.username).toBe("valid");
+    expect(checkChannel).toHaveBeenCalledTimes(2);
+  });
+
   it("does not select candidates whose validation cannot prove live category match", async () => {
     const unverifiable = channel("unverifiable", { isAclMatch: true });
     const valid = channel("valid", { isAclMatch: false });

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -76,6 +76,10 @@ export interface ChannelCandidate {
 export interface ChannelCheck {
   live: boolean;
   categoryMatches: boolean;
+  // Undefined when the platform cannot confirm campaign availability. A
+  // definitive false rejects the candidate; soft failures keep the existing
+  // live/category validation path usable.
+  campaignMatches?: boolean;
   reason?: string;
   candidate: ChannelCandidate;
 }

--- a/packages/site/src/changelog.ts
+++ b/packages/site/src/changelog.ts
@@ -51,6 +51,11 @@ export const changelog: ChangelogEntry[] = [
         text:
           "Twitch now ignores subscription, purchase, and other non-watch rewards when choosing campaigns to farm.",
       },
+      {
+        kind: "fixed",
+        text:
+          "Twitch now confirms that a selected live channel offers the intended campaign when that information is available.",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- confirm that a selected Twitch channel advertises the intended campaign when Twitch returns availability data
- cache definitive channel campaign results briefly while treating query, schema, integrity, and stale-hash failures as soft fallbacks
- prevent rewards that require both watch time and subscriptions from driving farming
- retain action-gated rewards so Twitch-issued claim instances can still be auto-claimed
- add explicit regression coverage for native badge and emote watch rewards without bypassing account-link enforcement

## Why

The Drops-enabled directory filter and live/category checks do not prove that a specific channel currently offers a specific campaign, especially for campaign allowlist channels. Twitch can also report rewards that combine watch time with paid requirements; classifying those as watch-farmable can leave LurkLoot watching an impossible target.

## Implementation

The shared channel check now carries an optional tri-state `campaignMatches` result. Twitch queries `DropsHighlightService_AvailableDrops` after a successful live/category check and caches well-formed positive or negative results for one minute. Explicit mismatches reject the candidate, while missing, malformed, stale, or failed responses preserve the existing validation path.

Rewards with `requiredSubs > 0` are retained but are no longer considered watch-farmable. They become claimable only when Twitch supplies a real drop instance. Linked watch-based `BADGE` and `EMOTE` rewards remain supported. Unlinked native rewards remain behind the account-link gate because the available sanitized payloads do not establish that Twitch's `isAccountConnected: false` signal can safely be ignored.

## Impact

LurkLoot is less likely to spend time on a live channel that does not earn the selected campaign, without making Twitch's private availability query a single point of failure. Mixed subscription/watch rewards no longer drive farming, while already-obtained rewards can still be claimed.

## Testing

- `pnpm verify`
  - all workspace typechecks
  - 294 Vitest tests
  - Chromium production build
  - Firefox production build

Closes #66


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Twitch campaign selection now verifies that a live channel offers the selected campaign when confirmation is available.
  - Channels with confirmed campaign unavailability are skipped in favor of eligible alternatives.
  - Added short-lived caching and fallback handling for unavailable or malformed Twitch confirmation data.
  - Subscription-based rewards now remain locked or in progress unless Twitch provides a valid claim instance.
  - Improved status handling for mixed watch-and-subscription rewards.

- **Documentation**
  - Updated Twitch integration architecture and changelog details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->