### PR TITLE
feat(popup): add rotating tips

### DIFF
--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -43,6 +43,7 @@ describe("settings", () => {
       notifyRewardEarned: true,
       notifyNoDropsLeft: true,
       autoStartDropFarming: true,
+      showTips: true,
       languageOverride: "browser",
       watchQueueFallbackOnly: true,
       pollIntervalMinutes: 1,
@@ -52,6 +53,12 @@ describe("settings", () => {
         kick: { excludedChannels: [], farmAllCategories: true, categories: [] },
       },
     });
+  });
+
+  it("shows popup tips by default and preserves an explicit hidden preference", () => {
+    expect(mergeSettings(undefined).showTips).toBe(true);
+    expect(mergeSettings({ showTips: false }).showTips).toBe(false);
+    expect(mergeSettings({ showTips: "no" } as never).showTips).toBe(true);
   });
 
   it("defaults subscription campaigns to visible while preserving persisted choices", () => {

--- a/packages/extension/tests/tips.test.ts
+++ b/packages/extension/tests/tips.test.ts
@@ -1,0 +1,104 @@
+import React, { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { I18nContext } from "../../popup-ui/src/context";
+import {
+  createTipRotator,
+  nextTipIndex,
+  randomTipIndex,
+  TIP_ROTATION_MS,
+  TipsBanner,
+} from "../../popup-ui/src/tips";
+
+describe("tip rotation", () => {
+  it("chooses a bounded random starting tip", () => {
+    expect(randomTipIndex(8, () => 0)).toBe(0);
+    expect(randomTipIndex(8, () => 0.999)).toBe(7);
+    expect(randomTipIndex(0, () => 0.5)).toBe(0);
+  });
+
+  it("advances sequentially and wraps without an immediate repeat", () => {
+    expect(nextTipIndex(2, 8)).toBe(3);
+    expect(nextTipIndex(7, 8)).toBe(0);
+    expect(nextTipIndex(0, 1)).toBe(0);
+  });
+
+  it("advances every ten seconds only while visible and cleans up", () => {
+    let tick: (() => void) | undefined;
+    let intervalMs = 0;
+    let cleared: unknown;
+    let visible = true;
+    let advances = 0;
+
+    const stop = createTipRotator({
+      onAdvance: () => { advances += 1; },
+      isVisible: () => visible,
+      setInterval: (callback, milliseconds) => {
+        tick = callback;
+        intervalMs = milliseconds;
+        return 42;
+      },
+      clearInterval: (handle) => { cleared = handle; },
+    });
+
+    expect(intervalMs).toBe(TIP_ROTATION_MS);
+    tick?.();
+    expect(advances).toBe(1);
+    visible = false;
+    tick?.();
+    expect(advances).toBe(1);
+    stop();
+    expect(cleared).toBe(42);
+  });
+});
+
+describe("TipsBanner", () => {
+  it("renders external actions with safe link attributes", () => {
+    const html = renderToStaticMarkup(createElement(
+      I18nContext.Provider,
+      { value: { t: (key: string) => key, dir: "ltr", locale: "en" } },
+      createElement(TipsBanner, { initialIndex: 5 }),
+    ));
+
+    expect(html).toContain("tipCli");
+    expect(html).toContain("target=\"_blank\"");
+    expect(html).toContain("rel=\"noreferrer\"");
+  });
+
+  it("is gated by the popup preference and deterministic in previews", () => {
+    const popupSource = readFileSync(resolve(import.meta.dirname, "../../popup-ui/src/Popup.tsx"), "utf8");
+    expect(popupSource).toContain("settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} /> : null");
+  });
+
+  it("has a Hide tips control in General settings", () => {
+    const settingsSource = readFileSync(resolve(import.meta.dirname, "../../popup-ui/src/settings.tsx"), "utf8");
+    expect(settingsSource).toContain('title={t("hideTipsTitle")}');
+    expect(settingsSource).toContain('checked={!settings.showTips}');
+    expect(settingsSource).toContain('onChange={(hideTips) => onSettingsChange({ showTips: !hideTips })}');
+  });
+
+  it("localizes every tip and the Hide tips setting in every catalog", () => {
+    const requiredKeys = [
+      "hideTipsTitle",
+      "hideTipsDescription",
+      "tipCampaignPriority",
+      "tipMissingCampaigns",
+      "tipCategorySelection",
+      "tipWatchQueue",
+      "tipTablessMode",
+      "tipCli",
+      "tipCliAction",
+      "tipFeedback",
+      "tipFeedbackAction",
+      "tipExcludedCampaigns",
+    ];
+    const locales = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar"];
+
+    for (const locale of locales) {
+      const catalog = JSON.parse(readFileSync(resolve(import.meta.dirname, `../../locales/messages/${locale}.json`), "utf8"));
+      for (const key of requiredKeys) expect(catalog[key]?.message, `${locale}.${key}`).toBeTruthy();
+      expect(catalog.priorityHint, `${locale}.priorityHint`).toBeUndefined();
+    }
+  });
+});

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "المشاهدة متوقفة مؤقتًا. فعّل المفتاح لاستئناف فارم Drops."
   },
-  "priorityHint": {
-    "message": "تأخذ Drops الأولوية دائمًا على قائمة المشاهدة. اسحب الحملات من المقبض لتحديد ترتيب الفارم."
-  },
+  "hideTipsTitle": { "message": "إخفاء النصائح" },
+  "hideTipsDescription": { "message": "يخفي النصائح المفيدة من النافذة الرئيسية." },
+  "tipCampaignPriority": { "message": "تأخذ Drops الأولوية على قائمة المشاهدة. اسحب الحملات من المقبض لترتيب الفارم." },
+  "tipMissingCampaigns": { "message": "هل هناك حملة مفقودة؟ تحقق من مخزون Drops في المنصة ثم من عوامل التصفية في الإعدادات." },
+  "tipCategorySelection": { "message": "تريد ألعابًا محددة فقط؟ عطّل «فارم كل الفئات» واختر فئاتك." },
+  "tipWatchQueue": { "message": "تفارم قائمة المشاهدة القنوات المختارة عند عدم توفر Drops مؤهلة." },
+  "tipTablessMode": { "message": "يستهلك الوضع بلا تبويبات موارد أقل ويفتح تبويبًا مكتومًا عند الحاجة." },
+  "tipCli": { "message": "تفضّل العمل بلا إضافة؟ يتوفر Lurkloot أيضًا كواجهة CLI عبر Docker." },
+  "tipCliAction": { "message": "اقرأ دليل CLI" },
+  "tipFeedback": { "message": "وجدت خطأ أو لديك فكرة؟" },
+  "tipFeedbackAction": { "message": "افتح issue على GitHub" },
+  "tipExcludedCampaigns": { "message": "استبعدت حملة بالخطأ؟ استعدها من إعدادات Drops." },
   "noCampaigns": {
     "message": "لم يتم اكتشاف أي حملات بعد."
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "Schauen pausiert. Schalter aktivieren, um Drop-Farming fortzusetzen."
   },
-  "priorityHint": {
-    "message": "Drops haben immer Vorrang vor der Warteschlange. Ziehe Kampagnen am Griff, um die Farming-Reihenfolge festzulegen."
-  },
+  "hideTipsTitle": { "message": "Tipps ausblenden" },
+  "hideTipsDescription": { "message": "Blendet hilfreiche Tipps im Hauptfenster aus." },
+  "tipCampaignPriority": { "message": "Drops haben Vorrang vor der Warteschlange. Ziehe Kampagnen am Griff, um sie zu ordnen." },
+  "tipMissingCampaigns": { "message": "Fehlt eine Kampagne? Prüfe das Drops-Inventar der Plattform und die Filter in den Einstellungen." },
+  "tipCategorySelection": { "message": "Nur bestimmte Spiele? Deaktiviere „Alle Kategorien farmen“ und wähle deine Kategorien." },
+  "tipWatchQueue": { "message": "Die Warteschlange farmt ausgewählte Kanäle, wenn keine geeigneten Drops verfügbar sind." },
+  "tipTablessMode": { "message": "Der tablose Modus spart Ressourcen und öffnet bei Bedarf einen stummgeschalteten Tab." },
+  "tipCli": { "message": "Lieber ohne Erweiterung? Lurkloot ist auch als Docker-CLI verfügbar." },
+  "tipCliAction": { "message": "CLI-Anleitung lesen" },
+  "tipFeedback": { "message": "Fehler gefunden oder eine Idee?" },
+  "tipFeedbackAction": { "message": "GitHub-Issue öffnen" },
+  "tipExcludedCampaigns": { "message": "Kampagne versehentlich ausgeschlossen? Stelle sie in den Drops-Einstellungen wieder her." },
   "noCampaigns": {
     "message": "Noch keine Kampagnen gefunden."
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "Watching paused. Toggle to resume drop farming."
   },
-  "priorityHint": {
-    "message": "Drops always take priority over the Watch Queue. Drag campaigns by the grip to set farming order."
-  },
+  "hideTipsTitle": { "message": "Hide tips" },
+  "hideTipsDescription": { "message": "Remove helpful tips from the main popup." },
+  "tipCampaignPriority": { "message": "Drops take priority over the Watch Queue. Drag campaigns by the grip to set their farming order." },
+  "tipMissingCampaigns": { "message": "Missing a campaign? Check your platform's Drops inventory, then review campaign filters in Settings." },
+  "tipCategorySelection": { "message": "Only farming certain games? Turn off ‘Farm all categories’ in platform settings and choose your categories." },
+  "tipWatchQueue": { "message": "The Watch Queue farms selected channels when no eligible drops are available." },
+  "tipTablessMode": { "message": "Tabless mode uses fewer resources and falls back to a muted tab when needed." },
+  "tipCli": { "message": "Prefer running without an extension? Lurkloot is also available as a Docker-based CLI." },
+  "tipCliAction": { "message": "Read the CLI guide" },
+  "tipFeedback": { "message": "Found a bug or have an idea?" },
+  "tipFeedbackAction": { "message": "Open a GitHub issue" },
+  "tipExcludedCampaigns": { "message": "Excluded a campaign by mistake? Restore excluded campaigns from Drops settings." },
   "noCampaigns": {
     "message": "No campaigns discovered yet."
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "Visualización pausada. Activa el interruptor para reanudar el farmeo de drops."
   },
-  "priorityHint": {
-    "message": "Los drops siempre tienen prioridad sobre la cola de visualización. Arrastra campañas por el agarre para definir el orden de farmeo."
-  },
+  "hideTipsTitle": { "message": "Ocultar consejos" },
+  "hideTipsDescription": { "message": "Oculta los consejos de la ventana principal." },
+  "tipCampaignPriority": { "message": "Los drops tienen prioridad sobre la cola. Arrastra las campañas por el agarre para ordenar el farmeo." },
+  "tipMissingCampaigns": { "message": "¿Falta una campaña? Comprueba el inventario de drops de la plataforma y los filtros en Ajustes." },
+  "tipCategorySelection": { "message": "¿Solo quieres ciertos juegos? Desactiva «Farmear todas las categorías» y elige las categorías." },
+  "tipWatchQueue": { "message": "La cola farmea los canales elegidos cuando no hay drops disponibles." },
+  "tipTablessMode": { "message": "El modo sin pestañas usa menos recursos y recurre a una pestaña silenciada cuando hace falta." },
+  "tipCli": { "message": "¿Prefieres no usar una extensión? Lurkloot también ofrece una CLI para Docker." },
+  "tipCliAction": { "message": "Ver guía de la CLI" },
+  "tipFeedback": { "message": "¿Encontraste un error o tienes una idea?" },
+  "tipFeedbackAction": { "message": "Abrir un issue en GitHub" },
+  "tipExcludedCampaigns": { "message": "¿Excluiste una campaña por error? Restáurala desde los ajustes de Drops." },
   "noCampaigns": {
     "message": "Aún no se han descubierto campañas."
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "Visionnage en pause. Activez le bouton pour reprendre le farm de drops."
   },
-  "priorityHint": {
-    "message": "Les drops ont toujours priorité sur la file de visionnage. Faites glisser les campagnes par la poignée pour définir l’ordre de farm."
-  },
+  "hideTipsTitle": { "message": "Masquer les astuces" },
+  "hideTipsDescription": { "message": "Masque les astuces de la fenêtre principale." },
+  "tipCampaignPriority": { "message": "Les drops ont priorité sur la file d’attente. Faites glisser les campagnes par la poignée pour les ordonner." },
+  "tipMissingCampaigns": { "message": "Une campagne manque ? Vérifiez l’inventaire Drops de la plateforme puis les filtres dans les paramètres." },
+  "tipCategorySelection": { "message": "Seulement certains jeux ? Désactivez « Farmer toutes les catégories » et choisissez vos catégories." },
+  "tipWatchQueue": { "message": "La file d’attente farme les chaînes choisies lorsqu’aucun drop éligible n’est disponible." },
+  "tipTablessMode": { "message": "Le mode sans onglet utilise moins de ressources et ouvre un onglet muet si nécessaire." },
+  "tipCli": { "message": "Vous préférez éviter l’extension ? Lurkloot existe aussi en CLI Docker." },
+  "tipCliAction": { "message": "Lire le guide CLI" },
+  "tipFeedback": { "message": "Un bug ou une idée ?" },
+  "tipFeedbackAction": { "message": "Ouvrir une issue GitHub" },
+  "tipExcludedCampaigns": { "message": "Campagne exclue par erreur ? Restaurez-la dans les paramètres des Drops." },
   "noCampaigns": {
     "message": "Aucune campagne découverte pour le moment."
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "देखना रुका है। Drops फ़ार्मिंग फिर शुरू करने के लिए टॉगल करें।"
   },
-  "priorityHint": {
-    "message": "Drops को देखने की कतार से हमेशा प्राथमिकता मिलती है। फ़ार्मिंग क्रम सेट करने के लिए कैंपेन को ग्रिप से खींचें।"
-  },
+  "hideTipsTitle": { "message": "सुझाव छिपाएँ" },
+  "hideTipsDescription": { "message": "मुख्य पॉपअप से उपयोगी सुझाव हटाएँ।" },
+  "tipCampaignPriority": { "message": "Drops को देखने की कतार पर प्राथमिकता मिलती है। क्रम तय करने के लिए कैंपेन को ग्रिप से खींचें।" },
+  "tipMissingCampaigns": { "message": "कैंपेन नहीं दिख रहा? प्लेटफ़ॉर्म की Drops इन्वेंट्री और सेटिंग्स के फ़िल्टर जाँचें।" },
+  "tipCategorySelection": { "message": "सिर्फ़ कुछ गेम चाहिए? ‘सभी श्रेणियाँ फ़ार्म करें’ बंद करके श्रेणियाँ चुनें।" },
+  "tipWatchQueue": { "message": "योग्य Drops न होने पर देखने की कतार चुने हुए चैनल फ़ार्म करती है।" },
+  "tipTablessMode": { "message": "टैबलेस मोड कम संसाधन इस्तेमाल करता है और ज़रूरत पर म्यूट टैब खोलता है।" },
+  "tipCli": { "message": "एक्सटेंशन नहीं चाहिए? Lurkloot Docker-आधारित CLI के रूप में भी उपलब्ध है।" },
+  "tipCliAction": { "message": "CLI गाइड पढ़ें" },
+  "tipFeedback": { "message": "बग मिला या कोई सुझाव है?" },
+  "tipFeedbackAction": { "message": "GitHub issue खोलें" },
+  "tipExcludedCampaigns": { "message": "गलती से कैंपेन हटाया? उसे Drops सेटिंग्स से वापस लाएँ।" },
   "noCampaigns": {
     "message": "अभी कोई अभियान नहीं मिला।"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "Visione in pausa. Attiva l’interruttore per riprendere il farming dei drop."
   },
-  "priorityHint": {
-    "message": "I drop hanno sempre priorità sulla coda di visione. Trascina le campagne dalla maniglia per impostare l’ordine di farming."
-  },
+  "hideTipsTitle": { "message": "Nascondi suggerimenti" },
+  "hideTipsDescription": { "message": "Nasconde i suggerimenti dalla finestra principale." },
+  "tipCampaignPriority": { "message": "I drop hanno priorità sulla coda. Trascina le campagne dalla maniglia per ordinarle." },
+  "tipMissingCampaigns": { "message": "Manca una campagna? Controlla l’inventario Drop della piattaforma e i filtri nelle impostazioni." },
+  "tipCategorySelection": { "message": "Vuoi solo alcuni giochi? Disattiva «Farma tutte le categorie» e scegli le categorie." },
+  "tipWatchQueue": { "message": "La coda farma i canali scelti quando non ci sono drop idonei." },
+  "tipTablessMode": { "message": "La modalità senza schede usa meno risorse e apre una scheda silenziata quando serve." },
+  "tipCli": { "message": "Preferisci non usare un’estensione? Lurkloot è disponibile anche come CLI Docker." },
+  "tipCliAction": { "message": "Leggi la guida CLI" },
+  "tipFeedback": { "message": "Hai trovato un bug o hai un’idea?" },
+  "tipFeedbackAction": { "message": "Apri una issue GitHub" },
+  "tipExcludedCampaigns": { "message": "Hai escluso una campagna per errore? Ripristinala dalle impostazioni Drop." },
   "noCampaigns": {
     "message": "Nessuna campagna scoperta finora."
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "Visualização pausada. Ative para retomar o farming de drops."
   },
-  "priorityHint": {
-    "message": "Drops sempre têm prioridade sobre a fila de visualização. Arraste campanhas pela alça para definir a ordem de farming."
-  },
+  "hideTipsTitle": { "message": "Ocultar dicas" },
+  "hideTipsDescription": { "message": "Oculta as dicas úteis da janela principal." },
+  "tipCampaignPriority": { "message": "Drops têm prioridade sobre a fila. Arraste as campanhas pela alça para definir a ordem." },
+  "tipMissingCampaigns": { "message": "Não encontrou uma campanha? Confira o inventário de Drops da plataforma e os filtros nas configurações." },
+  "tipCategorySelection": { "message": "Quer apenas certos jogos? Desative “Farmar todas as categorias” e escolha as categorias." },
+  "tipWatchQueue": { "message": "A fila farma os canais escolhidos quando não há Drops elegíveis." },
+  "tipTablessMode": { "message": "O modo sem abas usa menos recursos e abre uma aba silenciada quando necessário." },
+  "tipCli": { "message": "Prefere não usar uma extensão? O Lurkloot também oferece uma CLI para Docker." },
+  "tipCliAction": { "message": "Ler o guia da CLI" },
+  "tipFeedback": { "message": "Encontrou um bug ou tem uma ideia?" },
+  "tipFeedbackAction": { "message": "Abrir uma issue no GitHub" },
+  "tipExcludedCampaigns": { "message": "Excluiu uma campanha por engano? Restaure-a nas configurações de Drops." },
   "noCampaigns": {
     "message": "Nenhuma campanha descoberta ainda."
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "Просмотр приостановлен. Включите переключатель, чтобы продолжить фарм drops."
   },
-  "priorityHint": {
-    "message": "Drops всегда имеют приоритет над очередью просмотра. Перетаскивайте кампании за ручку, чтобы задать порядок фарма."
-  },
+  "hideTipsTitle": { "message": "Скрыть советы" },
+  "hideTipsDescription": { "message": "Скрывает полезные советы в главном окне." },
+  "tipCampaignPriority": { "message": "Drops имеют приоритет над очередью. Перетаскивайте кампании за ручку, чтобы задать порядок." },
+  "tipMissingCampaigns": { "message": "Нет кампании? Проверьте инвентарь Drops платформы и фильтры в настройках." },
+  "tipCategorySelection": { "message": "Нужны только отдельные игры? Отключите «Фармить все категории» и выберите категории." },
+  "tipWatchQueue": { "message": "Очередь фармит выбранные каналы, когда нет доступных Drops." },
+  "tipTablessMode": { "message": "Режим без вкладок экономит ресурсы и при необходимости открывает вкладку без звука." },
+  "tipCli": { "message": "Не хотите расширение? Lurkloot также доступен как CLI для Docker." },
+  "tipCliAction": { "message": "Открыть руководство CLI" },
+  "tipFeedback": { "message": "Нашли ошибку или есть идея?" },
+  "tipFeedbackAction": { "message": "Создать issue на GitHub" },
+  "tipExcludedCampaigns": { "message": "Исключили кампанию случайно? Восстановите её в настройках Drops." },
   "noCampaigns": {
     "message": "Кампании пока не обнаружены."
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -119,9 +119,18 @@
   "watchingPausedHint": {
     "message": "观看已暂停。切换开关以继续刷掉宝。"
   },
-  "priorityHint": {
-    "message": "Drops 始终优先于观看队列。拖动活动把手来设置刷取顺序。"
-  },
+  "hideTipsTitle": { "message": "隐藏提示" },
+  "hideTipsDescription": { "message": "在主弹窗中隐藏实用提示。" },
+  "tipCampaignPriority": { "message": "Drops 优先于观看队列。拖动活动把手即可设置刷取顺序。" },
+  "tipMissingCampaigns": { "message": "找不到活动？请检查平台的 Drops 库存，然后查看设置中的活动筛选器。" },
+  "tipCategorySelection": { "message": "只刷特定游戏？关闭平台设置中的“刷取所有类别”，然后选择类别。" },
+  "tipWatchQueue": { "message": "没有符合条件的 Drops 时，观看队列会刷取所选频道。" },
+  "tipTablessMode": { "message": "无标签页模式占用更少资源，并在需要时回退到静音标签页。" },
+  "tipCli": { "message": "不想使用扩展？Lurkloot 也提供基于 Docker 的 CLI。" },
+  "tipCliAction": { "message": "阅读 CLI 指南" },
+  "tipFeedback": { "message": "发现错误或有建议？" },
+  "tipFeedbackAction": { "message": "提交 GitHub issue" },
+  "tipExcludedCampaigns": { "message": "误排除了活动？可在 Drops 设置中恢复。" },
   "noCampaigns": {
     "message": "尚未发现活动。"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -4,7 +4,6 @@ import {
   ArrowLeft,
   Clock3,
   Gift,
-  Info,
   Play,
   RotateCcw,
   Settings as SettingsIcon,
@@ -59,6 +58,7 @@ import { DropsPanel } from "./drops";
 import { WatchQueuePanel } from "./watchQueue";
 import { AutomationHero, PlatformSwitcher } from "./automation";
 import { SettingsView } from "./settings";
+import { TipsBanner } from "./tips";
 export function screenshotVariant(id: string | null | undefined): ScreenshotVariant {
   return SCREENSHOT_VARIANTS[id ?? "twitch-drops"] ?? SCREENSHOT_VARIANTS["twitch-drops"];
 }
@@ -608,12 +608,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                   ) : null}
                 </AnimatePresence>
                 <AutomationHero platformLabel={PLATFORMS[platform].label} enabled={enabled} pending={automationPending} farmingTitle={activeCampaign?.title} farmingChannel={farmingChannel} onFarmingTitleClick={onFarmingTitleClick} statusMessage={resumingAutomation ? t("resumingAutomation") : session.message} onChange={setAutomation} />
-                <div className="flex items-start gap-2 rounded-xl px-2.5 py-2 text-[11px]" style={{ backgroundColor: "var(--accent-softer)" }}>
-                  <Info size={13} className="mt-0.5 shrink-0" style={{ color: "var(--accent-text)" }} />
-                  <p className="leading-snug text-zinc-600 dark:text-zinc-300">
-                    {t("priorityHint")}
-                  </p>
-                </div>
+                {settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} /> : null}
                 <SubTabs
                   tabs={[
                     { id: "drops", label: t("dropsTab"), icon: Gift, count: campaigns.length },

--- a/packages/popup-ui/src/constants.ts
+++ b/packages/popup-ui/src/constants.ts
@@ -17,6 +17,8 @@ export const CHROME_WEB_STORE_URL = `https://chromewebstore.google.com/detail/${
 export const CHROME_WEB_STORE_REVIEW_URL = `${CHROME_WEB_STORE_URL}/reviews`;
 // Canonical marketing/landing site for the extension.
 export const SITE_URL = "https://lurkloot.jamezrin.com";
+export const CLI_DOCS_URL = "https://github.com/jamezrin/lurkloot/tree/main/packages/cli#readme";
+export const GITHUB_NEW_ISSUE_URL = "https://github.com/jamezrin/lurkloot/issues/new/choose";
 // How long after install before the one-time "rate it" nudge appears.
 export const RATE_NUDGE_MIN_DAYS = 3;
 

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -91,6 +91,7 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
         />
         <SettingRow title={t("pauseManualTitle")} description={t("pauseManualDescription")} checked={settings.pauseOnManualWatch} onChange={set("pauseOnManualWatch")} />
         <SettingRow title={t("autoStartTitle")} description={t("autoStartDescription")} checked={settings.autoStartDropFarming} onChange={set("autoStartDropFarming")} />
+        <SettingRow title={t("hideTipsTitle")} description={t("hideTipsDescription")} checked={!settings.showTips} onChange={(hideTips) => onSettingsChange({ showTips: !hideTips })} />
       </SettingsSection>
       <SettingsSection title={t("notificationsTitle")} description={t("notificationsDescription")} icon={Bell}>
         <SettingRow title={t("rewardEarnedTitle")} description={t("rewardEarnedDescription")} checked={settings.notifyRewardEarned} onChange={set("notifyRewardEarned")} />

--- a/packages/popup-ui/src/tips.tsx
+++ b/packages/popup-ui/src/tips.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { Info } from "lucide-react";
+import { CLI_DOCS_URL, GITHUB_NEW_ISSUE_URL } from "./constants";
+import { useT } from "./context";
+
+export const TIP_ROTATION_MS = 10_000;
+
+interface TipDescriptor {
+  messageKey: string;
+  actionKey?: string;
+  href?: string;
+}
+
+const TIPS: TipDescriptor[] = [
+  { messageKey: "tipCampaignPriority" },
+  { messageKey: "tipMissingCampaigns" },
+  { messageKey: "tipCategorySelection" },
+  { messageKey: "tipWatchQueue" },
+  { messageKey: "tipTablessMode" },
+  { messageKey: "tipCli", actionKey: "tipCliAction", href: CLI_DOCS_URL },
+  { messageKey: "tipFeedback", actionKey: "tipFeedbackAction", href: GITHUB_NEW_ISSUE_URL },
+  { messageKey: "tipExcludedCampaigns" },
+];
+
+export function randomTipIndex(count: number, random: () => number = Math.random): number {
+  return count > 0 ? Math.floor(random() * count) : 0;
+}
+
+export function nextTipIndex(current: number, count: number): number {
+  return count > 0 ? (current + 1) % count : 0;
+}
+
+export function createTipRotator({
+  onAdvance,
+  isVisible,
+  setInterval: schedule = (callback, milliseconds) => globalThis.setInterval(callback, milliseconds),
+  clearInterval: cancel = (handle) => globalThis.clearInterval(handle as ReturnType<typeof globalThis.setInterval>),
+}: {
+  onAdvance(): void;
+  isVisible(): boolean;
+  setInterval?: (callback: () => void, milliseconds: number) => unknown;
+  clearInterval?: (handle: unknown) => void;
+}): () => void {
+  const handle = schedule(() => {
+    if (isVisible()) onAdvance();
+  }, TIP_ROTATION_MS);
+  return () => cancel(handle);
+}
+
+export function TipsBanner({ initialIndex }: { initialIndex?: number }): React.ReactElement {
+  const t = useT();
+  const reduceMotion = useReducedMotion();
+  const [tipIndex, setTipIndex] = React.useState(() => initialIndex ?? randomTipIndex(TIPS.length));
+
+  React.useEffect(() => createTipRotator({
+    onAdvance: () => setTipIndex((current) => nextTipIndex(current, TIPS.length)),
+    isVisible: () => typeof document === "undefined" || document.visibilityState === "visible",
+  }), []);
+
+  const tip = TIPS[tipIndex] ?? TIPS[0];
+  return (
+    <div className="flex items-start gap-2 rounded-xl px-2.5 py-2 text-[11px]" style={{ backgroundColor: "var(--accent-softer)" }}>
+      <Info size={13} className="mt-0.5 shrink-0" style={{ color: "var(--accent-text)" }} />
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.p
+          key={tip.messageKey}
+          initial={reduceMotion ? false : { opacity: 0, y: 2 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={reduceMotion ? undefined : { opacity: 0, y: -2 }}
+          transition={{ duration: reduceMotion ? 0 : 0.15 }}
+          className="leading-snug text-zinc-600 dark:text-zinc-300"
+        >
+          {t(tip.messageKey)}
+          {tip.href && tip.actionKey ? (
+            <>
+              {" "}
+              <a
+                href={tip.href}
+                target="_blank"
+                rel="noreferrer"
+                className="font-semibold text-[var(--accent-text)] underline decoration-current/35 underline-offset-2 hover:decoration-current"
+              >
+                {t(tip.actionKey)}
+              </a>
+            </>
+          ) : null}
+        </motion.p>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -252,6 +252,7 @@ export interface ExtensionSettings extends EngineSettings {
   // Which campaign states are shown in the Drops list. See CampaignFilterKey.
   campaignVisibility: Record<CampaignFilterKey, boolean>;
   rateNudgeStatus: RateNudgeStatus;
+  showTips: boolean;
   // Extension-only persistence policy. Normal farming activity is always
   // recorded; this opt-in adds lower-level technical diagnostics.
   diagnosticLogging: boolean;

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -65,6 +65,7 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
     finished: true,
   },
   rateNudgeStatus: "pending",
+  showTips: true,
   diagnosticLogging: false,
 };
 
@@ -129,6 +130,7 @@ export function mergeSettings(value: Partial<ExtensionSettings> | undefined): Ex
     rateNudgeStatus: RATE_NUDGE_STATUSES.includes(value?.rateNudgeStatus as RateNudgeStatus)
       ? (value!.rateNudgeStatus as RateNudgeStatus)
       : DEFAULT_SETTINGS.rateNudgeStatus,
+    showTips: booleanOr(value?.showTips, DEFAULT_SETTINGS.showTips),
     diagnosticLogging,
   };
 }


### PR DESCRIPTION
## Summary

- replace the fixed popup priority hint with eight localized tips that start randomly and rotate every 10 seconds
- add a General settings toggle that persists whether tips are hidden
- pause advancement while the popup is hidden, respect reduced motion, and keep preview screenshots deterministic
- add safe links from the CLI and feedback tips and translate the feature across all ten supported locales

## User impact

Users see a broader set of concise guidance in the existing hint banner instead of the same message on every popup open. Users who do not want the banner can disable it from General settings.

## Testing

- `pnpm test` — 420 extension tests and 69 CLI tests passed
- `pnpm typecheck`
- `pnpm build:site`
- `pnpm build`
- `pnpm build:firefox`
- Playwright visual QA against the interactive site demo at 1440×1000:
  - rotating banner rendered in the main popup
  - General settings rendered the unchecked **Hide tips** switch
  - toggling the switch changed `aria-checked` from `false` to `true`
  - returning to the main popup removed the banner
  - no application console errors

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rotating, localized tips to the main popup view.
  * Added a “Hide tips” toggle; tips are enabled by default.
  * Added contextual guidance covering campaigns, categories, watch queues, tabless mode, CLI usage, feedback, and excluded campaigns.
  * Added standardized links for CLI documentation and reporting new issues.
* **Localization**
  * Replaced the prior priority hint with new “hide tips” and detailed tip messages across supported languages.
* **Tests**
  * Added tip-rotation and TipsBanner UI coverage, plus updated settings default/merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->