### PR TITLE
docs(changelog): add 1.5.0 changes

### DIFF
--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -1,5 +1,22 @@
 [
   {
+    "version": "1.5.0",
+    "changes": [
+      {
+        "kind": "new",
+        "text": "Added rotating tips in the popup that point to useful settings and shortcuts, with an option to hide them."
+      },
+      {
+        "kind": "new",
+        "text": "Added Twitch and Kick compatibility profiles that keep farming working as those sites change — selected automatically, or manually with expert overrides."
+      },
+      {
+        "kind": "improved",
+        "text": "Exporting session credentials for the command-line app now confirms inline in the popup instead of through a browser dialog."
+      }
+    ]
+  },
+  {
     "version": "1.4.0",
     "changes": [
       {


### PR DESCRIPTION
## Summary

Adds a `1.5.0` entry to the site changelog covering the user-facing changes that landed after the 1.4.0-stable promotion (`548375f`, #101):

- **New:** rotating popup tips, with a hide option (#100)
- **New:** Twitch/Kick versioned compatibility profiles — automatic, with expert overrides (#104)
- **Improved:** inline confirmation for the CLI credential export instead of a browser dialog

The remaining commits since 1.4.0 are internal release/CI automation and are intentionally excluded from the user-facing changelog. No date is set since 1.5.0 is not yet released.

## Testing

- Validated `changelog.json` parses and all `kind` values are recognized by the loader.