### PR TITLE
fix(popup): show selected category artwork

### DIFF
--- a/docs/superpowers/plans/2026-07-14-category-selection-icons.md
+++ b/docs/superpowers/plans/2026-07-14-category-selection-icons.md
@@ -63,6 +63,19 @@ describe("popup category icons", () => {
       }),
     ]);
   });
+
+  it("keeps the synthetic no-category suggestion on the initials fallback", () => {
+    const campaign: DropCampaign = {
+      id: "uncategorized-drops",
+      platform: "kick",
+      name: "Event Drops",
+      gameImageUrl: "https://art.example/unused.jpg",
+      status: "active",
+      rewards: [],
+    };
+
+    expect(gameItemsFromCampaigns([campaign], t)[0]).not.toHaveProperty("imageUrl");
+  });
 });
 ```
 
@@ -127,7 +140,7 @@ Run:
 pnpm --filter @lurkloot/extension exec vitest run tests/popupCategoryIcons.test.ts
 ```
 
-Expected: PASS with 1 test passing.
+Expected: PASS with 2 tests passing.
 
 - [ ] **Step 5: Run the popup UI typecheck**
 
@@ -290,7 +303,7 @@ Run:
 pnpm --filter @lurkloot/extension exec vitest run tests/popupCategoryIcons.test.ts
 ```
 
-Expected: PASS with 3 tests passing and no warnings.
+Expected: PASS with 4 tests passing and no warnings.
 
 - [ ] **Step 6: Run the full extension tests and popup UI typecheck**
 

--- a/docs/superpowers/plans/2026-07-14-category-selection-icons.md
+++ b/docs/superpowers/plans/2026-07-14-category-selection-icons.md
@@ -1,0 +1,391 @@
+# Category Selection Icons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show available Twitch and Kick category artwork in selected-category rows and drag overlays while retaining initials for missing or failed images.
+
+**Architecture:** Preserve artwork on the existing `GameItem` to `CategorySelection` data path, then add an optional image input to the shared `CompactRow` primitive. Category settings opt into the image input; watch-queue consumers remain unchanged and the existing `ImageWithFallback` component owns error fallback behavior.
+
+**Tech Stack:** TypeScript, React 19, WXT, Vitest, React DOM server rendering, pnpm
+
+## Global Constraints
+
+- Render category artwork as a 32px rounded-square, cover-fitted thumbnail.
+- Fall back to the existing initials avatar when artwork is absent or fails to load.
+- Apply the same artwork to the selected row and its drag overlay.
+- Preserve existing watch-queue rendering and category filtering behavior.
+- Add no dependencies, permissions, storage migrations, or platform requests.
+- Follow strict TypeScript, ES modules, two-space indentation, double quotes, and semicolons.
+
+---
+
+### Task 1: Preserve active-drop category artwork
+
+**Files:**
+- Create: `packages/extension/tests/popupCategoryIcons.test.ts`
+- Modify: `packages/popup-ui/src/types.ts:5`
+- Modify: `packages/popup-ui/src/viewModels.ts:63-77`
+- Modify: `packages/popup-ui/src/settingsPlatform.tsx:257-266`
+
+**Interfaces:**
+- Consumes: `DropCampaign.gameImageUrl?: string` from `@lurkloot/shared/models`.
+- Produces: `GameItem.imageUrl?: string`, passed into `CategorySelection.imageUrl?: string` when an active-drop suggestion is selected.
+
+- [ ] **Step 1: Write the failing artwork-propagation test**
+
+Create `packages/extension/tests/popupCategoryIcons.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { DropCampaign } from "@lurkloot/shared/models";
+import { gameItemsFromCampaigns } from "../../popup-ui/src/viewModels";
+
+const t = (key: string): string => key;
+
+describe("popup category icons", () => {
+  it("preserves campaign category artwork in active-drop suggestions", () => {
+    const campaign: DropCampaign = {
+      id: "fortnite-drops",
+      platform: "twitch",
+      name: "Fortnite Drops",
+      categoryId: "33214",
+      gameName: "Fortnite",
+      gameImageUrl: "https://art.example/fortnite.jpg",
+      status: "active",
+      rewards: [],
+    };
+
+    expect(gameItemsFromCampaigns([campaign], t)).toEqual([
+      expect.objectContaining({
+        id: "33214",
+        name: "Fortnite",
+        imageUrl: "https://art.example/fortnite.jpg",
+      }),
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/popupCategoryIcons.test.ts
+```
+
+Expected: FAIL because the received `GameItem` has no `imageUrl` property.
+
+- [ ] **Step 3: Add the minimal artwork data path**
+
+Change `GameItem` in `packages/popup-ui/src/types.ts` to:
+
+```ts
+export type GameItem = {
+  id: string;
+  name: string;
+  short: string;
+  accent: string;
+  imageUrl?: string;
+};
+```
+
+In the non-synthetic branch of `gameItemsFromCampaigns` in
+`packages/popup-ui/src/viewModels.ts`, retain the campaign artwork:
+
+```ts
+      : {
+        id,
+        name: campaign.gameName ?? t("unknownGame"),
+        short: initials(campaign.gameName ?? campaign.name),
+        accent: GAME_ACCENTS[index % GAME_ACCENTS.length],
+        imageUrl: campaign.gameImageUrl,
+      });
+```
+
+In the active-drop suggestions map in
+`packages/popup-ui/src/settingsPlatform.tsx`, display and preserve the image:
+
+```tsx
+<CategoryAddChip
+  key={suggestion.id}
+  name={suggestion.name}
+  imageUrl={suggestion.imageUrl}
+  onClick={() => addCategory({
+    id: suggestion.id,
+    name: suggestion.name,
+    ...(suggestion.imageUrl ? { imageUrl: suggestion.imageUrl } : {}),
+  })}
+/>
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/popupCategoryIcons.test.ts
+```
+
+Expected: PASS with 1 test passing.
+
+- [ ] **Step 5: Run the popup UI typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/popup-ui typecheck
+```
+
+Expected: exit 0 with no TypeScript errors.
+
+- [ ] **Step 6: Commit the data-path change**
+
+```bash
+git add packages/extension/tests/popupCategoryIcons.test.ts packages/popup-ui/src/types.ts packages/popup-ui/src/viewModels.ts packages/popup-ui/src/settingsPlatform.tsx
+git commit -m "fix(popup): preserve category artwork"
+```
+
+---
+
+### Task 2: Render selected-category artwork with fallback
+
+**Files:**
+- Modify: `packages/extension/tests/popupCategoryIcons.test.ts`
+- Modify: `packages/popup-ui/src/primitives.tsx:121-139`
+- Modify: `packages/popup-ui/src/settingsPlatform.tsx:249-254,306-312`
+
+**Interfaces:**
+- Consumes: `CompactRow.avatarImageUrl?: string` alongside the existing `avatar` fallback string.
+- Produces: a fixed-size rounded-square image when a URL exists; otherwise `ImageWithFallback` renders `avatar` inside the same row position.
+
+- [ ] **Step 1: Write the failing selected-row rendering test**
+
+Extend `packages/extension/tests/popupCategoryIcons.test.ts` with these imports:
+
+```ts
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { mergeSettings } from "@lurkloot/shared/settings";
+import { PlatformSettingsGroup } from "../../popup-ui/src/settingsPlatform";
+```
+
+Add this helper and tests inside the existing `describe` block:
+
+```ts
+  function renderSelectedCategory(imageUrl?: string): string {
+    const settings = mergeSettings(undefined);
+    settings.platform.twitch.farmAllCategories = false;
+    settings.platform.twitch.categories = [{
+      id: "33214",
+      name: "Fort Night",
+      ...(imageUrl ? { imageUrl } : {}),
+    }];
+
+    return renderToStaticMarkup(createElement(PlatformSettingsGroup, {
+      platform: "twitch",
+      suggestions: [],
+      settings,
+      onFarmAllCategoriesChange: () => {},
+      onCategoriesChange: () => {},
+      onSearchCategories: async () => [],
+      onExcludedChannelsChange: () => {},
+    }));
+  }
+
+  it("renders selected category artwork as a rounded-square image", () => {
+    const markup = renderSelectedCategory("https://art.example/fortnite.jpg");
+
+    expect(markup).toContain('src="https://art.example/fortnite.jpg"');
+    expect(markup).toContain("h-8 w-8");
+    expect(markup).toContain("rounded-lg");
+  });
+
+  it("keeps initials when selected category artwork is absent", () => {
+    const markup = renderSelectedCategory();
+
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain(">FN</span>");
+  });
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/popupCategoryIcons.test.ts
+```
+
+Expected: the artwork rendering test FAILS because the selected row contains no
+`<img>`; the propagation and no-artwork fallback tests PASS.
+
+- [ ] **Step 3: Add image rendering to `CompactRow`**
+
+Replace the single-line `CompactRow` props declaration in
+`packages/popup-ui/src/primitives.tsx` with:
+
+```tsx
+export function CompactRow({
+  avatar,
+  avatarImageUrl,
+  avatarStyle,
+  index,
+  title,
+  titleHref,
+  subtitle,
+  trailing,
+  dragHandle,
+  isOverlay = false,
+  dimmed = false,
+}: {
+  avatar: string;
+  avatarImageUrl?: string;
+  avatarStyle: React.CSSProperties;
+  index: number;
+  title: string;
+  titleHref?: string;
+  subtitle?: string;
+  trailing: React.ReactNode;
+  dragHandle: React.ReactNode;
+  isOverlay?: boolean;
+  dimmed?: boolean;
+}) {
+```
+
+Replace its avatar span with:
+
+```tsx
+<span
+  className={cn(
+    "flex h-8 w-8 shrink-0 items-center justify-center text-[11px] font-bold",
+    avatarImageUrl ? "overflow-hidden rounded-lg" : "rounded-full",
+  )}
+  style={avatarStyle}
+>
+  <ImageWithFallback
+    src={avatarImageUrl}
+    alt=""
+    fit="cover"
+    fallback={avatar}
+  />
+</span>
+```
+
+`ImageWithFallback` already switches to `fallback` after `onError`, so failed
+remote artwork preserves the same 32px row footprint without new error logic.
+
+- [ ] **Step 4: Wire both category row forms to `avatarImageUrl`**
+
+In `packages/popup-ui/src/settingsPlatform.tsx`, add
+`avatarImageUrl={active.imageUrl}` to the drag-overlay `CompactRow`, and add
+`avatarImageUrl={category.imageUrl}` to the sortable-row `CompactRow`. Do not
+change either watch-queue call site.
+
+- [ ] **Step 5: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/popupCategoryIcons.test.ts
+```
+
+Expected: PASS with 3 tests passing and no warnings.
+
+- [ ] **Step 6: Run the full extension tests and popup UI typecheck**
+
+Run:
+
+```bash
+pnpm test
+pnpm --filter @lurkloot/popup-ui typecheck
+```
+
+Expected: all extension tests pass and the popup UI typecheck exits 0.
+
+- [ ] **Step 7: Commit the rendering change**
+
+```bash
+git add packages/extension/tests/popupCategoryIcons.test.ts packages/popup-ui/src/primitives.tsx packages/popup-ui/src/settingsPlatform.tsx
+git commit -m "fix(popup): show selected category artwork"
+```
+
+---
+
+### Task 3: Verify and prepare the pull request
+
+**Files:**
+- Review: `docs/superpowers/specs/2026-07-14-category-selection-icons-design.md`
+- Review: `docs/superpowers/plans/2026-07-14-category-selection-icons.md`
+- Review: all files changed since `origin/main`
+
+**Interfaces:**
+- Consumes: the completed data-path and rendering commits from Tasks 1 and 2.
+- Produces: verified PR-ready commits satisfying issue #91 and the approved design.
+
+- [ ] **Step 1: Inspect the complete diff and repository state**
+
+Run:
+
+```bash
+git status --short
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+```
+
+Expected: no unstaged implementation changes, no whitespace errors, and only the
+approved design, plan, tests, and popup UI changes are present.
+
+- [ ] **Step 2: Run fresh full verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, all workspace typechecks, extension tests, Astro site
+build, and Chromium and Firefox extension builds all exit 0.
+
+- [ ] **Step 3: Request code review and address findings**
+
+Request review of `origin/main...HEAD` against the approved design and issue #91.
+Fix all Critical and Important findings using a new red-green test cycle, rerun
+`pnpm verify`, and commit any required corrections with a focused Conventional
+Commit subject.
+
+- [ ] **Step 4: Confirm GitHub publishing prerequisites**
+
+Run:
+
+```bash
+gh --version
+gh auth status
+git status -sb
+```
+
+Expected: GitHub CLI is installed and authenticated, and the branch is clean.
+
+- [ ] **Step 5: Push the repository-convention branch**
+
+Run:
+
+```bash
+git push -u origin fix/category-selection-icons
+```
+
+Expected: the remote branch is created and tracks `origin/fix/category-selection-icons`.
+
+- [ ] **Step 6: Open a draft PR**
+
+Create a draft PR targeting `main` with Conventional Commit title:
+
+```text
+fix(popup): show selected category artwork
+```
+
+The PR body must summarize the two artwork data paths, explain that selected
+rows previously ignored or discarded `imageUrl`, list `pnpm verify` under
+testing, link `Closes #91`, and note that missing or failed images retain the
+initials fallback.

--- a/docs/superpowers/specs/2026-07-14-category-selection-icons-design.md
+++ b/docs/superpowers/specs/2026-07-14-category-selection-icons-design.md
@@ -1,0 +1,81 @@
+# Category Selection Icons Design
+
+## Problem
+
+Selected Twitch and Kick categories in the popup settings always render an
+initials placeholder, even when the category has artwork. Platform category
+search already returns `CategorySelection.imageUrl`, and settings normalization
+already preserves it. The selected row and drag overlay ignore that value.
+
+The zero-network "Has active drops" path has a second data-loss point:
+`gameItemsFromCampaigns` omits `DropCampaign.gameImageUrl`, and selecting a
+suggestion saves only its id and name.
+
+## Scope
+
+Fix issue #91 for both Twitch and Kick category settings. Selected categories
+with artwork render a 32px rounded-square thumbnail in the normal sortable row
+and its drag overlay. Categories without artwork, categories whose image fails
+to load, and the synthetic "No category" selection retain the initials fallback.
+
+This change does not alter farming eligibility, category ordering, platform
+requests, permissions, storage format, or watch-queue row behavior. It adds no
+dependencies.
+
+## Design
+
+Extend `GameItem` with an optional `imageUrl`. Populate it from
+`DropCampaign.gameImageUrl` in `gameItemsFromCampaigns`, and pass it through when
+a user adds a "Has active drops" suggestion. Search-selected categories already
+carry the same field and need no data-layer change.
+
+Extend `CompactRow` with an optional `avatarImageUrl`. When present, the avatar
+container uses the existing `ImageWithFallback` primitive to render a
+rounded-square, cover-fitted image. The fallback is the existing styled initials
+avatar. When absent, rendering remains identical to today. Only category rows
+and their drag overlay pass the new prop, so watch-queue consumers remain
+unchanged.
+
+The image should use an empty alternative description because the adjacent row
+title already names the category. A failed remote image switches to initials
+without changing row size or layout.
+
+## Data Flow
+
+For category search:
+
+1. The platform adapter returns `{ id, name, imageUrl }`.
+2. The popup saves the full `CategorySelection`.
+3. Settings normalization preserves `imageUrl`.
+4. The selected row and drag overlay pass it to `CompactRow`.
+5. `ImageWithFallback` displays the thumbnail or initials fallback.
+
+For active-drop suggestions:
+
+1. A campaign provides `gameImageUrl`.
+2. `gameItemsFromCampaigns` maps it to `GameItem.imageUrl`.
+3. Selecting the suggestion saves `{ id, name, imageUrl }`.
+4. Rendering follows the same selected-row path as search results.
+
+## Testing
+
+Add deterministic Vitest coverage for the two regression boundaries:
+
+- `gameItemsFromCampaigns` retains campaign category artwork and leaves the
+  synthetic "No category" item without an image.
+- `CompactRow` renders an image when `avatarImageUrl` is present and preserves
+  the initials-only markup when it is absent.
+
+The implementation follows a red-green cycle for each behavior. Final
+verification runs the focused tests, the full extension test suite, workspace
+typechecks, and the site build through `pnpm check`.
+
+## Acceptance Criteria
+
+- Search-selected categories with artwork show a rounded-square thumbnail.
+- Active-drop suggestions preserve and show available campaign artwork after
+  selection.
+- The drag overlay uses the same artwork as the selected row.
+- Missing or failed artwork falls back to initials without layout shift.
+- Twitch and Kick follow the same UI path.
+- Existing watch-queue avatars and category filtering behavior are unchanged.

--- a/packages/extension/tests/popupCategoryIcons.test.ts
+++ b/packages/extension/tests/popupCategoryIcons.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { DropCampaign } from "@lurkloot/shared/models";
+import { gameItemsFromCampaigns } from "../../popup-ui/src/viewModels";
+
+const t = (key: string): string => key;
+
+describe("popup category icons", () => {
+  it("preserves campaign category artwork in active-drop suggestions", () => {
+    const campaign: DropCampaign = {
+      id: "fortnite-drops",
+      platform: "twitch",
+      name: "Fortnite Drops",
+      categoryId: "33214",
+      gameName: "Fortnite",
+      gameImageUrl: "https://art.example/fortnite.jpg",
+      status: "active",
+      rewards: [],
+    };
+
+    expect(gameItemsFromCampaigns([campaign], t)).toEqual([
+      expect.objectContaining({
+        id: "33214",
+        name: "Fortnite",
+        imageUrl: "https://art.example/fortnite.jpg",
+      }),
+    ]);
+  });
+
+  it("keeps the synthetic no-category suggestion on the initials fallback", () => {
+    const campaign: DropCampaign = {
+      id: "uncategorized-drops",
+      platform: "kick",
+      name: "Event Drops",
+      gameImageUrl: "https://art.example/unused.jpg",
+      status: "active",
+      rewards: [],
+    };
+
+    expect(gameItemsFromCampaigns([campaign], t)[0]).not.toHaveProperty("imageUrl");
+  });
+});

--- a/packages/extension/tests/popupCategoryIcons.test.ts
+++ b/packages/extension/tests/popupCategoryIcons.test.ts
@@ -1,10 +1,49 @@
 import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import type { DropCampaign } from "@lurkloot/shared/models";
+import { mergeSettings } from "@lurkloot/shared/settings";
+import { PlatformSettingsGroup } from "../../popup-ui/src/settingsPlatform";
 import { gameItemsFromCampaigns } from "../../popup-ui/src/viewModels";
 
 const t = (key: string): string => key;
 
 describe("popup category icons", () => {
+  function renderSelectedCategory(imageUrl?: string): string {
+    const settings = mergeSettings(undefined);
+    settings.platform.twitch.farmAllCategories = false;
+    settings.platform.twitch.categories = [{
+      id: "33214",
+      name: "Fort Night",
+      ...(imageUrl ? { imageUrl } : {}),
+    }];
+
+    return renderToStaticMarkup(createElement(PlatformSettingsGroup, {
+      platform: "twitch",
+      suggestions: [],
+      settings,
+      onFarmAllCategoriesChange: () => {},
+      onCategoriesChange: () => {},
+      onSearchCategories: async () => [],
+      onExcludedChannelsChange: () => {},
+    }));
+  }
+
+  it("renders selected category artwork as a rounded-square image", () => {
+    const markup = renderSelectedCategory("https://art.example/fortnite.jpg");
+
+    expect(markup).toContain('src="https://art.example/fortnite.jpg"');
+    expect(markup).toContain("h-8 w-8");
+    expect(markup).toContain("rounded-lg");
+  });
+
+  it("keeps initials when selected category artwork is absent", () => {
+    const markup = renderSelectedCategory();
+
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain(">FN</span>");
+  });
+
   it("preserves campaign category artwork in active-drop suggestions", () => {
     const campaign: DropCampaign = {
       id: "fortnite-drops",

--- a/packages/extension/tests/popupCategoryIcons.test.ts
+++ b/packages/extension/tests/popupCategoryIcons.test.ts
@@ -65,6 +65,36 @@ describe("popup category icons", () => {
     ]);
   });
 
+  it("fills missing artwork from a later campaign in the same category", () => {
+    const firstCampaign: DropCampaign = {
+      id: "fortnite-drops-first",
+      platform: "twitch",
+      name: "Fortnite Drops First",
+      categoryId: "33214",
+      gameName: "Fortnite First",
+      status: "active",
+      rewards: [],
+    };
+    const laterCampaign: DropCampaign = {
+      id: "fortnite-drops-later",
+      platform: "twitch",
+      name: "Fortnite Drops Later",
+      categoryId: "33214",
+      gameName: "Fortnite Later",
+      gameImageUrl: "https://art.example/fortnite-later.jpg",
+      status: "active",
+      rewards: [],
+    };
+
+    expect(gameItemsFromCampaigns([firstCampaign, laterCampaign], t)).toEqual([
+      expect.objectContaining({
+        id: "33214",
+        name: "Fortnite First",
+        imageUrl: "https://art.example/fortnite-later.jpg",
+      }),
+    ]);
+  });
+
   it("keeps the synthetic no-category suggestion on the initials fallback", () => {
     const campaign: DropCampaign = {
       id: "uncategorized-drops",

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -118,12 +118,49 @@ export function EmptyPanel({ children }: { children: React.ReactNode }) {
   return <div className="grid min-h-24 place-items-center rounded-2xl border border-dashed border-zinc-300 bg-white p-4 text-center text-sm font-semibold text-zinc-400 dark:border-zinc-700 dark:bg-zinc-900">{children}</div>;
 }
 
-export function CompactRow({ avatar, avatarStyle, index, title, titleHref, subtitle, trailing, dragHandle, isOverlay = false, dimmed = false }: { avatar: string; avatarStyle: React.CSSProperties; index: number; title: string; titleHref?: string; subtitle?: string; trailing: React.ReactNode; dragHandle: React.ReactNode; isOverlay?: boolean; dimmed?: boolean }) {
+export function CompactRow({
+  avatar,
+  avatarImageUrl,
+  avatarStyle,
+  index,
+  title,
+  titleHref,
+  subtitle,
+  trailing,
+  dragHandle,
+  isOverlay = false,
+  dimmed = false,
+}: {
+  avatar: string;
+  avatarImageUrl?: string;
+  avatarStyle: React.CSSProperties;
+  index: number;
+  title: string;
+  titleHref?: string;
+  subtitle?: string;
+  trailing: React.ReactNode;
+  dragHandle: React.ReactNode;
+  isOverlay?: boolean;
+  dimmed?: boolean;
+}) {
   return (
     <div className={cn("flex items-center gap-2 rounded-xl border bg-white px-2 py-2 dark:bg-zinc-900", isOverlay ? "border-transparent shadow-2xl shadow-black/25" : "border-zinc-200 shadow-sm dark:border-zinc-800", dimmed && "opacity-40")}>
       {dragHandle}
       <span className="w-4 text-center text-[11px] font-bold tabular" style={{ color: "var(--accent-text)" }}>{index + 1}</span>
-      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[11px] font-bold" style={avatarStyle}>{avatar}</span>
+      <span
+        className={cn(
+          "flex h-8 w-8 shrink-0 items-center justify-center text-[11px] font-bold",
+          avatarImageUrl ? "overflow-hidden rounded-lg" : "rounded-full",
+        )}
+        style={avatarStyle}
+      >
+        <ImageWithFallback
+          src={avatarImageUrl}
+          alt=""
+          fit="cover"
+          fallback={avatar}
+        />
+      </span>
       <span className="flex min-w-0 flex-1 flex-col">
         {titleHref ? (
           <a href={titleHref} target="_blank" rel="noreferrer" className="truncate text-[13px] font-medium leading-tight text-zinc-900 outline-none hover:text-[var(--accent-text)] hover:underline focus-visible:text-[var(--accent-text)] dark:text-zinc-100">{title}</a>

--- a/packages/popup-ui/src/settingsPlatform.tsx
+++ b/packages/popup-ui/src/settingsPlatform.tsx
@@ -250,7 +250,7 @@ function CategoryFilterEditor({ platform, categories, suggestions, onChange, onS
           <SortableContext items={categories.map((category) => category.id)} strategy={verticalListSortingStrategy}>
             <div className="space-y-1.5">{categories.map((category, index) => <SortableCategoryRow key={category.id} category={category} index={index} accent={accentFor(index)} onRemove={() => void onChange(categories.filter((entry) => entry.id !== category.id))} />)}</div>
           </SortableContext>
-          <DragOverlay dropAnimation={null}>{active ? <CompactRow isOverlay index={activeIndex} avatar={initials(active.name)} avatarStyle={{ backgroundColor: accentFor(activeIndex), color: "#fff" }} title={active.name} dragHandle={<GripVertical size={16} className="text-zinc-400" />} trailing={<span className="w-4" />} /> : null}</DragOverlay>
+          <DragOverlay dropAnimation={null}>{active ? <CompactRow isOverlay index={activeIndex} avatar={initials(active.name)} avatarImageUrl={active.imageUrl} avatarStyle={{ backgroundColor: accentFor(activeIndex), color: "#fff" }} title={active.name} dragHandle={<GripVertical size={16} className="text-zinc-400" />} trailing={<span className="w-4" />} /> : null}</DragOverlay>
         </DndContext>
       )}
 
@@ -316,7 +316,7 @@ function SortableCategoryRow({ category, index, accent, onRemove }: { category: 
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: category.id });
   return (
     <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition }}>
-      <CompactRow index={index} avatar={initials(category.name)} avatarStyle={{ backgroundColor: accent, color: "#fff" }} title={category.name} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${category.name}`} />} trailing={<RemoveRowButton label={`Remove ${category.name}`} onClick={onRemove} />} />
+      <CompactRow index={index} avatar={initials(category.name)} avatarImageUrl={category.imageUrl} avatarStyle={{ backgroundColor: accent, color: "#fff" }} title={category.name} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${category.name}`} />} trailing={<RemoveRowButton label={`Remove ${category.name}`} onClick={onRemove} />} />
     </div>
   );
 }

--- a/packages/popup-ui/src/settingsPlatform.tsx
+++ b/packages/popup-ui/src/settingsPlatform.tsx
@@ -259,7 +259,16 @@ function CategoryFilterEditor({ platform, categories, suggestions, onChange, onS
           <div className="text-[10px] font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">{t("hasActiveDrops")}</div>
           <div className="flex flex-wrap gap-1.5">
             {unaddedSuggestions.map((suggestion) => (
-              <CategoryAddChip key={suggestion.id} name={suggestion.name} onClick={() => addCategory({ id: suggestion.id, name: suggestion.name })} />
+              <CategoryAddChip
+                key={suggestion.id}
+                name={suggestion.name}
+                imageUrl={suggestion.imageUrl}
+                onClick={() => addCategory({
+                  id: suggestion.id,
+                  name: suggestion.name,
+                  ...(suggestion.imageUrl ? { imageUrl: suggestion.imageUrl } : {}),
+                })}
+              />
             ))}
           </div>
         </div>

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -2,7 +2,13 @@ import type { CliCredentialBlob, RuntimeMessage } from "@lurkloot/shared/message
 import type { DropCampaign, Platform, SupportedLocale } from "@lurkloot/shared/models";
 
 export type PopupTab = "drops" | "watchQueue";
-export type GameItem = { id: string; name: string; short: string; accent: string };
+export type GameItem = {
+  id: string;
+  name: string;
+  short: string;
+  accent: string;
+  imageUrl?: string;
+};
 export type StreamerItem = { id: string; name: string; live: boolean; subtitle?: string; viewers?: number };
 export type FarmingChannelView = { name: string; category?: string; viewers?: number; url?: string };
 export type ChannelLink = { name: string; url: string };

--- a/packages/popup-ui/src/viewModels.ts
+++ b/packages/popup-ui/src/viewModels.ts
@@ -64,7 +64,13 @@ export function gameItemsFromCampaigns(campaigns: DropCampaign[], t: TFunction):
   const discovered = new Map<string, GameItem>();
   campaigns.forEach((campaign, index) => {
     const id = gameId(campaign);
-    if (discovered.has(id)) return;
+    const existing = discovered.get(id);
+    if (existing) {
+      if (id !== NO_CATEGORY_ID && !existing.imageUrl && campaign.gameImageUrl) {
+        discovered.set(id, { ...existing, imageUrl: campaign.gameImageUrl });
+      }
+      return;
+    }
     discovered.set(id, id === NO_CATEGORY_ID
       ? { id, name: t("noCategory"), short: "–", accent: NO_CATEGORY_ACCENT }
       : {

--- a/packages/popup-ui/src/viewModels.ts
+++ b/packages/popup-ui/src/viewModels.ts
@@ -72,6 +72,7 @@ export function gameItemsFromCampaigns(campaigns: DropCampaign[], t: TFunction):
         name: campaign.gameName ?? t("unknownGame"),
         short: initials(campaign.gameName ?? campaign.name),
         accent: GAME_ACCENTS[index % GAME_ACCENTS.length],
+        imageUrl: campaign.gameImageUrl,
       });
   });
   return [...discovered.values()].sort((left, right) => left.name.localeCompare(right.name));


### PR DESCRIPTION
## Summary

- preserve category artwork returned by Twitch and Kick search when categories are selected
- carry campaign artwork through the zero-network **Has active drops** suggestions
- render selected-category artwork as a 32px rounded-square thumbnail in rows and drag overlays
- retain initials when artwork is absent or fails to load

## Root cause

Selected category rows always rendered `initials(category.name)` even though searched categories already stored `imageUrl`. The active-drop suggestion path also discarded `campaign.gameImageUrl` before saving the category.

## Testing

- `pnpm verify`
- Playwright QA against the built Chromium extension:
  - selected artwork rendered at 32×32 with 8px rounding and `object-fit: cover`
  - drag overlay rendered the same artwork
  - forced image failure fell back to initials
  - no relevant console warnings or framework error overlay

Closes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category selections now show Twitch/Kick artwork in selected rows, drag overlays, and suggestion UI when available.
  * Artwork is rendered with a graceful initials fallback when images are missing or fail to load.
  * Active drop suggestions retain their category artwork.
* **Bug Fixes**
  * Fixed an issue where category selections could incorrectly show initials even when artwork existed.
* **Tests**
  * Added Vitest coverage for artwork rendering, initials fallback behavior, and active-drop suggestion artwork.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->