### PR TITLE
feat(site): attribute outbound store and GitHub links

### DIFF
--- a/docs/superpowers/plans/2026-07-14-website-link-attribution.md
+++ b/docs/superpowers/plans/2026-07-14-website-link-attribution.md
@@ -1,0 +1,199 @@
+# Website Link Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Attribute marketing-site referrals to the Chrome Web Store and GitHub-owned project pages without adding client-side analytics.
+
+**Architecture:** Keep canonical external destinations separate from anchor-ready attributed links in the site link catalog. Construct the attributed variants with the standard `URL` API so existing fragments remain correctly ordered, and keep Schema.org metadata pointed at the canonical Chrome Web Store destination.
+
+**Tech Stack:** TypeScript, Astro, Node test runner, pnpm
+
+## Global Constraints
+
+- Chrome links use `utm_source=lurkloot_website`, `utm_medium=referral`, and `utm_campaign=extension_install`.
+- GitHub repository, CLI documentation, and GHCR links use `utm_source=lurkloot_website`, `utm_medium=referral`, and `utm_campaign=open_source`.
+- Structured metadata, extension-popup links, README links, and other non-website surfaces remain untagged.
+- Do not add Google Tag Manager or any client-side analytics dependency.
+
+---
+
+### Task 1: Build attributed website destinations
+
+**Files:**
+- Create: `packages/site/tests/consts.test.mjs`
+- Modify: `packages/site/src/consts.ts`
+- Modify: `packages/site/package.json`
+
+**Interfaces:**
+- Consumes: Native `URL` and `URLSearchParams` behavior.
+- Produces: `EXTERNAL_URLS` canonical destination catalog and the existing `LINKS` anchor catalog with attributed Chrome and GitHub-owned URLs.
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+import assert from "node:assert/strict";
+import test from "node:test";
+import { EXTERNAL_URLS, LINKS } from "../src/consts.ts";
+
+test("attributes Chrome Web Store website referrals", () => {
+  const url = new URL(LINKS.chrome);
+  assert.equal(url.origin + url.pathname, EXTERNAL_URLS.chrome);
+  assert.deepEqual(Object.fromEntries(url.searchParams), {
+    utm_source: "lurkloot_website",
+    utm_medium: "referral",
+    utm_campaign: "extension_install",
+  });
+});
+
+test("attributes every GitHub-owned website destination", () => {
+  for (const key of ["github", "cli", "ghcr"]) {
+    const url = new URL(LINKS[key]);
+    assert.equal(`${url.origin}${url.pathname}`, EXTERNAL_URLS[key]);
+    assert.equal(url.searchParams.get("utm_source"), "lurkloot_website");
+    assert.equal(url.searchParams.get("utm_medium"), "referral");
+    assert.equal(url.searchParams.get("utm_campaign"), "open_source");
+  }
+  assert.equal(new URL(LINKS.cli).hash, "#readme");
+  assert.match(LINKS.cli, /\?[^#]+#readme$/);
+});
+```
+
+Add this script to `packages/site/package.json`:
+
+```json
+"test": "node --test tests/*.test.mjs"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/site test`
+
+Expected: FAIL because `EXTERNAL_URLS` is not exported and `LINKS` is not attributed.
+
+- [ ] **Step 3: Implement attributed links**
+
+In `packages/site/src/consts.ts`, define canonical destinations and construct anchor URLs:
+
+```ts
+export const EXTERNAL_URLS = {
+  chrome: "https://chromewebstore.google.com/detail/lurkloot/aobaackpofkghaejdnnmpmeaiaoibhdn",
+  github: "https://github.com/jamezrin/lurkloot",
+  cli: "https://github.com/jamezrin/lurkloot/tree/main/packages/cli",
+  ghcr: "https://github.com/jamezrin/lurkloot/pkgs/container/lurkloot-cli",
+} as const;
+
+function withCampaign(url: string, campaign: "extension_install" | "open_source"): string {
+  const attributed = new URL(url);
+  attributed.searchParams.set("utm_source", "lurkloot_website");
+  attributed.searchParams.set("utm_medium", "referral");
+  attributed.searchParams.set("utm_campaign", campaign);
+  return attributed.href;
+}
+
+export const LINKS = {
+  chrome: withCampaign(EXTERNAL_URLS.chrome, "extension_install"),
+  privacy: "/privacy",
+  changelog: "/changelog",
+  x: "https://x.com/jamezrin",
+  github: withCampaign(EXTERNAL_URLS.github, "open_source"),
+  cli: withCampaign(`${EXTERNAL_URLS.cli}#readme`, "open_source"),
+  ghcr: withCampaign(EXTERNAL_URLS.ghcr, "open_source"),
+} as const;
+```
+
+- [ ] **Step 4: Run focused tests and typecheck**
+
+Run: `pnpm --filter @lurkloot/site test && pnpm --filter @lurkloot/site typecheck`
+
+Expected: all link tests pass and Astro reports no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/site/package.json packages/site/src/consts.ts packages/site/tests/consts.test.mjs
+git commit -m "feat(site): attribute outbound store and GitHub links"
+```
+
+### Task 2: Preserve canonical structured metadata
+
+**Files:**
+- Modify: `packages/site/src/layouts/Base.astro`
+- Test: `packages/site/tests/consts.test.mjs`
+
+**Interfaces:**
+- Consumes: `EXTERNAL_URLS.chrome` from Task 1.
+- Produces: Schema.org `SoftwareApplication.downloadUrl` with no UTM parameters while visible anchors continue using `LINKS`.
+
+- [ ] **Step 1: Add a generated-output assertion that initially fails**
+
+Extend the test file to read the production homepage and verify the canonical structured-data destination:
+
+```js
+import { readFile } from "node:fs/promises";
+
+test("keeps the structured download URL canonical", async () => {
+  const html = await readFile(new URL("../dist/index.html", import.meta.url), "utf8");
+  const match = html.match(/<script type="application\/ld\+json">([^<]+)<\/script>/);
+  assert.ok(match);
+  const software = JSON.parse(match[1]);
+  assert.equal(software.downloadUrl, EXTERNAL_URLS.chrome);
+});
+```
+
+- [ ] **Step 2: Build and run the test to verify the metadata assertion fails**
+
+Run: `pnpm --filter @lurkloot/site build && pnpm --filter @lurkloot/site test`
+
+Expected: FAIL because `downloadUrl` still uses attributed `LINKS.chrome`.
+
+- [ ] **Step 3: Point structured data at the canonical destination**
+
+Update `packages/site/src/layouts/Base.astro`:
+
+```astro
+import { SITE, LINKS, EXTERNAL_URLS } from "../consts";
+```
+
+and:
+
+```ts
+downloadUrl: EXTERNAL_URLS.chrome,
+```
+
+- [ ] **Step 4: Verify tests, generated anchors, and the production build**
+
+Run: `pnpm --filter @lurkloot/site build && pnpm --filter @lurkloot/site test && rg -o 'https://(chromewebstore\.google\.com|github\.com)[^"< ]+' packages/site/dist -g '*.html'`
+
+Expected: tests pass; visible links include the specified UTM parameters; JSON-LD contains the canonical Chrome URL; the CLI URL places its query before `#readme`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/site/src/layouts/Base.astro packages/site/tests/consts.test.mjs
+git commit -m "test(site): verify canonical structured metadata"
+```
+
+### Task 3: Full verification and PR preparation
+
+**Files:**
+- Modify only if verification exposes an in-scope problem.
+
+**Interfaces:**
+- Consumes: Completed attributed URL catalog and canonical metadata behavior.
+- Produces: A verified branch ready for review.
+
+- [ ] **Step 1: Run repository verification**
+
+Run: `pnpm check`
+
+Expected: script tests, workspace typechecks, extension tests, and Astro build all pass.
+
+- [ ] **Step 2: Inspect branch scope**
+
+Run: `git status --short && git diff --check origin/main...HEAD && git diff --stat origin/main...HEAD`
+
+Expected: clean status, no whitespace errors, and only the spec, plan, site constants, site layout, site test, and site package manifest are changed.
+
+- [ ] **Step 3: Push and open a draft PR**
+
+Push `feat/website-link-attribution` and open a draft PR titled `feat(site): attribute outbound store and GitHub links` with the implementation summary and exact verification commands.

--- a/docs/superpowers/plans/2026-07-14-website-link-attribution.md
+++ b/docs/superpowers/plans/2026-07-14-website-link-attribution.md
@@ -61,7 +61,7 @@ test("attributes every GitHub-owned website destination", () => {
 Add this script to `packages/site/package.json`:
 
 ```json
-"test": "node --test tests/*.test.mjs"
+"test": "astro build && node --test tests/*.test.mjs"
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
@@ -142,7 +142,7 @@ test("keeps the structured download URL canonical", async () => {
 
 - [ ] **Step 2: Build and run the test to verify the metadata assertion fails**
 
-Run: `pnpm --filter @lurkloot/site build && pnpm --filter @lurkloot/site test`
+Run: `pnpm --filter @lurkloot/site test`
 
 Expected: FAIL because `downloadUrl` still uses attributed `LINKS.chrome`.
 
@@ -162,7 +162,7 @@ downloadUrl: EXTERNAL_URLS.chrome,
 
 - [ ] **Step 4: Verify tests, generated anchors, and the production build**
 
-Run: `pnpm --filter @lurkloot/site build && pnpm --filter @lurkloot/site test && rg -o 'https://(chromewebstore\.google\.com|github\.com)[^"< ]+' packages/site/dist -g '*.html'`
+Run: `pnpm --filter @lurkloot/site test && rg -o 'https://(chromewebstore\.google\.com|github\.com)[^"< ]+' packages/site/dist -g '*.html'`
 
 Expected: tests pass; visible links include the specified UTM parameters; JSON-LD contains the canonical Chrome URL; the CLI URL places its query before `#readme`.
 

--- a/docs/superpowers/plans/2026-07-14-website-link-attribution.md
+++ b/docs/superpowers/plans/2026-07-14-website-link-attribution.md
@@ -101,11 +101,11 @@ export const LINKS = {
 } as const;
 ```
 
-- [ ] **Step 4: Run focused tests and typecheck**
+- [ ] **Step 4: Run focused tests**
 
-Run: `pnpm --filter @lurkloot/site test && pnpm --filter @lurkloot/site typecheck`
+Run: `pnpm --filter @lurkloot/site test`
 
-Expected: all link tests pass and Astro reports no type errors.
+Expected: all link tests pass. The site has no standalone typecheck script; Task 2 and `pnpm check` validate it through the supported Astro production build.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-07-14-website-link-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-14-website-link-attribution-design.md
@@ -1,0 +1,35 @@
+# Website Link Attribution Design
+
+## Goal
+
+Identify visits that leave the Lurkloot marketing website for the Chrome Web Store or GitHub-owned project pages without adding client-side analytics to the website.
+
+## Design
+
+Visible outbound links rendered by the website will carry standard UTM query parameters. Chrome Web Store links will use:
+
+- `utm_source=lurkloot_website`
+- `utm_medium=referral`
+- `utm_campaign=extension_install`
+
+Links to the GitHub repository, CLI documentation, and GHCR package will use:
+
+- `utm_source=lurkloot_website`
+- `utm_medium=referral`
+- `utm_campaign=open_source`
+
+The website link catalog in `packages/site/src/consts.ts` remains the single source of truth. A small URL helper will append parameters safely so GitHub CLI documentation links retain the `#readme` fragment after the query string.
+
+Canonical destinations used as structured metadata, including the Schema.org `downloadUrl`, will remain untagged. Website anchors will use attributed variants. Links in the extension popup, repository README, and other non-website surfaces are out of scope because they do not represent website referrals.
+
+## Measurement Boundaries
+
+Chrome Web Store forwards `utm_source`, `utm_medium`, and `utm_campaign` to its analytics and associates them with listing and install events. GitHub does not expose UTM campaign dimensions in repository traffic analytics; its Insights view reports the referring website. The GitHub parameters provide consistent attribution labels but do not add new GitHub-side reporting.
+
+No Google Tag Manager or other client-side analytics script will be introduced. This avoids expanding website data collection or requiring related privacy-policy changes.
+
+## Verification
+
+- Add focused tests for URL construction, including fragment ordering and preservation of canonical URLs.
+- Run the site typecheck and production build.
+- Inspect generated HTML to confirm attributed anchor URLs and an untagged structured-data `downloadUrl`.

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -7,6 +7,7 @@
   "description": "Marketing landing page for the Lurkloot browser extension.",
   "scripts": {
     "dev": "astro dev",
+    "test": "node --test tests/*.test.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -7,7 +7,7 @@
   "description": "Marketing landing page for the Lurkloot browser extension.",
   "scripts": {
     "dev": "astro dev",
-    "test": "node --test tests/*.test.mjs",
+    "test": "astro build && node --test tests/*.test.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/packages/site/src/consts.ts
+++ b/packages/site/src/consts.ts
@@ -33,15 +33,30 @@ export const SITE = {
 // unified release workflow. Used verbatim in the CLI section's snippet.
 export const DOCKER_IMAGE = "ghcr.io/jamezrin/lurkloot-cli:latest";
 
-export const LINKS = {
+export const EXTERNAL_URLS = {
   chrome:
     "https://chromewebstore.google.com/detail/lurkloot/aobaackpofkghaejdnnmpmeaiaoibhdn",
+  github: "https://github.com/jamezrin/lurkloot",
+  cli: "https://github.com/jamezrin/lurkloot/tree/main/packages/cli",
+  ghcr: "https://github.com/jamezrin/lurkloot/pkgs/container/lurkloot-cli",
+} as const;
+
+function withCampaign(url: string, campaign: "extension_install" | "open_source"): string {
+  const attributed = new URL(url);
+  attributed.searchParams.set("utm_source", "lurkloot_website");
+  attributed.searchParams.set("utm_medium", "referral");
+  attributed.searchParams.set("utm_campaign", campaign);
+  return attributed.href;
+}
+
+export const LINKS = {
+  chrome: withCampaign(EXTERNAL_URLS.chrome, "extension_install"),
   // On-site page (rendered from the same source policy).
   privacy: "/privacy",
   changelog: "/changelog",
   x: "https://x.com/jamezrin",
   // The open-source repo (not the profile) — surfaced across hero/CLI/footer.
-  github: "https://github.com/jamezrin/lurkloot",
-  cli: "https://github.com/jamezrin/lurkloot/tree/main/packages/cli#readme",
-  ghcr: "https://github.com/jamezrin/lurkloot/pkgs/container/lurkloot-cli",
+  github: withCampaign(EXTERNAL_URLS.github, "open_source"),
+  cli: withCampaign(`${EXTERNAL_URLS.cli}#readme`, "open_source"),
+  ghcr: withCampaign(EXTERNAL_URLS.ghcr, "open_source"),
 } as const;

--- a/packages/site/src/layouts/Base.astro
+++ b/packages/site/src/layouts/Base.astro
@@ -1,6 +1,6 @@
 ---
 import "../styles/global.css";
-import { SITE, LINKS } from "../consts";
+import { EXTERNAL_URLS, SITE } from "../consts";
 import { faqItems } from "../faq";
 
 interface Props {
@@ -27,7 +27,7 @@ const softwareLd = {
   operatingSystem: "Chrome, Edge, Brave, Opera, Vivaldi, and other Chromium browsers",
   description: SITE.description,
   url: SITE.url,
-  downloadUrl: LINKS.chrome,
+  downloadUrl: EXTERNAL_URLS.chrome,
   softwareVersion: "1.0",
   offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
   author: { "@type": "Person", name: "jamezrin" },

--- a/packages/site/tests/consts.test.mjs
+++ b/packages/site/tests/consts.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { EXTERNAL_URLS, LINKS } from "../src/consts.ts";
+
+test("attributes Chrome Web Store website referrals", () => {
+  const url = new URL(LINKS.chrome);
+
+  assert.equal(url.origin + url.pathname, EXTERNAL_URLS.chrome);
+  assert.deepEqual(Object.fromEntries(url.searchParams), {
+    utm_source: "lurkloot_website",
+    utm_medium: "referral",
+    utm_campaign: "extension_install",
+  });
+});
+
+test("attributes every GitHub-owned website destination", () => {
+  for (const key of ["github", "cli", "ghcr"]) {
+    const url = new URL(LINKS[key]);
+
+    assert.equal(`${url.origin}${url.pathname}`, EXTERNAL_URLS[key]);
+    assert.equal(url.searchParams.get("utm_source"), "lurkloot_website");
+    assert.equal(url.searchParams.get("utm_medium"), "referral");
+    assert.equal(url.searchParams.get("utm_campaign"), "open_source");
+  }
+
+  assert.equal(new URL(LINKS.cli).hash, "#readme");
+  assert.match(LINKS.cli, /\?[^#]+#readme$/);
+});

--- a/packages/site/tests/consts.test.mjs
+++ b/packages/site/tests/consts.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { EXTERNAL_URLS, LINKS } from "../src/consts.ts";
 
@@ -25,4 +26,13 @@ test("attributes every GitHub-owned website destination", () => {
 
   assert.equal(new URL(LINKS.cli).hash, "#readme");
   assert.match(LINKS.cli, /\?[^#]+#readme$/);
+});
+
+test("keeps the structured download URL canonical", async () => {
+  const html = await readFile(new URL("../dist/index.html", import.meta.url), "utf8");
+  const match = html.match(/<script type="application\/ld\+json">([^<]+)<\/script>/);
+
+  assert.ok(match);
+  const software = JSON.parse(match[1]);
+  assert.equal(software.downloadUrl, EXTERNAL_URLS.chrome);
 });


### PR DESCRIPTION
## Summary

- add UTM attribution to website links targeting the Chrome Web Store
- add matching attribution to repository, CLI documentation, and GHCR links
- keep structured-data destinations canonical and untagged
- add self-contained site tests for campaign parameters and URL fragment ordering

## Why

This makes Chrome Web Store listing visits and installs attributable to the Lurkloot website while keeping the site free of client-side analytics. GitHub continues to expose the website through repository referrer insights, with consistent UTM labels on outbound URLs.

## Testing

- `pnpm --filter @lurkloot/site test`
- `pnpm check`
- generated HTML inspection for Chrome Web Store, GitHub, and CLI fragment URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added referral attribution to outbound Chrome Web Store and GitHub links.
  * Preserved canonical destinations in structured metadata for search engines.
  * Retained existing link fragments and navigation behavior.

* **Tests**
  * Added coverage verifying attributed URLs and canonical structured-data links.
  * Added a site build and test command for validation.

* **Documentation**
  * Added design and implementation documentation for website link attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->