### PR TITLE
chore(release): promote 1.4.0 to stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lurkloot",
   "version": "1.4.0",
   "release": {
-    "channel": "prerelease"
+    "channel": "stable"
   },
   "description": "Cross-browser Twitch and Kick drops farming WebExtension using visible muted tabs.",
   "license": "Apache-2.0",

--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -42,7 +42,8 @@
         "kind": "fixed",
         "text": "Twitch now confirms that a selected live channel offers the intended campaign when that information is available."
       }
-    ]
+    ],
+    "date": "2026-07-15"
   },
   {
     "version": "1.3.0",


### PR DESCRIPTION
Promotes **1.4.0** from pre-release to **stable**, publishing the CWS-approved revision and cutting the stable GitHub release, Docker aliases, and production site.

## Changes
- `package.json`: `release.channel` `prerelease` → `stable`
- `packages/site/src/changelog.json`: date 1.4.0 entry `2026-07-15`

Generated by `pnpm release:prepare 1.4.0 --stable --date 2026-07-15`; `pnpm release:check` passes.

## Provenance note
The CWS 1.4.0 revision was **uploaded/submitted manually** in the Developer Dashboard (current-`main` build), so the automated `cws-v1.4.0-candidate` tag never advanced past `f741fc7` (2026-07-13). I re-pointed the candidate tag at `9e97c6a` (current `origin/main`, the source matching the approved store build) with `chrome_zip_sha256` of the Chrome ZIP rebuilt from that commit. This is build-identical to the promotion commit (only `release.channel` + changelog date differ, both excluded from the build-input guard), so the workflow's provenance validation passes honestly.

## Before merging
- Confirm CWS reports **1.4.0 as `STAGED`** (approved, awaiting publish).
- On merge, **approve the `stable-releases` deployment** in Actions.

## After the workflow succeeds
- Verify Chrome Web Store + GitHub Release show 1.4.0, then upload the Firefox ZIP/source ZIP to AMO.
- Confirm the dated changelog deployed to https://lurkloot.jamezrin.com.
- Prepare the next pre-release before merging further feature work (the stable guard refuses to mutate a released version).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Promoted the release channel from prerelease to stable.
  * Added the release date for version 1.4.0 to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->