### PR TITLE
feat(ci): trigger releases from a release/* label and document the flow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,17 +1,11 @@
 name: Prepare release
 
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: Which component to bump
-        type: choice
-        options: [patch, minor, major]
-        required: true
-      version:
-        description: Optional explicit version (X.Y.Z), overrides the bump
-        type: string
-        default: ""
+  pull_request:
+    types: [labeled]
+    # branches filters on the base, so labelling anything that is not aimed at main — every renovate
+    # pull request into develop, for one — never starts a run at all.
+    branches: [main]
 
 permissions:
   contents: read
@@ -22,43 +16,93 @@ concurrency:
 
 jobs:
   prepare:
+    # A release/* label on a pull request into main is the whole trigger. The pull request already
+    # states both things a release needs — the bump comes from the label, the branch to cut from is
+    # its head — so a normal release (develop -> main) and a hotfix (hotfix/x -> main) are the same
+    # mechanism with nothing to keep in sync by hand.
+    #
+    # This is a pull_request, not a pull_request_target, event on purpose: a fork's pull request gets
+    # a read-only token, so labelling one fails harmlessly instead of running fork code with write
+    # access. Releases are cut from same-repository branches.
+    if: startsWith(github.event.label.name, 'release/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
+      # persist-credentials: false keeps the write token out of .git/config while the release
+      # scripts — which come from the labelled branch, not from main — are running. The push step
+      # supplies the token itself.
       - uses: actions/checkout@v7
         with:
-          ref: develop
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 22
       - id: version
         env:
-          BUMP: ${{ inputs.bump }}
-          VERSION: ${{ inputs.version }}
+          LABEL: ${{ github.event.label.name }}
         run: |
           tags=$(git tag --list 'v*' | tr '\n' ' ')
-          node scripts/release/cli.mjs next-version --tags "$tags" --bump "$BUMP" --version "$VERSION"
+          node scripts/release/cli.mjs next-version --tags "$tags" --bump "${LABEL#release/}"
+      - name: Refuse to overwrite another pull request's candidate
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TRIGGER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # Two pull requests labelled with the same bump before either is released compute the same
+          # version, and the second would force-push its own contents over the first candidate and
+          # take over its pull request. Retries from the same trigger stay a no-op; a different one
+          # stops here rather than silently replacing a prepared release.
+          body=$(gh pr list --head "release/$VERSION" --state open --json body --jq '.[0].body // ""')
+          if [ -n "$body" ] && ! printf '%s' "$body" | grep -qF "via #$TRIGGER."; then
+            echo "release/$VERSION is already prepared from a different pull request." >&2
+            echo "Release that one first, or close it before labelling this one." >&2
+            exit 1
+          fi
       - name: Bump the workspace
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: node scripts/release/cli.mjs prepare-workspace --version "$VERSION" --date "$(date -u +%F)"
-      - name: Open the release PR
+      - name: Open the release pull request
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          TRIGGER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "release/$VERSION"
-          # Re-running the same bump leaves the tree already at the target version, and git commit
-          # exits 1 with nothing staged. Skip only the commit so the push and PR reconciliation below
-          # still run and the re-run stays a no-op rather than a failure.
+          # Re-labelling an already prepared release leaves the tree at the target version, and git
+          # commit exits 1 with nothing staged. Skip only the commit so the push and the pull request
+          # reconciliation below still run and the re-run stays a no-op rather than a failure.
           git diff --quiet || git commit -am "chore(release): $VERSION"
-          git push --force origin "release/$VERSION"
+          # Checkout kept no credentials, so authenticate this one push explicitly. release/* is the
+          # only ref CI ever writes; main and develop are protected and CI cannot push to them.
+          git push --force "https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" \
+            "HEAD:refs/heads/release/$VERSION"
           gh pr create --base main --head "release/$VERSION" \
             --title "Release $VERSION" \
-            --body "Version bump and changelog date for $VERSION. Merge this, then run **Release** on main." \
+            --body "Version bump and changelog date for $VERSION, cut from \`$HEAD_REF\` via #$TRIGGER. Merge this, then run **Release** on main." \
             || gh pr edit "release/$VERSION" --title "Release $VERSION"
+      - name: Supersede the triggering pull request
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TRIGGER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # release/$VERSION carries every commit this pull request had plus the bump, so leaving
+          # both open into main invites merging this one instead — which would ship the changes with
+          # no version bump, and Release would then no-op against the already published version.
+          #
+          # Skip when it is already closed, so re-applying the label to retry a failed run neither
+          # errors on the close nor posts the same comment twice.
+          if [ "$(gh pr view "$TRIGGER" --json state --jq .state)" = "OPEN" ]; then
+            url=$(gh pr view "release/$VERSION" --json url --jq .url)
+            gh pr comment "$TRIGGER" --body "Superseded by $url, which is this branch plus the $VERSION bump. Closing so it cannot be merged into main without the bump."
+            gh pr close "$TRIGGER"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,19 @@ jobs:
           path: release-assets
       - name: Tag the released commit
         run: |
-          gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
-            -f ref="refs/tags/v$VERSION" -f sha="$GITHUB_SHA" \
-            || gh api -X PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/v$VERSION" \
-                 -f sha="$GITHUB_SHA" -F force=true
+          # Re-running Release is meant to be a safe no-op, so an existing tag at this same commit is
+          # fine. An existing tag at a *different* commit is not: it means main moved on without a
+          # version bump, and force-moving v$VERSION would silently re-point a published release at
+          # code that was never released under that version.
+          existing=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v$VERSION" --jq .object.sha 2>/dev/null || true)
+          if [ -z "$existing" ]; then
+            gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/v$VERSION" -f sha="$GITHUB_SHA"
+          elif [ "$existing" != "$GITHUB_SHA" ]; then
+            echo "v$VERSION already tags $existing, refusing to move it to $GITHUB_SHA." >&2
+            echo "Prepare a new version instead of re-releasing a published one." >&2
+            exit 1
+          fi
       - name: Render release notes
         run: node scripts/release/cli.mjs notes --version "$VERSION" --out notes.md
       - name: Create or update the GitHub release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,11 +32,13 @@ Use pnpm for all package tasks. The root `package.json` orchestrates the workspa
 
 ## Cutting a Release
 
-Releases run from the Actions tab. Run **Prepare release** (choose patch/minor/major) to open the
-version-bump PR into `main`, merge it, then run **Release** on `main`. Release tags the commit,
-builds every artifact, publishes the GitHub release, GHCR aliases, the Chrome Web Store submission
-and the production site, then opens the `main` to `develop` sync PR. Every step is idempotent: if
-one fails, fix the cause and run **Release** again. Do not push tags by hand.
+Label a pull request into `main` with `release/patch`, `release/minor` or `release/major`. Prepare
+release cuts `release/X.Y.Z` from that PR's head, bumps the version, opens its own PR into `main` and
+closes the one you labelled. Merge the release PR, then run **Release** on `main`. Release tags the
+commit, builds every artifact, publishes the GitHub release, GHCR aliases, the Chrome Web Store
+submission and the production site, then opens the `main` to `develop` sync PR. A hotfix is the same
+flow with `release/patch` on a PR branched from `main`. Every step is idempotent: if one fails, fix
+the cause and run **Release** again. Do not push tags by hand.
 
 Follow [RELEASING.md](RELEASING.md) for the `preview` and `production` environments, the single release approval, credentials, Chrome Web Store publication timing, and required repository configuration.
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ For implementation details and package boundaries, see [the architecture guide](
 
 ## Releasing
 
-Releases run from the GitHub Actions tab. **Prepare release** opens a version-bump pull request from `develop` into `main`; merging it and then running **Release** on `main` tags the commit and publishes every artifact. Hotfixes are ordinary pull requests into `main` followed by the same **Release** run, and are synchronized back to `develop` afterwards.
+Labelling a pull request into `main` with `release/patch`, `release/minor` or `release/major` opens a version-bump pull request from `release/X.Y.Z`; merging that and then running **Release** on `main` tags the commit and publishes every artifact. A hotfix is the same flow, labelling a pull request branched from `main` rather than the `develop` promotion, and is synchronized back to `develop` afterwards.
 
-See [RELEASING.md](RELEASING.md) for the dispatch-driven flow, the release environments and approval, credentials, and recovery.
+See [RELEASING.md](RELEASING.md) for the release flow, the environments and approval, credentials, and recovery.
 
 ## Disclaimer
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -96,14 +96,14 @@ steps against a different pull request:
    `develop`.
 
 **Do not merge the fix yourself and skip the label.** Release reads the version from `package.json`
-on `main`; if the hotfix does not bump it, Release re-runs against the already-published version and
-does nothing — it re-tags the same version, edits the existing GitHub release, and the store reports
-the version as already submitted. It succeeds while shipping nothing. Closing the labelled pull
-request automatically is what keeps that from happening by accident.
+on `main`, so without a bump it would try to release the already-published version again. It fails at
+the tagging step rather than re-pointing `vX.Y.Z` at the new commit, so nothing is corrupted — but
+nothing ships either, and the fix sits on `main` looking released. Closing the labelled pull request
+automatically is what keeps that from happening by accident.
 
 ## Chrome Web Store timing
 
-The submission uses `PUBLISH_IMMEDIATELY`, so **Google publishes the item itself once review
+The submission uses `DEFAULT_PUBLISH`, so **Google publishes the item itself once review
 passes** — hours or days after the run finishes, with no further human action and no polling on our
 side. The store deliberately trails the GitHub release. Accepting that trade is what removed the
 staged-review, polling and cancellation machinery; do not add a workflow that waits for the store.
@@ -150,9 +150,14 @@ site deploy all tolerate re-running. **This idempotency is what replaces rollbac
 rollback and no cancellation flow.
 
 If a step fails, fix the cause and run **Release** again. A re-run with nothing left to change is a
-harmless no-op: the tag is updated to the same SHA, the release is edited rather than recreated, the
-aliases are re-pointed at the same digest, and the store upload reports that the version is already
-submitted and does nothing.
+harmless no-op: the tag already points at this commit and is left alone, the release is edited rather
+than recreated, the aliases are re-pointed at the same digest, and the store upload reports that the
+version is already submitted and does nothing.
+
+The one thing a re-run will not do is move a tag. If `vX.Y.Z` already points at a *different* commit,
+Release fails instead of re-pointing it — that state means `main` moved on without a version bump,
+and re-tagging would silently attach a published version to code that was never released as it.
+Prepare a new version rather than re-releasing a published one.
 
 Re-applying a `release/*` label for a version that is already prepared is likewise a no-op; it
 refreshes `release/X.Y.Z`, leaves the existing pull request in place, and skips the supersede comment

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,24 @@ Releases are driven from the Actions tab. Two workflow dispatches and one pull r
 every release, including hotfixes. Do not create or move tags by hand; CI never pushes to a
 protected branch, it only creates tags, releases and pull requests.
 
+## Before you start: write the changelog
+
+Release notes are rendered *only* from `packages/site/src/changelog.json`. Add the entry for the new
+version to `develop` before running Prepare release, since that is the branch it cuts from. Put it at
+the top of the array; omit `date`, because Prepare release stamps it:
+
+```json
+{ "version": "1.5.1", "changes": [
+  { "kind": "fixed", "text": "Fixed a thing." }
+] }
+```
+
+The only valid `kind` values are `new`, `improved` and `fixed`; anything else fails the site build.
+
+If no entry exists, Prepare release creates one with `"changes": []` rather than failing, and the
+GitHub release then ships with an **empty body**. That is the intended escape hatch for a build-only
+release, but it is silent — so write the entry first unless you mean it.
+
 ## The three steps
 
 1. **Actions → Prepare release.** Choose `patch`, `minor` or `major`, or type an explicit `X.Y.Z` to
@@ -28,6 +46,26 @@ protected branch, it only creates tags, releases and pull requests.
 
 Upload the Firefox ZIP and the source ZIP from the GitHub release to AMO; AMO publication remains
 manual.
+
+## Where the version number comes from
+
+Nobody edits a version by hand.
+
+Prepare release derives it from **git tags, not from `package.json`**: it reads `git tag --list 'v*'`,
+takes the highest stable tag, and applies your bump. Prereleases and leftover `candidate-*` tags are
+filtered out, so a stray tag cannot skew a bump. It then writes that version into all seven manifests
+and the changelog entry, as a single `chore(release): X.Y.Z` commit.
+
+Release reads the version back out of `package.json` on `main`. **That committed value is what is
+actually released** — the tag, the GHCR tags and the store package all follow it.
+
+The version is therefore derived from what was last released, and committed *before* anything is
+built. Nothing is frozen, so nothing can be invalidated mid-release.
+
+`checkWorkspace` runs as part of the bump and fails loudly if the seven manifests disagree or the
+changelog has no entry for the version, so a half-edited workspace cannot reach a release. An
+explicit version override must be bare `X.Y.Z`; a `v` prefix is rejected before any branch is
+created.
 
 ## Branch model and hotfixes
 
@@ -65,11 +103,14 @@ Restrict `preview`'s deployment branches to `main` and `release/*`.
 
 ## Credentials
 
-Environment secrets: `CRX_PRIVATE_KEY` in `preview`, `CWS_SERVICE_ACCOUNT_JSON` in `production`.
+Secrets: `CRX_PRIVATE_KEY`, `CWS_SERVICE_ACCOUNT_JSON`, `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID`. All four are currently **repository** secrets, which every job reads via
+`secrets: inherit`. The "Holds" column above describes where the two publishing credentials belong
+once the optional hardening below is applied; until then the environments provide the approval gate
+and the branch restriction, but not a credential boundary.
 
-Repository secrets: `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. These stay at the
-repository level deliberately — the site deploys from both environments, so scoping them to one
-would break the other channel.
+`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` stay at the repository level permanently — the
+site deploys from both environments, so scoping them to one would break the other channel.
 
 Variables: `CWS_PUBLISHER_ID`, `CWS_EXTENSION_ID`.
 
@@ -89,6 +130,30 @@ submitted and does nothing.
 
 Re-running **Prepare release** for a version that is already prepared is likewise a no-op; it
 refreshes the branch and leaves the existing pull request in place.
+
+## After a release: reconcile `develop`
+
+Both branches require linear history, so pull requests between them merge by rebase. Rebasing
+rewrites the commits, so once the sync PR merges, `main` and `develop` end up with **identical trees
+but no shared history** — their merge-base stays at the commit before the merge.
+
+The consequence is cosmetic but compounds: the next `release/X.Y.Z` branch is cut from `develop`, so
+its pull request diffs from that stale merge-base and shows the previous release's version bump on
+top of the intended one. It still merges cleanly, because patch-equivalent commits are dropped on
+rebase.
+
+Check with:
+
+```sh
+git rev-parse origin/main^{tree} origin/develop^{tree}   # should match
+git merge-base origin/main origin/develop                # should equal origin/main
+```
+
+If the trees match but the merge-base is stale, reconcile `develop` to `main`. This needs a force
+push, so temporarily set `allow_force_pushes: true` and `enforce_admins: false` on `develop`, run
+`git push --force-with-lease origin origin/main:refs/heads/develop`, then restore both settings
+immediately. Only do this when the trees are already identical — it is a history fix, not a content
+change.
 
 ## Repository configuration
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -172,15 +172,24 @@ rebase.
 Check with:
 
 ```sh
+git fetch origin main develop                            # never check against stale refs
 git rev-parse origin/main^{tree} origin/develop^{tree}   # should match
 git merge-base origin/main origin/develop                # should equal origin/main
 ```
+
+Fetch first every time. The whole safety argument for the force push below is "the trees are already
+identical", and a stale `origin/develop` can satisfy that check while the real branch has moved on —
+in which case the push discards commits.
 
 If the trees match but the merge-base is stale, reconcile `develop` to `main`. This needs a force
 push, so temporarily set `allow_force_pushes: true` and `enforce_admins: false` on `develop`, run
 `git push --force-with-lease origin origin/main:refs/heads/develop`, then restore both settings
 immediately. Only do this when the trees are already identical — it is a history fix, not a content
 change.
+
+A branch cut from `develop` *before* a reconciliation keeps the old commit SHAs and starts conflicting
+with it. Replant it with `git rebase --onto origin/develop <last-commit-shared-with-old-develop>`; the
+duplicated commits drop as patch-equivalent, and the tree hash should be unchanged afterwards.
 
 ## Repository configuration
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,16 @@
 # Releasing Lurkloot
 
-Releases are driven from the Actions tab. Two workflow dispatches and one pull request merge cover
-every release, including hotfixes. Do not create or move tags by hand; CI never pushes to a
-protected branch, it only creates tags, releases and pull requests.
+Label a pull request into `main`, merge the release pull request that appears, then run **Release**.
+That covers every release, including hotfixes. Do not create or move tags by hand; the only branch CI
+ever pushes is the generated `release/X.Y.Z`. It cannot push to `main` or `develop` — beyond that
+branch it only creates tags, releases and pull requests.
 
 ## Before you start: write the changelog
 
 Release notes are rendered *only* from `packages/site/src/changelog.json`. Add the entry for the new
-version to `develop` before running Prepare release, since that is the branch it cuts from. Put it at
-the top of the array; omit `date`, because Prepare release stamps it:
+version to the branch you are releasing — `develop` for a normal release — before you apply the
+label, since Prepare release cuts from that branch. Put it at the top of the array; omit `date`,
+because Prepare release stamps it:
 
 ```json
 { "version": "1.5.1", "changes": [
@@ -24,13 +26,22 @@ release, but it is silent — so write the entry first unless you mean it.
 
 ## The three steps
 
-1. **Actions → Prepare release.** Choose `patch`, `minor` or `major`, or type an explicit `X.Y.Z` to
-   override the bump. The workflow branches `release/X.Y.Z` from `develop`, bumps the version in all
-   seven `package.json` files, stamps the date on the changelog entry, and opens a pull request into
-   `main`.
-2. **Review and merge that pull request.** This merge *is* the `develop` to `main` promotion. There
-   is no separate promotion step.
+1. **Open a pull request into `main` and label it** `release/patch`, `release/minor` or
+   `release/major`. For a normal release that is the `develop` to `main` promotion pull request; for
+   a hotfix it is the fix's own pull request. Prepare release cuts `release/X.Y.Z` from that pull
+   request's head, bumps the version in all seven `package.json` files, stamps the date on the
+   changelog entry, and opens its own pull request into `main`.
+2. **Review and merge the `release/X.Y.Z` pull request.** This merge *is* the promotion. There is no
+   separate promotion step.
 3. **Actions → Release, run on `main`.** The workflow refuses to run from any other branch.
+
+The label says how much to bump; the pull request says what is being released. There is no base or
+version input to keep in sync with the branch, because the pull request already carries both facts.
+
+Prepare release then comments on the pull request you labelled and **closes it**. That is deliberate:
+`release/X.Y.Z` is the same branch plus the bump, so leaving both open into `main` would let you
+merge the one without the version bump. If a run fails part way, remove the label and add it again to
+retry.
 
 ## What Release does
 
@@ -52,9 +63,10 @@ manual.
 Nobody edits a version by hand.
 
 Prepare release derives it from **git tags, not from `package.json`**: it reads `git tag --list 'v*'`,
-takes the highest stable tag, and applies your bump. Prereleases and leftover `candidate-*` tags are
-filtered out, so a stray tag cannot skew a bump. It then writes that version into all seven manifests
-and the changelog entry, as a single `chore(release): X.Y.Z` commit.
+takes the highest stable tag, and applies the bump named by the label. Prereleases and leftover
+`candidate-*` tags are filtered out, so a stray tag cannot skew a bump. It then writes that version
+into all seven manifests and the changelog entry, as a single `chore(release): X.Y.Z` commit on
+`release/X.Y.Z`.
 
 Release reads the version back out of `package.json` on `main`. **That committed value is what is
 actually released** — the tag, the GHCR tags and the store package all follow it.
@@ -63,17 +75,31 @@ The version is therefore derived from what was last released, and committed *bef
 built. Nothing is frozen, so nothing can be invalidated mid-release.
 
 `checkWorkspace` runs as part of the bump and fails loudly if the seven manifests disagree or the
-changelog has no entry for the version, so a half-edited workspace cannot reach a release. An
-explicit version override must be bare `X.Y.Z`; a `v` prefix is rejected before any branch is
-created.
+changelog has no entry for the version, so a half-edited workspace cannot reach a release. Only
+`release/patch`, `release/minor` and `release/major` name a valid bump; any other `release/*` label
+fails the run before a branch is created rather than guessing.
 
 ## Branch model and hotfixes
 
 `develop` is what is in development. `main` is what is ready to release or already released.
 
-A hotfix is an ordinary pull request into `main` followed by **Release**. There is no hotfix
-machinery, no hotfix label, and no separate workflow. The `main` to `develop` sync PR that Release
-opens carries the fix back to `develop`.
+There is no hotfix machinery, no hotfix label, and no separate workflow. A hotfix is the same three
+steps against a different pull request:
+
+1. Branch from `main`, not `develop`, and open the fix as an ordinary pull request into `main`.
+   **Do not merge it.**
+2. Label it `release/patch`. Prepare release cuts `release/X.Y.Z` from your fix branch, so the
+   release carries the already-released commits plus your fix and *none* of develop's unreleased
+   work. Your pull request is then closed as superseded.
+3. Merge the `release/X.Y.Z` pull request, then run **Release** on `main` as usual.
+4. Merge the `main` to `develop` sync PR that Release opens, so the fix and the version bump reach
+   `develop`.
+
+**Do not merge the fix yourself and skip the label.** Release reads the version from `package.json`
+on `main`; if the hotfix does not bump it, Release re-runs against the already-published version and
+does nothing — it re-tags the same version, edits the existing GitHub release, and the store reports
+the version as already submitted. It succeeds while shipping nothing. Closing the labelled pull
+request automatically is what keeps that from happening by accident.
 
 ## Chrome Web Store timing
 
@@ -128,8 +154,9 @@ harmless no-op: the tag is updated to the same SHA, the release is edited rather
 aliases are re-pointed at the same digest, and the store upload reports that the version is already
 submitted and does nothing.
 
-Re-running **Prepare release** for a version that is already prepared is likewise a no-op; it
-refreshes the branch and leaves the existing pull request in place.
+Re-applying a `release/*` label for a version that is already prepared is likewise a no-op; it
+refreshes `release/X.Y.Z`, leaves the existing pull request in place, and skips the supersede comment
+because the labelled pull request is already closed.
 
 ## After a release: reconcile `develop`
 
@@ -169,8 +196,9 @@ Applied:
 - [x] `main`'s required status checks are `verify`, `extension / build`,
       `docker / build (linux/amd64, ubuntu-latest, amd64)` and
       `docker / build (linux/arm64, ubuntu-24.04-arm, arm64)`. `develop` matches.
-- [x] Obsolete labels `release/patch`, `release/minor`, `release/major` and `release/hotfix`
-      deleted.
+- [x] Labels `release/patch`, `release/minor` and `release/major` exist — they are the release
+      trigger. There is deliberately no `release/hotfix`: a hotfix is a `release/patch` on a pull
+      request whose head is a hotfix branch.
 - [x] Default workflow token permission is `read`.
 
 ### Optional hardening: scope the credentials to environments

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,4 +2,4 @@
 
 The canonical release runbook is [RELEASING.md](../RELEASING.md).
 
-It documents the **Prepare release** and **Release** workflow dispatches, the branch model and hotfixes, the release environments and approval, credentials, Chrome Web Store publication timing, and recovery.
+It documents the `release/*` label that triggers **Prepare release**, the **Release** dispatch, the branch model and hotfixes, the release environments and approval, credentials, Chrome Web Store publication timing, and recovery.

--- a/scripts/cws.mjs
+++ b/scripts/cws.mjs
@@ -173,13 +173,15 @@ export class ChromeWebStoreClient {
     });
   }
 
-  // PUBLISH_IMMEDIATELY makes Google publish the item as soon as review passes, so no polling,
-  // no deferred-publish gate and no second workflow are required.
+  // DEFAULT_PUBLISH makes Google publish the item as soon as review passes, so no polling, no
+  // deferred-publish gate and no second workflow are required. The v2 PublishType enum accepts only
+  // PUBLISH_TYPE_UNSPECIFIED, DEFAULT_PUBLISH and STAGED_PUBLISH — STAGED_PUBLISH is the one that
+  // holds the item for a manual release, which is exactly what this pipeline does not want.
   publish() {
     return this.request(`/v2/${this.item}:publish`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ publishType: "PUBLISH_IMMEDIATELY", blockOnWarnings: true }),
+      body: JSON.stringify({ publishType: "DEFAULT_PUBLISH", blockOnWarnings: true }),
     });
   }
 

--- a/scripts/cws.test.mjs
+++ b/scripts/cws.test.mjs
@@ -88,7 +88,7 @@ test("publishes immediately so approval goes live unattended", async () => {
   });
   await client.publish();
   await client.cancelSubmission();
-  assert.deepEqual(JSON.parse(requests[0].init.body), { publishType: "PUBLISH_IMMEDIATELY", blockOnWarnings: true });
+  assert.deepEqual(JSON.parse(requests[0].init.body), { publishType: "DEFAULT_PUBLISH", blockOnWarnings: true });
   assert.match(requests[0].url, /:publish$/);
   assert.match(requests[1].url, /:cancelSubmission$/);
   assert.equal(requests[1].init.body, undefined);


### PR DESCRIPTION
Fills four gaps found by reading RELEASING.md back against real questions about the new pipeline.

- **Where the version comes from.** The doc said Prepare release "bumps the version" but never that the number is derived from the highest `v*` git tag, nor that Release reads it back from `package.json` on `main`.
- **Changelog authoring.** Notes render only from `changelog.json`, and a missing entry silently yields `"changes": []` and an empty release body. Now documented as a step that happens on `develop` before Prepare release, with the valid `kind` values.
- **Credentials contradiction.** The Credentials section described the post-hardening layout as if it were current, contradicting the hardening section below it. Now states plainly that all four secrets are repository secrets today.
- **Branch reconciliation.** Rebase merges leave `main` and `develop` with identical trees but no shared history, which makes each subsequent release PR diff against a stale merge-base. Documented with the check commands and the force-push fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release preparation is now automated: label a PR targeting `main` with `release/patch`, `release/minor`, or `release/major`.
  * The workflow derives the bump from the label, creates a `release/X.Y.Z` branch/PR, supersedes the labeled PR, and prevents overwriting an existing open release-candidate.
* **Bug Fixes**
  * Re-running **Release** is safer: version tags won’t be force-moved; existing tags are validated and failures occur if a tag points elsewhere.
* **Documentation**
  * Updated release instructions across AGENTS/README/RELEASING and release docs to match the label-driven flow, versioning rules, approvals/environments, publishing timing, and recovery guidance.
* **Tests**
  * Updated Chrome Web Store publish payload expectations to match `DEFAULT_PUBLISH` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->