### PR TITLE
feat(twitch): support subscription-required drops

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -113,7 +113,9 @@ Env-var overrides (useful for Docker secrets) take precedence over the store:
 - `validate-config` — load + normalize the config; print the effective settings.
 - `discover` — one discovery pass per enabled platform.
 - `run` — full farming loop (discovery + watch heartbeats) until SIGINT/SIGTERM,
-  persisting `state.json`. `--once` runs a single tick.
+  persisting `state.json`. `pnpm cli run --once` is the explicit refresh command:
+  it discovers campaigns, refreshes authoritative progress, claims eligible
+  rewards, persists state, and exits.
 - `auth import <file>` — import an extension credential export ("-" = stdin).
 - `auth twitch device-login` — Twitch device-code OAuth (no browser).
 - `auth kick device-login` — Kick smart-TV link flow (no browser).
@@ -138,6 +140,15 @@ go to stderr and are filtered only by `--log`; `state.json` contains scheduler
 state, never new event history. Use Docker logs, systemd/journald, Loki, or
 another external collector when retention is needed. Loading and saving an old
 state file also removes any legacy embedded `events` field.
+
+Subscription requirements are reported separately from watch progress. The CLI
+never tries to satisfy them by opening or farming a stream, and it reports
+partial subscription progress as unavailable when Twitch does not provide an
+authoritative count rather than inventing `0/N`. During the normal loop, a
+waiting requirement is logged only when it first appears; once Twitch confirms
+the reward, the next poll detects and claims it, with the existing reward-claimed
+engine event providing the notification. Run `pnpm cli run --once` whenever an
+immediate non-interactive refresh is needed.
 
 ## Docker
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,12 +2,13 @@
 import { dirname, join, resolve } from "node:path";
 import yargs, { type Argv, type ArgumentsCamelCase, type CommandModule } from "yargs";
 import { hideBin } from "yargs/helpers";
-import type { Platform } from "@lurkloot/shared/models";
+import type { DropCampaign, Platform } from "@lurkloot/shared/models";
 import { KickWafBlockedError } from "@lurkloot/core/tabs";
 import { loadConfig, TRANSPORTS, type CliConfig, type Transport } from "./config";
 import { forgetCredentials, hasKickAuth, hasTwitchAuth, loadCredentials } from "./authStore";
 import { createTransport, type EnabledPlatforms } from "./transport";
 import { runLoop } from "./runtime/run";
+import { formatDiscoveredCampaign } from "./runtime/status";
 import { importCredentials } from "./auth/importCredentials";
 import { twitchDeviceLogin } from "./auth/twitchDeviceFlow";
 import { kickDeviceLogin } from "./auth/kickDeviceFlow";
@@ -179,11 +180,13 @@ const authCommand: CommandModule = {
   handler: () => { /* a subcommand always runs; see demandCommand above */ },
 };
 
-async function discoverPlatform(platform: Platform, adapter: { discoverCampaigns(): Promise<{ name: string }[]> }, logger: ReturnType<typeof createLogger>): Promise<void> {
+async function discoverPlatform(platform: Platform, adapter: { discoverCampaigns(): Promise<DropCampaign[]> }, logger: ReturnType<typeof createLogger>): Promise<void> {
   try {
     const campaigns = await adapter.discoverCampaigns();
     logger.info(`discovered ${campaigns.length} campaign(s)`, platform);
-    for (const campaign of campaigns.slice(0, 20)) logger.info(`• ${campaign.name}`, platform);
+    for (const campaign of campaigns.slice(0, 20)) {
+      for (const line of formatDiscoveredCampaign(campaign)) logger.info(line, platform);
+    }
   } catch (error) {
     if (error instanceof KickWafBlockedError) {
       logger.warn(`Cloudflare WAF blocked the request (HTTP 403). Use the "impersonate" transport to reach Kick without a browser. (${error.message})`, platform);

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -1,10 +1,11 @@
 import { createBackgroundController } from "@lurkloot/core/controller";
-import type { SchedulerState } from "@lurkloot/shared/models";
+import type { Platform, SchedulerState } from "@lurkloot/shared/models";
 import { loadState, saveState } from "../storage";
 import { toEngineSettings, type CliSettings } from "../settings";
 import type { TransportHandle } from "../transport";
 import type { Logger } from "../logger";
 import { reportCliEvents } from "../events";
+import { subscriptionWaitKeys } from "./status";
 
 export interface RunOptions {
   settings: CliSettings;
@@ -26,6 +27,7 @@ export async function runLoop(options: RunOptions): Promise<void> {
   // The shared engine works on the EngineSettings contract; expand the CLI's
   // schema once, pinning the headless invariants (always running, always tabless).
   const engineSettings = toEngineSettings(settings);
+  const seenSubscriptionWaits = new Set<string>();
 
   const controller = createBackgroundController({
     loadSettings: async () => engineSettings,
@@ -43,6 +45,16 @@ export async function runLoop(options: RunOptions): Promise<void> {
   const tickOnce = async () => {
     try {
       await controller.tick();
+      const state = await loadState(statePath);
+      const waits = subscriptionWaitKeys([...state.campaigns.twitch, ...state.campaigns.kick]);
+      for (const key of seenSubscriptionWaits) {
+        if (!waits.has(key)) seenSubscriptionWaits.delete(key);
+      }
+      for (const [key, message] of waits) {
+        if (seenSubscriptionWaits.has(key)) continue;
+        seenSubscriptionWaits.add(key);
+        logger.info(message, key.slice(0, key.indexOf(":")) as Platform);
+      }
     } catch (error) {
       logger.error(error instanceof Error ? error.message : String(error), "tick");
     }

--- a/packages/cli/src/runtime/status.ts
+++ b/packages/cli/src/runtime/status.ts
@@ -1,5 +1,5 @@
 import type { DropCampaign, DropReward } from "@lurkloot/shared/models";
-import { isSubscriptionReward, rewardRequirementType } from "@lurkloot/shared/rewards";
+import { campaignHasWatchRewards, isWaitingSubscriptionReward, rewardRequirementType } from "@lurkloot/shared/rewards";
 
 function subscriptionRequirement(required: number): string {
   return `${required} qualifying ${required === 1 ? "subscription" : "subscriptions"}`;
@@ -28,8 +28,9 @@ export function formatDiscoveredCampaign(campaign: DropCampaign): string[] {
 export function subscriptionWaitKeys(campaigns: DropCampaign[]): Map<string, string> {
   const waits = new Map<string, string>();
   for (const campaign of campaigns) {
+    if (!campaignCanWaitForSubscription(campaign)) continue;
     for (const reward of campaign.rewards) {
-      if (!isSubscriptionReward(reward) || reward.status === "claimed") continue;
+      if (!isWaitingSubscriptionReward(reward)) continue;
       const required = reward.requiredSubs ?? 1;
       waits.set(
         `${campaign.platform}:${campaign.id}:${reward.id}`,
@@ -38,4 +39,17 @@ export function subscriptionWaitKeys(campaigns: DropCampaign[]): Map<string, str
     }
   }
   return waits;
+}
+
+function campaignCanWaitForSubscription(campaign: DropCampaign): boolean {
+  if (campaign.status !== "active" || campaign.accountLinked === false) return false;
+  const genuinelyWaiting = campaign.eligibility === "waiting_for_subscription"
+    || (campaign.eligibility === "eligible" && campaignHasWatchRewards(campaign));
+  if (!genuinelyWaiting) return false;
+  const now = Date.now();
+  const startsAt = campaign.startsAt ? Date.parse(campaign.startsAt) : undefined;
+  const endsAt = campaign.endsAt ? Date.parse(campaign.endsAt) : undefined;
+  if (startsAt != null && !Number.isNaN(startsAt) && now < startsAt) return false;
+  if (endsAt != null && !Number.isNaN(endsAt) && now >= endsAt) return false;
+  return true;
 }

--- a/packages/cli/src/runtime/status.ts
+++ b/packages/cli/src/runtime/status.ts
@@ -1,0 +1,41 @@
+import type { DropCampaign, DropReward } from "@lurkloot/shared/models";
+import { isSubscriptionReward, rewardRequirementType } from "@lurkloot/shared/rewards";
+
+function subscriptionRequirement(required: number): string {
+  return `${required} qualifying ${required === 1 ? "subscription" : "subscriptions"}`;
+}
+
+function formatReward(reward: DropReward): string {
+  if (reward.status === "claimed") return `  ◦ ${reward.name} — earned`;
+
+  switch (rewardRequirementType(reward)) {
+    case "subscription": {
+      const required = reward.requiredSubs ?? 1;
+      return `  ◦ ${reward.name} — requires ${subscriptionRequirement(required)}; progress unavailable`;
+    }
+    case "watch":
+      return `  ◦ ${reward.name} — requires ${reward.requiredMinutes} minutes watched; progress ${reward.watchedMinutes}/${reward.requiredMinutes} minutes`;
+    case "action":
+      return `  ◦ ${reward.name} — action required; progress unavailable`;
+  }
+}
+
+export function formatDiscoveredCampaign(campaign: DropCampaign): string[] {
+  const waiting = campaign.eligibility === "waiting_for_subscription" ? " — waiting for subscription" : "";
+  return [`• ${campaign.name}${waiting}`, ...campaign.rewards.map(formatReward)];
+}
+
+export function subscriptionWaitKeys(campaigns: DropCampaign[]): Map<string, string> {
+  const waits = new Map<string, string>();
+  for (const campaign of campaigns) {
+    for (const reward of campaign.rewards) {
+      if (!isSubscriptionReward(reward) || reward.status === "claimed") continue;
+      const required = reward.requiredSubs ?? 1;
+      waits.set(
+        `${campaign.platform}:${campaign.id}:${reward.id}`,
+        `Waiting for ${subscriptionRequirement(required)}: ${reward.name} from ${campaign.name}`,
+      );
+    }
+  }
+  return waits;
+}

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -178,11 +178,12 @@ describe("CLI campaign status reporting", () => {
     ]);
   });
 
-  it("returns a stable message key for every unclaimed subscription reward", () => {
+  it("returns stable message keys for active subscription rewards that are genuinely waiting", () => {
     const campaign = dropCampaign({
+      eligibility: "waiting_for_subscription",
       rewards: [
         dropReward({ id: "duffel", name: "Purple Duffel Bag", requiredSubs: 1 }),
-        dropReward({ id: "mace", name: "Bastion Mace", requirement: "subscription", requiredSubs: 3 }),
+        dropReward({ id: "mace", name: "Bastion Mace", requirement: "subscription", requiredSubs: 3, status: "in_progress" }),
         dropReward({ id: "watch", name: "Watch Crown", requirement: "watch", requiredMinutes: 60 }),
         dropReward({ id: "earned", name: "Earned Badge", requirement: "subscription", requiredSubs: 1, status: "claimed" }),
       ],
@@ -191,6 +192,54 @@ describe("CLI campaign status reporting", () => {
     expect([...subscriptionWaitKeys([campaign])]).toEqual([
       ["twitch:arc-raiders-summer:duffel", "Waiting for 1 qualifying subscription: Purple Duffel Bag from ARC Raiders Summer Drops"],
       ["twitch:arc-raiders-summer:mace", "Waiting for 3 qualifying subscriptions: Bastion Mace from ARC Raiders Summer Drops"],
+    ]);
+  });
+
+  it("excludes subscription rewards that are not currently waiting for the user", () => {
+    const waiting = dropCampaign({
+      eligibility: "waiting_for_subscription",
+      rewards: [
+        dropReward({ id: "claimable", requirement: "subscription", requiredSubs: 1, status: "claimable" }),
+        dropReward({ id: "claimed", requirement: "subscription", requiredSubs: 1, status: "claimed" }),
+        dropReward({ id: "future", requirement: "subscription", requiredSubs: 1, availableFrom: "2999-01-01T00:00:00.000Z" }),
+        dropReward({ id: "ended", requirement: "subscription", requiredSubs: 1, availableUntil: "2000-01-01T00:00:00.000Z" }),
+        dropReward({ id: "prerequisite", requirement: "subscription", requiredSubs: 1, preconditionsMet: false }),
+      ],
+    });
+    const mixed = dropCampaign({
+      id: "mixed",
+      eligibility: "eligible",
+      rewards: [
+        dropReward({ id: "watch", requirement: "watch", requiredMinutes: 60 }),
+        dropReward({ id: "mixed-sub", name: "Mixed Subscription", requirement: "subscription", requiredSubs: 2 }),
+      ],
+    });
+    const upcoming = dropCampaign({
+      id: "upcoming",
+      status: "upcoming",
+      eligibility: "upcoming",
+      rewards: [dropReward({ id: "upcoming-sub", requirement: "subscription", requiredSubs: 1 })],
+    });
+    const expired = dropCampaign({
+      id: "expired",
+      status: "expired",
+      eligibility: "expired",
+      rewards: [dropReward({ id: "expired-sub", requirement: "subscription", requiredSubs: 1 })],
+    });
+    const unlinked = dropCampaign({
+      id: "unlinked",
+      eligibility: "account_not_linked",
+      accountLinked: false,
+      rewards: [dropReward({ id: "unlinked-sub", requirement: "subscription", requiredSubs: 1 })],
+    });
+    const eligibleSubscriptionOnly = dropCampaign({
+      id: "eligible-subscription-only",
+      eligibility: "eligible",
+      rewards: [dropReward({ id: "not-genuinely-waiting", requirement: "subscription", requiredSubs: 1 })],
+    });
+
+    expect([...subscriptionWaitKeys([waiting, mixed, upcoming, expired, unlinked, eligibleSubscriptionOnly])]).toEqual([
+      ["twitch:mixed:mixed-sub", "Waiting for 2 qualifying subscriptions: Mixed Subscription from ARC Raiders Summer Drops"],
     ]);
   });
 });

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1,8 +1,32 @@
 import { describe, expect, it, vi } from "vitest";
 import type { EngineEvent, FarmingStopReason } from "@lurkloot/shared/events";
+import type { DropCampaign, DropReward } from "@lurkloot/shared/models";
 import type { Logger } from "../src/logger";
 import { formatCliEvent, reportCliEvents } from "../src/events";
 import { createLogger } from "../src/logger";
+import { formatDiscoveredCampaign, subscriptionWaitKeys } from "../src/runtime/status";
+
+function dropReward(overrides: Partial<DropReward>): DropReward {
+  return {
+    id: "reward",
+    name: "Reward",
+    requiredMinutes: 0,
+    watchedMinutes: 0,
+    status: "locked",
+    ...overrides,
+  };
+}
+
+function dropCampaign(overrides: Partial<DropCampaign> = {}): DropCampaign {
+  return {
+    id: "arc-raiders-summer",
+    platform: "twitch",
+    name: "ARC Raiders Summer Drops",
+    status: "active",
+    rewards: [],
+    ...overrides,
+  };
+}
 
 function rewardEvent(
   code: "farming_started" | "farming_stopped" | "reward_claimed",
@@ -116,5 +140,57 @@ describe("CLI engine event reporting", () => {
       expect(formatCliEvent(rewardEvent("farming_stopped", "Reward", { reason })))
         .toContain(reason.replaceAll("_", " "));
     }
+  });
+});
+
+describe("CLI campaign status reporting", () => {
+  it("formats subscription requirements without inventing partial progress", () => {
+    const campaign = dropCampaign({
+      eligibility: "waiting_for_subscription",
+      rewards: [
+        dropReward({ id: "duffel", name: "Purple Duffel Bag", requirement: "subscription", requiredSubs: 1 }),
+        dropReward({ id: "mace", name: "Bastion Mace", requirement: "subscription", requiredSubs: 3 }),
+      ],
+    });
+
+    expect(formatDiscoveredCampaign(campaign)).toEqual([
+      "• ARC Raiders Summer Drops — waiting for subscription",
+      "  ◦ Purple Duffel Bag — requires 1 qualifying subscription; progress unavailable",
+      "  ◦ Bastion Mace — requires 3 qualifying subscriptions; progress unavailable",
+    ]);
+  });
+
+  it("labels claimed rewards as earned and preserves both requirement types in mixed campaigns", () => {
+    const campaign = dropCampaign({
+      name: "Mixed Drops",
+      rewards: [
+        dropReward({ id: "watch", name: "Watch Crown", requirement: "watch", requiredMinutes: 60, watchedMinutes: 30 }),
+        dropReward({ id: "sub", name: "Subscriber Cape", requirement: "subscription", requiredSubs: 2 }),
+        dropReward({ id: "earned", name: "Earned Badge", requirement: "subscription", requiredSubs: 1, status: "claimed" }),
+      ],
+    });
+
+    expect(formatDiscoveredCampaign(campaign)).toEqual([
+      "• Mixed Drops",
+      "  ◦ Watch Crown — requires 60 minutes watched; progress 30/60 minutes",
+      "  ◦ Subscriber Cape — requires 2 qualifying subscriptions; progress unavailable",
+      "  ◦ Earned Badge — earned",
+    ]);
+  });
+
+  it("returns a stable message key for every unclaimed subscription reward", () => {
+    const campaign = dropCampaign({
+      rewards: [
+        dropReward({ id: "duffel", name: "Purple Duffel Bag", requiredSubs: 1 }),
+        dropReward({ id: "mace", name: "Bastion Mace", requirement: "subscription", requiredSubs: 3 }),
+        dropReward({ id: "watch", name: "Watch Crown", requirement: "watch", requiredMinutes: 60 }),
+        dropReward({ id: "earned", name: "Earned Badge", requirement: "subscription", requiredSubs: 1, status: "claimed" }),
+      ],
+    });
+
+    expect([...subscriptionWaitKeys([campaign])]).toEqual([
+      ["twitch:arc-raiders-summer:duffel", "Waiting for 1 qualifying subscription: Purple Duffel Bag from ARC Raiders Summer Drops"],
+      ["twitch:arc-raiders-summer:mace", "Waiting for 3 qualifying subscriptions: Bastion Mace from ARC Raiders Summer Drops"],
+    ]);
   });
 });

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2,7 +2,7 @@ import type { CategorySearchResult, CoreRuntimeMessage, PlaybackControl, Runtime
 import type { DropCampaign, DropReward, EngineSettings, Platform, PlaybackTelemetry, SchedulerState, WatchReasonCode, WatchSession } from "@lurkloot/shared/models";
 import type { ActivityEvent, DiagnosticEvent, EngineEvent, EventEmitter, EventReporter, FarmingStopReason } from "@lurkloot/shared/events";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
-import { isWatchReward } from "@lurkloot/shared/rewards";
+import { isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
 import { MANUAL_WATCH_TTL_MS, runSchedulerTick, type StopPageContextTabs } from "../core/scheduler";
 import { setTwitchIntegrity } from "../core/tabs";
 import { integrityFromHeaders } from "../core/twitchIntegrity";
@@ -675,12 +675,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           const rewards = item.rewards.map((candidate) => candidate.id === reward.id && claimed
             ? { ...candidate, status: "claimed" as const, watchedMinutes: candidate.requiredMinutes }
             : candidate);
-          const completed = rewards.length > 0 && rewards.every((candidate) => candidate.status === "claimed");
-          return {
-            ...item,
-            rewards,
-            status: completed ? "completed" as const : item.status,
-          };
+          return reconcileCampaignAfterClaims(item, rewards);
         });
         stateWithCampaigns = {
           ...state,

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2,6 +2,7 @@ import type { CategorySearchResult, CoreRuntimeMessage, PlaybackControl, Runtime
 import type { DropCampaign, DropReward, EngineSettings, Platform, PlaybackTelemetry, SchedulerState, WatchReasonCode, WatchSession } from "@lurkloot/shared/models";
 import type { ActivityEvent, DiagnosticEvent, EngineEvent, EventEmitter, EventReporter, FarmingStopReason } from "@lurkloot/shared/events";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
+import { isWatchReward } from "@lurkloot/shared/rewards";
 import { MANUAL_WATCH_TTL_MS, runSchedulerTick, type StopPageContextTabs } from "../core/scheduler";
 import { setTwitchIntegrity } from "../core/tabs";
 import { integrityFromHeaders } from "../core/twitchIntegrity";
@@ -674,10 +675,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           const rewards = item.rewards.map((candidate) => candidate.id === reward.id && claimed
             ? { ...candidate, status: "claimed" as const, watchedMinutes: candidate.requiredMinutes }
             : candidate);
+          const completed = rewards.length > 0 && rewards.every((candidate) => candidate.status === "claimed");
           return {
             ...item,
             rewards,
-            status: rewards.every((candidate) => candidate.status === "claimed") ? "completed" as const : item.status,
+            status: completed ? "completed" as const : item.status,
           };
         });
         stateWithCampaigns = {
@@ -1069,7 +1071,7 @@ function hasEarnableReward(campaign: DropCampaign): boolean {
     && !hasCampaignEnded(campaign)
     && campaign.accountLinked !== false
     && (!campaign.eligibility || campaign.eligibility === "eligible")
-    && campaign.rewards.some((reward) => reward.isWatchBased !== false && reward.status !== "claimed" && reward.status !== "claimable" && reward.preconditionsMet !== false);
+    && campaign.rewards.some((reward) => isWatchReward(reward) && reward.status !== "claimed" && reward.status !== "claimable" && reward.preconditionsMet !== false);
 }
 
 function hasCampaignEnded(campaign: DropCampaign): boolean {

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -233,8 +233,11 @@ function onlyWaitingSubscriptionCampaigns(campaigns: DropCampaign[], settings: E
 
 function onlySubscriptionCampaigns(campaigns: DropCampaign[], settings: EngineSettings): boolean {
   const notExcluded = campaigns.filter((campaign) => !settings.excludedCampaignIds.includes(campaign.id));
-  return notExcluded.length > 0 && notExcluded.every((campaign) =>
-    campaign.rewards.length > 0 && campaign.rewards.every(isSubscriptionReward));
+  return notExcluded.length > 0 && notExcluded.every((campaign) => {
+    const remainingRewards = campaign.rewards.filter((reward) =>
+      reward.status !== "claimed" && reward.status !== "claimable");
+    return remainingRewards.length > 0 && remainingRewards.every(isSubscriptionReward);
+  });
 }
 
 async function firstValidCandidate(

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -11,6 +11,7 @@ import type {
   WatchSession,
 } from "@lurkloot/shared/models";
 import { categoryListIndex } from "@lurkloot/shared/categories";
+import { isSubscriptionReward, isWatchReward } from "@lurkloot/shared/rewards";
 import type { EngineEvent, EventEmitter, FarmingStopReason } from "@lurkloot/shared/events";
 import { currentManagedPageContextTabs, forgetManagedPageContextTabs, registerManagedPageContextTabs, type SchedulerManagedPageContexts } from "./tabs";
 import type { LogLevel } from "@lurkloot/shared/logging";
@@ -126,6 +127,7 @@ export async function chooseCampaignDecision(
 ): Promise<WatchDecision> {
   const sorted = sortCampaigns(campaigns.filter((campaign) => isEligible(campaign, settings)), settings);
   const noCampaignReason = noEligibleCampaignReason(campaigns, settings);
+  const waitingForSubscription = onlyWaitingSubscriptionCampaigns(campaigns, settings);
 
   for (const campaign of sorted) {
     const reward = activeReward(campaign);
@@ -169,7 +171,12 @@ export async function chooseCampaignDecision(
     };
   }
 
-  return { platform, action: "idle", reason: `${noCampaignReason} and no Watch Queue channels`, reasonCode: "no_eligible_channel" };
+  return {
+    platform,
+    action: "idle",
+    reason: `${noCampaignReason} and no Watch Queue channels`,
+    reasonCode: waitingForSubscription ? "campaign_ineligible" : "no_eligible_channel",
+  };
 }
 
 function noEligibleCampaignReason(campaigns: DropCampaign[], settings: EngineSettings): string {
@@ -184,6 +191,9 @@ function noEligibleCampaignReason(campaigns: DropCampaign[], settings: EngineSet
   }
   if (notExcluded.every((campaign) => campaign.status === "completed" || campaign.eligibility === "completed")) {
     return "All campaigns are completed";
+  }
+  if (onlyWaitingSubscriptionCampaigns(campaigns, settings)) {
+    return "Waiting for a qualifying subscription";
   }
   if (notExcluded.every((campaign) => campaign.eligibility === "no_rewards" || campaign.rewards.length === 0)) {
     return "Campaigns have no time-based rewards";
@@ -201,6 +211,14 @@ function noEligibleCampaignReason(campaigns: DropCampaign[], settings: EngineSet
     return "No prioritized campaigns are eligible";
   }
   return "No eligible campaigns";
+}
+
+function onlyWaitingSubscriptionCampaigns(campaigns: DropCampaign[], settings: EngineSettings): boolean {
+  const notExcluded = campaigns.filter((campaign) => !settings.excludedCampaignIds.includes(campaign.id));
+  return notExcluded.length > 0 && notExcluded.every((campaign) =>
+    campaign.eligibility === "waiting_for_subscription"
+    && campaign.rewards.length > 0
+    && campaign.rewards.every(isSubscriptionReward));
 }
 
 async function firstValidCandidate(
@@ -701,13 +719,16 @@ async function claimReadyRewards(
         rewards.push(reward);
       }
     }
+    const claimedIds = new Set(rewards.filter((reward) => reward.status === "claimed").map((reward) => reward.id));
+    const unlockedRewards = rewards.map((reward) => ({
+      ...reward,
+      preconditionsMet: (reward.preconditionRewardIds ?? []).every((id) => claimedIds.has(id)),
+    }));
+    const completed = unlockedRewards.length > 0 && unlockedRewards.every((reward) => reward.status === "claimed");
     updated.push({
       ...campaign,
-      rewards,
-      status: rewards.some((reward) => reward.isWatchBased !== false)
-        && rewards.filter((reward) => reward.isWatchBased !== false).every((reward) => reward.status === "claimed")
-        ? "completed"
-        : campaign.status,
+      rewards: unlockedRewards,
+      status: completed ? "completed" : campaign.status,
     });
   }
 
@@ -726,7 +747,7 @@ function campaignDiagnosticFingerprint(campaigns: readonly DropCampaign[]): stri
 }
 
 function isRewardAvailableToEarn(reward: DropReward): boolean {
-  if (reward.isWatchBased === false) return false;
+  if (!isWatchReward(reward)) return false;
   const now = Date.now();
   const startsAt = reward.availableFrom ? Date.parse(reward.availableFrom) : undefined;
   const endsAt = reward.availableUntil ? Date.parse(reward.availableUntil) : undefined;

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -11,7 +11,7 @@ import type {
   WatchSession,
 } from "@lurkloot/shared/models";
 import { categoryListIndex } from "@lurkloot/shared/categories";
-import { isSubscriptionReward, isWatchReward } from "@lurkloot/shared/rewards";
+import { isSubscriptionReward, isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
 import type { EngineEvent, EventEmitter, FarmingStopReason } from "@lurkloot/shared/events";
 import { currentManagedPageContextTabs, forgetManagedPageContextTabs, registerManagedPageContextTabs, type SchedulerManagedPageContexts } from "./tabs";
 import type { LogLevel } from "@lurkloot/shared/logging";
@@ -128,6 +128,7 @@ export async function chooseCampaignDecision(
   const sorted = sortCampaigns(campaigns.filter((campaign) => isEligible(campaign, settings)), settings);
   const noCampaignReason = noEligibleCampaignReason(campaigns, settings);
   const waitingForSubscription = onlyWaitingSubscriptionCampaigns(campaigns, settings);
+  const subscriptionOnly = onlySubscriptionCampaigns(campaigns, settings);
 
   for (const campaign of sorted) {
     const reward = activeReward(campaign);
@@ -153,6 +154,15 @@ export async function chooseCampaignDecision(
         reasonCode: "eligible_campaign",
       };
     }
+  }
+
+  if (subscriptionOnly) {
+    return {
+      platform,
+      action: "idle",
+      reason: noCampaignReason,
+      reasonCode: "campaign_ineligible",
+    };
   }
 
   const fallbackCandidates = settings.platform[platform].watchQueueChannels
@@ -219,6 +229,12 @@ function onlyWaitingSubscriptionCampaigns(campaigns: DropCampaign[], settings: E
     campaign.eligibility === "waiting_for_subscription"
     && campaign.rewards.length > 0
     && campaign.rewards.every(isSubscriptionReward));
+}
+
+function onlySubscriptionCampaigns(campaigns: DropCampaign[], settings: EngineSettings): boolean {
+  const notExcluded = campaigns.filter((campaign) => !settings.excludedCampaignIds.includes(campaign.id));
+  return notExcluded.length > 0 && notExcluded.every((campaign) =>
+    campaign.rewards.length > 0 && campaign.rewards.every(isSubscriptionReward));
 }
 
 async function firstValidCandidate(
@@ -719,17 +735,7 @@ async function claimReadyRewards(
         rewards.push(reward);
       }
     }
-    const claimedIds = new Set(rewards.filter((reward) => reward.status === "claimed").map((reward) => reward.id));
-    const unlockedRewards = rewards.map((reward) => ({
-      ...reward,
-      preconditionsMet: (reward.preconditionRewardIds ?? []).every((id) => claimedIds.has(id)),
-    }));
-    const completed = unlockedRewards.length > 0 && unlockedRewards.every((reward) => reward.status === "claimed");
-    updated.push({
-      ...campaign,
-      rewards: unlockedRewards,
-      status: completed ? "completed" : campaign.status,
-    });
+    updated.push(reconcileCampaignAfterClaims(campaign, rewards));
   }
 
   previouslyWaitingRewardIds.clear();

--- a/packages/core/src/platforms/kick/parser.ts
+++ b/packages/core/src/platforms/kick/parser.ts
@@ -177,12 +177,14 @@ export function kickRewardImageUrl(value: string | undefined): string | undefine
 function parseKickReward(reward: KickReward): DropReward {
   const requiredMinutes =
     reward.required_units ?? reward.required_minutes ?? reward.minutes_required ?? reward.watch_time_required ?? 0;
+  const requirement = requiredMinutes > 0 ? "watch" as const : "action" as const;
   return {
     id: String(reward.id),
     name: reward.name ?? reward.title ?? `Reward ${reward.id}`,
     imageUrl: kickRewardImageUrl(reward.image_url ?? reward.image),
     requiredMinutes,
-    isWatchBased: requiredMinutes > 0,
+    requirement,
+    isWatchBased: requirement === "watch",
     watchedMinutes: 0,
     status: reward.claimed || reward.is_claimed ? "claimed" : "locked",
   };

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -296,9 +296,9 @@ function eligibility(
   if (status === "upcoming") return "upcoming";
   if (status === "expired") return "expired";
   if (status === "completed") return "completed";
+  if (rewards.length > 0 && rewards.every((reward) => reward.status === "claimed")) return "completed";
   if (rewards.some(isWatchReward)) return "eligible";
   if (rewards.some(isWaitingSubscriptionReward)) return "waiting_for_subscription";
-  if (rewards.length > 0 && rewards.every((reward) => reward.status === "claimed")) return "completed";
   return "no_rewards";
 }
 
@@ -307,9 +307,9 @@ function eligibilityReason(status: DropCampaign["status"], accountLinked: boolea
   if (status === "upcoming") return "Campaign has not started";
   if (status === "expired") return "Campaign has ended";
   if (status === "completed") return "All rewards are claimed";
+  if (rewards.length > 0 && rewards.every((reward) => reward.status === "claimed")) return "All rewards are claimed";
   if (rewards.some(isWatchReward)) return "Eligible";
   if (rewards.some(isWaitingSubscriptionReward)) return "Waiting for a qualifying subscription";
-  if (rewards.length > 0 && rewards.every((reward) => reward.status === "claimed")) return "All rewards are claimed";
   return "Campaign has no time-based rewards";
 }
 

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -1,5 +1,5 @@
 import type { ChannelCandidate, DropCampaign, DropReward } from "@lurkloot/shared/models";
-import { isSubscriptionReward, isWatchReward } from "@lurkloot/shared/rewards";
+import { isWaitingSubscriptionReward, isWatchReward } from "@lurkloot/shared/rewards";
 
 interface TwitchInventory {
   data?: {
@@ -169,10 +169,12 @@ function parseTwitchReward(
   const benefits = (reward.benefitEdges ?? [])
     .map((edge) => edge.benefit)
     .filter((benefit): benefit is NonNullable<typeof benefit> => Boolean(benefit));
-  // A benefit already present in gameEventDrops means the user owns this reward,
-  // so the drop is effectively claimed even if Twitch still reports a self edge
-  // with isClaimed=false (e.g. a campaign re-running a reward you already earned).
-  const ownsBenefit = ownsRewardBenefit(benefits.map((benefit) => benefit.id), gameEventDrops);
+  // For watch rewards, a benefit already present in gameEventDrops means the
+  // user owns this reward even if Twitch still reports isClaimed=false. That
+  // inventory is campaign-agnostic, so subscription rewards must rely only on
+  // their campaign-specific self state / drop instance.
+  const ownsBenefit = isWatchBased
+    && ownsRewardBenefit(benefits.map((benefit) => benefit.id), gameEventDrops);
   const isClaimed = reward.self?.isClaimed === true || ownsBenefit;
   // Twitch's real dropInstanceID has the form `userID#campaignID#dropID` (see
   // TwitchDropsMiner inventory.py generate_claim and its inventory dump, which
@@ -241,10 +243,15 @@ export function mergeTwitchCampaignProgress(
     const rewards = campaign.rewards.map((reward) => {
       const progressReward = progress?.rewards.find((item) => item.id === reward.id);
       const merged = progressReward ? { ...reward, ...progressReward } : reward;
-      // A claimed campaign falls out of dropCampaignsInProgress, so the merge
-      // above can't update it. gameEventDrops is always returned, so cross-check
-      // ownership to detect rewards the user already has.
-      if (merged.status !== "claimed" && ownsRewardBenefit(merged.benefitIds ?? [], gameEventDrops)) {
+      // A claimed watch campaign falls out of dropCampaignsInProgress, so the
+      // merge above can't update it. gameEventDrops is always returned, so
+      // cross-check watch ownership without applying its campaign-agnostic
+      // benefit ids to subscription rewards.
+      if (
+        merged.status !== "claimed"
+        && isWatchReward(merged)
+        && ownsRewardBenefit(merged.benefitIds ?? [], gameEventDrops)
+      ) {
         return { ...merged, status: "claimed" as const, watchedMinutes: merged.requiredMinutes };
       }
       return merged;
@@ -290,7 +297,7 @@ function eligibility(
   if (status === "expired") return "expired";
   if (status === "completed") return "completed";
   if (rewards.some(isWatchReward)) return "eligible";
-  if (rewards.some((reward) => isSubscriptionReward(reward) && reward.status !== "claimed")) return "waiting_for_subscription";
+  if (rewards.some(isWaitingSubscriptionReward)) return "waiting_for_subscription";
   if (rewards.length > 0 && rewards.every((reward) => reward.status === "claimed")) return "completed";
   return "no_rewards";
 }
@@ -301,7 +308,7 @@ function eligibilityReason(status: DropCampaign["status"], accountLinked: boolea
   if (status === "expired") return "Campaign has ended";
   if (status === "completed") return "All rewards are claimed";
   if (rewards.some(isWatchReward)) return "Eligible";
-  if (rewards.some((reward) => isSubscriptionReward(reward) && reward.status !== "claimed")) return "Waiting for a qualifying subscription";
+  if (rewards.some(isWaitingSubscriptionReward)) return "Waiting for a qualifying subscription";
   if (rewards.length > 0 && rewards.every((reward) => reward.status === "claimed")) return "All rewards are claimed";
   return "Campaign has no time-based rewards";
 }

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -82,7 +82,7 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
     const slug = campaign.game?.slug;
     const startsAt = campaign.startAt;
     const endsAt = campaign.endAt;
-    const accountLinked = campaign.self?.isAccountConnected ?? campaign.accountLinkURL == null;
+    const accountLinked = campaign.accountLinkURL == null || campaign.self?.isAccountConnected !== false;
     const rawStatus = campaign.status?.toLowerCase();
     const status = startsAt && Date.parse(startsAt) > now
       ? "upcoming"

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -1,4 +1,5 @@
 import type { ChannelCandidate, DropCampaign, DropReward } from "@lurkloot/shared/models";
+import { isSubscriptionReward, isWatchReward } from "@lurkloot/shared/rewards";
 
 interface TwitchInventory {
   data?: {
@@ -107,8 +108,7 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
       ),
     }));
 
-    const watchRewards = rewards.filter((reward) => reward.isWatchBased !== false);
-    const finalStatus = watchRewards.length > 0 && watchRewards.every((reward) => reward.status === "claimed") ? "completed" : status;
+    const finalStatus = rewards.length > 0 && rewards.every((reward) => reward.status === "claimed") ? "completed" : status;
 
     return {
       id: campaign.id,
@@ -124,8 +124,8 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
       accountLinkUrl,
       status: finalStatus,
       url: campaign.detailsURL ?? undefined,
-      eligibility: eligibility(finalStatus, accountLinked, watchRewards.length),
-      eligibilityReason: eligibilityReason(finalStatus, accountLinked, watchRewards.length),
+      eligibility: eligibility(finalStatus, accountLinked, rewards),
+      eligibilityReason: eligibilityReason(finalStatus, accountLinked, rewards),
       allowedChannels,
       connectionUrls: allowedChannels.length > 0
         ? allowedChannels.map((login) => `https://www.twitch.tv/${login}`)
@@ -160,9 +160,12 @@ function parseTwitchReward(
   const watchedMinutes = reward.self?.currentMinutesWatched ?? 0;
   const requiredMinutes = reward.requiredMinutesWatched ?? 0;
   const requiredSubs = reward.requiredSubs ?? 0;
-  // A reward that also requires subscriptions cannot be completed by watching
-  // alone. Keep it for ownership/claim tracking, but never let it drive farming.
-  const isWatchBased = requiredMinutes > 0 && requiredSubs <= 0;
+  const requirement = requiredSubs > 0
+    ? "subscription" as const
+    : requiredMinutes > 0
+      ? "watch" as const
+      : "action" as const;
+  const isWatchBased = requirement === "watch";
   const benefits = (reward.benefitEdges ?? [])
     .map((edge) => edge.benefit)
     .filter((benefit): benefit is NonNullable<typeof benefit> => Boolean(benefit));
@@ -188,6 +191,7 @@ function parseTwitchReward(
     benefitType: benefits[0]?.distributionType,
     requiredMinutes,
     requiredSubs: reward.requiredSubs,
+    requirement,
     isWatchBased,
     watchedMinutes: isClaimed ? requiredMinutes : watchedMinutes,
     claimId,
@@ -245,10 +249,13 @@ export function mergeTwitchCampaignProgress(
       }
       return merged;
     });
-    const watchRewards = rewards.filter((reward) => reward.isWatchBased !== false);
-    const allClaimed = watchRewards.length > 0 && watchRewards.every((reward) => reward.status === "claimed");
-    const next = { ...campaign, status: progress?.status ?? campaign.status, rewards };
-    return allClaimed ? withCampaignStatus(next, "completed") : next;
+    const allClaimed = rewards.length > 0 && rewards.every((reward) => reward.status === "claimed");
+    const status = allClaimed
+      ? "completed"
+      : progress?.status === "completed"
+        ? campaign.status
+        : progress?.status ?? campaign.status;
+    return withCampaignStatus({ ...campaign, rewards }, status);
   });
 }
 
@@ -276,23 +283,27 @@ function ownsRewardBenefit(benefitIds: (string | undefined)[], gameEventDrops: T
 function eligibility(
   status: DropCampaign["status"],
   accountLinked: boolean,
-  rewardCount: number,
+  rewards: DropReward[],
 ): DropCampaign["eligibility"] {
   if (!accountLinked) return "account_not_linked";
   if (status === "upcoming") return "upcoming";
   if (status === "expired") return "expired";
   if (status === "completed") return "completed";
-  if (rewardCount === 0) return "no_rewards";
-  return "eligible";
+  if (rewards.some(isWatchReward)) return "eligible";
+  if (rewards.some((reward) => isSubscriptionReward(reward) && reward.status !== "claimed")) return "waiting_for_subscription";
+  if (rewards.length > 0 && rewards.every((reward) => reward.status === "claimed")) return "completed";
+  return "no_rewards";
 }
 
-function eligibilityReason(status: DropCampaign["status"], accountLinked: boolean, rewardCount: number): string {
+function eligibilityReason(status: DropCampaign["status"], accountLinked: boolean, rewards: DropReward[]): string {
   if (!accountLinked) return "Account is not linked for this campaign";
   if (status === "upcoming") return "Campaign has not started";
   if (status === "expired") return "Campaign has ended";
   if (status === "completed") return "All rewards are claimed";
-  if (rewardCount === 0) return "Campaign has no time-based rewards";
-  return "Eligible";
+  if (rewards.some(isWatchReward)) return "Eligible";
+  if (rewards.some((reward) => isSubscriptionReward(reward) && reward.status !== "claimed")) return "Waiting for a qualifying subscription";
+  if (rewards.length > 0 && rewards.every((reward) => reward.status === "claimed")) return "All rewards are claimed";
+  return "Campaign has no time-based rewards";
 }
 
 // Returns a copy of the campaign with a new status and consistent eligibility
@@ -300,12 +311,11 @@ function eligibilityReason(status: DropCampaign["status"], accountLinked: boolea
 // longer lists the campaign as active) that the inventory payload can't convey.
 export function withCampaignStatus(campaign: DropCampaign, status: DropCampaign["status"]): DropCampaign {
   const accountLinked = campaign.accountLinked !== false;
-  const watchRewardCount = campaign.rewards.filter((reward) => reward.isWatchBased !== false).length;
   return {
     ...campaign,
     status,
-    eligibility: eligibility(status, accountLinked, watchRewardCount),
-    eligibilityReason: eligibilityReason(status, accountLinked, watchRewardCount),
+    eligibility: eligibility(status, accountLinked, campaign.rewards),
+    eligibilityReason: eligibilityReason(status, accountLinked, campaign.rewards),
   };
 }
 

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -82,7 +82,9 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
     const slug = campaign.game?.slug;
     const startsAt = campaign.startAt;
     const endsAt = campaign.endAt;
-    const accountLinked = campaign.accountLinkURL == null || campaign.self?.isAccountConnected !== false;
+    const accountLinkUrl = normalizeTwitchAccountLinkUrl(campaign.accountLinkURL);
+    const hasAccountLink = Boolean(accountLinkUrl);
+    const accountLinked = !hasAccountLink || campaign.self?.isAccountConnected !== false;
     const rawStatus = campaign.status?.toLowerCase();
     const status = startsAt && Date.parse(startsAt) > now
       ? "upcoming"
@@ -119,7 +121,7 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
       startsAt,
       endsAt,
       accountLinked,
-      accountLinkUrl: campaign.accountLinkURL ?? undefined,
+      accountLinkUrl,
       status: finalStatus,
       url: campaign.detailsURL ?? undefined,
       eligibility: eligibility(finalStatus, accountLinked, watchRewards.length),
@@ -134,6 +136,18 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
       rewards,
     };
   });
+}
+
+function normalizeTwitchAccountLinkUrl(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  try {
+    const hostname = new URL(trimmed).hostname.toLowerCase().replace(/^www\./, "");
+    if (hostname === "twitch.tv" || hostname.endsWith(".twitch.tv")) return undefined;
+  } catch {
+    // Preserve non-URL values for compatibility; Twitch normally returns an absolute URL.
+  }
+  return trimmed;
 }
 
 function parseTwitchReward(

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1197,9 +1197,21 @@ describe("background controller", () => {
     });
   });
 
-  it("manually claims a claimable reward through the platform adapter", async () => {
+  it("completes a campaign after manually claiming its last subscription reward", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: false });
-    const twitchCampaign = campaign("twitch", "claimable");
+    const subscriptionReward: DropReward = {
+      ...reward("claimable"),
+      id: "subscription-reward",
+      requirement: "subscription",
+      requiredSubs: 1,
+      requiredMinutes: 0,
+      watchedMinutes: 0,
+      isWatchBased: false,
+    };
+    const twitchCampaign = {
+      ...campaign("twitch", "claimed"),
+      rewards: [reward("claimed"), subscriptionReward],
+    };
     vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([twitchCampaign]);
 
     await env.controller.tick();
@@ -1207,16 +1219,19 @@ describe("background controller", () => {
       type: "claimReward",
       platform: "twitch",
       campaignId: "twitch-campaign",
-      rewardId: "reward",
+      rewardId: "subscription-reward",
     }));
 
     expect(env.twitch.claimReward).toHaveBeenCalledWith(
       expect.objectContaining({ id: "twitch-campaign" }),
-      expect.objectContaining({ id: "reward", status: "claimable" }),
+      expect.objectContaining({ id: "subscription-reward", status: "claimable", requirement: "subscription" }),
     );
     expect(snapshot.state.campaigns.twitch[0]).toMatchObject({
       status: "completed",
-      rewards: [{ id: "reward", status: "claimed", watchedMinutes: 60 }],
+      rewards: [
+        { id: "reward", status: "claimed" },
+        { id: "subscription-reward", status: "claimed", watchedMinutes: 0 },
+      ],
     });
     expect(env.reportEvents).toHaveBeenCalledWith(expect.arrayContaining([
       expect.objectContaining({
@@ -1225,6 +1240,40 @@ describe("background controller", () => {
         data: expect.objectContaining({ method: "manual" }),
       }),
     ]));
+  });
+
+  it("keeps a mixed campaign active after manually claiming its subscription reward", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: false });
+    const subscriptionReward: DropReward = {
+      ...reward("claimable"),
+      id: "subscription-reward",
+      requirement: "subscription",
+      requiredSubs: 1,
+      requiredMinutes: 0,
+      watchedMinutes: 0,
+      isWatchBased: false,
+    };
+    const twitchCampaign = {
+      ...campaign("twitch"),
+      rewards: [subscriptionReward, { ...reward("locked"), id: "watch-reward", requirement: "watch" as const }],
+    };
+    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([twitchCampaign]);
+
+    await env.controller.tick();
+    const snapshot = asSnapshot(await env.controller.handleMessage({
+      type: "claimReward",
+      platform: "twitch",
+      campaignId: "twitch-campaign",
+      rewardId: "subscription-reward",
+    }));
+
+    expect(snapshot.state.campaigns.twitch[0]).toMatchObject({
+      status: "active",
+      rewards: [
+        { id: "subscription-reward", status: "claimed" },
+        { id: "watch-reward", status: "locked" },
+      ],
+    });
   });
 
   it("does not publish manual-claim events when the corresponding state save fails", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1276,6 +1276,51 @@ describe("background controller", () => {
     });
   });
 
+  it("unlocks a dependent watch reward immediately after a manual subscription claim", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: false });
+    const subscriptionReward: DropReward = {
+      ...reward("claimable"),
+      id: "subscription-reward",
+      requirement: "subscription",
+      requiredSubs: 1,
+      requiredMinutes: 0,
+      watchedMinutes: 0,
+      isWatchBased: false,
+    };
+    const twitchCampaign: DropCampaign = {
+      ...campaign("twitch"),
+      eligibility: "eligible",
+      rewards: [
+        subscriptionReward,
+        {
+          ...reward("locked"),
+          id: "watch-reward",
+          requirement: "watch",
+          preconditionRewardIds: [subscriptionReward.id],
+          preconditionsMet: false,
+        },
+      ],
+    };
+    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([twitchCampaign]);
+
+    await env.controller.tick();
+    const snapshot = asSnapshot(await env.controller.handleMessage({
+      type: "claimReward",
+      platform: "twitch",
+      campaignId: "twitch-campaign",
+      rewardId: subscriptionReward.id,
+    }));
+
+    expect(snapshot.state.campaigns.twitch[0]).toMatchObject({
+      status: "active",
+      eligibility: "eligible",
+      rewards: [
+        { id: subscriptionReward.id, status: "claimed" },
+        { id: "watch-reward", status: "locked", preconditionsMet: true },
+      ],
+    });
+  });
+
   it("does not publish manual-claim events when the corresponding state save fails", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: false }, {
       saveState: vi.fn().mockRejectedValueOnce(new Error("storage unavailable")),

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -68,6 +68,34 @@ describe("i18n", () => {
     }
   });
 
+  it("defines subscription drop states with matching placeholders in every catalog", () => {
+    const englishMessages = {
+      subscriptionRequired: "Subscription required",
+      subscriptionRewards: "Subscription rewards",
+      qualifyingSubscriptionsRequired: "$1 qualifying subscriptions required",
+      subscriptionProgressUnknown: "Progress unavailable",
+      notEarnableByWatching: "Not earnable by watching",
+      subscribedRefresh: "I've subscribed — refresh status",
+      waitingForSubscription: "Waiting for a qualifying subscription",
+      actionRequired: "Action required",
+      earned: "Earned",
+    };
+    const placeholders = (message: string) => message.match(/\$\d+/g) ?? [];
+
+    const english = readCatalog("en");
+    for (const [key, message] of Object.entries(englishMessages)) {
+      expect(english[key]?.message, key).toBe(message);
+    }
+
+    for (const locale of localeCodes()) {
+      const catalog = readCatalog(locale);
+      for (const key of Object.keys(englishMessages)) {
+        expect(catalog[key]?.message, `${locale}:${key}`).toBeTypeOf("string");
+        expect(placeholders(catalog[key].message), `${locale}:${key}`).toEqual(placeholders(english[key].message));
+      }
+    }
+  });
+
   it("does not leave non-English catalogs as English except product/common terms", () => {
     const english = readCatalog("en");
     const allowedSameAsEnglish = new Set([

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -49,6 +49,25 @@ describe("i18n", () => {
     }
   });
 
+  it("localizes the subscription campaign filter in every catalog", () => {
+    const translations: Record<string, string> = {
+      ar: "حملات الاشتراك",
+      de: "Abo-Kampagnen",
+      en: "Subscription campaigns",
+      es: "Campañas de suscripción",
+      fr: "Campagnes avec abonnement",
+      hi: "सदस्यता अभियान",
+      it: "Campagne con abbonamento",
+      pt_BR: "Campanhas de inscrição",
+      ru: "Кампании за подписку",
+      zh_CN: "订阅活动",
+    };
+
+    for (const locale of localeCodes()) {
+      expect(readCatalog(locale).subscriptionCampaigns?.message, locale).toBe(translations[locale]);
+    }
+  });
+
   it("does not leave non-English catalogs as English except product/common terms", () => {
     const english = readCatalog("en");
     const allowedSameAsEnglish = new Set([

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -58,7 +58,7 @@ describe("i18n", () => {
       fr: "Campagnes avec abonnement",
       hi: "सदस्यता अभियान",
       it: "Campagne con abbonamento",
-      pt_BR: "Campanhas de inscrição",
+      pt_BR: "Campanhas de assinatura",
       ru: "Кампании за подписку",
       zh_CN: "订阅活动",
     };

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -379,6 +379,34 @@ describe("Twitch parsers", () => {
     expect(campaigns[0].eligibility).toBe("account_not_linked");
   });
 
+  it("treats a URL-less disconnected Twitch campaign as linked", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "url-less-ewc-like",
+      self: { isAccountConnected: false },
+      timeBasedDrops: [{ id: "drop", requiredMinutesWatched: 60 }],
+    }]);
+
+    expect(campaigns[0]).toMatchObject({
+      accountLinked: true,
+      eligibility: "eligible",
+    });
+  });
+
+  it("keeps a genuine disconnected Twitch campaign unlinked when it provides a link URL", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "genuine-unlinked",
+      self: { isAccountConnected: false },
+      accountLinkURL: "https://example.test/connect",
+      timeBasedDrops: [{ id: "drop", requiredMinutesWatched: 60 }],
+    }]);
+
+    expect(campaigns[0]).toMatchObject({
+      accountLinked: false,
+      accountLinkUrl: "https://example.test/connect",
+      eligibility: "account_not_linked",
+    });
+  });
+
   it("does not unlock a watch reward whose paid prerequisite was excluded", () => {
     const campaigns = parseTwitchInventory([{
       id: "paid-prerequisite-campaign",

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -369,6 +369,7 @@ describe("Twitch parsers", () => {
     const campaigns = parseTwitchInventory([{
       id: "unlinked-native",
       self: { isAccountConnected: false },
+      accountLinkURL: "https://example.test/connect",
       timeBasedDrops: [{
         id: "badge",
         requiredMinutesWatched: 30,

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -262,24 +262,75 @@ describe("Kick parsers", () => {
       }],
     });
 
-    expect(campaigns[0].rewards.map((reward) => reward.isWatchBased)).toEqual([false, false]);
+    expect(campaigns[0].rewards).toMatchObject([
+      { requirement: "action", isWatchBased: false },
+      { requirement: "action", isWatchBased: false },
+    ]);
+  });
+
+  it("classifies positive-duration Kick rewards as watch rewards", () => {
+    const campaigns = parseKickCampaigns({
+      data: [{
+        id: "campaign",
+        rewards: [{ id: "watch", required_units: 30 }],
+      }],
+    });
+
+    expect(campaigns[0].rewards[0]).toMatchObject({
+      requirement: "watch",
+      isWatchBased: true,
+    });
   });
 });
 
 describe("Twitch parsers", () => {
-  it("marks subscription-only and other zero-minute rewards as non-watch rewards", () => {
+  it("classifies subscription-only campaigns as waiting for a qualifying subscription", () => {
     const campaigns = parseTwitchInventory([{
       id: "subscription-campaign",
       name: "Jubilee Badge",
-      timeBasedDrops: [
-        { id: "subscription", name: "Jubilee Badge", requiredMinutesWatched: 0, requiredSubs: 1 },
-        { id: "purchase", name: "Purchase Reward" },
-      ],
+      timeBasedDrops: [{ id: "subscription", name: "Jubilee Badge", requiredMinutesWatched: 0, requiredSubs: 1 }],
     }]);
 
-    expect(campaigns[0].rewards).toHaveLength(2);
-    expect(campaigns[0].rewards.every((reward) => reward.isWatchBased === false)).toBe(true);
+    expect(campaigns[0]).toMatchObject({
+      eligibility: "waiting_for_subscription",
+      eligibilityReason: "Waiting for a qualifying subscription",
+    });
+    expect(campaigns[0].rewards[0]).toMatchObject({
+      requirement: "subscription",
+      requiredSubs: 1,
+      isWatchBased: false,
+    });
+  });
+
+  it("classifies unknown zero-minute rewards as action-gated with no farmable rewards", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "action-campaign",
+      timeBasedDrops: [{ id: "purchase", name: "Purchase Reward" }],
+    }]);
+
+    expect(campaigns[0].rewards[0]).toMatchObject({
+      requirement: "action",
+      isWatchBased: false,
+    });
     expect(campaigns[0].eligibility).toBe("no_rewards");
+  });
+
+  it("marks claimed subscription-only campaigns completed", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "claimed-subscription-campaign",
+      timeBasedDrops: [{
+        id: "subscription",
+        requiredSubs: 1,
+        self: { isClaimed: true },
+      }],
+    }]);
+
+    expect(campaigns[0].rewards[0]).toMatchObject({
+      requirement: "subscription",
+      status: "claimed",
+    });
+    expect(campaigns[0].status).toBe("completed");
+    expect(campaigns[0].eligibility).toBe("completed");
   });
 
   it("keeps only watch-based rewards in mixed campaigns", () => {
@@ -295,6 +346,7 @@ describe("Twitch parsers", () => {
 
     expect(campaigns[0].rewards.filter((reward) => reward.isWatchBased !== false).map((reward) => reward.id)).toEqual(["watch"]);
     expect(campaigns[0].rewards.find((reward) => reward.id === "combined")).toMatchObject({
+      requirement: "subscription",
       requiredSubs: 1,
       isWatchBased: false,
       status: "locked",
@@ -314,8 +366,9 @@ describe("Twitch parsers", () => {
       }],
     }]);
 
-    expect(campaigns[0].eligibility).toBe("no_rewards");
+    expect(campaigns[0].eligibility).toBe("waiting_for_subscription");
     expect(campaigns[0].rewards[0]).toMatchObject({
+      requirement: "subscription",
       isWatchBased: false,
       status: "in_progress",
       claimId: undefined,
@@ -465,6 +518,31 @@ describe("Twitch parsers", () => {
       isWatchBased: false,
       status: "claimable",
       claimId: "subscription-instance",
+    });
+  });
+
+  it("does not synthesize a claim id for subscription rewards", () => {
+    const campaigns = parseTwitchInventory({
+      data: {
+        currentUser: {
+          id: "user-id",
+          inventory: {
+            dropCampaignsInProgress: [{
+              id: "subscription-campaign",
+              timeBasedDrops: [{
+                id: "subscription",
+                requiredSubs: 1,
+              }],
+            }],
+          },
+        },
+      },
+    });
+
+    expect(campaigns[0].rewards[0]).toMatchObject({
+      requirement: "subscription",
+      status: "locked",
+      claimId: undefined,
     });
   });
 
@@ -740,6 +818,68 @@ describe("Twitch parsers", () => {
     expect(merged[0].eligibility).toBe("completed");
   });
 
+  it("keeps a mixed campaign active when only its watch reward is claimed", () => {
+    const details = parseTwitchInventory([{
+      id: "mixed-campaign",
+      timeBasedDrops: [{
+        id: "watch",
+        requiredMinutesWatched: 30,
+      }, {
+        id: "subscription",
+        requiredSubs: 1,
+      }],
+    }]);
+
+    const merged = mergeTwitchCampaignProgress(details, [{
+      id: "mixed-campaign",
+      timeBasedDrops: [{
+        id: "watch",
+        requiredMinutesWatched: 30,
+        self: { currentMinutesWatched: 30, isClaimed: true },
+      }, {
+        id: "subscription",
+        requiredSubs: 1,
+      }],
+    }]);
+
+    expect(merged[0].status).toBe("active");
+    expect(merged[0].eligibility).toBe("eligible");
+    expect(merged[0].rewards).toMatchObject([
+      { requirement: "watch", status: "claimed" },
+      { requirement: "subscription", status: "locked" },
+    ]);
+  });
+
+  it("completes a mixed campaign when every tracked reward is claimed", () => {
+    const details = parseTwitchInventory([{
+      id: "mixed-campaign",
+      timeBasedDrops: [{
+        id: "watch",
+        requiredMinutesWatched: 30,
+      }, {
+        id: "subscription",
+        requiredSubs: 1,
+      }],
+    }]);
+
+    const merged = mergeTwitchCampaignProgress(details, [{
+      id: "mixed-campaign",
+      timeBasedDrops: [{
+        id: "watch",
+        requiredMinutesWatched: 30,
+        self: { currentMinutesWatched: 30, isClaimed: true },
+      }, {
+        id: "subscription",
+        requiredSubs: 1,
+        self: { isClaimed: true },
+      }],
+    }]);
+
+    expect(merged[0].status).toBe("completed");
+    expect(merged[0].eligibility).toBe("completed");
+    expect(merged[0].rewards.every((reward) => reward.status === "claimed")).toBe(true);
+  });
+
   it("evaluates Twitch reward preconditions from claimed prior drops", () => {
     const campaigns = parseTwitchInventory([{
       id: "campaign",
@@ -815,6 +955,18 @@ describe("Twitch parsers", () => {
     expect(expired.eligibilityReason).toBe("Campaign has ended");
     // original is untouched
     expect(campaign.status).toBe("active");
+  });
+
+  it("re-derives subscription eligibility with withCampaignStatus", () => {
+    const [campaign] = parseTwitchInventory([{
+      id: "subscription-campaign",
+      timeBasedDrops: [{ id: "subscription", requiredSubs: 1 }],
+    }]);
+
+    const active = withCampaignStatus(campaign, "active");
+
+    expect(active.eligibility).toBe("waiting_for_subscription");
+    expect(active.eligibilityReason).toBe("Waiting for a qualifying subscription");
   });
 
   it("detects claimable rewards with campaignHasClaimableReward", () => {

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -1014,6 +1014,21 @@ describe("Twitch parsers", () => {
     expect(active.eligibilityReason).toBe("Waiting for a qualifying subscription");
   });
 
+  it("keeps an active-status fallback completed when every reward is claimed", () => {
+    const [campaign] = parseTwitchInventory([{
+      id: "claimed-mixed-campaign",
+      timeBasedDrops: [
+        { id: "watch", requiredMinutesWatched: 60, self: { isClaimed: true } },
+        { id: "subscription", requiredSubs: 1, self: { isClaimed: true } },
+      ],
+    }]);
+
+    const active = withCampaignStatus(campaign, "active");
+
+    expect(active.eligibility).toBe("completed");
+    expect(active.eligibilityReason).toBe("All rewards are claimed");
+  });
+
   it("detects claimable rewards with campaignHasClaimableReward", () => {
     const [inProgress] = parseTwitchInventory([{
       id: "in-progress",

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -521,6 +521,22 @@ describe("Twitch parsers", () => {
     });
   });
 
+  it("does not call a Twitch-confirmed claimable subscription reward waiting", () => {
+    const [campaign] = parseTwitchInventory([{
+      id: "claimable-subscription-campaign",
+      timeBasedDrops: [{
+        id: "subscription",
+        requiredSubs: 1,
+        self: { dropInstanceID: "subscription-instance" },
+      }],
+    }]);
+
+    expect(campaign.status).toBe("active");
+    expect(campaign.eligibility).toBe("no_rewards");
+    expect(campaign.eligibilityReason).not.toContain("Waiting");
+    expect(campaign.rewards[0].status).toBe("claimable");
+  });
+
   it("does not synthesize a claim id for subscription rewards", () => {
     const campaigns = parseTwitchInventory({
       data: {
@@ -816,6 +832,35 @@ describe("Twitch parsers", () => {
     expect(merged[0].rewards[0].watchedMinutes).toBe(120);
     expect(merged[0].status).toBe("completed");
     expect(merged[0].eligibility).toBe("completed");
+  });
+
+  it("does not treat an old owned benefit as the current campaign's subscription reward", () => {
+    const [campaign] = parseTwitchInventory({
+      data: {
+        currentUser: {
+          inventory: {
+            gameEventDrops: [{ id: "reused-benefit", lastAwardedAt: "2025-06-15T12:00:00.000Z" }],
+            dropCampaignsInProgress: [{
+              id: "current-subscription-campaign",
+              timeBasedDrops: [{
+                id: "current-subscription-drop",
+                requiredSubs: 1,
+                benefitEdges: [{ benefit: { id: "reused-benefit", name: "Returning Reward" } }],
+                self: { isClaimed: false },
+              }],
+            }],
+          },
+        },
+      },
+    });
+
+    expect(campaign.status).toBe("active");
+    expect(campaign.eligibility).toBe("waiting_for_subscription");
+    expect(campaign.rewards[0]).toMatchObject({
+      requirement: "subscription",
+      status: "locked",
+      watchedMinutes: 0,
+    });
   });
 
   it("keeps a mixed campaign active when only its watch reward is claimed", () => {

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -393,6 +393,35 @@ describe("Twitch parsers", () => {
     });
   });
 
+  it("treats an empty-link disconnected Twitch campaign as linked", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "empty-link-ewc-like",
+      self: { isAccountConnected: false },
+      accountLinkURL: "",
+      timeBasedDrops: [{ id: "drop", requiredMinutesWatched: 60 }],
+    }]);
+
+    expect(campaigns[0]).toMatchObject({
+      accountLinked: true,
+      eligibility: "eligible",
+    });
+  });
+
+  it("ignores Twitch-hosted account links for disconnected Twitch campaigns", () => {
+    const campaigns = parseTwitchInventory([{
+      id: "twitch-link-ewc-like",
+      self: { isAccountConnected: false },
+      accountLinkURL: "https://www.twitch.tv/drops/inventory",
+      timeBasedDrops: [{ id: "drop", requiredMinutesWatched: 60 }],
+    }]);
+
+    expect(campaigns[0]).toMatchObject({
+      accountLinked: true,
+      accountLinkUrl: undefined,
+      eligibility: "eligible",
+    });
+  });
+
   it("keeps a genuine disconnected Twitch campaign unlinked when it provides a link URL", () => {
     const campaigns = parseTwitchInventory([{
       id: "genuine-unlinked",

--- a/packages/extension/tests/rewards.test.ts
+++ b/packages/extension/tests/rewards.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { DropCampaign, DropReward } from "@lurkloot/shared/models";
+import {
+  campaignHasSubscriptionRewards,
+  campaignHasWatchRewards,
+  rewardRequirementType,
+} from "@lurkloot/shared/rewards";
+
+const reward = (patch: Partial<DropReward>): DropReward => ({
+  id: "reward",
+  name: "Reward",
+  requiredMinutes: 0,
+  watchedMinutes: 0,
+  status: "locked",
+  ...patch,
+});
+
+describe("reward requirements", () => {
+  it("classifies explicit and legacy rewards", () => {
+    expect(rewardRequirementType(reward({ requirement: "subscription", requiredMinutes: 60 }))).toBe("subscription");
+    expect(rewardRequirementType(reward({ requiredSubs: 1 }))).toBe("subscription");
+    expect(rewardRequirementType(reward({ requiredMinutes: 30 }))).toBe("watch");
+    expect(rewardRequirementType(reward({ isWatchBased: false }))).toBe("action");
+  });
+
+  it("detects both requirement types in a mixed campaign", () => {
+    const campaign = {
+      rewards: [reward({ requirement: "subscription", requiredSubs: 1 }), reward({ requirement: "watch", requiredMinutes: 30 })],
+    } as DropCampaign;
+    expect(campaignHasSubscriptionRewards(campaign)).toBe(true);
+    expect(campaignHasWatchRewards(campaign)).toBe(true);
+  });
+});

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1251,6 +1251,48 @@ describe("scheduler tick", () => {
     });
   });
 
+  it.each(["claimed", "claimable"] as const)(
+    "does not start Watch Queue when a historical watch reward is %s and only a subscription reward remains",
+    async (watchStatus) => {
+      const waiting = campaign("mixed-drops", {
+        eligibility: "waiting_for_subscription",
+        rewards: [
+          { ...reward(watchStatus), requirement: "watch" },
+          {
+            ...reward("locked"),
+            id: "subscription-reward",
+            requiredMinutes: 0,
+            watchedMinutes: 0,
+            requirement: "subscription",
+            requiredSubs: 1,
+            isWatchBased: false,
+          },
+        ],
+      });
+      const checkChannel = vi.fn(async (candidate: ChannelCandidate) => ({
+        live: true,
+        categoryMatches: true,
+        candidate,
+      }));
+
+      const decision = await chooseCampaignDecision(
+        "twitch",
+        [waiting],
+        settings({ platform: { twitch: { watchQueueChannels: ["fallback"] } } }),
+        {
+          listCandidateChannels: vi.fn(async () => []),
+          checkChannel,
+        },
+      );
+
+      expect(checkChannel).not.toHaveBeenCalled();
+      expect(decision).toMatchObject({
+        action: "idle",
+        reasonCode: "campaign_ineligible",
+      });
+    },
+  );
+
   it("stops an existing Watch Queue fallback when only subscription campaigns remain", async () => {
     const waiting = campaign("subscription-drops", {
       eligibility: "waiting_for_subscription",

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1217,6 +1217,83 @@ describe("scheduler tick", () => {
     expect(result.state.sessions.twitch.message).toContain("Waiting for a qualifying subscription");
   });
 
+  it("does not start a live Watch Queue fallback for subscription-only campaigns", async () => {
+    const waiting = campaign("subscription-drops", {
+      eligibility: "waiting_for_subscription",
+      rewards: [{
+        ...reward("locked"),
+        requiredMinutes: 0,
+        watchedMinutes: 0,
+        requirement: "subscription",
+        requiredSubs: 1,
+        isWatchBased: false,
+      }],
+    });
+    const twitch = adapter("twitch", [waiting], []);
+
+    const result = await runSchedulerTick(
+      {
+        sessions: {
+          twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [], kick: [] },
+      },
+      settings({ platform: { twitch: { enabled: true, watchQueueChannels: ["fallback"] }, kick: { enabled: false, watchQueueChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(twitch.checkChannel).not.toHaveBeenCalled();
+    expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
+    expect(result.state.sessions.twitch).toMatchObject({
+      status: "idle",
+      reasonCode: "campaign_ineligible",
+    });
+  });
+
+  it("stops an existing Watch Queue fallback when only subscription campaigns remain", async () => {
+    const waiting = campaign("subscription-drops", {
+      eligibility: "waiting_for_subscription",
+      rewards: [{
+        ...reward("locked"),
+        requiredMinutes: 0,
+        watchedMinutes: 0,
+        requirement: "subscription",
+        requiredSubs: 1,
+        isWatchBased: false,
+      }],
+    });
+    const twitch = adapter("twitch", [waiting], []);
+    const fallback = channel("fallback");
+
+    const result = await runSchedulerTick(
+      {
+        sessions: {
+          twitch: {
+            platform: "twitch",
+            status: "watching",
+            channel: fallback,
+            offlineChecks: 0,
+            tabId: 7,
+            tabManagedByExtension: true,
+          },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [], kick: [] },
+      },
+      settings({ platform: { twitch: { enabled: true, watchQueueChannels: ["fallback"] }, kick: { enabled: false, watchQueueChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(twitch.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 7 }));
+    expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
+    expect(result.state.sessions.twitch).toMatchObject({
+      status: "idle",
+      reasonCode: "campaign_ineligible",
+    });
+    expect(result.state.sessions.twitch.channel).toBeUndefined();
+  });
+
   it("unlocks and selects a chained watch reward after claiming its subscription prerequisite", async () => {
     const subscriptionReward: DropReward = {
       ...reward("claimable"),

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1155,10 +1155,12 @@ describe("scheduler tick", () => {
       requiredMinutes: 0,
       watchedMinutes: 0,
       isWatchBased: false,
+      requirement: "subscription" as const,
+      requiredSubs: 1,
       claimId: "subscription-instance",
     };
     const ready = campaign("subscription-drops", {
-      eligibility: "no_rewards",
+      eligibility: "waiting_for_subscription",
       rewards: [actionReward],
     });
     const twitch = adapter("twitch", [ready], [channel("allowed")]);
@@ -1177,7 +1179,90 @@ describe("scheduler tick", () => {
 
     expect(twitch.claimReward).toHaveBeenCalledWith(ready, actionReward);
     expect(twitch.listCandidateChannels).not.toHaveBeenCalled();
+    expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
     expect(result.state.sessions.twitch.status).toBe("idle");
+  });
+
+  it("keeps a locked subscription-only campaign idle", async () => {
+    const subscriptionReward = {
+      ...reward("locked"),
+      requiredMinutes: 0,
+      watchedMinutes: 0,
+      isWatchBased: false,
+      requirement: "subscription" as const,
+      requiredSubs: 1,
+    };
+    const waiting = campaign("subscription-drops", {
+      eligibility: "waiting_for_subscription",
+      rewards: [subscriptionReward],
+    });
+    const twitch = adapter("twitch", [waiting], [channel("allowed")]);
+
+    const result = await runSchedulerTick(
+      {
+        sessions: {
+          twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [], kick: [] },
+      },
+      settings({ platform: { twitch: { enabled: true, watchQueueChannels: [] }, kick: { enabled: false, watchQueueChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(twitch.listCandidateChannels).not.toHaveBeenCalled();
+    expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
+    expect(result.state.sessions.twitch.status).toBe("idle");
+    expect(result.state.sessions.twitch.reasonCode).toBe("campaign_ineligible");
+    expect(result.state.sessions.twitch.message).toContain("Waiting for a qualifying subscription");
+  });
+
+  it("unlocks and selects a chained watch reward after claiming its subscription prerequisite", async () => {
+    const subscriptionReward: DropReward = {
+      ...reward("claimable"),
+      id: "subscription-reward",
+      requiredMinutes: 0,
+      watchedMinutes: 0,
+      isWatchBased: false,
+      requirement: "subscription",
+      requiredSubs: 1,
+      claimId: "subscription-instance",
+    };
+    const watchReward: DropReward = {
+      ...reward("locked"),
+      id: "watch-reward",
+      requirement: "watch",
+      preconditionRewardIds: [subscriptionReward.id],
+      preconditionsMet: false,
+    };
+    const chained = campaign("chained-drops", {
+      eligibility: "eligible",
+      rewards: [subscriptionReward, watchReward],
+    });
+    const twitch = adapter("twitch", [chained], [channel("allowed")]);
+
+    const result = await runSchedulerTick(
+      {
+        sessions: {
+          twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [], kick: [] },
+      },
+      settings({ platform: { twitch: { enabled: true, watchQueueChannels: [] }, kick: { enabled: false, watchQueueChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(result.state.campaigns.twitch[0].rewards).toEqual([
+      expect.objectContaining({ id: subscriptionReward.id, status: "claimed" }),
+      expect.objectContaining({ id: watchReward.id, preconditionsMet: true }),
+    ]);
+    expect(result.state.sessions.twitch).toMatchObject({
+      status: "watching",
+      campaignId: chained.id,
+      rewardId: watchReward.id,
+    });
+    expect(twitch.prepareWatchTab).toHaveBeenCalled();
   });
 
   it("defers claiming a ready reward until the adapter reports it is claim-ready", async () => {

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -54,6 +54,12 @@ describe("settings", () => {
     });
   });
 
+  it("defaults subscription campaigns to visible while preserving persisted choices", () => {
+    expect(DEFAULT_SETTINGS.campaignVisibility.subscription).toBe(true);
+    expect(mergeSettings({ campaignVisibility: { subscription: false } } as never).campaignVisibility.subscription).toBe(false);
+    expect(mergeSettings({ campaignVisibility: { expired: true } } as never).campaignVisibility.subscription).toBe(true);
+  });
+
   it("clamps persisted numeric settings to browser-safe ranges", () => {
     expect(mergeSettings({ pollIntervalMinutes: 0, offlineRetryLimit: 0 }).pollIntervalMinutes).toBe(1);
     expect(mergeSettings({ pollIntervalMinutes: 0.75 }).pollIntervalMinutes).toBe(1);

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { DropCampaign, DropReward, WatchSession } from "@lurkloot/shared/models";
 import { mergeSettings } from "@lurkloot/shared/settings";
 import { CAMPAIGN_FILTERS } from "../../popup-ui/src/constants";
+import { I18nContext } from "../../popup-ui/src/context";
 import { DropsPanel } from "../../popup-ui/src/drops";
 import {
   campaignFilterCategories,
@@ -11,6 +12,7 @@ import {
   campaignViewFromCampaign,
   isCampaignVisible,
 } from "../../popup-ui/src/viewModels";
+import type { CampaignView, TFunction } from "../../popup-ui/src/types";
 
 const idleSession: WatchSession = {
   platform: "twitch",
@@ -37,6 +39,40 @@ function campaign(id: string, rewards: DropReward[]): DropCampaign {
     status: "active",
     rewards,
   };
+}
+
+const testMessages: Record<string, string> = {
+  actionRequired: "Action required",
+  earned: "Earned",
+  excludeFromFarming: "Exclude from farming",
+  notEarnableByWatching: "Not earnable by watching",
+  qualifyingSubscriptionsRequired: "Requires $1 qualifying subscriptions",
+  subscribedRefresh: "I've subscribed — refresh status",
+  subscriptionProgressUnknown: "Progress unavailable",
+  subscriptionRequired: "Subscription required",
+};
+
+const testT: TFunction = (key, substitutions) => {
+  const message = testMessages[key] ?? key;
+  const values = Array.isArray(substitutions) ? substitutions : [substitutions];
+  return values.reduce<string>((translated, value, index) => (
+    value == null ? translated : translated.replace(`$${index + 1}`, value)
+  ), message);
+};
+
+function renderDrops(campaigns: CampaignView[], refreshing = false): string {
+  return renderToStaticMarkup(createElement(
+    I18nContext.Provider,
+    { value: { t: testT, dir: "ltr", locale: "en" } },
+    createElement(DropsPanel, {
+      campaigns,
+      gameMap: {},
+      refreshing,
+      onRefreshCampaign: () => {},
+      onReorder: () => {},
+      onToggleExclude: () => {},
+    }),
+  ));
 }
 
 describe("subscription drop popup views", () => {
@@ -103,23 +139,70 @@ describe("subscription drop popup views", () => {
     expect(campaignStats(view)).toMatchObject({ kind: "action", progress: undefined, totalRewards: 1 });
   });
 
-  it("renders unknown progress without showing a fabricated zero percent", () => {
+  it("renders subscription-only campaigns without watch progress or exclusion controls", () => {
     const source = campaign("subscription-only", [
-      reward({ id: "subscribe", name: "Subscribe", requirement: "subscription", requiredSubs: 1 }),
+      reward({ id: "subscribe", name: "Subscriber Sword", requirement: "subscription", requiredSubs: 3 }),
     ]);
     const view = campaignViewFromCampaign(source, 0, idleSession, false);
-    let markup = "";
+    const markup = renderDrops([view]);
 
-    expect(() => {
-      markup = renderToStaticMarkup(createElement(DropsPanel, {
-        campaigns: [view],
-        gameMap: {},
-        onReorder: () => {},
-        onToggleExclude: () => {},
-      }));
-    }).not.toThrow();
-    expect(markup).toContain(">—</span>");
-    expect(markup).not.toContain(">0%</span>");
+    expect(markup).toContain("Subscription required");
+    expect(markup).toContain("Requires 3 qualifying subscriptions");
+    expect(markup).toContain("Progress unavailable");
+    expect(markup).toContain("Not earnable by watching");
+    expect(markup).toContain("subscribed — refresh status");
+    expect(markup).not.toContain("0/0");
+    expect(markup).not.toContain("0%");
+    expect(markup).not.toContain("&lt;1m");
+    expect(markup).not.toContain("Exclude from farming");
+  });
+
+  it("keeps watch controls and every reward on mixed campaigns", () => {
+    const source = campaign("mixed", [
+      reward({ id: "watch", name: "Watch Crown", requirement: "watch", requiredMinutes: 60, watchedMinutes: 30, status: "in_progress" }),
+      reward({ id: "subscribe", name: "Subscriber Cape", requirement: "subscription", requiredSubs: 2 }),
+    ]);
+    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)]);
+
+    expect(markup).toContain("Subscription required");
+    expect(markup).toContain("Watch Crown");
+    expect(markup).toContain("Subscriber Cape");
+    expect(markup).toContain("Exclude from farming");
+    expect(markup).toContain("50%");
+    expect(markup).toContain("Progress unavailable");
+    expect(markup).not.toContain("&lt;1m");
+  });
+
+  it("labels obtained subscription rewards as earned", () => {
+    const source = campaign("earned-subscription", [
+      reward({ id: "subscribe", name: "Earned Subscriber Badge", requirement: "subscription", requiredSubs: 1, status: "claimed" }),
+    ]);
+    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)]);
+
+    expect(markup).toContain("Earned");
+    expect(markup).not.toContain("100%");
+  });
+
+  it("renders action campaigns without watch statistics", () => {
+    const source = campaign("action-only", [
+      reward({ id: "purchase", name: "Purchase Bonus", requirement: "action", isWatchBased: false }),
+    ]);
+    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)]);
+
+    expect(markup).toContain("Action required");
+    expect(markup).toContain("Purchase Bonus");
+    expect(markup).not.toContain("0%");
+    expect(markup).not.toContain("&lt;1m");
+    expect(markup).not.toContain("Exclude from farming");
+  });
+
+  it("disables the in-card subscription refresh while refreshing", () => {
+    const source = campaign("subscription-only", [
+      reward({ id: "subscribe", requirement: "subscription", requiredSubs: 1 }),
+    ]);
+    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)], true);
+
+    expect(markup).toMatch(/<button[^>]*disabled=""[^>]*>.*subscribed — refresh status<\/button>/);
   });
 
   it("categorizes and filters subscription campaigns while preserving claimable visibility", () => {

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -44,7 +44,9 @@ function campaign(id: string, rewards: DropReward[]): DropCampaign {
 const testMessages: Record<string, string> = {
   actionRequired: "Action required",
   earned: "Earned",
+  excluded: "Excluded",
   excludeFromFarming: "Exclude from farming",
+  farmingLabel: "Farming",
   notEarnableByWatching: "Not earnable by watching",
   qualifyingSubscriptionsRequired: "Requires $1 qualifying subscriptions",
   subscribedRefresh: "I've subscribed — refresh status",
@@ -143,7 +145,11 @@ describe("subscription drop popup views", () => {
     const source = campaign("subscription-only", [
       reward({ id: "subscribe", name: "Subscriber Sword", requirement: "subscription", requiredSubs: 3 }),
     ]);
-    const view = campaignViewFromCampaign(source, 0, idleSession, false);
+    const view: CampaignView = {
+      ...campaignViewFromCampaign(source, 0, idleSession, false),
+      excluded: true,
+      farmingChannel: { name: "stale-channel" },
+    };
     const markup = renderDrops([view]);
 
     expect(markup).toContain("Subscription required");
@@ -155,6 +161,8 @@ describe("subscription drop popup views", () => {
     expect(markup).not.toContain("0%");
     expect(markup).not.toContain("&lt;1m");
     expect(markup).not.toContain("Exclude from farming");
+    expect(markup).not.toContain("Farming");
+    expect(markup).not.toContain("Excluded");
   });
 
   it("keeps watch controls and every reward on mixed campaigns", () => {

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -181,6 +181,24 @@ describe("subscription drop popup views", () => {
     expect(markup).not.toContain("&lt;1m");
   });
 
+  it("shows unknown remaining work after mixed campaign watch minutes are complete", () => {
+    const source = campaign("mixed", [
+      reward({
+        id: "watch",
+        name: "Watch Crown",
+        requirement: "watch",
+        requiredMinutes: 60,
+        watchedMinutes: 60,
+        status: "claimed",
+      }),
+      reward({ id: "subscribe", name: "Subscriber Cape", requirement: "subscription", requiredSubs: 2 }),
+    ]);
+    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)]);
+
+    expect(markup).not.toContain("&lt;1m");
+    expect(markup.match(/Progress unavailable/g)).toHaveLength(2);
+  });
+
   it("labels obtained subscription rewards as earned", () => {
     const source = campaign("earned-subscription", [
       reward({ id: "subscribe", name: "Earned Subscriber Badge", requirement: "subscription", requiredSubs: 1, status: "claimed" }),

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { DropCampaign, DropReward, WatchSession } from "@lurkloot/shared/models";
+import { mergeSettings } from "@lurkloot/shared/settings";
+import { CAMPAIGN_FILTERS } from "../../popup-ui/src/constants";
+import { DropsPanel } from "../../popup-ui/src/drops";
+import {
+  campaignFilterCategories,
+  campaignStats,
+  campaignViewFromCampaign,
+  isCampaignVisible,
+} from "../../popup-ui/src/viewModels";
+
+const idleSession: WatchSession = {
+  platform: "twitch",
+  offlineChecks: 0,
+  status: "idle",
+};
+
+function reward(overrides: Partial<DropReward>): DropReward {
+  return {
+    id: "reward",
+    name: "Reward",
+    requiredMinutes: 0,
+    watchedMinutes: 0,
+    status: "locked",
+    ...overrides,
+  };
+}
+
+function campaign(id: string, rewards: DropReward[]): DropCampaign {
+  return {
+    id,
+    platform: "twitch",
+    name: id,
+    status: "active",
+    rewards,
+  };
+}
+
+describe("subscription drop popup views", () => {
+  it("preserves subscription rewards without fabricating progress", () => {
+    const source = campaign("subscription-only", [
+      reward({ id: "subscribe-once", name: "Subscribe once", requirement: "subscription", requiredSubs: 1 }),
+      reward({ id: "subscribe-twice", name: "Subscribe twice", requirement: "subscription", requiredSubs: 2 }),
+    ]);
+
+    const view = campaignViewFromCampaign(source, 0, idleSession, false);
+
+    expect(view.rewards).toHaveLength(2);
+    expect(view.rewards[0]).toMatchObject({
+      requirement: "subscription",
+      requiredSubs: 1,
+      progress: undefined,
+    });
+    expect(view.hasSubscriptionRewards).toBe(true);
+    expect(view.hasWatchRewards).toBe(false);
+    expect(campaignStats(view)).toMatchObject({
+      kind: "subscription",
+      totalRequired: 0,
+      totalFarmed: 0,
+      remaining: 0,
+      progress: undefined,
+      completed: 0,
+      totalRewards: 2,
+      complete: false,
+    });
+  });
+
+  it("uses only watch rewards for mixed-campaign minute totals", () => {
+    const source = campaign("mixed", [
+      reward({ id: "watch", name: "Watch", requirement: "watch", requiredMinutes: 60, watchedMinutes: 30, status: "in_progress" }),
+      reward({ id: "subscribe", name: "Subscribe", requirement: "subscription", requiredSubs: 1, status: "claimed" }),
+    ]);
+
+    const view = campaignViewFromCampaign(source, 0, idleSession, false);
+
+    expect(view.rewards).toHaveLength(2);
+    expect(view.rewards[1]).toMatchObject({ requirement: "subscription", progress: 100, obtained: true });
+    expect(view.hasSubscriptionRewards).toBe(true);
+    expect(view.hasWatchRewards).toBe(true);
+    expect(campaignStats(view)).toMatchObject({
+      kind: "mixed",
+      totalRequired: 60,
+      totalFarmed: 30,
+      remaining: 30,
+      progress: 50,
+      completed: 1,
+      totalRewards: 2,
+      complete: false,
+    });
+  });
+
+  it("models action-only campaigns without watch progress", () => {
+    const source = campaign("action-only", [
+      reward({ id: "purchase", name: "Purchase", requirement: "action", isWatchBased: false }),
+    ]);
+
+    const view = campaignViewFromCampaign(source, 0, idleSession, false);
+
+    expect(view.rewards[0]).toMatchObject({ requirement: "action", progress: undefined });
+    expect(campaignStats(view)).toMatchObject({ kind: "action", progress: undefined, totalRewards: 1 });
+  });
+
+  it("renders unknown progress without showing a fabricated zero percent", () => {
+    const source = campaign("subscription-only", [
+      reward({ id: "subscribe", name: "Subscribe", requirement: "subscription", requiredSubs: 1 }),
+    ]);
+    const view = campaignViewFromCampaign(source, 0, idleSession, false);
+    let markup = "";
+
+    expect(() => {
+      markup = renderToStaticMarkup(createElement(DropsPanel, {
+        campaigns: [view],
+        gameMap: {},
+        onReorder: () => {},
+        onToggleExclude: () => {},
+      }));
+    }).not.toThrow();
+    expect(markup).toContain(">—</span>");
+    expect(markup).not.toContain(">0%</span>");
+  });
+
+  it("categorizes and filters subscription campaigns while preserving claimable visibility", () => {
+    const source = campaign("subscription-only", [
+      reward({ requirement: "subscription", requiredSubs: 1 }),
+    ]);
+    const excludedIds = new Set<string>();
+    const settings = mergeSettings(undefined);
+
+    expect(campaignFilterCategories(source, excludedIds)).toEqual(["subscription"]);
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(true);
+
+    settings.campaignVisibility.subscription = false;
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(false);
+    expect(isCampaignVisible({
+      ...source,
+      rewards: [{ ...source.rewards[0], status: "claimable" }],
+    }, settings, excludedIds)).toBe(true);
+  });
+
+  it("exposes the subscription campaign filter", () => {
+    expect(CAMPAIGN_FILTERS).toContainEqual({ key: "subscription", label: "subscriptionCampaigns" });
+  });
+});

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "غير مرتبط"
   },
+  "subscriptionCampaigns": {
+    "message": "حملات الاشتراك"
+  },
   "linkAccount": {
     "message": "اربط حسابك"
   },

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "حملات الاشتراك"
   },
+  "subscriptionRequired": {
+    "message": "الاشتراك مطلوب"
+  },
+  "subscriptionRewards": {
+    "message": "مكافآت الاشتراك"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "عدد الاشتراكات المؤهلة المطلوبة: $1"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "التقدم غير متاح"
+  },
+  "notEarnableByWatching": {
+    "message": "لا يمكن كسبه بالمشاهدة"
+  },
+  "subscribedRefresh": {
+    "message": "لقد اشتركت — تحديث الحالة"
+  },
+  "waitingForSubscription": {
+    "message": "في انتظار اشتراك مؤهل"
+  },
+  "actionRequired": {
+    "message": "يلزم اتخاذ إجراء"
+  },
+  "earned": {
+    "message": "تم الحصول عليها"
+  },
   "linkAccount": {
     "message": "اربط حسابك"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "Abo-Kampagnen"
   },
+  "subscriptionRequired": {
+    "message": "Abonnement erforderlich"
+  },
+  "subscriptionRewards": {
+    "message": "Abonnement-Belohnungen"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "$1 qualifizierende Abonnements erforderlich"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "Fortschritt nicht verfügbar"
+  },
+  "notEarnableByWatching": {
+    "message": "Nicht durch Zuschauen erhältlich"
+  },
+  "subscribedRefresh": {
+    "message": "Ich habe abonniert — Status aktualisieren"
+  },
+  "waitingForSubscription": {
+    "message": "Auf ein qualifizierendes Abonnement warten"
+  },
+  "actionRequired": {
+    "message": "Aktion erforderlich"
+  },
+  "earned": {
+    "message": "Verdient"
+  },
   "linkAccount": {
     "message": "Konto verknüpfen"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "Nicht verknüpft"
   },
+  "subscriptionCampaigns": {
+    "message": "Abo-Kampagnen"
+  },
   "linkAccount": {
     "message": "Konto verknüpfen"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "Subscription campaigns"
   },
+  "subscriptionRequired": {
+    "message": "Subscription required"
+  },
+  "subscriptionRewards": {
+    "message": "Subscription rewards"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "$1 qualifying subscriptions required"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "Progress unavailable"
+  },
+  "notEarnableByWatching": {
+    "message": "Not earnable by watching"
+  },
+  "subscribedRefresh": {
+    "message": "I've subscribed — refresh status"
+  },
+  "waitingForSubscription": {
+    "message": "Waiting for a qualifying subscription"
+  },
+  "actionRequired": {
+    "message": "Action required"
+  },
+  "earned": {
+    "message": "Earned"
+  },
   "linkAccount": {
     "message": "Link your account"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "Not linked"
   },
+  "subscriptionCampaigns": {
+    "message": "Subscription campaigns"
+  },
   "linkAccount": {
     "message": "Link your account"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "No vinculado"
   },
+  "subscriptionCampaigns": {
+    "message": "Campañas de suscripción"
+  },
   "linkAccount": {
     "message": "Vincula tu cuenta"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "Campañas de suscripción"
   },
+  "subscriptionRequired": {
+    "message": "Suscripción obligatoria"
+  },
+  "subscriptionRewards": {
+    "message": "Recompensas por suscripción"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "Se requieren $1 suscripciones válidas"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "Progreso no disponible"
+  },
+  "notEarnableByWatching": {
+    "message": "No se puede obtener viendo el canal"
+  },
+  "subscribedRefresh": {
+    "message": "Ya me he suscrito — actualizar el estado"
+  },
+  "waitingForSubscription": {
+    "message": "Esperando una suscripción válida"
+  },
+  "actionRequired": {
+    "message": "Acción necesaria"
+  },
+  "earned": {
+    "message": "Obtenido"
+  },
   "linkAccount": {
     "message": "Vincula tu cuenta"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "Campagnes avec abonnement"
   },
+  "subscriptionRequired": {
+    "message": "Abonnement requis"
+  },
+  "subscriptionRewards": {
+    "message": "Récompenses d’abonnement"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "$1 abonnements admissibles requis"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "Progression indisponible"
+  },
+  "notEarnableByWatching": {
+    "message": "Impossible à obtenir en regardant"
+  },
+  "subscribedRefresh": {
+    "message": "Abonnement effectué — actualiser le statut"
+  },
+  "waitingForSubscription": {
+    "message": "En attente d’un abonnement admissible"
+  },
+  "actionRequired": {
+    "message": "Action requise"
+  },
+  "earned": {
+    "message": "Obtenu"
+  },
   "linkAccount": {
     "message": "Associez votre compte"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "Non lié"
   },
+  "subscriptionCampaigns": {
+    "message": "Campagnes avec abonnement"
+  },
   "linkAccount": {
     "message": "Associez votre compte"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "लिंक नहीं"
   },
+  "subscriptionCampaigns": {
+    "message": "सदस्यता अभियान"
+  },
   "linkAccount": {
     "message": "अपना खाता लिंक करें"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "सदस्यता अभियान"
   },
+  "subscriptionRequired": {
+    "message": "सदस्यता आवश्यक है"
+  },
+  "subscriptionRewards": {
+    "message": "सदस्यता पुरस्कार"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "योग्य सदस्यताओं की आवश्यक संख्या: $1"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "प्रगति उपलब्ध नहीं है"
+  },
+  "notEarnableByWatching": {
+    "message": "देखकर अर्जित नहीं किया जा सकता"
+  },
+  "subscribedRefresh": {
+    "message": "मैंने सदस्यता ले ली है — स्थिति रीफ़्रेश करें"
+  },
+  "waitingForSubscription": {
+    "message": "योग्य सदस्यता की प्रतीक्षा है"
+  },
+  "actionRequired": {
+    "message": "कार्रवाई आवश्यक है"
+  },
+  "earned": {
+    "message": "अर्जित"
+  },
   "linkAccount": {
     "message": "अपना खाता लिंक करें"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "Non collegato"
   },
+  "subscriptionCampaigns": {
+    "message": "Campagne con abbonamento"
+  },
   "linkAccount": {
     "message": "Collega il tuo account"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "Campagne con abbonamento"
   },
+  "subscriptionRequired": {
+    "message": "Abbonamento richiesto"
+  },
+  "subscriptionRewards": {
+    "message": "Ricompense per abbonamento"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "$1 abbonamenti validi richiesti"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "Avanzamento non disponibile"
+  },
+  "notEarnableByWatching": {
+    "message": "Non ottenibile guardando"
+  },
+  "subscribedRefresh": {
+    "message": "Abbonamento effettuato — aggiorna lo stato"
+  },
+  "waitingForSubscription": {
+    "message": "In attesa di un abbonamento valido"
+  },
+  "actionRequired": {
+    "message": "Azione richiesta"
+  },
+  "earned": {
+    "message": "Ottenuto"
+  },
   "linkAccount": {
     "message": "Collega il tuo account"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -153,16 +153,16 @@
     "message": "Não vinculado"
   },
   "subscriptionCampaigns": {
-    "message": "Campanhas de inscrição"
+    "message": "Campanhas de assinatura"
   },
   "subscriptionRequired": {
-    "message": "Inscrição obrigatória"
+    "message": "Assinatura obrigatória"
   },
   "subscriptionRewards": {
-    "message": "Recompensas por inscrição"
+    "message": "Recompensas por assinatura"
   },
   "qualifyingSubscriptionsRequired": {
-    "message": "$1 inscrições qualificadas necessárias"
+    "message": "$1 assinaturas qualificadas necessárias"
   },
   "subscriptionProgressUnknown": {
     "message": "Progresso indisponível"
@@ -171,10 +171,10 @@
     "message": "Não pode ser obtido assistindo"
   },
   "subscribedRefresh": {
-    "message": "Já me inscrevi — atualizar status"
+    "message": "Assinei — atualizar status"
   },
   "waitingForSubscription": {
-    "message": "Aguardando uma inscrição qualificada"
+    "message": "Aguardando uma assinatura qualificada"
   },
   "actionRequired": {
     "message": "Ação necessária"

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "Não vinculado"
   },
+  "subscriptionCampaigns": {
+    "message": "Campanhas de inscrição"
+  },
   "linkAccount": {
     "message": "Vincule sua conta"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "Campanhas de inscrição"
   },
+  "subscriptionRequired": {
+    "message": "Inscrição obrigatória"
+  },
+  "subscriptionRewards": {
+    "message": "Recompensas por inscrição"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "$1 inscrições qualificadas necessárias"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "Progresso indisponível"
+  },
+  "notEarnableByWatching": {
+    "message": "Não pode ser obtido assistindo"
+  },
+  "subscribedRefresh": {
+    "message": "Já me inscrevi — atualizar status"
+  },
+  "waitingForSubscription": {
+    "message": "Aguardando uma inscrição qualificada"
+  },
+  "actionRequired": {
+    "message": "Ação necessária"
+  },
+  "earned": {
+    "message": "Obtido"
+  },
   "linkAccount": {
     "message": "Vincule sua conta"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "Кампании за подписку"
   },
+  "subscriptionRequired": {
+    "message": "Требуется подписка"
+  },
+  "subscriptionRewards": {
+    "message": "Награды за подписку"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "Необходимое количество подходящих подписок: $1"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "Данные о прогрессе недоступны"
+  },
+  "notEarnableByWatching": {
+    "message": "Нельзя получить за просмотр"
+  },
+  "subscribedRefresh": {
+    "message": "Подписка оформлена — обновить статус"
+  },
+  "waitingForSubscription": {
+    "message": "Ожидание подходящей подписки"
+  },
+  "actionRequired": {
+    "message": "Требуется действие"
+  },
+  "earned": {
+    "message": "Получено"
+  },
   "linkAccount": {
     "message": "Привязать аккаунт"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "Не привязано"
   },
+  "subscriptionCampaigns": {
+    "message": "Кампании за подписку"
+  },
   "linkAccount": {
     "message": "Привязать аккаунт"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -155,6 +155,33 @@
   "subscriptionCampaigns": {
     "message": "订阅活动"
   },
+  "subscriptionRequired": {
+    "message": "需要订阅"
+  },
+  "subscriptionRewards": {
+    "message": "订阅奖励"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "需要 $1 个符合条件的订阅"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "无法获取进度"
+  },
+  "notEarnableByWatching": {
+    "message": "无法通过观看获得"
+  },
+  "subscribedRefresh": {
+    "message": "我已订阅——刷新状态"
+  },
+  "waitingForSubscription": {
+    "message": "正在等待符合条件的订阅"
+  },
+  "actionRequired": {
+    "message": "需要操作"
+  },
+  "earned": {
+    "message": "已获得"
+  },
   "linkAccount": {
     "message": "关联账号"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -152,6 +152,9 @@
   "notLinked": {
     "message": "未关联"
   },
+  "subscriptionCampaigns": {
+    "message": "订阅活动"
+  },
   "linkAccount": {
     "message": "关联账号"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -629,6 +629,8 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                         campaigns={campaigns}
                         gameMap={gameMap}
                         focus={campaignFocus}
+                        refreshing={refreshing}
+                        onRefreshCampaign={() => refreshNow()}
                         onReorder={(ordered) => updateSettings({ campaignPriorities: prioritiesFromOrder(ordered) })}
                         onToggleExclude={(id) => {
                           const next = new Set(settings.excludedCampaignIds);

--- a/packages/popup-ui/src/constants.ts
+++ b/packages/popup-ui/src/constants.ts
@@ -54,6 +54,7 @@ export const EVENT_LEVEL_COLOR: Record<LogLevel, string> = {
 
 export const CAMPAIGN_FILTERS: Array<{ key: CampaignFilterKey; label: string }> = [
   { key: "notLinked", label: "notLinked" },
+  { key: "subscription", label: "subscriptionCampaigns" },
   { key: "upcoming", label: "upcoming" },
   { key: "expired", label: "expired" },
   { key: "excluded", label: "excluded" },

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -214,7 +214,15 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, refreshing,
                   </div>
                   <div className="grid grid-cols-3 gap-1.5">
                     <MetaStat icon={Clock3} label={t("farmed")} value={formatHours(stats.totalFarmed)} />
-                    <MetaStat icon={RotateCcw} label={t("left")} value={stats.complete ? t("done") : formatMinutes(stats.remaining)} />
+                    <MetaStat
+                      icon={RotateCcw}
+                      label={t("left")}
+                      value={stats.complete
+                        ? t("done")
+                        : stats.nextReward?.requirement === "watch"
+                          ? formatMinutes(stats.remaining)
+                          : t("subscriptionProgressUnknown")}
+                    />
                     <MetaStat icon={Trophy} label={t("rewards")} value={`${stats.completed}/${stats.totalRewards}`} />
                   </div>
                 </>

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -157,14 +157,14 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, refreshing,
               <Pill tone="accent">#{index + 1}</Pill>
               {campaign.hasSubscriptionRewards ? <Pill tone="outline"><Users size={9} /> {t("subscriptionRequired")}</Pill> : null}
               {stats.kind === "action" ? <Pill tone="outline"><AlertTriangle size={9} /> {t("actionRequired")}</Pill> : null}
-              {isFarming && <Pill tone="accent"><Radio size={9} /> {t("farmingLabel")}</Pill>}
+              {isFarming && campaign.hasWatchRewards ? <Pill tone="accent"><Radio size={9} /> {t("farmingLabel")}</Pill> : null}
               {lifecyclePill && (
                 <Pill tone={lifecyclePill.tone}>
                   <lifecyclePill.icon size={9} /> {lifecyclePill.label}
                 </Pill>
               )}
               {!campaign.linked && <Pill tone="danger"><Link2 size={9} /> {t("notLinked")}</Pill>}
-              {campaign.excluded && <Pill tone="outline"><Ban size={9} /> {t("excluded")}</Pill>}
+              {campaign.excluded && campaign.hasWatchRewards ? <Pill tone="outline"><Ban size={9} /> {t("excluded")}</Pill> : null}
             </div>
             {showsWatchProgress ? <div className="mt-2"><ProgressBar value={stats.progress ?? 0} glow={emphasized} /></div> : null}
           </div>

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -37,7 +37,7 @@ import {
   useDndSensors,
 } from "./primitives";
 
-export function DropsPanel({ campaigns, gameMap, focus, onReorder, onToggleExclude }: { campaigns: CampaignView[]; gameMap: Record<string, GameItem>; focus?: { id: string; seq: number } | null; onReorder(campaigns: CampaignView[]): void | Promise<void>; onToggleExclude(id: string): void | Promise<void> }) {
+export function DropsPanel({ campaigns, gameMap, focus, refreshing, onRefreshCampaign, onReorder, onToggleExclude }: { campaigns: CampaignView[]; gameMap: Record<string, GameItem>; focus?: { id: string; seq: number } | null; refreshing: boolean; onRefreshCampaign(id: string): void | Promise<void>; onReorder(campaigns: CampaignView[]): void | Promise<void>; onToggleExclude(id: string): void | Promise<void> }) {
   const t = useT();
   const sensors = useDndSensors();
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -73,18 +73,18 @@ export function DropsPanel({ campaigns, gameMap, focus, onReorder, onToggleExclu
       <SortableContext items={campaigns.map((campaign) => campaign.id)} strategy={verticalListSortingStrategy}>
         <div ref={listRef} className="space-y-2">
           {campaigns.map((campaign, index) => (
-            <SortableCampaign key={campaign.id} campaign={campaign} index={index} anyFarming={anyFarming} game={gameMap[campaign.gameId] ?? fallbackGame(campaign, index, t)} expanded={Boolean(expandedIds[campaign.id])} onToggle={() => setExpandedIds((current) => ({ ...current, [campaign.id]: !current[campaign.id] }))} onToggleExclude={onToggleExclude} />
+            <SortableCampaign key={campaign.id} campaign={campaign} index={index} anyFarming={anyFarming} game={gameMap[campaign.gameId] ?? fallbackGame(campaign, index, t)} expanded={Boolean(expandedIds[campaign.id])} refreshing={refreshing} onToggle={() => setExpandedIds((current) => ({ ...current, [campaign.id]: !current[campaign.id] }))} onRefreshCampaign={onRefreshCampaign} onToggleExclude={onToggleExclude} />
           ))}
         </div>
       </SortableContext>
       <DragOverlay dropAnimation={null}>
-        {activeCampaign ? <CampaignCard campaign={activeCampaign} index={activeIndex} anyFarming={anyFarming} game={gameMap[activeCampaign.gameId] ?? fallbackGame(activeCampaign, activeIndex, t)} expanded={false} onToggle={() => undefined} isOverlay dragHandle={<GripVertical size={16} className="text-zinc-400" />} /> : null}
+        {activeCampaign ? <CampaignCard campaign={activeCampaign} index={activeIndex} anyFarming={anyFarming} game={gameMap[activeCampaign.gameId] ?? fallbackGame(activeCampaign, activeIndex, t)} expanded={false} refreshing={refreshing} onToggle={() => undefined} onRefreshCampaign={onRefreshCampaign} isOverlay dragHandle={<GripVertical size={16} className="text-zinc-400" />} /> : null}
       </DragOverlay>
     </DndContext>
   );
 }
 
-function SortableCampaign(props: { campaign: CampaignView; index: number; anyFarming: boolean; game: GameItem; expanded: boolean; onToggle(): void; onToggleExclude(id: string): void | Promise<void> }) {
+function SortableCampaign(props: { campaign: CampaignView; index: number; anyFarming: boolean; game: GameItem; expanded: boolean; refreshing: boolean; onToggle(): void; onRefreshCampaign(id: string): void | Promise<void>; onToggleExclude(id: string): void | Promise<void> }) {
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: props.campaign.id });
   return (
     <div ref={setNodeRef} data-campaign-id={props.campaign.id} style={{ transform: CSS.Transform.toString(transform), transition }}>
@@ -93,7 +93,7 @@ function SortableCampaign(props: { campaign: CampaignView; index: number; anyFar
   );
 }
 
-function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, onToggleExclude, dragHandle, isOverlay = false, dimmed = false }: { campaign: CampaignView; index: number; anyFarming: boolean; game: GameItem; expanded: boolean; onToggle(): void; onToggleExclude?(id: string): void | Promise<void>; dragHandle?: React.ReactNode; isOverlay?: boolean; dimmed?: boolean }) {
+function CampaignCard({ campaign, index, anyFarming, game, expanded, refreshing, onToggle, onRefreshCampaign, onToggleExclude, dragHandle, isOverlay = false, dimmed = false }: { campaign: CampaignView; index: number; anyFarming: boolean; game: GameItem; expanded: boolean; refreshing: boolean; onToggle(): void; onRefreshCampaign(id: string): void | Promise<void>; onToggleExclude?(id: string): void | Promise<void>; dragHandle?: React.ReactNode; isOverlay?: boolean; dimmed?: boolean }) {
   const t = useT();
   const stats = campaignStats(campaign);
   const isFarming = Boolean(campaign.farmingChannel);
@@ -103,6 +103,12 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
     ? t("startsIn", formatCountdown(campaign.starts, t))
     : t("endsIn", formatCountdown(campaign.ends, t));
   const lifecyclePill = campaignLifecyclePill(campaign.lifecycle, t);
+  const showsWatchProgress = stats.kind === "watch" || stats.kind === "mixed";
+  const headlineStatus = stats.kind === "subscription"
+    ? `${stats.completed}/${stats.totalRewards}`
+    : stats.kind === "action"
+      ? t("actionRequired")
+      : `${(stats.progress ?? 0).toFixed(0)}%`;
 
   return (
     <article className={cn("overflow-hidden rounded-2xl border bg-white transition-shadow dark:bg-zinc-900", emphasized ? "border-transparent" : "border-zinc-200 dark:border-zinc-800", isOverlay ? "shadow-2xl shadow-black/25" : "shadow-sm", dimmed && "opacity-40")} style={emphasized ? { boxShadow: isOverlay ? "0 20px 50px -12px rgba(0,0,0,0.5)" : "0 0 0 1.5px var(--accent-ring), 0 10px 30px -18px var(--accent-glow)" } : undefined}>
@@ -139,7 +145,7 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
               </div>
               <div className="flex shrink-0 items-center gap-1.5">
                 <span className="text-[13px] font-bold tabular leading-none" style={{ color: "var(--accent-text)" }}>
-                  {stats.progress == null ? "—" : `${stats.progress.toFixed(0)}%`}
+                  {headlineStatus}
                 </span>
                 <motion.div animate={{ rotate: expanded ? 180 : 0 }} transition={{ duration: 0.2 }} className="shrink-0 text-zinc-400 dark:text-zinc-500"><ChevronDown size={16} /></motion.div>
               </div>
@@ -149,6 +155,8 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
               <span className="truncate">{game.name}</span>
               <span className="shrink-0 text-zinc-300 dark:text-zinc-600">·</span>
               <Pill tone="accent">#{index + 1}</Pill>
+              {campaign.hasSubscriptionRewards ? <Pill tone="outline"><Users size={9} /> {t("subscriptionRequired")}</Pill> : null}
+              {stats.kind === "action" ? <Pill tone="outline"><AlertTriangle size={9} /> {t("actionRequired")}</Pill> : null}
               {isFarming && <Pill tone="accent"><Radio size={9} /> {t("farmingLabel")}</Pill>}
               {lifecyclePill && (
                 <Pill tone={lifecyclePill.tone}>
@@ -158,7 +166,7 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
               {!campaign.linked && <Pill tone="danger"><Link2 size={9} /> {t("notLinked")}</Pill>}
               {campaign.excluded && <Pill tone="outline"><Ban size={9} /> {t("excluded")}</Pill>}
             </div>
-            <div className="mt-2"><ProgressBar value={stats.progress ?? 0} glow={emphasized} /></div>
+            {showsWatchProgress ? <div className="mt-2"><ProgressBar value={stats.progress ?? 0} glow={emphasized} /></div> : null}
           </div>
         </div>
       </div>
@@ -166,22 +174,51 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
         {expanded && (
           <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: "auto", opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.22 }} className="overflow-hidden">
             <div className="space-y-2.5 p-2.5">
-              <div className="rounded-xl border border-zinc-100 bg-zinc-50/70 p-2.5 dark:border-zinc-800 dark:bg-zinc-800/40">
-                <div className="flex items-end justify-between gap-2">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-1 text-[10px] font-medium text-zinc-500 dark:text-zinc-400"><Clock3 size={10} /> {timingLabel}</div>
-                    {stats.complete
-                      ? <div className="mt-0.5 truncate text-[11px] font-medium" style={{ color: "var(--accent-text)" }}>{t("complete")}</div>
-                      : <div className="mt-0.5 truncate text-[11px] text-zinc-600 dark:text-zinc-300">{t("nextReward", stats.nextReward?.name ?? "")}</div>}
+              {stats.kind === "subscription" ? (
+                <div className="rounded-xl border border-zinc-100 bg-zinc-50/70 p-2.5 dark:border-zinc-800 dark:bg-zinc-800/40">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1 text-[10px] font-medium text-zinc-500 dark:text-zinc-400"><Clock3 size={10} /> {timingLabel}</div>
+                      <div className="mt-1 text-[11px] font-semibold text-zinc-700 dark:text-zinc-200">{t("subscriptionRequired")}</div>
+                      <div className="mt-0.5 text-[10px] text-zinc-500 dark:text-zinc-400">{t("notEarnableByWatching")}</div>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <div className="text-xs font-semibold tabular" style={{ color: "var(--accent-text)" }}>{stats.completed}/{stats.totalRewards}</div>
+                      <div className="mt-0.5 text-[9px] font-medium uppercase text-zinc-400 dark:text-zinc-500">{t("subscriptionRewards")}</div>
+                      <div className="mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">{stats.complete ? t("complete") : t("subscriptionProgressUnknown")}</div>
+                    </div>
                   </div>
-                  {!stats.complete && <div className="shrink-0 text-right text-[10px] tabular text-zinc-500 dark:text-zinc-400">{formatMinutes(stats.remaining)} {t("left").toLowerCase()}</div>}
                 </div>
-              </div>
-              <div className="grid grid-cols-3 gap-1.5">
-                <MetaStat icon={Clock3} label={t("farmed")} value={formatHours(stats.totalFarmed)} />
-                <MetaStat icon={RotateCcw} label={t("left")} value={stats.complete ? t("done") : formatMinutes(stats.remaining)} />
-                <MetaStat icon={Trophy} label={t("rewards")} value={`${stats.completed}/${stats.totalRewards}`} />
-              </div>
+              ) : stats.kind === "action" ? (
+                <div className="rounded-xl border border-zinc-100 bg-zinc-50/70 p-2.5 dark:border-zinc-800 dark:bg-zinc-800/40">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1 text-[10px] font-medium text-zinc-500 dark:text-zinc-400"><Clock3 size={10} /> {timingLabel}</div>
+                      <div className="mt-1 text-[11px] font-semibold text-zinc-700 dark:text-zinc-200">{t("actionRequired")}</div>
+                    </div>
+                    <div className="shrink-0 text-xs font-semibold tabular" style={{ color: "var(--accent-text)" }}>{stats.completed}/{stats.totalRewards}</div>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="rounded-xl border border-zinc-100 bg-zinc-50/70 p-2.5 dark:border-zinc-800 dark:bg-zinc-800/40">
+                    <div className="flex items-end justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1 text-[10px] font-medium text-zinc-500 dark:text-zinc-400"><Clock3 size={10} /> {timingLabel}</div>
+                        {stats.complete
+                          ? <div className="mt-0.5 truncate text-[11px] font-medium" style={{ color: "var(--accent-text)" }}>{t("complete")}</div>
+                          : <div className="mt-0.5 truncate text-[11px] text-zinc-600 dark:text-zinc-300">{t("nextReward", stats.nextReward?.name ?? "")}</div>}
+                      </div>
+                      {!stats.complete && stats.nextReward?.requirement === "watch" ? <div className="shrink-0 text-right text-[10px] tabular text-zinc-500 dark:text-zinc-400">{formatMinutes(stats.remaining)} {t("left").toLowerCase()}</div> : null}
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-3 gap-1.5">
+                    <MetaStat icon={Clock3} label={t("farmed")} value={formatHours(stats.totalFarmed)} />
+                    <MetaStat icon={RotateCcw} label={t("left")} value={stats.complete ? t("done") : formatMinutes(stats.remaining)} />
+                    <MetaStat icon={Trophy} label={t("rewards")} value={`${stats.completed}/${stats.totalRewards}`} />
+                  </div>
+                </>
+              )}
               <div>
                 <div className="mb-1.5 flex items-center justify-between">
                   <span className="flex items-center gap-1 text-[11px] font-semibold text-zinc-700 dark:text-zinc-200"><Gift size={12} style={{ color: "var(--accent-text)" }} /> {t("rewards")}</span>
@@ -189,6 +226,17 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
                 </div>
                 <RewardCarousel rewards={campaign.rewards} />
               </div>
+              {campaign.hasSubscriptionRewards ? (
+                <button
+                  type="button"
+                  onClick={() => void onRefreshCampaign(campaign.id)}
+                  disabled={refreshing}
+                  className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-[var(--accent-ring)] py-1.5 text-[11px] font-medium text-[var(--accent-text)] transition-colors hover:bg-[var(--accent-soft)] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <RotateCcw size={12} className={cn(refreshing && "animate-spin")} />
+                  {t("subscribedRefresh")}
+                </button>
+              ) : null}
               <div className="rounded-lg bg-zinc-50 px-2 py-1.5 dark:bg-zinc-800/60">
                 <div className="flex items-center gap-1.5 text-[11px] text-zinc-500 dark:text-zinc-400">
                   <Users size={12} className="shrink-0" />
@@ -224,7 +272,7 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
                   <ExternalLink size={11} className="ml-auto shrink-0 opacity-70" />
                 </a>
               )}
-              {onToggleExclude && (
+              {onToggleExclude && campaign.hasWatchRewards ? (
                 <button
                   type="button"
                   onClick={() => void onToggleExclude(campaign.id)}
@@ -237,7 +285,7 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
                 >
                   <Ban size={12} /> {campaign.excluded ? t("includeInFarming") : t("excludeFromFarming")}
                 </button>
-              )}
+              ) : null}
             </div>
           </motion.div>
         )}
@@ -327,6 +375,7 @@ function campaignLifecyclePill(lifecycle: CampaignLifecycleState | undefined, t:
 }
 
 function RewardTile({ reward }: { reward: RewardView }) {
+  const t = useT();
   const done = reward.obtained || (reward.progress ?? 0) >= 100;
   return (
     <div className="w-[128px] shrink-0 rounded-xl border border-zinc-200 bg-white p-2 dark:border-zinc-800 dark:bg-zinc-900">
@@ -339,13 +388,25 @@ function RewardTile({ reward }: { reward: RewardView }) {
         {done && <span className="absolute right-1 top-1 flex h-4 w-4 items-center justify-center rounded-full bg-emerald-500 text-white"><Check size={11} strokeWidth={3} /></span>}
       </div>
       <div className="mb-1.5 line-clamp-1 text-[11px] font-medium text-zinc-800 dark:text-zinc-200" title={reward.name}>{reward.name}</div>
-      <ProgressBar value={reward.progress ?? 0} size="sm" />
-      <div className="mt-1.5 flex items-center justify-between text-[10px] text-zinc-500 dark:text-zinc-400">
-        <span className="font-semibold tabular" style={(reward.progress ?? 0) > 0 ? { color: "var(--accent-text)" } : undefined}>
-          {reward.progress == null ? "—" : `${reward.progress.toFixed(0)}%`}
-        </span>
-        <span className="tabular">{formatMinutes(reward.requiredMinutes)}</span>
-      </div>
+      {reward.requirement === "watch" ? (
+        <>
+          <ProgressBar value={reward.progress ?? 0} size="sm" />
+          <div className="mt-1.5 flex items-center justify-between text-[10px] text-zinc-500 dark:text-zinc-400">
+            <span className="font-semibold tabular" style={(reward.progress ?? 0) > 0 ? { color: "var(--accent-text)" } : undefined}>
+              {reward.progress == null ? "—" : `${reward.progress.toFixed(0)}%`}
+            </span>
+            <span className="tabular">{formatMinutes(reward.requiredMinutes)}</span>
+          </div>
+        </>
+      ) : reward.requirement === "subscription" ? (
+        <div className="space-y-1 text-[10px] leading-tight text-zinc-500 dark:text-zinc-400">
+          <div className="font-semibold text-zinc-700 dark:text-zinc-200">{t("subscriptionRequired")}</div>
+          <div>{t("qualifyingSubscriptionsRequired", String(reward.requiredSubs ?? 1))}</div>
+          <div className={cn("font-medium", reward.obtained && "text-emerald-600 dark:text-emerald-400")}>{reward.obtained ? t("earned") : t("subscriptionProgressUnknown")}</div>
+        </div>
+      ) : (
+        <div className="text-[10px] font-semibold text-zinc-600 dark:text-zinc-300">{t("actionRequired")}</div>
+      )}
     </div>
   );
 }

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -138,7 +138,9 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
                 )}
               </div>
               <div className="flex shrink-0 items-center gap-1.5">
-                <span className="text-[13px] font-bold tabular leading-none" style={{ color: "var(--accent-text)" }}>{stats.progress.toFixed(0)}%</span>
+                <span className="text-[13px] font-bold tabular leading-none" style={{ color: "var(--accent-text)" }}>
+                  {stats.progress == null ? "—" : `${stats.progress.toFixed(0)}%`}
+                </span>
                 <motion.div animate={{ rotate: expanded ? 180 : 0 }} transition={{ duration: 0.2 }} className="shrink-0 text-zinc-400 dark:text-zinc-500"><ChevronDown size={16} /></motion.div>
               </div>
             </div>
@@ -156,7 +158,7 @@ function CampaignCard({ campaign, index, anyFarming, game, expanded, onToggle, o
               {!campaign.linked && <Pill tone="danger"><Link2 size={9} /> {t("notLinked")}</Pill>}
               {campaign.excluded && <Pill tone="outline"><Ban size={9} /> {t("excluded")}</Pill>}
             </div>
-            <div className="mt-2"><ProgressBar value={stats.progress} glow={emphasized} /></div>
+            <div className="mt-2"><ProgressBar value={stats.progress ?? 0} glow={emphasized} /></div>
           </div>
         </div>
       </div>
@@ -325,7 +327,7 @@ function campaignLifecyclePill(lifecycle: CampaignLifecycleState | undefined, t:
 }
 
 function RewardTile({ reward }: { reward: RewardView }) {
-  const done = reward.obtained || reward.progress >= 100;
+  const done = reward.obtained || (reward.progress ?? 0) >= 100;
   return (
     <div className="w-[128px] shrink-0 rounded-xl border border-zinc-200 bg-white p-2 dark:border-zinc-800 dark:bg-zinc-900">
       <div className="relative mb-2 flex h-[68px] items-center justify-center overflow-hidden rounded-lg bg-zinc-50 dark:bg-zinc-800/40">
@@ -337,9 +339,11 @@ function RewardTile({ reward }: { reward: RewardView }) {
         {done && <span className="absolute right-1 top-1 flex h-4 w-4 items-center justify-center rounded-full bg-emerald-500 text-white"><Check size={11} strokeWidth={3} /></span>}
       </div>
       <div className="mb-1.5 line-clamp-1 text-[11px] font-medium text-zinc-800 dark:text-zinc-200" title={reward.name}>{reward.name}</div>
-      <ProgressBar value={reward.progress} size="sm" />
+      <ProgressBar value={reward.progress ?? 0} size="sm" />
       <div className="mt-1.5 flex items-center justify-between text-[10px] text-zinc-500 dark:text-zinc-400">
-        <span className="font-semibold tabular" style={reward.progress > 0 ? { color: "var(--accent-text)" } : undefined}>{reward.progress.toFixed(0)}%</span>
+        <span className="font-semibold tabular" style={(reward.progress ?? 0) > 0 ? { color: "var(--accent-text)" } : undefined}>
+          {reward.progress == null ? "—" : `${reward.progress.toFixed(0)}%`}
+        </span>
         <span className="tabular">{formatMinutes(reward.requiredMinutes)}</span>
       </div>
     </div>

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -1,5 +1,5 @@
 import type { CliCredentialBlob, RuntimeMessage } from "@lurkloot/shared/messages";
-import type { DropCampaign, Platform, SupportedLocale } from "@lurkloot/shared/models";
+import type { DropCampaign, Platform, RewardRequirementType, SupportedLocale } from "@lurkloot/shared/models";
 
 export type PopupTab = "drops" | "watchQueue";
 export type GameItem = {
@@ -12,8 +12,31 @@ export type GameItem = {
 export type StreamerItem = { id: string; name: string; live: boolean; subtitle?: string; viewers?: number };
 export type FarmingChannelView = { name: string; category?: string; viewers?: number; url?: string };
 export type ChannelLink = { name: string; url: string };
-export type RewardView = { id: string; name: string; progress: number; requiredMinutes: number; obtained: boolean; art: string; tint: string; imageUrl?: string };
+export type RewardView = {
+  id: string;
+  name: string;
+  progress?: number;
+  requiredMinutes: number;
+  requiredSubs?: number;
+  requirement: RewardRequirementType;
+  obtained: boolean;
+  art: string;
+  tint: string;
+  imageUrl?: string;
+};
 export type CampaignLifecycleState = "upcoming" | "expired" | "finished";
+
+export type CampaignStats = {
+  kind: "watch" | "subscription" | "mixed" | "action";
+  totalRequired: number;
+  totalFarmed: number;
+  remaining: number;
+  progress?: number;
+  completed: number;
+  totalRewards: number;
+  nextReward?: RewardView;
+  complete: boolean;
+};
 
 export type CampaignView = {
   id: string;
@@ -38,6 +61,8 @@ export type CampaignView = {
   tint: string;
   imageUrl?: string;
   rewards: RewardView[];
+  hasWatchRewards: boolean;
+  hasSubscriptionRewards: boolean;
 };
 
 export type TFunction = (key: string, substitutions?: string | string[]) => string;

--- a/packages/popup-ui/src/viewModels.ts
+++ b/packages/popup-ui/src/viewModels.ts
@@ -1,8 +1,14 @@
 import type { CampaignFilterKey, DropCampaign, ExtensionSettings, Platform, WatchSession } from "@lurkloot/shared/models";
 import { NO_CATEGORY_ID, categoryListIndex, isUncategorizedCampaign } from "@lurkloot/shared/categories";
+import {
+  campaignHasSubscriptionRewards,
+  campaignHasWatchRewards,
+  isWatchReward,
+  rewardRequirementType,
+} from "@lurkloot/shared/rewards";
 import { CAMPAIGN_TINTS, GAME_ACCENTS, NO_CATEGORY_ACCENT, REWARD_TINTS } from "./constants";
 import { initials } from "./format";
-import type { CampaignLifecycleState, CampaignView, ChannelLink, FarmingChannelView, GameItem, StreamerItem, TFunction } from "./types";
+import type { CampaignLifecycleState, CampaignStats, CampaignView, ChannelLink, FarmingChannelView, GameItem, RewardView, StreamerItem, TFunction } from "./types";
 
 const KICK_ASSET_BASE = "https://ext.kick.com";
 
@@ -30,6 +36,7 @@ export function campaignFilterCategories(campaign: DropCampaign, excludedIds: Se
   const categories: CampaignFilterKey[] = [];
   if (excludedIds.has(campaign.id)) categories.push("excluded");
   if (campaign.accountLinked === false) categories.push("notLinked");
+  if (campaignHasSubscriptionRewards(campaign)) categories.push("subscription");
   if (isCampaignFinished(campaign)) categories.push("finished");
   else if (isCampaignExpired(campaign)) categories.push("expired");
   else if (campaign.status === "upcoming") categories.push("upcoming");
@@ -103,15 +110,24 @@ export function fallbackGame(campaign: DropCampaign | CampaignView, index: numbe
   return { id, name, short, accent: GAME_ACCENTS[Math.max(0, index) % GAME_ACCENTS.length] };
 }
 
-export function campaignStats(campaign: CampaignView) {
-  const totalRequired = campaign.rewards.reduce((sum, reward) => sum + reward.requiredMinutes, 0);
-  const totalFarmed = campaign.rewards.reduce((sum, reward) => sum + (reward.requiredMinutes * reward.progress) / 100, 0);
+export function campaignStats(campaign: CampaignView): CampaignStats {
+  const watchRewards = campaign.rewards.filter(isWatchReward);
+  const requirementKinds = new Set(campaign.rewards.map(rewardRequirementType));
+  const kind = requirementKinds.size > 1
+    ? "mixed"
+    : requirementKinds.values().next().value ?? "watch";
+  const totalRequired = watchRewards.reduce((sum, reward) => sum + reward.requiredMinutes, 0);
+  const totalFarmed = watchRewards.reduce((sum, reward) => sum + (reward.requiredMinutes * (reward.progress ?? 0)) / 100, 0);
   const remaining = Math.max(totalRequired - totalFarmed, 0);
-  const progress = totalRequired ? Math.min(100, (totalFarmed / totalRequired) * 100) : 0;
-  const completed = campaign.rewards.filter((reward) => reward.obtained || reward.progress >= 100).length;
-  const nextReward = campaign.rewards.find((reward) => !reward.obtained && reward.progress < 100) ?? campaign.rewards.at(-1);
-  const complete = campaign.rewards.length > 0 && progress >= 100;
-  return { totalRequired, totalFarmed, remaining, progress, completed, totalRewards: campaign.rewards.length, nextReward, complete };
+  const progress = totalRequired ? Math.min(100, (totalFarmed / totalRequired) * 100) : undefined;
+  const completed = campaign.rewards.filter(rewardComplete).length;
+  const nextReward = campaign.rewards.find((reward) => !rewardComplete(reward)) ?? campaign.rewards.at(-1);
+  const complete = campaign.rewards.length > 0 && campaign.rewards.every((reward) => reward.obtained);
+  return { kind, totalRequired, totalFarmed, remaining, progress, completed, totalRewards: campaign.rewards.length, nextReward, complete };
+}
+
+function rewardComplete(reward: RewardView): boolean {
+  return reward.obtained || (reward.progress ?? 0) >= 100;
 }
 
 export function campaignViewFromCampaign(campaign: DropCampaign, index: number, session: WatchSession, excluded: boolean): CampaignView {
@@ -132,21 +148,26 @@ export function campaignViewFromCampaign(campaign: DropCampaign, index: number, 
     thumbnail: initials(campaign.gameName ?? campaign.name),
     tint: CAMPAIGN_TINTS[index % CAMPAIGN_TINTS.length],
     imageUrl: campaign.gameImageUrl,
-    rewards: campaign.rewards.filter((reward) => reward.isWatchBased !== false).map((reward, rewardIndex) => {
-      const progress = reward.requiredMinutes > 0
+    rewards: campaign.rewards.map((reward, rewardIndex) => {
+      const requirement = rewardRequirementType(reward);
+      const progress = isWatchReward(reward) && reward.requiredMinutes > 0
         ? Math.min(100, (Math.min(reward.watchedMinutes, reward.requiredMinutes) / reward.requiredMinutes) * 100)
-        : reward.status === "claimed" ? 100 : 0;
+        : reward.status === "claimed" ? 100 : undefined;
       return {
         id: reward.id,
         name: reward.name,
         progress,
         requiredMinutes: reward.requiredMinutes,
+        requiredSubs: reward.requiredSubs,
+        requirement,
         obtained: reward.status === "claimed",
         art: initials(reward.name).slice(0, 8),
         tint: REWARD_TINTS[rewardIndex % REWARD_TINTS.length],
         imageUrl: campaign.platform === "kick" ? kickRewardImageUrl(reward.imageUrl) : reward.imageUrl,
       };
     }),
+    hasWatchRewards: campaignHasWatchRewards(campaign),
+    hasSubscriptionRewards: campaignHasSubscriptionRewards(campaign),
   };
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
     "./settings": "./src/settings.ts",
     "./i18n": "./src/i18n.ts",
     "./logging": "./src/logging.ts",
+    "./rewards": "./src/rewards.ts",
     "./events": "./src/events.ts"
   },
   "scripts": {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -4,6 +4,8 @@ export type CampaignStatus = "active" | "upcoming" | "expired" | "completed";
 
 export type RewardStatus = "locked" | "in_progress" | "claimable" | "claimed";
 
+export type RewardRequirementType = "watch" | "subscription" | "action";
+
 // Lifecycle of the one-time Chrome Web Store rate/review nudge. "pending" until
 // the user either rates or dismisses it, after which it never shows again.
 export type RateNudgeStatus = "pending" | "rated" | "dismissed";
@@ -17,6 +19,7 @@ export interface DropReward {
   requiredMinutes: number;
   requiredSubs?: number;
   isWatchBased?: boolean;
+  requirement?: RewardRequirementType;
   watchedMinutes: number;
   status: RewardStatus;
   claimId?: string;
@@ -45,7 +48,7 @@ export interface DropCampaign {
   isGeneralDrop?: boolean;
   accountLinked?: boolean;
   accountLinkUrl?: string;
-  eligibility?: "eligible" | "account_not_linked" | "upcoming" | "expired" | "completed" | "no_rewards";
+  eligibility?: "eligible" | "account_not_linked" | "waiting_for_subscription" | "upcoming" | "expired" | "completed" | "no_rewards";
   eligibilityReason?: string;
   priority?: number;
   url?: string;
@@ -163,7 +166,7 @@ export type PriorityMode = "ending_soonest" | "lowest_availability" | "priority_
 
 // Visibility categories for the Drops list. A campaign in one of these states is
 // only shown when its toggle is on; campaigns in none of them are always shown.
-export type CampaignFilterKey = "notLinked" | "upcoming" | "expired" | "excluded" | "finished";
+export type CampaignFilterKey = "notLinked" | "subscription" | "upcoming" | "expired" | "excluded" | "finished";
 
 export interface PlaybackTelemetry {
   platform: Platform;

--- a/packages/shared/src/rewards.ts
+++ b/packages/shared/src/rewards.ts
@@ -1,0 +1,15 @@
+import type { DropCampaign, DropReward, RewardRequirementType } from "./models";
+
+type RequirementFields = Pick<DropReward, "requirement" | "requiredMinutes" | "requiredSubs" | "isWatchBased">;
+
+export function rewardRequirementType(reward: RequirementFields): RewardRequirementType {
+  if (reward.requirement) return reward.requirement;
+  if ((reward.requiredSubs ?? 0) > 0) return "subscription";
+  if (reward.requiredMinutes > 0 && reward.isWatchBased !== false) return "watch";
+  return "action";
+}
+
+export const isWatchReward = (reward: RequirementFields): boolean => rewardRequirementType(reward) === "watch";
+export const isSubscriptionReward = (reward: RequirementFields): boolean => rewardRequirementType(reward) === "subscription";
+export const campaignHasWatchRewards = (campaign: Pick<DropCampaign, "rewards">): boolean => campaign.rewards.some(isWatchReward);
+export const campaignHasSubscriptionRewards = (campaign: Pick<DropCampaign, "rewards">): boolean => campaign.rewards.some(isSubscriptionReward);

--- a/packages/shared/src/rewards.ts
+++ b/packages/shared/src/rewards.ts
@@ -11,5 +11,37 @@ export function rewardRequirementType(reward: RequirementFields): RewardRequirem
 
 export const isWatchReward = (reward: RequirementFields): boolean => rewardRequirementType(reward) === "watch";
 export const isSubscriptionReward = (reward: RequirementFields): boolean => rewardRequirementType(reward) === "subscription";
+
+export function isWaitingSubscriptionReward(reward: DropReward, now = Date.now()): boolean {
+  if (!isSubscriptionReward(reward)) return false;
+  if (reward.status !== "locked" && reward.status !== "in_progress") return false;
+  if (reward.preconditionsMet === false) return false;
+  const startsAt = reward.availableFrom ? Date.parse(reward.availableFrom) : undefined;
+  const endsAt = reward.availableUntil ? Date.parse(reward.availableUntil) : undefined;
+  if (startsAt != null && !Number.isNaN(startsAt) && now < startsAt) return false;
+  if (endsAt != null && !Number.isNaN(endsAt) && now >= endsAt) return false;
+  return true;
+}
+
 export const campaignHasWatchRewards = (campaign: Pick<DropCampaign, "rewards">): boolean => campaign.rewards.some(isWatchReward);
 export const campaignHasSubscriptionRewards = (campaign: Pick<DropCampaign, "rewards">): boolean => campaign.rewards.some(isSubscriptionReward);
+
+export function reconcileCampaignAfterClaims(campaign: DropCampaign, rewards: DropReward[]): DropCampaign {
+  const claimedIds = new Set(
+    rewards.filter((reward) => reward.status === "claimed").map((reward) => reward.id),
+  );
+  const reconciledRewards = rewards.map((reward) => ({
+    ...reward,
+    preconditionsMet: (reward.preconditionRewardIds ?? []).every((id) => claimedIds.has(id)),
+  }));
+  const completed = reconciledRewards.length > 0
+    && reconciledRewards.every((reward) => reward.status === "claimed");
+
+  return {
+    ...campaign,
+    rewards: reconciledRewards,
+    status: completed ? "completed" : campaign.status,
+    eligibility: completed ? "completed" : campaign.eligibility,
+    eligibilityReason: completed ? "All rewards are claimed" : campaign.eligibilityReason,
+  };
+}

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -2,7 +2,7 @@ import type { AdFocusMode, CampaignFilterKey, CategorySelection, EngineSettings,
 
 const AD_FOCUS_MODES: AdFocusMode[] = ["none", "tab", "window"];
 const PRIORITY_MODES: PriorityMode[] = ["ending_soonest", "lowest_availability", "priority_list_only"];
-const CAMPAIGN_FILTER_KEYS: CampaignFilterKey[] = ["notLinked", "upcoming", "expired", "excluded", "finished"];
+const CAMPAIGN_FILTER_KEYS: CampaignFilterKey[] = ["notLinked", "subscription", "upcoming", "expired", "excluded", "finished"];
 const RATE_NUDGE_STATUSES: RateNudgeStatus[] = ["pending", "rated", "dismissed"];
 export const SUPPORTED_LOCALES: SupportedLocale[] = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar"];
 const LANGUAGE_OVERRIDES: LanguageOverride[] = ["browser", ...SUPPORTED_LOCALES];
@@ -58,6 +58,7 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
   // finished campaigns; hide expired and excluded ones unless opted back in.
   campaignVisibility: {
     notLinked: true,
+    subscription: true,
     upcoming: true,
     expired: false,
     excluded: false,


### PR DESCRIPTION
## Summary

- detect Twitch Drops that require paid or gifted subscriptions and keep those campaigns visible by default
- prevent subscription-only rewards from entering the watch queue while clearly showing that user action is required
- handle mixed campaigns by continuing to farm watch-based rewards and presenting subscription rewards separately
- add a campaign-local **I've subscribed — refresh status** action without storing credentials or bypassing Twitch eligibility checks
- expose subscription campaign filtering and requirement status in the popup, localized catalogs, and CLI

## User impact

Subscription-required campaigns no longer appear as ordinary watch-time campaigns with misleading progress. Users can see why a reward cannot be farmed automatically, refresh its state after subscribing, and still farm any watch-eligible rewards in a mixed campaign.

The CLI reports subscription requirements and waits safely instead of attempting to farm rewards that cannot progress through viewing.

## Validation

- `pnpm verify`
- Playwright UI QA covering watch-only, subscription-only, mixed, wide, and responsive campaign states
- verified campaign exclusion, carousel behavior, refresh single-flight behavior, no console errors, and no horizontal overflow
- final whole-branch code review completed with no findings

## Screenshots

The popup states were exercised in the Playwright rendered QA harness for watch-only, subscription-only, and mixed campaigns.

Closes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for subscription-based and mixed reward campaigns.
  * Subscription-only campaigns now clearly show requirements, progress availability, earned rewards, and required actions.
  * Added a subscription campaign filter and refresh action in the popup.
  * Chained rewards now unlock automatically after completing subscription prerequisites.
  * CLI campaign status output now includes detailed reward requirements and waiting states.
* **Bug Fixes**
  * Improved campaign completion and reward progress tracking across watch, subscription, and action rewards.
  * Prevented subscription-only campaigns from opening watch sessions unnecessarily.
* **Localization**
  * Added subscription-related translations across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->