### PR TITLE
fix(site): source popup demo version from release

### DIFF
--- a/packages/site/src/popup-ui/PopupDemo.tsx
+++ b/packages/site/src/popup-ui/PopupDemo.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { Popup, createDemoPopupAdapter, screenshotVariant } from "@lurkloot/popup-ui";
 import popupCss from "@lurkloot/popup-ui/styles.css?inline";
+import rootManifest from "../../../../package.json";
 
 // Tailwind v4 backs many utilities (border-style, shadows, rings, gradients,
 // transforms…) with registered @property custom properties. @property only
@@ -52,7 +53,7 @@ export default function PopupDemo() {
     // contained, no portal/event-retargeting caveats.
     const root = createRoot(mount);
     rootRef.current = root;
-    const adapter = createDemoPopupAdapter({ locale: "en", version: "1.0.0" });
+    const adapter = createDemoPopupAdapter({ locale: "en", version: rootManifest.version });
     root.render(
       <Popup
         adapter={adapter}


### PR DESCRIPTION
## Summary

- source the landing-site popup demo version from the root release manifest
- remove the stale `1.0.0` literal from the site adapter setup

## Why

The interactive popup preview always displayed `v1.0.0` because `PopupDemo.tsx` passed that value explicitly. The root `package.json` is already the canonical release declaration, so consuming it directly keeps prerelease and stable site deployments aligned automatically.

## Impact

The popup footer in the landing-site preview now shows the version represented by the deployed commit. Future release preparations update it through the existing root manifest without requiring a separate site edit.

## Testing

- `pnpm check`
- confirmed the production site bundle contains the current root version (`1.4.0`)

Closes #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the demo popup to display the current package version automatically instead of a fixed version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->