### PR TITLE
docs(changelog): update 1.4.0 changes

### DIFF
--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -23,8 +23,20 @@
         "text": "What’s New is now shown as a notice in the popup after meaningful updates instead of opening a browser tab automatically."
       },
       {
+        "kind": "improved",
+        "text": "Activity now shows localized farming events separately from diagnostic logs, with paged history for easier review."
+      },
+      {
+        "kind": "improved",
+        "text": "Selected category lists now show category artwork when available."
+      },
+      {
         "kind": "fixed",
         "text": "Twitch now ignores subscription, purchase, and other non-watch rewards when choosing campaigns to farm."
+      },
+      {
+        "kind": "fixed",
+        "text": "Twitch campaigns no longer appear as “Not linked” when Twitch does not provide a genuine external account-link flow."
       },
       {
         "kind": "fixed",


### PR DESCRIPTION
## Summary

- document the separated Activity event history
- mention category artwork in selected category lists
- document the Twitch false account-link status fix

## Testing

- `pnpm build:site`
- changelog JSON parse validation
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Localized farming activity is now distinguished from diagnostic logs, with paged history available.
  - Category artwork is displayed when available.

- **Bug Fixes**
  - Twitch campaign selection continues to exclude non-watch rewards, such as subscriptions and purchases.
  - Twitch campaigns no longer appear as “Not linked” when no external account-link flow is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->