### PR TITLE
feat(cli): generate default JSONC config

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 ENV NODE_ENV=production
 
-# Mount a data dir holding config.json (and the auth/ produced by `login`).
+# Mount a data dir; the CLI creates config.json and auth/ on first use.
 # `run` is the default; override the command for discover/validate-config/etc.
 WORKDIR /data
 ENTRYPOINT ["node", "/app/dist/index.mjs"]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -131,8 +131,8 @@ No browser means a slim Node image:
 # build from the repo root
 docker build -f packages/cli/Dockerfile -t lurkloot-cli .
 
-# Or use the published image. The first command creates a documented config.json
-# with Kick-capable defaults. Authenticate each platform you want to use.
+# Or use the published image. The first command creates a documented config.json.
+# Authenticate Twitch and/or Kick before starting the farming loop.
 docker run --rm -it -v "$PWD/data:/data" \
   ghcr.io/jamezrin/lurkloot-cli:latest auth twitch device-login
 docker run --rm -it -v "$PWD/data:/data" \

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,6 +17,11 @@ pnpm cli validate-config --config ./config.json
 
 ## Config
 
+The CLI creates the requested config file automatically when it does not exist.
+The generated file is JSONC: it lists every supported default and includes
+comments explaining the important choices. Existing `.json` and `.jsonc` files
+both accept `//` / `/* */` comments and trailing commas.
+
 The CLI has its **own** settings schema — it is *not* the extension's
 `ExtensionSettings` verbatim. Only settings that do something in the headless,
 tabless watch path are accepted; the schema is validated strictly, so an unknown
@@ -38,7 +43,7 @@ Rejected (extension-only, no effect headlessly): `running`, `tablessMode`,
 
 ```jsonc
 {
-  "transport": "impersonate",   // "http" | "impersonate"
+  "transport": "impersonate",   // default; use "http" for Twitch-only setups
   "authDir": "auth",            // resolved relative to this file
   "settings": {                 // CLI settings schema, merged over defaults
     "pollIntervalMinutes": 5,
@@ -126,7 +131,18 @@ No browser means a slim Node image:
 # build from the repo root
 docker build -f packages/cli/Dockerfile -t lurkloot-cli .
 
-# run the loop against a mounted data dir holding config.json (+ auth/)
+# Or use the published image. The first command creates a documented config.json
+# with Kick-capable defaults. Authenticate each platform you want to use.
+docker run --rm -it -v "$PWD/data:/data" \
+  ghcr.io/jamezrin/lurkloot-cli:latest auth twitch device-login
+docker run --rm -it -v "$PWD/data:/data" \
+  ghcr.io/jamezrin/lurkloot-cli:latest auth kick device-login
+
+# Leave the farming loop running in the background.
+docker run -d --name lurkloot --restart unless-stopped \
+  -v "$PWD/data:/data" ghcr.io/jamezrin/lurkloot-cli:latest
+
+# The same flow with an image built locally:
 docker run --rm -v "$PWD/data:/data" lurkloot-cli
 # one-off discovery
 docker run --rm -v "$PWD/data:/data" lurkloot-cli discover --config /data/config.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "lurkloot": "./dist/index.mjs"
   },
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/index.mjs --external:cycletls",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node22 --main-fields=module,main --outfile=dist/index.mjs --external:cycletls",
     "cli": "pnpm build && node dist/index.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
@@ -17,6 +17,7 @@
     "@lurkloot/core": "workspace:*",
     "@lurkloot/shared": "workspace:*",
     "cycletls": "^2.0.5",
+    "jsonc-parser": "^3.3.1",
     "yargs": "^18.0.0"
   },
   "devDependencies": {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,7 @@
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { parseCliSettings, type CliSettings } from "./settings";
+import { parse as parseJsonc, printParseErrorCode, type ParseError } from "jsonc-parser";
+import { DEFAULT_CLI_SETTINGS, parseCliSettings, type CliSettings } from "./settings";
 
 export const TRANSPORTS = ["http", "impersonate"] as const;
 export type Transport = (typeof TRANSPORTS)[number];
@@ -15,6 +16,69 @@ export interface CliConfig {
 
 const CONFIG_KEYS = new Set<string>(["transport", "authDir", "settings"]);
 
+function json(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+// The generated file is intentionally verbose: it doubles as the complete CLI
+// settings reference while remaining safe to edit as JSONC. Values are read
+// from DEFAULT_CLI_SETTINGS so the template cannot silently drift from runtime
+// behavior when a shared default changes.
+export function defaultConfigJsonc(): string {
+  const defaults = DEFAULT_CLI_SETTINGS;
+  const twitch = defaults.platform.twitch;
+  const kick = defaults.platform.kick;
+  return `{
+  // "impersonate" works with both Twitch and Kick. Use "http" only for a
+  // lighter Twitch-only setup; Kick's API rejects plain Node TLS requests.
+  "transport": "impersonate",
+
+  // Credentials are stored separately in this directory, relative to this file.
+  "authDir": "auth",
+
+  "settings": {
+    // Automatically claim completed drops and Twitch channel-point bonuses.
+    "autoClaim": ${json(defaults.autoClaim)},
+    "autoClaimChannelPoints": ${json(defaults.autoClaimChannelPoints)},
+
+    // ending_soonest | lowest_availability | priority_list_only
+    "priorityMode": ${json(defaults.priorityMode)},
+    // Map campaign IDs to numeric priorities; larger numbers are preferred.
+    "campaignPriorities": ${json(defaults.campaignPriorities)},
+    "excludedCampaignIds": ${json(defaults.excludedCampaignIds)},
+
+    // Prefer explicit watch queues; fall back to discovered eligible channels.
+    "watchQueueFallbackOnly": ${json(defaults.watchQueueFallbackOnly)},
+    "offlineRetryLimit": ${json(defaults.offlineRetryLimit)},
+    // How often campaign discovery and watch state are refreshed (1-60 minutes).
+    "pollIntervalMinutes": ${json(defaults.pollIntervalMinutes)},
+    "enabledLogLevels": ${json(defaults.enabledLogLevels)},
+    "notifyRewardEarned": ${json(defaults.notifyRewardEarned)},
+    "notifyNoDropsLeft": ${json(defaults.notifyNoDropsLeft)},
+
+    "platform": {
+      "twitch": {
+        "enabled": ${json(twitch.enabled)},
+        "watchQueueChannels": ${json(twitch.watchQueueChannels)},
+        "excludedChannels": ${json(twitch.excludedChannels)},
+        "farmAllCategories": ${json(twitch.farmAllCategories)},
+        // Used when farmAllCategories is false.
+        "categories": ${json(twitch.categories)}
+      },
+      "kick": {
+        "enabled": ${json(kick.enabled)},
+        "watchQueueChannels": ${json(kick.watchQueueChannels)},
+        "excludedChannels": ${json(kick.excludedChannels)},
+        "farmAllCategories": ${json(kick.farmAllCategories)},
+        // Used when farmAllCategories is false.
+        "categories": ${json(kick.categories)}
+      }
+    }
+  }
+}
+`;
+}
+
 // Builds a validated config from already-parsed JSON. `transport` and `authDir`
 // are CLI-specific; `settings` is the CLI's own settings schema (see settings.ts)
 // — decoupled from the extension's ExtensionSettings and strict about unknown or
@@ -28,7 +92,7 @@ export function parseConfig(raw: unknown, configPath: string): CliConfig {
   if (unknown.length > 0) {
     throw new Error(`Unknown config ${unknown.length === 1 ? "key" : "keys"}: ${unknown.map((k) => `"${k}"`).join(", ")}; expected one of: ${[...CONFIG_KEYS].join(", ")}`);
   }
-  const transport = (data.transport as string | undefined) ?? "http";
+  const transport = (data.transport as string | undefined) ?? "impersonate";
   if (!TRANSPORTS.includes(transport as Transport)) {
     throw new Error(`Unknown transport "${transport}"; expected one of: ${TRANSPORTS.join(", ")}`);
   }
@@ -47,13 +111,39 @@ export function loadConfig(configPath: string): CliConfig {
   try {
     text = readFileSync(absolute, "utf8");
   } catch (error) {
-    throw new Error(`Could not read config at ${absolute}: ${error instanceof Error ? error.message : String(error)}`);
+    if (!isErrno(error, "ENOENT")) {
+      throw new Error(`Could not read config at ${absolute}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    try {
+      mkdirSync(dirname(absolute), { recursive: true });
+      writeFileSync(absolute, defaultConfigJsonc(), { encoding: "utf8", flag: "wx", mode: 0o644 });
+      process.stderr.write(`Created default config at ${absolute}\n`);
+    } catch (writeError) {
+      // Another process may have initialized the same mounted data directory
+      // between our read and write. In that case, keep its file and read it.
+      if (!isErrno(writeError, "EEXIST")) {
+        throw new Error(`Could not create default config at ${absolute}: ${writeError instanceof Error ? writeError.message : String(writeError)}`);
+      }
+    }
+    try {
+      text = readFileSync(absolute, "utf8");
+    } catch (readError) {
+      throw new Error(`Could not read config at ${absolute}: ${readError instanceof Error ? readError.message : String(readError)}`);
+    }
   }
-  let raw: unknown;
-  try {
-    raw = JSON.parse(text);
-  } catch (error) {
-    throw new Error(`Config at ${absolute} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  const errors: ParseError[] = [];
+  const raw = parseJsonc(text, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    const first = errors[0];
+    const before = text.slice(0, first.offset);
+    const line = before.split("\n").length;
+    const lastNewline = before.lastIndexOf("\n");
+    const column = first.offset - lastNewline;
+    throw new Error(`Config at ${absolute} is not valid JSONC: ${printParseErrorCode(first.error)} at line ${line}, column ${column}`);
   }
   return parseConfig(raw, absolute);
+}
+
+function isErrno(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === code;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -193,7 +193,7 @@ function buildCli(argv: string[]): Argv {
   return yargs(argv)
     .scriptName("lurkloot")
     .usage("$0 <command> [options]")
-    .option("config", { type: "string", default: "config.json", describe: "Config file", global: true })
+    .option("config", { type: "string", default: "config.json", describe: "Config file (created with defaults if missing)", global: true })
     .option("log", { type: "string", choices: ["debug", "info", "warn", "error"], default: "info", describe: "Log level", global: true })
     .command(validateConfigCommand)
     .command(discoverCommand)

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -8,7 +8,7 @@ import { DEFAULT_CLI_SETTINGS } from "../src/settings";
 const CONFIG_PATH = "/tmp/lurkloot/config.json";
 
 describe("parseConfig", () => {
-  it("defaults to the Kick-capable impersonate transport and <configDir>/auth", () => {
+  it("defaults to the impersonate transport and <configDir>/auth", () => {
     const config = parseConfig({}, CONFIG_PATH);
     expect(config.transport).toBe("impersonate");
     expect(config.authDir).toBe(resolve("/tmp/lurkloot", "auth"));

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { resolve } from "node:path";
-import { parseConfig } from "../src/config";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { defaultConfigJsonc, loadConfig, parseConfig } from "../src/config";
+import { DEFAULT_CLI_SETTINGS } from "../src/settings";
 
 const CONFIG_PATH = "/tmp/lurkloot/config.json";
 
 describe("parseConfig", () => {
-  it("defaults the transport to http and authDir to <configDir>/auth", () => {
+  it("defaults to the Kick-capable impersonate transport and <configDir>/auth", () => {
     const config = parseConfig({}, CONFIG_PATH);
-    expect(config.transport).toBe("http");
+    expect(config.transport).toBe("impersonate");
     expect(config.authDir).toBe(resolve("/tmp/lurkloot", "auth"));
   });
 
@@ -49,5 +52,64 @@ describe("parseConfig", () => {
   it("rejects a non-object config", () => {
     expect(() => parseConfig([], CONFIG_PATH)).toThrow(/must be a JSON object/);
     expect(() => parseConfig(null, CONFIG_PATH)).toThrow(/must be a JSON object/);
+  });
+});
+
+describe("loadConfig", () => {
+  it("creates and loads a documented default JSONC config when the file is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lurkloot-config-"));
+    try {
+      const path = join(dir, "nested", "config.json");
+      const config = loadConfig(path);
+      const generated = readFileSync(path, "utf8");
+
+      expect(generated).toContain("// Credentials are stored separately");
+      expect(generated).toContain('"transport": "impersonate"');
+      expect(config.transport).toBe("impersonate");
+      expect(config.authDir).toBe(join(dir, "nested", "auth"));
+      expect(config.settings).toEqual(DEFAULT_CLI_SETTINGS);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts comments and trailing commas in an existing config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lurkloot-config-"));
+    try {
+      const path = join(dir, "config.jsonc");
+      writeFileSync(path, `{
+        // Kick-compatible transport
+        "transport": "impersonate",
+        "settings": {
+          "pollIntervalMinutes": 7,
+        },
+      }`);
+
+      expect(loadConfig(path).settings.pollIntervalMinutes).toBe(7);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a useful location for malformed JSONC", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lurkloot-config-"));
+    try {
+      const path = join(dir, "config.json");
+      writeFileSync(path, "{\n  \"transport\":,\n}\n");
+      expect(() => loadConfig(path)).toThrow(/not valid JSONC: .*line 2, column/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the generated template aligned with runtime defaults", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lurkloot-config-"));
+    try {
+      const path = join(dir, "config.json");
+      writeFileSync(path, defaultConfigJsonc());
+      expect(loadConfig(path).settings).toEqual(DEFAULT_CLI_SETTINGS);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/site/src/components/Cli.astro
+++ b/packages/site/src/components/Cli.astro
@@ -40,12 +40,16 @@ const points = [
           <span></span><span></span><span></span>
           <em>lurkloot — docker</em>
         </div>
-        <pre class="cli__code"><code><span class="c"># one prebuilt, multi-arch image — nothing to build</span>
-<span class="p">docker</span> run -v <span class="s">"$PWD/data:/data"</span> \
+        <pre class="cli__code"><code><span class="c"># config.json is created with sensible defaults</span>
+<span class="p">docker</span> run --rm -it -v <span class="s">"$PWD/data:/data"</span> \
   <span class="i">{DOCKER_IMAGE}</span> auth twitch device-login
 
-<span class="c"># then just run the loop</span>
-<span class="p">docker</span> run -v <span class="s">"$PWD/data:/data"</span> <span class="i">{DOCKER_IMAGE}</span></code></pre>
+<span class="p">docker</span> run --rm -it -v <span class="s">"$PWD/data:/data"</span> \
+  <span class="i">{DOCKER_IMAGE}</span> auth kick device-login
+
+<span class="c"># then leave the farming loop running</span>
+<span class="p">docker</span> run -d --name lurkloot --restart unless-stopped \
+  -v <span class="s">"$PWD/data:/data"</span> <span class="i">{DOCKER_IMAGE}</span></code></pre>
       </div>
 
       <div class="cli__side">

--- a/packages/site/src/consts.ts
+++ b/packages/site/src/consts.ts
@@ -29,9 +29,9 @@ export const SITE = {
   ].join(", "),
 } as const;
 
-// Published headless image — built multi-arch (amd64 + arm64) on GHCR by
-// .github/workflows/cli-docker.yml. Used verbatim in the CLI section's snippet.
-export const DOCKER_IMAGE = "ghcr.io/jamezrin/lurkloot-cli";
+// Published headless image — built multi-arch (amd64 + arm64) on GHCR by the
+// unified release workflow. Used verbatim in the CLI section's snippet.
+export const DOCKER_IMAGE = "ghcr.io/jamezrin/lurkloot-cli:latest";
 
 export const LINKS = {
   chrome:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       cycletls:
         specifier: ^2.0.5
         version: 2.0.5
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       yargs:
         specifier: ^18.0.0
         version: 18.0.0


### PR DESCRIPTION
## Summary

- create a documented default CLI configuration automatically when the configured file is missing
- accept JSONC comments and trailing commas while preserving strict settings validation
- use the cross-platform impersonation transport as the default
- simplify the Docker onboarding instructions while keeping Twitch and Kick authentication explicit
- reference the published Docker image with the `:latest` tag

## Why

The Docker setup previously required users to create a configuration file manually before authenticating and running the CLI. Generating a complete, commented configuration provides sensible defaults and makes the available settings discoverable with fewer setup commands.

## Validation

- `pnpm --filter @lurkloot/cli test` (50 tests)
- `pnpm --filter @lurkloot/cli typecheck`
- `pnpm build:cli`
- `pnpm verify` (294 extension tests plus typechecks and browser builds)
- `pnpm build:site`
- local Docker smoke test for config generation and validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now auto-creates a documented JSONC config (with supported defaults) when the config file is missing.
  * JSONC config parsing supports comments and trailing commas, with clearer error locations.
  * Default transport is now `impersonate` when omitted.

* **Documentation**
  * Updated CLI README configuration and Docker usage steps for both Twitch and Kick device-login, plus a named persistent container workflow.
  * Updated the site “server / no browser” terminal example accordingly.

* **Tests**
  * Expanded coverage for default config generation, JSONC parsing, and transport defaults.

* **Chores**
  * Headless Docker image reference now uses the `latest` tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->