### PR TITLE
Release 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurkloot",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Cross-browser Twitch and Kick drops farming WebExtension using visible muted tabs.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lurkloot/cli",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "private": true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lurkloot/core",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "private": true,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lurkloot/extension",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Cross-browser Twitch and Kick drops farming WebExtension using visible muted tabs.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/extension/tests/settingsCredentialExport.test.tsx
+++ b/packages/extension/tests/settingsCredentialExport.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
+import { I18nContext, PopupRuntimeContext } from "../../popup-ui/src/context";
+import { SettingsView } from "../../popup-ui/src/settings";
+import type { PopupAdapter } from "../../popup-ui/src/types";
+
+const labels: Record<string, string> = {
+  cliExportTitle: "Headless CLI",
+  cliExportDescription: "Use this browser session with the CLI.",
+  cliExportHint: "Keep the exported session credentials private.",
+  cliExportConfirm: "Anyone with this file can use your sessions.",
+  cliExportButton: "Export credentials",
+  cliExportCancel: "Cancel",
+  cliExportConfirmButton: "Confirm export",
+};
+
+let root: Root | undefined;
+
+const adapter: PopupAdapter = {
+  version: "test",
+  send: async () => undefined as never,
+  getStorage: async () => ({}),
+  setStorage: async () => undefined,
+  getMessage: (key) => key,
+  getUiLanguage: () => "en",
+  openLink: () => undefined,
+};
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+function renderSettings(onExportCredentials: () => void): void {
+  act(() => {
+    root?.render(
+      <PopupRuntimeContext.Provider value={{ adapter, preview: true }}>
+        <I18nContext.Provider value={{ t: (key) => labels[key] ?? key, dir: "ltr", locale: "en" }}>
+          <SettingsView
+            suggestions={{ twitch: [], kick: [] }}
+            onSearchCategories={async () => []}
+            settings={DEFAULT_SETTINGS}
+            onSettingsChange={async () => undefined}
+            onExportCredentials={onExportCredentials}
+          />
+        </I18nContext.Provider>
+      </PopupRuntimeContext.Provider>,
+    );
+  });
+}
+
+function mount(onExportCredentials = vi.fn()) {
+  const { document, window } = parseHTML("<div id=app></div>");
+  const confirm = vi.fn();
+  Object.defineProperty(window, "confirm", { configurable: true, value: confirm });
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.getElementById("app")!;
+  root = createRoot(container);
+  renderSettings(onExportCredentials);
+  return { confirm, container, onExportCredentials };
+}
+
+function byText(container: Element, text: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find((item) => item.textContent?.includes(text));
+  if (!button) throw new Error(`Missing button: ${text}`);
+  return button as HTMLButtonElement;
+}
+
+function openCliSection(container: Element): void {
+  act(() => byText(container, "Headless CLI").click());
+}
+
+describe("settings credential export", () => {
+  it("requires an inline confirmation and supports explicit cancellation", () => {
+    const { confirm, container, onExportCredentials } = mount();
+    openCliSection(container);
+
+    expect(container.textContent).toContain("Export credentials");
+    expect(container.textContent).not.toContain("Confirm export");
+
+    act(() => byText(container, "Export credentials").click());
+    expect(container.textContent).toContain("Anyone with this file can use your sessions.");
+    expect(container.textContent).toContain("Cancel");
+    expect(container.textContent).toContain("Confirm export");
+    expect(onExportCredentials).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+
+    act(() => byText(container, "Cancel").click());
+    expect(container.textContent).toContain("Export credentials");
+    expect(container.textContent).not.toContain("Confirm export");
+    expect(onExportCredentials).not.toHaveBeenCalled();
+
+    act(() => byText(container, "Export credentials").click());
+    act(() => byText(container, "Confirm export").click());
+    expect(onExportCredentials).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("Export credentials");
+    expect(container.textContent).not.toContain("Confirm export");
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("cancels an armed export when Settings unmounts", () => {
+    const { container, onExportCredentials } = mount();
+    openCliSection(container);
+
+    act(() => byText(container, "Export credentials").click());
+    expect(container.textContent).toContain("Confirm export");
+
+    act(() => root?.render(<div>Outside settings</div>));
+    renderSettings(onExportCredentials);
+    openCliSection(container);
+
+    expect(container.textContent).toContain("Export credentials");
+    expect(container.textContent).not.toContain("Confirm export");
+    expect(onExportCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/tests/settingsCredentialExport.test.tsx
+++ b/packages/extension/tests/settingsCredentialExport.test.tsx
@@ -3,12 +3,11 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { parseHTML } from "linkedom";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
-import { I18nContext, PopupRuntimeContext } from "../../popup-ui/src/context";
-import { SettingsView } from "../../popup-ui/src/settings";
-import type { PopupAdapter } from "../../popup-ui/src/types";
+import { Popup, createDemoPopupAdapter, screenshotVariant, type PopupAdapter } from "@lurkloot/popup-ui";
 
 const labels: Record<string, string> = {
+  openSettings: "Open settings",
+  back: "Back",
   cliExportTitle: "Headless CLI",
   cliExportDescription: "Use this browser session with the CLI.",
   cliExportHint: "Keep the exported session credentials private.",
@@ -20,51 +19,36 @@ const labels: Record<string, string> = {
 
 let root: Root | undefined;
 
-const adapter: PopupAdapter = {
-  version: "test",
-  send: async () => undefined as never,
-  getStorage: async () => ({}),
-  setStorage: async () => undefined,
-  getMessage: (key) => key,
-  getUiLanguage: () => "en",
-  openLink: () => undefined,
-};
-
 afterEach(() => {
   if (root) act(() => root?.unmount());
   root = undefined;
   vi.unstubAllGlobals();
 });
 
-function renderSettings(onExportCredentials: () => void): void {
-  act(() => {
-    root?.render(
-      <PopupRuntimeContext.Provider value={{ adapter, preview: true }}>
-        <I18nContext.Provider value={{ t: (key) => labels[key] ?? key, dir: "ltr", locale: "en" }}>
-          <SettingsView
-            suggestions={{ twitch: [], kick: [] }}
-            onSearchCategories={async () => []}
-            settings={DEFAULT_SETTINGS}
-            onSettingsChange={async () => undefined}
-            onExportCredentials={onExportCredentials}
-          />
-        </I18nContext.Provider>
-      </PopupRuntimeContext.Provider>,
-    );
-  });
-}
-
-function mount(onExportCredentials = vi.fn()) {
+async function mount() {
   const { document, window } = parseHTML("<div id=app></div>");
   const confirm = vi.fn();
+  const exportCredentials = vi.fn();
   Object.defineProperty(window, "confirm", { configurable: true, value: confirm });
   vi.stubGlobal("window", window);
   vi.stubGlobal("document", document);
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => window.setTimeout(() => callback(Date.now()), 0));
+  vi.stubGlobal("cancelAnimationFrame", (handle: number) => window.clearTimeout(handle));
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr" }));
   const container = document.getElementById("app")!;
-  root = createRoot(container);
-  renderSettings(onExportCredentials);
-  return { confirm, container, onExportCredentials };
+  const demoAdapter = createDemoPopupAdapter();
+  const adapter: PopupAdapter = {
+    ...demoAdapter,
+    getMessage: (key) => labels[key] ?? demoAdapter.getMessage(key),
+    exportCredentials,
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} initialState={{ preview: true, variant: screenshotVariant("settings") }} />);
+    await Promise.resolve();
+  });
+  return { confirm, container, exportCredentials };
 }
 
 function byText(container: Element, text: string): HTMLButtonElement {
@@ -73,13 +57,26 @@ function byText(container: Element, text: string): HTMLButtonElement {
   return button as HTMLButtonElement;
 }
 
+function byLabel(container: Element, label: string): HTMLButtonElement {
+  const button = container.querySelector(`button[aria-label="${label}"]`);
+  if (!button) throw new Error(`Missing button label: ${label}`);
+  return button as HTMLButtonElement;
+}
+
+function openSettings(container: Element): void {
+  act(() => byLabel(container, "Open settings").click());
+}
+
 function openCliSection(container: Element): void {
-  act(() => byText(container, "Headless CLI").click());
+  const sectionButton = byText(container, "Headless CLI");
+  if (sectionButton.getAttribute("aria-expanded") !== "true") {
+    act(() => sectionButton.click());
+  }
 }
 
 describe("settings credential export", () => {
-  it("requires an inline confirmation and supports explicit cancellation", () => {
-    const { confirm, container, onExportCredentials } = mount();
+  it("requires an inline confirmation and supports explicit cancellation", async () => {
+    const { confirm, container, exportCredentials } = await mount();
     openCliSection(container);
 
     expect(container.textContent).toContain("Export credentials");
@@ -89,35 +86,35 @@ describe("settings credential export", () => {
     expect(container.textContent).toContain("Anyone with this file can use your sessions.");
     expect(container.textContent).toContain("Cancel");
     expect(container.textContent).toContain("Confirm export");
-    expect(onExportCredentials).not.toHaveBeenCalled();
+    expect(exportCredentials).not.toHaveBeenCalled();
     expect(confirm).not.toHaveBeenCalled();
 
     act(() => byText(container, "Cancel").click());
     expect(container.textContent).toContain("Export credentials");
     expect(container.textContent).not.toContain("Confirm export");
-    expect(onExportCredentials).not.toHaveBeenCalled();
+    expect(exportCredentials).not.toHaveBeenCalled();
 
     act(() => byText(container, "Export credentials").click());
-    act(() => byText(container, "Confirm export").click());
-    expect(onExportCredentials).toHaveBeenCalledTimes(1);
+    await act(async () => byText(container, "Confirm export").click());
+    expect(exportCredentials).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("Export credentials");
     expect(container.textContent).not.toContain("Confirm export");
     expect(confirm).not.toHaveBeenCalled();
   });
 
-  it("cancels an armed export when Settings unmounts", () => {
-    const { container, onExportCredentials } = mount();
+  it("cancels an armed export after Back followed by immediate reopen", async () => {
+    const { container, exportCredentials } = await mount();
     openCliSection(container);
 
     act(() => byText(container, "Export credentials").click());
     expect(container.textContent).toContain("Confirm export");
 
-    act(() => root?.render(<div>Outside settings</div>));
-    renderSettings(onExportCredentials);
+    act(() => byLabel(container, "Back").click());
+    openSettings(container);
     openCliSection(container);
 
     expect(container.textContent).toContain("Export credentials");
     expect(container.textContent).not.toContain("Confirm export");
-    expect(onExportCredentials).not.toHaveBeenCalled();
+    expect(exportCredentials).not.toHaveBeenCalled();
   });
 });

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "سيؤدي هذا إلى تنزيل رموز جلسات Twitch وKick في ملف. أي شخص يملك هذا الملف يمكنه التصرف نيابةً عنك على هذه المواقع. هل تريد المتابعة؟"
   },
+  "cliExportCancel": {
+    "message": "إلغاء"
+  },
+  "cliExportConfirmButton": {
+    "message": "تأكيد التصدير"
+  },
   "cliExportButton": {
     "message": "تصدير بيانات الاعتماد"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "Dies lädt deine Twitch- und Kick-Sitzungstokens in eine Datei herunter. Wer diese Datei besitzt, kann auf diesen Seiten in deinem Namen handeln. Fortfahren?"
   },
+  "cliExportCancel": {
+    "message": "Abbrechen"
+  },
+  "cliExportConfirmButton": {
+    "message": "Export bestätigen"
+  },
   "cliExportButton": {
     "message": "Anmeldedaten exportieren"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "This downloads your Twitch and Kick session tokens to a file. Anyone with that file can act as you on those sites. Continue?"
   },
+  "cliExportCancel": {
+    "message": "Cancel"
+  },
+  "cliExportConfirmButton": {
+    "message": "Confirm export"
+  },
   "cliExportButton": {
     "message": "Export credentials"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "Esto descargará tus tokens de sesión de Twitch y Kick a un archivo. Cualquiera que tenga ese archivo podrá actuar como tú en esos sitios. ¿Continuar?"
   },
+  "cliExportCancel": {
+    "message": "Cancelar"
+  },
+  "cliExportConfirmButton": {
+    "message": "Confirmar exportación"
+  },
   "cliExportButton": {
     "message": "Exportar credenciales"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "Ceci télécharge vos jetons de session Twitch et Kick dans un fichier. Quiconque possède ce fichier peut agir en votre nom sur ces sites. Continuer ?"
   },
+  "cliExportCancel": {
+    "message": "Annuler"
+  },
+  "cliExportConfirmButton": {
+    "message": "Confirmer l’exportation"
+  },
   "cliExportButton": {
     "message": "Exporter les identifiants"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "यह आपके Twitch और Kick सत्र टोकन को एक फ़ाइल में डाउनलोड करेगा। उस फ़ाइल वाला कोई भी व्यक्ति उन साइटों पर आपके रूप में कार्य कर सकता है। जारी रखें?"
   },
+  "cliExportCancel": {
+    "message": "रद्द करें"
+  },
+  "cliExportConfirmButton": {
+    "message": "निर्यात की पुष्टि करें"
+  },
   "cliExportButton": {
     "message": "क्रेडेंशियल निर्यात करें"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "Questo scaricherà i token di sessione di Twitch e Kick in un file. Chiunque abbia quel file può agire come te su quei siti. Continuare?"
   },
+  "cliExportCancel": {
+    "message": "Annulla"
+  },
+  "cliExportConfirmButton": {
+    "message": "Conferma esportazione"
+  },
   "cliExportButton": {
     "message": "Esporta credenziali"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "Isto baixará seus tokens de sessão da Twitch e da Kick em um arquivo. Qualquer pessoa com esse arquivo pode agir como você nesses sites. Continuar?"
   },
+  "cliExportCancel": {
+    "message": "Cancelar"
+  },
+  "cliExportConfirmButton": {
+    "message": "Confirmar exportação"
+  },
   "cliExportButton": {
     "message": "Exportar credenciais"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "Это сохранит токены сессий Twitch и Kick в файл. Любой, у кого есть этот файл, сможет действовать от вашего имени на этих сайтах. Продолжить?"
   },
+  "cliExportCancel": {
+    "message": "Отмена"
+  },
+  "cliExportConfirmButton": {
+    "message": "Подтвердить экспорт"
+  },
   "cliExportButton": {
     "message": "Экспортировать учётные данные"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -609,6 +609,12 @@
   "cliExportConfirm": {
     "message": "这会将你的 Twitch 和 Kick 会话令牌下载为一个文件。任何拥有该文件的人都能在这些网站上以你的身份操作。是否继续？"
   },
+  "cliExportCancel": {
+    "message": "取消"
+  },
+  "cliExportConfirmButton": {
+    "message": "确认导出"
+  },
   "cliExportButton": {
     "message": "导出凭据"
   },

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lurkloot/locales",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "private": true,

--- a/packages/popup-ui/package.json
+++ b/packages/popup-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lurkloot/popup-ui",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "private": true,

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -454,8 +454,8 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   }
 
   // Exports the session tokens the headless CLI's `login --import` consumes.
-  // Gated behind a confirm dialog in the settings view; available only when the
-  // host adapter supports credential export (the live extension, not the demo).
+  // Gated behind inline confirmation in the settings view; available only when
+  // the host adapter supports credential export (the live extension, not demo).
   const exportCredentials = adapter.exportCredentials
     ? async () => {
         const blob = await adapter.send<CliCredentialBlob>({ type: "exportCliCredentials" });

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -76,6 +76,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const [platform, setPlatform] = useState<Platform>(preview ? initialVariant.platform : "twitch");
   const [tab, setTab] = useState<PopupTab>(preview && initialVariant.view === "watchQueue" ? "watchQueue" : "drops");
   const [settingsOpen, setSettingsOpen] = useState(preview && initialVariant.view === "settings");
+  const [settingsOpenGeneration, setSettingsOpenGeneration] = useState(0);
   const [activityOpen, setActivityOpen] = useState(preview && initialVariant.view === "activity");
   const [activityStream, setActivityStream] = useState<ActivityStream>(createActivityStream);
   const [diagnosticStream, setDiagnosticStream] = useState<ActivityStream>(createActivityStream);
@@ -547,7 +548,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                 <IconButton label={t("openActivity")} onClick={() => { setActivityOpen(true); setSettingsOpen(false); }}>
                   <Clock3 size={16} />
                 </IconButton>
-                <IconButton label={t("openSettings")} onClick={() => { setSettingsOpen(true); closeActivityView(); }}>
+                <IconButton label={t("openSettings")} onClick={() => { setSettingsOpenGeneration((current) => current + 1); setSettingsOpen(true); closeActivityView(); }}>
                   <SettingsIcon size={16} />
                 </IconButton>
               </>
@@ -568,7 +569,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
           <AnimatePresence mode="wait" initial={false}>
             {settingsOpen ? (
               <motion.div key="settings" initial={{ opacity: 0, x: 14 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 14 }} transition={{ duration: 0.18 }} className="space-y-2.5">
-                <SettingsView suggestions={dropCategorySuggestions} onSearchCategories={searchCategories} settings={settings} onSettingsChange={updateSettings} onExportCredentials={exportCredentials} compatibilityRegistry={adapter.compatibilityRegistry} compatibilityResolution={compatibilityResolution} initialPlatform={platform} />
+                <SettingsView suggestions={dropCategorySuggestions} onSearchCategories={searchCategories} settings={settings} onSettingsChange={updateSettings} onExportCredentials={exportCredentials} exportConfirmationResetKey={settingsOpenGeneration} compatibilityRegistry={adapter.compatibilityRegistry} compatibilityResolution={compatibilityResolution} initialPlatform={platform} />
               </motion.div>
             ) : activityOpen ? (
               <motion.div key="activity" initial={{ opacity: 0, x: 14 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 14 }} transition={{ duration: 0.18 }}>

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -45,6 +45,7 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
   const t = useT();
   const [platformTab, setPlatformTab] = useState<Platform>(initialPlatform);
   const [compatibilityExpertExpanded, setCompatibilityExpertExpanded] = useState(false);
+  const [exportArmed, setExportArmed] = useState(false);
   const set = (key: keyof ExtensionSettings) => (value: boolean) => onSettingsChange({ [key]: value } as SettingsPatch);
   const pollIntervalSeconds = Math.round(settings.pollIntervalMinutes * 60);
   const tabPlaybackDisabled = settings.tablessMode;
@@ -157,18 +158,43 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
       </SettingsSection>
       {onExportCredentials && (
         <SettingsSection title={t("cliExportTitle")} description={t("cliExportDescription")} icon={Terminal}>
-          <div className="flex items-center justify-between gap-3 px-1 py-1">
-            <p className="text-xs text-zinc-500 dark:text-zinc-400">{t("cliExportHint")}</p>
-            <button
-              type="button"
-              className="shrink-0 rounded-xl bg-[var(--accent)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-contrast)]"
-              onClick={() => {
-                if (window.confirm(t("cliExportConfirm"))) void onExportCredentials();
-              }}
-            >
-              {t("cliExportButton")}
-            </button>
-          </div>
+          {exportArmed ? (
+            <div className="space-y-2 px-1 py-1">
+              <p className="text-xs leading-relaxed text-amber-700 dark:text-amber-300">
+                {t("cliExportConfirm")}
+              </p>
+              <div className="flex flex-wrap justify-end gap-2">
+                <button
+                  type="button"
+                  className="rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  onClick={() => setExportArmed(false)}
+                >
+                  {t("cliExportCancel")}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-xl bg-[var(--accent)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-contrast)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+                  onClick={() => {
+                    setExportArmed(false);
+                    void onExportCredentials();
+                  }}
+                >
+                  {t("cliExportConfirmButton")}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between gap-3 px-1 py-1">
+              <p className="text-xs text-zinc-500 dark:text-zinc-400">{t("cliExportHint")}</p>
+              <button
+                type="button"
+                className="shrink-0 rounded-xl bg-[var(--accent)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-contrast)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+                onClick={() => setExportArmed(true)}
+              >
+                {t("cliExportButton")}
+              </button>
+            </div>
+          )}
         </SettingsSection>
       )}
     </div>

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import {
   Bell,
@@ -30,7 +30,7 @@ import { useT } from "./context";
 import type { GameItem, PopupCompatibilityRegistry, PopupCompatibilityResolution } from "./types";
 import { CompatibilitySettings } from "./compatibilitySettings";
 
-export function SettingsView({ suggestions, onSearchCategories, settings, onSettingsChange, onExportCredentials, compatibilityRegistry, compatibilityResolution, initialPlatform = "twitch" }: {
+export function SettingsView({ suggestions, onSearchCategories, settings, onSettingsChange, onExportCredentials, exportConfirmationResetKey, compatibilityRegistry, compatibilityResolution, initialPlatform = "twitch" }: {
   suggestions: Record<Platform, GameItem[]>;
   onSearchCategories(platform: Platform, query: string): Promise<CategorySelection[]>;
   settings: ExtensionSettings;
@@ -38,6 +38,7 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
   // Optional: when provided, the settings view shows an "Export credentials"
   // action for the headless CLI. The extension wires it; the demo omits it.
   onExportCredentials?: () => void | Promise<void>;
+  exportConfirmationResetKey: number;
   compatibilityRegistry?: PopupCompatibilityRegistry;
   compatibilityResolution?: PopupCompatibilityResolution;
   initialPlatform?: Platform;
@@ -46,6 +47,7 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
   const [platformTab, setPlatformTab] = useState<Platform>(initialPlatform);
   const [compatibilityExpertExpanded, setCompatibilityExpertExpanded] = useState(false);
   const [exportArmed, setExportArmed] = useState(false);
+  useEffect(() => setExportArmed(false), [exportConfirmationResetKey]);
   const set = (key: keyof ExtensionSettings) => (value: boolean) => onSettingsChange({ [key]: value } as SettingsPatch);
   const pollIntervalSeconds = Math.round(settings.pollIntervalMinutes * 60);
   const tabPlaybackDisabled = settings.tablessMode;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lurkloot/shared",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "private": true,

--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -1,5 +1,22 @@
 [
   {
+    "version": "1.5.0",
+    "changes": [
+      {
+        "kind": "new",
+        "text": "Added rotating tips in the popup that point to useful settings and shortcuts, with an option to hide them."
+      },
+      {
+        "kind": "new",
+        "text": "Added Twitch and Kick compatibility profiles that keep farming working as those sites change — selected automatically, or manually with expert overrides."
+      },
+      {
+        "kind": "improved",
+        "text": "Exporting session credentials for the command-line app now confirms inline in the popup instead of through a browser dialog."
+      }
+    ]
+  },
+  {
     "version": "1.4.0",
     "changes": [
       {

--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -14,7 +14,8 @@
         "kind": "improved",
         "text": "Exporting session credentials for the command-line app now confirms inline in the popup instead of through a browser dialog."
       }
-    ]
+    ],
+    "date": "2026-07-18"
   },
   {
     "version": "1.4.0",


### PR DESCRIPTION
## Summary

Release candidate for 1.5.0, driven end-to-end by the PR-driven release automation.

Contains the unreleased user-facing work:

- **Improved:** inline confirmation for the CLI credential export instead of a browser dialog
- **Docs:** 1.5.0 changelog entry (rotating tips and compatibility profiles already landed on `main` earlier and are covered in the notes)

The release tooling itself lives on `main` and is intentionally excluded from this candidate, so the automation gates only the product changes.

Version bump and changelog date are left to the automation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an inline, two-step session credential export flow in the popup (arm, then Confirm/Cancel).
  - Added localized Cancel/Confirm labels for the export confirmation UI.
  - Rotating popup tips (with option to hide) and added Twitch/Kick compatibility profiles.

- **Bug Fixes**
  - Improved consistency by removing browser confirmation dialogs from the export flow.
  - Export confirmation state now resets reliably when reopening Settings or using back-and-reopen.

- **Tests**
  - Added a popup UI test suite covering arm/confirm/cancel and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->