### PR TITLE
fix(twitch): ignore bogus account links

### DIFF
--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -82,7 +82,7 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
     const slug = campaign.game?.slug;
     const startsAt = campaign.startAt;
     const endsAt = campaign.endAt;
-    const accountLinked = campaign.self?.isAccountConnected ?? campaign.accountLinkURL == null;
+    const accountLinked = campaign.accountLinkURL == null || campaign.self?.isAccountConnected !== false;
     const rawStatus = campaign.status?.toLowerCase();
     const status = startsAt && Date.parse(startsAt) > now
       ? "upcoming"

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -82,7 +82,9 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
     const slug = campaign.game?.slug;
     const startsAt = campaign.startAt;
     const endsAt = campaign.endAt;
-    const accountLinked = campaign.accountLinkURL == null || campaign.self?.isAccountConnected !== false;
+    const accountLinkUrl = normalizeTwitchAccountLinkUrl(campaign.accountLinkURL);
+    const hasAccountLink = Boolean(accountLinkUrl);
+    const accountLinked = !hasAccountLink || campaign.self?.isAccountConnected !== false;
     const rawStatus = campaign.status?.toLowerCase();
     const status = startsAt && Date.parse(startsAt) > now
       ? "upcoming"
@@ -119,7 +121,7 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
       startsAt,
       endsAt,
       accountLinked,
-      accountLinkUrl: campaign.accountLinkURL ?? undefined,
+      accountLinkUrl,
       status: finalStatus,
       url: campaign.detailsURL ?? undefined,
       eligibility: eligibility(finalStatus, accountLinked, watchRewards.length),
@@ -134,6 +136,18 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
       rewards,
     };
   });
+}
+
+function normalizeTwitchAccountLinkUrl(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  try {
+    const hostname = new URL(trimmed).hostname.toLowerCase().replace(/^www\./, "");
+    if (hostname === "twitch.tv" || hostname.endsWith(".twitch.tv")) return undefined;
+  } catch {
+    // Preserve non-URL values for compatibility; Twitch normally returns an absolute URL.
+  }
+  return trimmed;
 }
 
 function parseTwitchReward(

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -379,6 +379,34 @@ describe("Twitch parsers", () => {
     expect(campaigns[0].eligibility).toBe("account_not_linked");
   });
 
+  it("treats a URL-less disconnected Twitch campaign as linked", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "url-less-ewc-like",
+      self: { isAccountConnected: false },
+      timeBasedDrops: [{ id: "drop", requiredMinutesWatched: 60 }],
+    }]);
+
+    expect(campaigns[0]).toMatchObject({
+      accountLinked: true,
+      eligibility: "eligible",
+    });
+  });
+
+  it("keeps a genuine disconnected Twitch campaign unlinked when it provides a link URL", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "genuine-unlinked",
+      self: { isAccountConnected: false },
+      accountLinkURL: "https://example.test/connect",
+      timeBasedDrops: [{ id: "drop", requiredMinutesWatched: 60 }],
+    }]);
+
+    expect(campaigns[0]).toMatchObject({
+      accountLinked: false,
+      accountLinkUrl: "https://example.test/connect",
+      eligibility: "account_not_linked",
+    });
+  });
+
   it("does not unlock a watch reward whose paid prerequisite was excluded", () => {
     const campaigns = parseTwitchInventory([{
       id: "paid-prerequisite-campaign",

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -369,6 +369,7 @@ describe("Twitch parsers", () => {
     const campaigns = parseTwitchInventory([{
       id: "unlinked-native",
       self: { isAccountConnected: false },
+      accountLinkURL: "https://example.test/connect",
       timeBasedDrops: [{
         id: "badge",
         requiredMinutesWatched: 30,

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -393,6 +393,35 @@ describe("Twitch parsers", () => {
     });
   });
 
+  it("treats an empty-link disconnected Twitch campaign as linked", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "empty-link-ewc-like",
+      self: { isAccountConnected: false },
+      accountLinkURL: "",
+      timeBasedDrops: [{ id: "drop", requiredMinutesWatched: 60 }],
+    }]);
+
+    expect(campaigns[0]).toMatchObject({
+      accountLinked: true,
+      eligibility: "eligible",
+    });
+  });
+
+  it("ignores Twitch-hosted account links for disconnected Twitch campaigns", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "twitch-link-ewc-like",
+      self: { isAccountConnected: false },
+      accountLinkURL: "https://www.twitch.tv/drops/inventory",
+      timeBasedDrops: [{ id: "drop", requiredMinutesWatched: 60 }],
+    }]);
+
+    expect(campaigns[0]).toMatchObject({
+      accountLinked: true,
+      accountLinkUrl: undefined,
+      eligibility: "eligible",
+    });
+  });
+
   it("keeps a genuine disconnected Twitch campaign unlinked when it provides a link URL", () => {
     const campaigns = parseTwitchInventory([{
       id: "genuine-unlinked",


### PR DESCRIPTION
## Summary

- Treat Twitch campaigns without a meaningful account-link URL as linked.
- Ignore empty URLs and Twitch-hosted URLs such as `https://www.twitch.tv/`.
- Preserve genuine external publisher account links and add regression coverage.

## Root cause

Twitch returned `isAccountConnected: false` together with a Twitch homepage URL for EWC 2026. Lurkloot interpreted that URL as a real publisher account-link flow, which produced the misleading “Not linked” badge and link action.

## Validation

- `pnpm test` — passed (65 CLI, 378 extension, 3 site tests)
- `pnpm typecheck` — passed
- `pnpm build` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account-link detection for Twitch campaigns.
  * Twitch-hosted, missing, or empty account links are now handled correctly.
  * External account links are preserved and accurately reflected in campaign eligibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->