### PR TITLE
ci(release): automate candidate promotion

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -1,0 +1,25 @@
+name: Build site artifact
+description: Build and checksum the Cloudflare Pages site without deployment credentials
+inputs:
+  channel:
+    description: Site deployment channel
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v6
+      with:
+        version: 11.9.0
+    - uses: actions/setup-node@v7
+      with:
+        node-version: 24
+        cache: pnpm
+    - shell: bash
+      run: pnpm install --frozen-lockfile
+    - shell: bash
+      env:
+        SITE_DEPLOYMENT_CHANNEL: ${{ inputs.channel }}
+      run: pnpm build:site
+    - shell: bash
+      working-directory: packages/site/dist
+      run: find . -type f ! -name SITE_SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SITE_SHA256SUMS

--- a/.github/actions/deploy-site/action.yml
+++ b/.github/actions/deploy-site/action.yml
@@ -19,7 +19,7 @@ runs:
     - shell: bash
       working-directory: ${{ inputs.directory }}
       run: sha256sum -c SITE_SHA256SUMS
-    - uses: cloudflare/wrangler-action@v4
+    - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
       with:
         apiToken: ${{ inputs.api_token }}
         accountId: ${{ inputs.account_id }}

--- a/.github/actions/deploy-site/action.yml
+++ b/.github/actions/deploy-site/action.yml
@@ -1,0 +1,27 @@
+name: Deploy site artifact
+description: Verify and deploy a previously built site artifact to Cloudflare Pages
+inputs:
+  channel:
+    description: prerelease or production
+    required: true
+  directory:
+    description: Directory containing the site artifact
+    required: true
+  api_token:
+    description: Cloudflare API token
+    required: true
+  account_id:
+    description: Cloudflare account ID
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.directory }}
+      run: sha256sum -c SITE_SHA256SUMS
+    - uses: cloudflare/wrangler-action@v4
+      with:
+        apiToken: ${{ inputs.api_token }}
+        accountId: ${{ inputs.account_id }}
+        workingDirectory: ${{ inputs.directory }}
+        command: pages deploy . --project-name=lurkloot --branch=${{ inputs.channel == 'production' && 'main' || 'next' }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,6 +20,10 @@ on:
       push:
         type: boolean
         default: false
+      export_oci:
+        description: Upload verified OCI archives without writing to the registry
+        type: boolean
+        default: false
     outputs:
       image_tag:
         value: ${{ jobs.publish.outputs.image_tag }}
@@ -73,7 +77,7 @@ jobs:
           outputs: type=docker,dest=/tmp/image-${{ matrix.arch }}.tar
       - name: Checksum OCI artifact
         run: cd /tmp && sha256sum image-${{ matrix.arch }}.tar > image-${{ matrix.arch }}.tar.sha256
-      - if: inputs.push
+      - if: inputs.push || inputs.export_oci
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_prefix }}-oci-${{ matrix.arch }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -10,6 +10,10 @@ on:
         description: Optional release version to overlay before building
         type: string
         default: ""
+      image_tag:
+        description: Optional registry tag, independent from the committed workspace version
+        type: string
+        default: ""
       artifact_prefix:
         type: string
         default: docker-digest
@@ -63,10 +67,9 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }},ignore-error=true
           push: false
-          # The publish job re-finds the loaded image by this exact tag, so version must be used
-          # verbatim when set. Validation builds pass no version, so fall back to a valid literal
-          # rather than emitting an invalid ":-arch" reference.
-          tags: ${{ env.IMAGE_NAME }}:${{ inputs.version || 'validation' }}-${{ matrix.arch }}
+          # Candidate images use a mutable candidate-X.Y.Z tag without overlaying the committed
+          # workspace version. Stable builds default the registry tag to the supplied version.
+          tags: ${{ env.IMAGE_NAME }}:${{ inputs.image_tag || inputs.version || 'validation' }}-${{ matrix.arch }}
           outputs: type=docker,dest=/tmp/image-${{ matrix.arch }}.tar
       - name: Checksum OCI artifact
         run: cd /tmp && sha256sum image-${{ matrix.arch }}.tar > image-${{ matrix.arch }}.tar.sha256
@@ -114,12 +117,13 @@ jobs:
       - id: publish
         name: Push the version tags
         env:
-          VERSION: ${{ inputs.version }}
+          IMAGE_TAG: ${{ inputs.image_tag || inputs.version }}
         run: |
+          test -n "$IMAGE_TAG"
           docker load --input images/image-amd64.tar
-          docker push "$IMAGE_NAME:$VERSION-amd64"
+          docker push "$IMAGE_NAME:$IMAGE_TAG-amd64"
           docker load --input images/image-arm64.tar
-          docker push "$IMAGE_NAME:$VERSION-arm64"
-          docker buildx imagetools create --tag "$IMAGE_NAME:$VERSION" \
-            "$IMAGE_NAME:$VERSION-amd64" "$IMAGE_NAME:$VERSION-arm64"
-          echo "image_tag=$IMAGE_NAME:$VERSION" >> "$GITHUB_OUTPUT"
+          docker push "$IMAGE_NAME:$IMAGE_TAG-arm64"
+          docker buildx imagetools create --tag "$IMAGE_NAME:$IMAGE_TAG" \
+            "$IMAGE_NAME:$IMAGE_TAG-amd64" "$IMAGE_NAME:$IMAGE_TAG-arm64"
+          echo "image_tag=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -32,9 +32,13 @@ jobs:
     if: inputs.sign_crx
     runs-on: ubuntu-latest
     steps:
+      - name: Require an explicit trusted signer ref
+        env:
+          TRUSTED_REF: ${{ inputs.trusted_ref }}
+        run: test -n "$TRUSTED_REF"
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.trusted_ref || github.sha }}
+          ref: ${{ inputs.trusted_ref }}
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -6,6 +6,10 @@ on:
       ref:
         type: string
         default: ""
+      trusted_ref:
+        description: Trusted commit used only to prepare integrity-pinned signing tooling
+        type: string
+        default: ""
       version:
         description: Optional release version to overlay before building
         type: string
@@ -24,6 +28,37 @@ permissions:
   contents: read
 
 jobs:
+  prepare-signer:
+    if: inputs.sign_crx
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.trusted_ref || github.sha }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.9.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Prepare signer from the trusted integrity-pinned lockfile
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm --filter lurkloot deploy --legacy --dev signer
+          test "$(node -p "require('$GITHUB_WORKSPACE/signer/node_modules/crx3/package.json').version")" = 2.0.0
+          tar -czf signer.tar.gz signer
+          sha256sum signer.tar.gz > SIGNER_SHA256
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact_name }}-signer
+          path: |
+            signer.tar.gz
+            SIGNER_SHA256
+          if-no-files-found: error
+          retention-days: 1
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -38,36 +73,12 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-      - name: Install and verify the pinned signer
-        if: inputs.sign_crx && inputs.version != ''
-        run: |
-          pnpm install --frozen-lockfile --ignore-scripts
-          mkdir -p signer
-          printf '{"private":true,"dependencies":{"crx3":"2.0.0"}}\n' > signer/package.json
-          pnpm --dir signer install --offline --ignore-scripts --prod --lockfile=false --ignore-workspace
-          test "$(node -p "require('$GITHUB_WORKSPACE/signer/node_modules/crx3/package.json').version")" = 2.0.0
-          tar -czf signer.tar.gz signer
-          sha256sum signer.tar.gz > SIGNER_SHA256
       - name: Set the release version
         if: inputs.version != ''
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         run: node scripts/release/cli.mjs prepare-workspace --version "$RELEASE_VERSION" --date "$(date -u +%F)"
       - run: pnpm install --frozen-lockfile
-      - name: Verify trusted signer bundle exists before credentialed job
-        if: inputs.sign_crx
-        run: |
-          test -s signer.tar.gz
-          sha256sum -c SIGNER_SHA256
-      - uses: actions/upload-artifact@v7
-        if: inputs.sign_crx
-        with:
-          name: ${{ inputs.artifact_name }}-signer
-          path: |
-            signer.tar.gz
-            SIGNER_SHA256
-          if-no-files-found: error
-          retention-days: 1
       - run: pnpm release:check
       - run: pnpm zip && pnpm zip:firefox
       - name: Normalize reproducible ZIP artifacts
@@ -103,7 +114,11 @@ jobs:
           retention-days: 1
 
   finalize:
-    needs: build
+    needs: [build, prepare-signer]
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      (needs.prepare-signer.result == 'success' || needs.prepare-signer.result == 'skipped')
     runs-on: ubuntu-latest
     # Environments collapse to two: `preview` (no required reviewer) and `production` (required
     # reviewer). Signing produces an artifact but distributes nothing, so it belongs behind the

--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -6,6 +6,9 @@ on:
       ref:
         type: string
         required: true
+      trusted_ref:
+        type: string
+        required: true
       version:
         type: string
         required: true
@@ -21,7 +24,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pending:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.trusted_ref }}
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Mark the candidate head as pending
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SHA: ${{ inputs.ref }}
+          TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: >-
+          node scripts/release/cli.mjs candidate-checks
+          --sha "$SHA" --state pending --target-url "$TARGET_URL"
+
   verify:
+    needs: pending
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,6 +73,7 @@ jobs:
     uses: ./.github/workflows/build-extension.yml
     with:
       ref: ${{ inputs.ref }}
+      trusted_ref: ${{ inputs.trusted_ref }}
       artifact_name: candidate-extension-${{ inputs.version }}
       sign_crx: true
     secrets: inherit
@@ -74,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ inputs.trusted_ref }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@v7
@@ -124,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ inputs.trusted_ref }}
           persist-credentials: false
       - uses: actions/setup-node@v7
         with:
@@ -139,3 +166,38 @@ jobs:
         run: >-
           node scripts/release/cli.mjs candidate-comment
           --pr "$PR" --version "$VERSION" --sha "$SHA" --state ready --url "$URL"
+
+  gate:
+    if: always()
+    needs: [verify, extension, docker, publish, site, status]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.trusted_ref }}
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Record the required candidate result on its head SHA
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SHA: ${{ inputs.ref }}
+          TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          VERIFY: ${{ needs.verify.result }}
+          EXTENSION: ${{ needs.extension.result }}
+          DOCKER: ${{ needs.docker.result }}
+          PUBLISH: ${{ needs.publish.result }}
+          SITE: ${{ needs.site.result }}
+          STATUS: ${{ needs.status.result }}
+        run: |
+          state=success
+          for result in "$VERIFY" "$EXTENSION" "$DOCKER" "$PUBLISH" "$SITE" "$STATUS"; do
+            test "$result" = success || state=failure
+          done
+          node scripts/release/cli.mjs candidate-checks \
+            --sha "$SHA" --state "$state" --target-url "$TARGET_URL"
+          test "$state" = success

--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -1,0 +1,139 @@
+name: Build release candidate
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: true
+      version:
+        type: string
+        required: true
+      pr_number:
+        type: number
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-candidate-${{ inputs.version }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.9.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+
+  extension:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-extension.yml
+    with:
+      ref: ${{ inputs.ref }}
+      artifact_name: candidate-extension-${{ inputs.version }}
+      sign_crx: true
+    secrets: inherit
+
+  docker:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-docker.yml
+    with:
+      ref: ${{ inputs.ref }}
+      image_tag: candidate-${{ inputs.version }}
+      artifact_prefix: candidate-docker-${{ inputs.version }}
+      push: true
+    secrets: inherit
+
+  publish:
+    needs: [verify, extension, docker]
+    runs-on: ubuntu-latest
+    environment: preview
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          path: candidate
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v8
+        with:
+          name: candidate-extension-${{ inputs.version }}
+          path: release-assets
+      - name: Render candidate release notes
+        working-directory: candidate
+        env:
+          VERSION: ${{ inputs.version }}
+        run: node ../trusted/scripts/release/cli.mjs notes --version "$VERSION" --out ../notes.md
+      - name: Create or refresh the owned GitHub prerelease
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.pr_number }}
+          VERSION: ${{ inputs.version }}
+          SHA: ${{ inputs.ref }}
+        run: >-
+          node trusted/scripts/release/cli.mjs publish-candidate
+          --pr "$PR" --version "$VERSION" --sha "$SHA"
+          --assets release-assets --notes notes.md
+
+  site:
+    needs: verify
+    permissions:
+      contents: read
+    uses: ./.github/workflows/site-deploy.yml
+    with:
+      channel: prerelease
+      ref: ${{ inputs.ref }}
+    secrets: inherit
+
+  status:
+    needs: [publish, site]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Update the candidate status comment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.pr_number }}
+          VERSION: ${{ inputs.version }}
+          SHA: ${{ inputs.ref }}
+          URL: https://github.com/${{ github.repository }}/releases/tag/candidate-v${{ inputs.version }}
+        run: >-
+          node scripts/release/cli.mjs candidate-comment
+          --pr "$PR" --version "$VERSION" --sha "$SHA" --state ready --url "$URL"

--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -41,6 +41,7 @@ jobs:
       - run: pnpm check
 
   extension:
+    needs: verify
     permissions:
       contents: read
     uses: ./.github/workflows/build-extension.yml
@@ -51,6 +52,7 @@ jobs:
     secrets: inherit
 
   docker:
+    needs: verify
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -15,6 +15,13 @@ on:
       pr_number:
         type: number
         required: true
+    secrets:
+      CRX_PRIVATE_KEY:
+        required: false
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
 
 permissions:
   contents: read
@@ -76,7 +83,8 @@ jobs:
       trusted_ref: ${{ inputs.trusted_ref }}
       artifact_name: candidate-extension-${{ inputs.version }}
       sign_crx: true
-    secrets: inherit
+    secrets:
+      CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
 
   docker:
     needs: verify
@@ -89,7 +97,6 @@ jobs:
       image_tag: candidate-${{ inputs.version }}
       artifact_prefix: candidate-docker-${{ inputs.version }}
       push: true
-    secrets: inherit
 
   publish:
     needs: [verify, extension, docker]
@@ -140,7 +147,9 @@ jobs:
     with:
       channel: prerelease
       ref: ${{ inputs.ref }}
-    secrets: inherit
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   status:
     needs: [publish, site]

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -131,9 +131,11 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+      statuses: write
     uses: ./.github/workflows/build-release-candidate.yml
     with:
       ref: ${{ needs.prepare.outputs.release_sha }}
+      trusted_ref: ${{ github.event.pull_request.base.sha }}
       version: ${{ needs.prepare.outputs.version }}
       pr_number: ${{ fromJSON(needs.prepare.outputs.release_pr) }}
     secrets: inherit

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -138,4 +138,7 @@ jobs:
       trusted_ref: ${{ github.event.pull_request.base.sha }}
       version: ${{ needs.prepare.outputs.version }}
       pr_number: ${{ fromJSON(needs.prepare.outputs.release_pr) }}
-    secrets: inherit
+    secrets:
+      CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,10 +1,8 @@
 name: Prepare release
 
 on:
-  pull_request:
-    types: [labeled]
-    # branches filters on the base, so labelling anything that is not aimed at main — every renovate
-    # pull request into develop, for one — never starts a run at all.
+  pull_request_target:
+    types: [labeled, unlabeled]
     branches: [main]
 
 permissions:
@@ -16,93 +14,126 @@ concurrency:
 
 jobs:
   prepare:
-    # A release/* label on a pull request into main is the whole trigger. The pull request already
-    # states both things a release needs — the bump comes from the label, the branch to cut from is
-    # its head — so a normal release (develop -> main) and a hotfix (hotfix/x -> main) are the same
-    # mechanism with nothing to keep in sync by hand.
-    #
-    # This is a pull_request, not a pull_request_target, event on purpose: a fork's pull request gets
-    # a read-only token, so labelling one fails harmlessly instead of running fork code with write
-    # access. Releases are cut from same-repository branches.
-    if: startsWith(github.event.label.name, 'release/')
+    if: >-
+      startsWith(github.event.label.name, 'release/') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      action: ${{ steps.policy.outputs.action }}
+      version: ${{ steps.policy.outputs.version }}
+      release_pr: ${{ steps.open.outputs.release_pr }}
+      release_sha: ${{ steps.open.outputs.release_sha }}
     steps:
-      # persist-credentials: false keeps the write token out of .git/config while the release
-      # scripts — which come from the labelled branch, not from main — are running. The push step
-      # supplies the token itself.
+      # pull_request_target supplies a write token, so only trusted base-branch tooling is executed.
+      # Candidate source is checked out as data in a separate directory and mutated by that tooling.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+          path: trusted
           persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-      - id: version
+      - id: policy
+        name: Resolve the live release policy
         env:
-          LABEL: ${{ github.event.label.name }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          tags=$(git tag --list 'v*' | tr '\n' ' ')
-          node scripts/release/cli.mjs next-version --tags "$tags" --bump "${LABEL#release/}"
-      - name: Refuse to overwrite another pull request's candidate
+          labels=$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")
+          tags=$(git -C trusted tag --list 'v*' | tr '\n' ' ')
+          if ! node trusted/scripts/release/cli.mjs policy --labels "$labels" --head "$HEAD_REF" --tags "$tags"; then
+            gh pr comment "$PR" --body "Release preparation is blocked: only one of \`release/patch\`, \`release/minor\`, or \`release/major\` may be applied."
+            exit 1
+          fi
+      - name: Report an orphaned candidate
+        if: steps.policy.outputs.action == 'orphan'
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: gh pr comment "$PR" --body "All release labels were removed. Any candidate already prepared from this pull request is now orphaned and will not be deleted automatically."
+      - name: Check out candidate source without credentials
+        if: steps.policy.outputs.action == 'prepare'
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          path: candidate
+          persist-credentials: false
+      - name: Refuse to overwrite another pull request's release branch
+        if: steps.policy.outputs.action == 'prepare'
+        env:
+          VERSION: ${{ steps.policy.outputs.version }}
           TRIGGER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # Two pull requests labelled with the same bump before either is released compute the same
-          # version, and the second would force-push its own contents over the first candidate and
-          # take over its pull request. Retries from the same trigger stay a no-op; a different one
-          # stops here rather than silently replacing a prepared release.
           body=$(gh pr list --head "release/$VERSION" --state open --json body --jq '.[0].body // ""')
           if [ -n "$body" ] && ! printf '%s' "$body" | grep -qF "via #$TRIGGER."; then
-            echo "release/$VERSION is already prepared from a different pull request." >&2
-            echo "Release that one first, or close it before labelling this one." >&2
+            gh pr comment "$TRIGGER" --body "Release \`$VERSION\` is already owned by another pull request. Release or close that candidate first."
             exit 1
           fi
-      - name: Bump the workspace
+      - name: Bump the workspace with trusted tooling
+        if: steps.policy.outputs.action == 'prepare'
+        working-directory: candidate
         env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: node scripts/release/cli.mjs prepare-workspace --version "$VERSION" --date "$(date -u +%F)"
-      - name: Open the release pull request
+          VERSION: ${{ steps.policy.outputs.version }}
+        run: node ../trusted/scripts/release/cli.mjs prepare-workspace --version "$VERSION" --date "$(date -u +%F)"
+      - id: open
+        name: Push the release branch and open its pull request
+        if: steps.policy.outputs.action == 'prepare'
+        working-directory: candidate
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.policy.outputs.version }}
+          LABEL: ${{ steps.policy.outputs.label }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           TRIGGER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git switch -c "release/$VERSION"
-          # Re-labelling an already prepared release leaves the tree at the target version, and git
-          # commit exits 1 with nothing staged. Skip only the commit so the push and the pull request
-          # reconciliation below still run and the re-run stays a no-op rather than a failure.
-          git diff --quiet || git commit -am "chore(release): $VERSION"
-          # Checkout kept no credentials, so authenticate this one push explicitly. release/* is the
-          # only ref CI ever writes; main and develop are protected and CI cannot push to them.
+          git switch -C "release/$VERSION"
+          git add package.json packages/*/package.json packages/site/src/changelog.json
+          git diff --cached --quiet || git commit -m "chore(release): bump version to $VERSION"
           git push --force "https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" \
             "HEAD:refs/heads/release/$VERSION"
           gh pr create --base main --head "release/$VERSION" \
-            --title "Release $VERSION" \
-            --body "Version bump and changelog date for $VERSION, cut from \`$HEAD_REF\` via #$TRIGGER. Merge this, then run **Release** on main." \
-            || gh pr edit "release/$VERSION" --title "Release $VERSION"
+            --title "chore(release): bump version to $VERSION" \
+            --label "$LABEL" \
+            --body "Version bump and changelog date for $VERSION, cut from \`$HEAD_REF\` via #$TRIGGER. Merge with a merge commit to publish automatically." \
+            || gh pr edit "release/$VERSION" --title "chore(release): bump version to $VERSION" --add-label "$LABEL"
+          release_pr=$(gh pr view "release/$VERSION" --json number --jq .number)
+          echo "release_pr=$release_pr" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Supersede the triggering pull request
+        if: steps.policy.outputs.action == 'prepare'
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.policy.outputs.version }}
           TRIGGER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # release/$VERSION carries every commit this pull request had plus the bump, so leaving
-          # both open into main invites merging this one instead — which would ship the changes with
-          # no version bump, and Release would then no-op against the already published version.
-          #
-          # Skip when it is already closed, so re-applying the label to retry a failed run neither
-          # errors on the close nor posts the same comment twice.
           if [ "$(gh pr view "$TRIGGER" --json state --jq .state)" = "OPEN" ]; then
             url=$(gh pr view "release/$VERSION" --json url --jq .url)
-            gh pr comment "$TRIGGER" --body "Superseded by $url, which is this branch plus the $VERSION bump. Closing so it cannot be merged into main without the bump."
+            gh pr comment "$TRIGGER" --body "Superseded by $url, which contains this branch plus the committed $VERSION release metadata."
             gh pr close "$TRIGGER"
           fi
+
+  preview:
+    needs: prepare
+    if: needs.prepare.outputs.action == 'prepare'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    uses: ./.github/workflows/build-release-candidate.yml
+    with:
+      ref: ${{ needs.prepare.outputs.release_sha }}
+      version: ${{ needs.prepare.outputs.version }}
+      pr_number: ${{ fromJSON(needs.prepare.outputs.release_pr) }}
+    secrets: inherit

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,62 @@
+name: Refresh release candidate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-candidate-controller-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.policy.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - id: policy
+        run: |
+          labels=$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")
+          tags=$(git tag --list 'v*' | tr '\n' ' ')
+          node scripts/release/cli.mjs policy --labels "$labels" --head candidate-source --tags "$tags"
+      - name: Match the committed release identity
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.policy.outputs.version }}
+        run: |
+          committed=$(gh api "repos/$GITHUB_REPOSITORY/contents/package.json?ref=$HEAD_SHA" --jq .content | base64 -d | jq -r .version)
+          expected=${HEAD_REF#release/}
+          test "$committed" = "$expected"
+          test "$committed" = "$VERSION"
+
+  preview:
+    needs: resolve
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    uses: ./.github/workflows/build-release-candidate.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      version: ${{ needs.resolve.outputs.version }}
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -85,4 +85,7 @@ jobs:
       trusted_ref: ${{ github.event.pull_request.base.sha }}
       version: ${{ needs.resolve.outputs.version }}
       pr_number: ${{ github.event.pull_request.number }}
-    secrets: inherit
+    secrets:
+      CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -13,6 +13,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  non-release:
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository ||
+      !startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Mark release candidate / ready as not required
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: >-
+          node scripts/release/cli.mjs commit-status
+          --sha "$SHA" --state success --target-url "$TARGET_URL"
+
   resolve:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -54,9 +79,11 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+      statuses: write
     uses: ./.github/workflows/build-release-candidate.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
+      trusted_ref: ${{ github.event.pull_request.base.sha }}
       version: ${{ needs.resolve.outputs.version }}
       pr_number: ${{ github.event.pull_request.number }}
     secrets: inherit

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -15,7 +15,6 @@ concurrency:
 jobs:
   non-release:
     if: >-
-      github.event.pull_request.head.repo.full_name != github.repository ||
       !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,11 @@ jobs:
             test "$GITHUB_REF" = refs/heads/main
             pr_number=$(gh pr list --base main --head "release/$version" --state merged --limit 1 --json number --jq '.[0].number // ""')
             test -n "$pr_number"
+            release_ref=$(gh pr view "$pr_number" --json mergeCommit --jq '.mergeCommit.oid // ""')
+            test -n "$release_ref"
+            git fetch --no-tags origin "$release_ref"
+            git checkout --detach "$release_ref"
+            test "$(node -p "require('./package.json').version")" = "$version"
             labels=$(gh pr view "$pr_number" --json labels --jq '[.labels[].name] | join(",")')
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -80,7 +85,8 @@ jobs:
       ref: ${{ needs.resolve.outputs.ref }}
       trusted_ref: ${{ needs.resolve.outputs.ref }}
       sign_crx: true
-    secrets: inherit
+    secrets:
+      CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
 
   docker:
     needs: resolve
@@ -92,7 +98,6 @@ jobs:
       image_tag: ${{ needs.resolve.outputs.version }}
       artifact_prefix: stable-docker-${{ github.run_id }}-${{ github.run_attempt }}
       export_oci: true
-    secrets: inherit
 
   site-build:
     needs: resolve
@@ -231,7 +236,11 @@ jobs:
         env:
           SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}
         run: |
-          git remote set-url origin "https://x-access-token:$SYNC_TOKEN@github.com/$GITHUB_REPOSITORY"
+          auth=$(printf 'x-access-token:%s' "$SYNC_TOKEN" | base64 -w0)
+          echo "::add-mask::$auth"
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
+          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth"
           node scripts/release/cli.mjs sync-branches --remote origin
       - name: Report stable publication
         run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
     uses: ./.github/workflows/build-extension.yml
     with:
       ref: ${{ needs.resolve.outputs.ref }}
+      trusted_ref: ${{ needs.resolve.outputs.ref }}
       sign_crx: true
     secrets: inherit
 
@@ -84,12 +85,12 @@ jobs:
     needs: resolve
     permissions:
       contents: read
-      packages: write
     uses: ./.github/workflows/build-docker.yml
     with:
       ref: ${{ needs.resolve.outputs.ref }}
       image_tag: ${{ needs.resolve.outputs.version }}
-      push: true
+      artifact_prefix: stable-docker-${{ github.run_id }}-${{ github.run_attempt }}
+      export_oci: true
     secrets: inherit
 
   site-build:
@@ -143,6 +144,11 @@ jobs:
           path: release-assets
       - uses: actions/download-artifact@v8
         with:
+          pattern: stable-docker-${{ github.run_id }}-${{ github.run_attempt }}-oci-*
+          path: docker-images
+          merge-multiple: true
+      - uses: actions/download-artifact@v8
+        with:
           name: stable-site-${{ github.run_id }}-${{ github.run_attempt }}
           path: site-artifact
       - name: Tag the released commit without ever moving a stable tag
@@ -168,15 +174,36 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Promote stable image aliases
+      - name: Verify and publish immutable stable image
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/lurkloot-cli
         run: |
           major="${VERSION%%.*}"
           minor="${VERSION%.*}"
+          staging="release-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          cd docker-images
+          sha256sum -c image-amd64.tar.sha256
+          sha256sum -c image-arm64.tar.sha256
+          for arch in amd64 arm64; do
+            docker load --input "image-$arch.tar"
+            docker tag "$IMAGE:$VERSION-$arch" "$IMAGE:$staging-$arch"
+            docker push "$IMAGE:$staging-$arch"
+          done
+          docker buildx imagetools create --tag "$IMAGE:$staging" \
+            "$IMAGE:$staging-amd64" "$IMAGE:$staging-arm64"
+          desired=$(docker buildx imagetools inspect "$IMAGE:$staging" --raw | sha256sum | cut -d' ' -f1)
+          if docker buildx imagetools inspect "$IMAGE:$VERSION" --raw > existing-manifest.json 2>/dev/null; then
+            existing=$(sha256sum existing-manifest.json | cut -d' ' -f1)
+            if [ "$existing" != "$desired" ]; then
+              echo "refusing to move immutable image $IMAGE:$VERSION from sha256:$existing to sha256:$desired" >&2
+              exit 1
+            fi
+          fi
           docker buildx imagetools create \
             --tag "$IMAGE:$VERSION" --tag "$IMAGE:$minor" --tag "$IMAGE:$major" --tag "$IMAGE:latest" \
-            "$IMAGE:$VERSION"
+            "$IMAGE:$staging"
+          published=$(docker buildx imagetools inspect "$IMAGE:$VERSION" --raw | sha256sum | cut -d' ' -f1)
+          test "$published" = "$desired"
       - name: Publish to the Chrome Web Store
         env:
           CWS_SERVICE_ACCOUNT_JSON: ${{ secrets.CWS_SERVICE_ACCOUNT_JSON }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  pull_request:
+    types: [closed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -12,15 +15,60 @@ concurrency:
 
 jobs:
   resolve:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged &&
+      startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ steps.metadata.outputs.version }}
+      ref: ${{ steps.metadata.outputs.ref }}
+      pr_number: ${{ steps.metadata.outputs.pr_number }}
     steps:
       - uses: actions/checkout@v7
-      - name: Refuse to release from anywhere but main
-        run: test "$GITHUB_REF" = "refs/heads/main"
-      - id: version
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || 'main' }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - id: metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          version=$(node -p "require('./package.json').version")
+          if [ "$EVENT_NAME" = pull_request ]; then
+            pr_number=$EVENT_PR
+            labels=$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")
+          else
+            test "$GITHUB_REF" = refs/heads/main
+            pr_number=$(gh pr list --base main --head "release/$version" --state merged --limit 1 --json number --jq '.[0].number // ""')
+            test -n "$pr_number"
+            labels=$(gh pr view "$pr_number" --json labels --jq '[.labels[].name] | join(",")')
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "labels=$labels" >> "$GITHUB_OUTPUT"
+      - id: policy
+        env:
+          LABELS: ${{ steps.metadata.outputs.labels }}
+          VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          tags=$(git tag --list 'v*' | grep -vx "v$VERSION" | tr '\n' ' ' || true)
+          node scripts/release/cli.mjs policy --labels "$LABELS" --head stable-source --tags "$tags"
+      - name: Match the committed release version
+        env:
+          COMMITTED: ${{ steps.metadata.outputs.version }}
+          EXPECTED: ${{ steps.policy.outputs.version }}
+        run: test "$COMMITTED" = "$EXPECTED"
+      - run: node scripts/release.mjs check
 
   extension:
     needs: resolve
@@ -28,7 +76,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/build-extension.yml
     with:
-      version: ${{ needs.resolve.outputs.version }}
+      ref: ${{ needs.resolve.outputs.ref }}
       sign_crx: true
     secrets: inherit
 
@@ -39,48 +87,76 @@ jobs:
       packages: write
     uses: ./.github/workflows/build-docker.yml
     with:
-      version: ${{ needs.resolve.outputs.version }}
+      ref: ${{ needs.resolve.outputs.ref }}
+      image_tag: ${{ needs.resolve.outputs.version }}
       push: true
     secrets: inherit
 
+  site-build:
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+          persist-credentials: false
+      - uses: ./.github/actions/build-site
+        with:
+          channel: production
+      - uses: actions/upload-artifact@v7
+        with:
+          name: stable-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: packages/site/dist
+          if-no-files-found: error
+          retention-days: 1
+
   publish:
-    needs: [resolve, extension, docker]
+    needs: [resolve, extension, docker, site-build]
     runs-on: ubuntu-latest
     environment: production
     permissions:
       contents: write
       packages: write
+      pull-requests: write
     env:
       VERSION: ${{ needs.resolve.outputs.version }}
+      RELEASE_SHA: ${{ needs.resolve.outputs.ref }}
+      RELEASE_PR: ${{ needs.resolve.outputs.pr_number }}
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+          fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.9.0
       - uses: actions/download-artifact@v8
         with:
           name: extension-release-assets
           path: release-assets
-      - name: Tag the released commit
+      - uses: actions/download-artifact@v8
+        with:
+          name: stable-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: site-artifact
+      - name: Tag the released commit without ever moving a stable tag
         run: |
-          # Re-running Release is meant to be a safe no-op, so an existing tag at this same commit is
-          # fine. An existing tag at a *different* commit is not: it means main moved on without a
-          # version bump, and force-moving v$VERSION would silently re-point a published release at
-          # code that was never released under that version.
           existing=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v$VERSION" --jq .object.sha 2>/dev/null || true)
           if [ -z "$existing" ]; then
-            gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
-              -f ref="refs/tags/v$VERSION" -f sha="$GITHUB_SHA"
-          elif [ "$existing" != "$GITHUB_SHA" ]; then
-            echo "v$VERSION already tags $existing, refusing to move it to $GITHUB_SHA." >&2
-            echo "Prepare a new version instead of re-releasing a published one." >&2
+            gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/v$VERSION" -f sha="$RELEASE_SHA"
+          elif [ "$existing" != "$RELEASE_SHA" ]; then
+            echo "v$VERSION already tags $existing; refusing to move it to $RELEASE_SHA." >&2
             exit 1
           fi
-      - name: Render release notes
-        run: node scripts/release/cli.mjs notes --version "$VERSION" --out notes.md
-      - name: Create or update the GitHub release
+      - name: Create or update the stable GitHub release
         run: |
+          node scripts/release/cli.mjs notes --version "$VERSION" --out notes.md
           if gh release view "v$VERSION" >/dev/null 2>&1; then
             gh release edit "v$VERSION" --notes-file notes.md --latest
           else
@@ -92,7 +168,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Promote the image aliases
+      - name: Promote stable image aliases
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/lurkloot-cli
         run: |
@@ -106,33 +182,30 @@ jobs:
           CWS_SERVICE_ACCOUNT_JSON: ${{ secrets.CWS_SERVICE_ACCOUNT_JSON }}
           CWS_PUBLISHER_ID: ${{ vars.CWS_PUBLISHER_ID }}
           CWS_EXTENSION_ID: ${{ vars.CWS_EXTENSION_ID }}
+        run: >-
+          node scripts/release/cli.mjs cws-release
+          --version "$VERSION" --package "release-assets/lurkloot-$VERSION-chrome.zip"
+      - uses: ./.github/actions/deploy-site
+        with:
+          channel: production
+          directory: site-artifact
+          api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Retire the matching mutable candidate
+        run: node scripts/release/cli.mjs retire-candidate --pr "$RELEASE_PR" --version "$VERSION"
+      - id: sync-token
+        name: Mint the dedicated branch synchronization token
+        env:
+          RELEASE_SYNC_APP_ID: ${{ secrets.RELEASE_SYNC_APP_ID }}
+          RELEASE_SYNC_APP_PRIVATE_KEY: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
+        run: node scripts/release/cli.mjs app-token
+      - name: Merge main directly into develop with the dedicated App
+        env:
+          SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}
         run: |
-          node scripts/release/cli.mjs cws-release \
-            --version "$VERSION" --package "release-assets/lurkloot-$VERSION-chrome.zip"
-
-  site:
-    needs: [resolve, publish]
-    permissions:
-      contents: read
-    uses: ./.github/workflows/site-deploy.yml
-    with:
-      channel: production
-      ref: main
-    secrets: inherit
-
-  sync:
-    needs: [resolve, publish]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v7
-      - env:
-          GITHUB_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.resolve.outputs.version }}
-        run: |
-          gh pr create --base develop --head main \
-            --title "Sync main into develop after $VERSION" \
-            --body "Brings the $VERSION release commit back into develop." \
-            || echo "sync PR already open"
+          git remote set-url origin "https://x-access-token:$SYNC_TOKEN@github.com/$GITHUB_REPOSITORY"
+          node scripts/release/cli.mjs sync-branches --remote origin
+      - name: Report stable publication
+        run: >-
+          gh pr comment "$RELEASE_PR"
+          --body "Released v$VERSION. Chrome Web Store review was requested with automatic publication: https://chrome.google.com/webstore/devconsole/5fdc4582-d1e8-4714-819e-d4bdcee7da79/aobaackpofkghaejdnnmpmeaiaoibhdn"

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -50,21 +50,9 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
-      - uses: pnpm/action-setup@v6
+      - uses: ./.github/actions/build-site
         with:
-          version: 11.9.0
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build:site
-        env:
-          SITE_DEPLOYMENT_CHANNEL: ${{ inputs.channel }}
-      - name: Checksum static site artifact
-        run: |
-          cd packages/site/dist
-          find . -type f ! -name SITE_SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SITE_SHA256SUMS
+          channel: ${{ inputs.channel }}
       - uses: actions/upload-artifact@v7
         with:
           name: site-${{ inputs.channel }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -84,20 +72,22 @@ jobs:
       name: ${{ inputs.channel == 'production' && 'production' || 'preview' }}
       url: ${{ inputs.channel == 'production' && 'https://lurkloot.jamezrin.com' || 'https://next.lurkloot.pages.dev' }}
     steps:
+      # The local deployment action comes from the trusted caller commit. Candidate source remains
+      # confined to the credential-free build job and crosses this boundary only as checksummed data.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
       - uses: actions/download-artifact@v8
         with:
           name: site-${{ inputs.channel }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: site-artifact
-      - name: Verify static site artifact
-        working-directory: site-artifact
-        run: sha256sum -c SITE_SHA256SUMS
-      - name: Deploy the site
-        uses: cloudflare/wrangler-action@v4
+      - uses: ./.github/actions/deploy-site
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: site-artifact
-          command: pages deploy . --project-name=lurkloot --branch=${{ inputs.channel == 'production' && 'main' || 'next' }}
+          channel: ${{ inputs.channel }}
+          directory: site-artifact
+          api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Summarize deployment
         env:
           DEPLOY_CHANNEL: ${{ inputs.channel }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,12 +33,13 @@ Use pnpm for all package tasks. The root `package.json` orchestrates the workspa
 ## Cutting a Release
 
 Label a pull request into `main` with `release/patch`, `release/minor` or `release/major`. Prepare
-release cuts `release/X.Y.Z` from that PR's head, bumps the version, opens its own PR into `main` and
-closes the one you labelled. Merge the release PR, then run **Release** on `main`. Release tags the
-commit, builds every artifact, publishes the GitHub release, GHCR aliases, the Chrome Web Store
-submission and the production site, then opens the `main` to `develop` sync PR. A hotfix is the same
-flow with `release/patch` on a PR branched from `main`. Every step is idempotent: if one fails, fix
-the cause and run **Release** again. Do not push tags by hand.
+release cuts `release/X.Y.Z` from that PR's head, commits the version, opens its own PR into `main`,
+closes the one you labelled, and publishes mutable candidate artifacts on every release-branch push.
+Merge the generated release PR with a merge commit; **Release** starts automatically, publishes the
+GitHub release, GHCR aliases, Chrome Web Store submission and production site after one approval,
+then merges `main` directly into `develop` with the dedicated sync App. A hotfix is the same flow
+with `release/patch` on a PR branched from `main`. Use manual **Release** dispatch only for idempotent
+recovery. Do not create or move tags by hand.
 
 Follow [RELEASING.md](RELEASING.md) for the `preview` and `production` environments, the single release approval, credentials, Chrome Web Store publication timing, and required repository configuration.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,8 +60,13 @@ Candidate pointers are deliberately mutable:
 - Site: `https://next.lurkloot.pages.dev`
 
 Every generated release-branch push rebuilds and refreshes those targets. Ownership metadata binds
-the candidate release to its pull request. Automation refuses to move a candidate tag when no owned
-prerelease proves its identity, and it never modifies a stable release through the candidate path.
+the candidate release to its pull request. An exact-SHA tag left behind by interrupted initial
+creation is recovered; a tag at any other SHA is rejected. Automation never modifies a stable
+release through the candidate path.
+
+The candidate pipeline writes all five required contexts directly to the generated release PR head:
+the four build/verification contexts plus `release candidate / ready`. This is necessary because
+GitHub intentionally suppresses new workflow events caused by the `GITHUB_TOKEN` that opens the PR.
 
 Only the most recently completed site candidate matters. Concurrent candidates therefore share the
 `next` deployment and the last successful deployment wins.
@@ -93,7 +98,9 @@ Stable publication operates on the exact merged commit and is idempotent:
 - `vX.Y.Z` is created once and is never moved.
 - The signed CRX, Chrome ZIP, Firefox ZIP, Firefox source ZIP, and checksums are uploaded to the
   stable GitHub release.
-- GHCR receives `X.Y.Z`, `X.Y`, `X`, and `latest`.
+- Docker architectures are exported as checksummed OCI archives before approval. GHCR receives
+  `X.Y.Z`, `X.Y`, `X`, and `latest` only inside the approved production job; an existing `X.Y.Z`
+  digest is never replaced.
 - Chrome Web Store receives the Chrome ZIP with `DEFAULT_PUBLISH`; Google publishes it automatically
   after review approval.
 - The production site deploys to `https://lurkloot.jamezrin.com`.
@@ -173,6 +180,7 @@ only then removes the conflicting classic protections. It refuses to run without
 
 - pull requests merged with `merge` only;
 - `verify`, `extension / build`, and both Docker architecture checks;
+- `release candidate / ready`, reported against the PR head by trusted workflow code;
 - branches up to date with `main` before merge;
 - no deletion or force push;
 - no bypass actors.
@@ -180,7 +188,7 @@ only then removes the conflicting classic protections. It refuses to run without
 `develop squash history` targets `develop` and requires:
 
 - pull requests merged with `squash` only for ordinary actors;
-- the same four checks and strict up-to-date policy;
+- the same five checks and strict up-to-date policy;
 - no deletion or force push;
 - only the Lurkloot Release Sync App as an always-allowed bypass actor.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,241 +1,203 @@
 # Releasing Lurkloot
 
-Label a pull request into `main`, merge the release pull request that appears, then run **Release**.
-That covers every release, including hotfixes. Do not create or move tags by hand; the only branch CI
-ever pushes is the generated `release/X.Y.Z`. It cannot push to `main` or `develop` — beyond that
-branch it only creates tags, releases and pull requests.
+Label a pull request into `main`, inspect the generated candidate, and merge the generated release
+pull request. Publication starts automatically after that merge and pauses once for approval on the
+`production` environment. Do not create or move tags by hand.
 
 ## Before you start: write the changelog
 
-Release notes are rendered *only* from `packages/site/src/changelog.json`. Add the entry for the new
-version to the branch you are releasing — `develop` for a normal release — before you apply the
-label, since Prepare release cuts from that branch. Put it at the top of the array; omit `date`,
-because Prepare release stamps it:
+Release notes are rendered only from `packages/site/src/changelog.json`. Add the entry for the new
+version to the branch being released before applying the label. Put it at the top and omit `date`;
+Prepare release stamps it:
 
 ```json
-{ "version": "1.5.1", "changes": [
-  { "kind": "fixed", "text": "Fixed a thing." }
+{ "version": "1.6.0", "changes": [
+  { "kind": "new", "text": "Added a feature." }
 ] }
 ```
 
-The only valid `kind` values are `new`, `improved` and `fixed`; anything else fails the site build.
+Valid change kinds are `new`, `improved`, and `fixed`. If no entry exists, preparation creates an
+empty entry. That intentionally permits build-only releases, but produces an empty release body.
 
-If no entry exists, Prepare release creates one with `"changes": []` rather than failing, and the
-GitHub release then ships with an **empty body**. That is the intended escape hatch for a build-only
-release, but it is silent — so write the entry first unless you mean it.
+## Normal release flow
 
-## The three steps
+1. Open the intended source pull request into `main`. For a normal release this is the `develop` to
+   `main` promotion pull request.
+2. Apply exactly one of `release/patch`, `release/minor`, or `release/major`.
+3. Prepare release cuts `release/X.Y.Z` from the source head, commits the version in all seven
+   workspace manifests, dates the changelog, opens a generated pull request into `main`, copies the
+   release label to it, and closes the original pull request as superseded.
+4. Candidate automation verifies the generated pull request, publishes the signed extension
+   artifacts as the mutable `candidate-vX.Y.Z` GitHub prerelease, pushes GHCR
+   `candidate-X.Y.Z`, and deploys the site to `next.lurkloot.pages.dev`.
+5. Review and merge the generated `release/X.Y.Z` pull request with a **merge commit**. Squash and
+   rebase are blocked on `main`; the original `develop` commit SHAs remain in `main` history.
+6. Release rebuilds from the merged `main` commit. Approve its single `production` job. It publishes
+   GitHub, GHCR, Chrome Web Store, and the production site, retires the candidate, then merges `main`
+   directly into `develop` with the dedicated synchronization App.
 
-1. **Open a pull request into `main` and label it** `release/patch`, `release/minor` or
-   `release/major`. For a normal release that is the `develop` to `main` promotion pull request; for
-   a hotfix it is the fix's own pull request. Prepare release cuts `release/X.Y.Z` from that pull
-   request's head, bumps the version in all seven `package.json` files, stamps the date on the
-   changelog entry, and opens its own pull request into `main`.
-2. **Review and merge the `release/X.Y.Z` pull request.** This merge *is* the promotion. There is no
-   separate promotion step.
-3. **Actions → Release, run on `main`.** The workflow refuses to run from any other branch.
+`workflow_dispatch` remains on **Release** only for idempotent recovery. A successful release does
+not require a manual dispatch.
 
-The label says how much to bump; the pull request says what is being released. There is no base or
-version input to keep in sync with the branch, because the pull request already carries both facts.
+## Label lifecycle
 
-Prepare release then comments on the pull request you labelled and **closes it**. That is deliberate:
-`release/X.Y.Z` is the same branch plus the bump, so leaving both open into `main` would let you
-merge the one without the version bump. If a run fails part way, remove the label and add it again to
-retry.
+- No recognized label means ordinary pull-request behavior.
+- More than one recognized release label blocks preparation and posts an explanatory comment.
+- Removing one label while another remains prepares the remaining selection.
+- Removing the final release label reports the already-created candidate as orphaned. Automation
+  does not delete it, because it may already be under review.
+- Generated `release/*` pull requests carry their release label for promotion validation but are
+  ignored as new preparation sources.
+- Fork pull requests cannot prepare releases. In this public repository, native GitHub roles limit
+  label application to users with triage-or-higher access; currently only `jamezrin` has that access.
 
-## What Release does
+## Candidate behavior
 
-- Tags `vX.Y.Z` on the released commit.
-- Builds the extension, including the signed CRX, and the CLI Docker image for `linux/amd64` and
-  `linux/arm64`.
-- Creates or updates the GitHub release, marks it Latest, and uploads the signed CRX, both browser
-  ZIPs, the sources ZIP and the checksums.
-- Pushes the GHCR version tags, then moves the aliases `X.Y`, `X` and `latest`.
-- Uploads the Chrome Web Store submission.
-- Deploys the production site.
-- Opens the `main` to `develop` synchronization pull request.
+Candidate pointers are deliberately mutable:
 
-Upload the Firefox ZIP and the source ZIP from the GitHub release to AMO; AMO publication remains
-manual.
+- GitHub tag/release: `candidate-vX.Y.Z`
+- GHCR image: `candidate-X.Y.Z`
+- Site: `https://next.lurkloot.pages.dev`
 
-## Where the version number comes from
+Every generated release-branch push rebuilds and refreshes those targets. Ownership metadata binds
+the candidate release to its pull request. Automation refuses to move a candidate tag when no owned
+prerelease proves its identity, and it never modifies a stable release through the candidate path.
 
-Nobody edits a version by hand.
+Only the most recently completed site candidate matters. Concurrent candidates therefore share the
+`next` deployment and the last successful deployment wins.
 
-Prepare release derives it from **git tags, not from `package.json`**: it reads `git tag --list 'v*'`,
-takes the highest stable tag, and applies the bump named by the label. Prereleases and leftover
-`candidate-*` tags are filtered out, so a stray tag cannot skew a bump. It then writes that version
-into all seven manifests and the changelog entry, as a single `chore(release): X.Y.Z` commit on
-`release/X.Y.Z`.
+## Parallel hotfix and normal candidates
 
-Release reads the version back out of `package.json` on `main`. **That committed value is what is
-actually released** — the tag, the GHCR tags and the store package all follow it.
+Different versions may be prepared concurrently. For example, with `1.5.0` stable:
 
-The version is therefore derived from what was last released, and committed *before* anything is
-built. Nothing is frozen, so nothing can be invalidated mid-release.
+```text
+release/1.5.1  <- patch candidate from a hotfix branch based on main
+release/1.6.0  <- minor candidate from a develop snapshot
+```
 
-`checkWorkspace` runs as part of the bump and fails loudly if the seven manifests disagree or the
-changelog has no entry for the version, so a half-edited workspace cannot reach a release. Only
-`release/patch`, `release/minor` and `release/major` name a valid bump; any other `release/*` label
-fails the run before a branch is created rather than guessing.
+If `1.5.1` publishes first, `1.6.0` remains the correct minor version, but its old candidate does
+not contain the hotfix. Merge the updated `main` into `release/1.6.0`, resolve manifest or changelog
+conflicts by keeping version `1.6.0` and both changelog entries, and push. Do not rebase: merging
+preserves the original development commit SHAs. The push rebuilds the candidate before it can merge.
 
-## Branch model and hotfixes
+If `1.6.0` publishes first, a pending `1.5.1` is invalid because releases cannot go backwards.
+Re-prepare the hotfix as `1.6.1`.
 
-`develop` is what is in development. `main` is what is ready to release or already released.
+Two pull requests may not own the same candidate version. The second preparation fails instead of
+force-pushing over the first release branch.
 
-There is no hotfix machinery, no hotfix label, and no separate workflow. A hotfix is the same three
-steps against a different pull request:
+## Stable publication
 
-1. Branch from `main`, not `develop`, and open the fix as an ordinary pull request into `main`.
-   **Do not merge it.**
-2. Label it `release/patch`. Prepare release cuts `release/X.Y.Z` from your fix branch, so the
-   release carries the already-released commits plus your fix and *none* of develop's unreleased
-   work. Your pull request is then closed as superseded.
-3. Merge the `release/X.Y.Z` pull request, then run **Release** on `main` as usual.
-4. Merge the `main` to `develop` sync PR that Release opens, so the fix and the version bump reach
-   `develop`.
+Stable publication operates on the exact merged commit and is idempotent:
 
-**Do not merge the fix yourself and skip the label.** Release reads the version from `package.json`
-on `main`, so without a bump it would try to release the already-published version again. It fails at
-the tagging step rather than re-pointing `vX.Y.Z` at the new commit, so nothing is corrupted — but
-nothing ships either, and the fix sits on `main` looking released. Closing the labelled pull request
-automatically is what keeps that from happening by accident.
+- `vX.Y.Z` is created once and is never moved.
+- The signed CRX, Chrome ZIP, Firefox ZIP, Firefox source ZIP, and checksums are uploaded to the
+  stable GitHub release.
+- GHCR receives `X.Y.Z`, `X.Y`, `X`, and `latest`.
+- Chrome Web Store receives the Chrome ZIP with `DEFAULT_PUBLISH`; Google publishes it automatically
+  after review approval.
+- The production site deploys to `https://lurkloot.jamezrin.com`.
+- The owned mutable candidate release and tag are removed after the stable release exists.
+- `main` is merged directly into `develop` after local `pnpm verify` succeeds.
 
-## Chrome Web Store timing
+Firefox Add-ons publication remains manual. Upload the Firefox and source ZIPs from the GitHub
+release to AMO.
 
-The submission uses `DEFAULT_PUBLISH`, so **Google publishes the item itself once review
-passes** — hours or days after the run finishes, with no further human action and no polling on our
-side. The store deliberately trails the GitHub release. Accepting that trade is what removed the
-staged-review, polling and cancellation machinery; do not add a workflow that waits for the store.
+## Branch model
 
-## Environments and approval
+- Ordinary feature and fix pull requests into `develop` use squash merge.
+- Release and hotfix pull requests into `main` use merge commits.
+- Rebase merging is disabled repository-wide.
+- Force pushes and deletions remain blocked on both protected branches.
+- The dedicated synchronization App may bypass only the `develop` pull-request requirement so it
+  can fast-forward or merge `main` directly after publication.
+- The general GitHub Actions App is not a bypass actor.
 
-There are exactly two environments.
+The direct synchronization is a fast-forward when `develop` has not advanced. When it has advanced,
+the sync creates a merge commit, verifies the combined tree, and pushes it. A conflict aborts before
+any remote update.
 
-| Environment | Reviewer | Holds | Used by |
-| --- | --- | --- | --- |
-| `preview` | none | `CRX_PRIVATE_KEY` | extension signing, the Docker version-tag push, prerelease site deploys |
-| `production` | required, repository admins | `CWS_SERVICE_ACCOUNT_JSON` | the `publish` job in `release.yml`, the production site deploy |
+## Environments and credentials
 
-`preview` holds the signing key that *produces* artifacts. `production` gates what actually
-publishes: the GitHub release, the moving GHCR aliases, the Chrome Web Store upload and the
-production site.
+There are exactly two environments:
 
-A release run pauses for approval twice: once before `publish`, and once before the production
-site deploy, because both target `production`. An unapproved build can produce artifacts and
-immutable version-specific tags, but it can never move `latest` or publish anything.
+| Environment | Approval | Credentials and purpose |
+| --- | --- | --- |
+| `preview` | none | `CRX_PRIVATE_KEY`; candidate signing, candidate GHCR, preview site |
+| `production` | `jamezrin` | CWS credentials and sync App credentials; all stable publication |
 
-Restrict `preview`'s deployment branches to `main` and `release/*`.
+Repository secrets used from both channels remain `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID`. Variables are `CWS_PUBLISHER_ID` and `CWS_EXTENSION_ID`.
 
-## Credentials
+Move `CRX_PRIVATE_KEY` to `preview` and `CWS_SERVICE_ACCOUNT_JSON` to `production` when their
+plaintext values are available. Never delete the repository copy until the environment copy has
+been written successfully. Losing the CRX key changes the extension ID.
 
-Secrets: `CRX_PRIVATE_KEY`, `CWS_SERVICE_ACCOUNT_JSON`, `CLOUDFLARE_API_TOKEN` and
-`CLOUDFLARE_ACCOUNT_ID`. All four are currently **repository** secrets, which every job reads via
-`secrets: inherit`. The "Holds" column above describes where the two publishing credentials belong
-once the optional hardening below is applied; until then the environments provide the approval gate
-and the branch restriction, but not a credential boundary.
+The production environment additionally requires:
 
-`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` stay at the repository level permanently — the
-site deploys from both environments, so scoping them to one would break the other channel.
+- `RELEASE_SYNC_APP_ID`
+- `RELEASE_SYNC_APP_PRIVATE_KEY`
 
-Variables: `CWS_PUBLISHER_ID`, `CWS_EXTENSION_ID`.
+## One-time dedicated App setup
 
-The CWS service-account email must be a member of the Chrome Web Store publisher, and the CRX
-private key must be preserved permanently — losing it changes the extension ID.
+The settings template is `docs/github-apps/release-sync-manifest.json`. GitHub requires the owner to
+authorize App registration; a workflow cannot create this identity for itself.
+
+1. In GitHub, open **Settings -> Developer settings -> GitHub Apps -> New GitHub App**.
+2. Use the template name and URL, disable the webhook, keep the App private, grant repository
+   `Contents: Read and write`, and subscribe to no events.
+3. Install the App only on `jamezrin/lurkloot`.
+4. Record the numeric App ID and generate one private key PEM.
+5. Store them on the protected environment:
+
+   ```sh
+   gh secret set RELEASE_SYNC_APP_ID --env production --body "APP_ID"
+   gh secret set RELEASE_SYNC_APP_PRIVATE_KEY --env production < release-sync.private-key.pem
+   ```
+
+6. Preview the ruleset migration, then apply it using the App ID:
+
+   ```sh
+   export GITHUB_REPOSITORY=jamezrin/lurkloot
+   export GH_TOKEN="$(gh auth token)"
+   node scripts/release/cli.mjs configure-repository --sync-app-id "APP_ID"
+   node scripts/release/cli.mjs configure-repository --sync-app-id "APP_ID" --apply true
+   ```
+
+Apply mode enables merge+squash, disables rebase, creates and reads back both active rulesets, and
+only then removes the conflicting classic protections. It refuses to run without a positive App ID.
+
+## Repository policy after migration
+
+`main release history` targets `main` and requires:
+
+- pull requests merged with `merge` only;
+- `verify`, `extension / build`, and both Docker architecture checks;
+- branches up to date with `main` before merge;
+- no deletion or force push;
+- no bypass actors.
+
+`develop squash history` targets `develop` and requires:
+
+- pull requests merged with `squash` only for ordinary actors;
+- the same four checks and strict up-to-date policy;
+- no deletion or force push;
+- only the Lurkloot Release Sync App as an always-allowed bypass actor.
+
+The repository default workflow token remains read-only.
 
 ## Recovery
 
-Every step is idempotent. Tagging, the GitHub release, the GHCR aliases, the store upload and the
-site deploy all tolerate re-running. **This idempotency is what replaces rollback.** There is no
-rollback and no cancellation flow.
+- Preparation failure: fix the cause and remove/reapply the release label.
+- Candidate failure: re-run the failed workflow or push the corrected release branch.
+- Stable failure after merge: fix the external/configuration problem and manually dispatch
+  **Release** on `main`. Matching completed steps are no-ops.
+- Existing stable tag at another SHA: stop and prepare a new version. Never move it.
+- Sync conflict: merge `main` into `develop` locally, run `pnpm verify`, and push with the dedicated
+  App credential; alternatively use a one-off reviewed synchronization PR. Do not disable branch
+  protection.
+- Missing App configuration: publication reports the completed stable steps and fails at sync. Add
+  the two production secrets and rerun Release.
 
-If a step fails, fix the cause and run **Release** again. A re-run with nothing left to change is a
-harmless no-op: the tag already points at this commit and is left alone, the release is edited rather
-than recreated, the aliases are re-pointed at the same digest, and the store upload reports that the
-version is already submitted and does nothing.
-
-The one thing a re-run will not do is move a tag. If `vX.Y.Z` already points at a *different* commit,
-Release fails instead of re-pointing it — that state means `main` moved on without a version bump,
-and re-tagging would silently attach a published version to code that was never released as it.
-Prepare a new version rather than re-releasing a published one.
-
-Re-applying a `release/*` label for a version that is already prepared is likewise a no-op; it
-refreshes `release/X.Y.Z`, leaves the existing pull request in place, and skips the supersede comment
-because the labelled pull request is already closed.
-
-## After a release: reconcile `develop`
-
-Both branches require linear history, so pull requests between them merge by rebase. Rebasing
-rewrites the commits, so once the sync PR merges, `main` and `develop` end up with **identical trees
-but no shared history** — their merge-base stays at the commit before the merge.
-
-The consequence is cosmetic but compounds: the next `release/X.Y.Z` branch is cut from `develop`, so
-its pull request diffs from that stale merge-base and shows the previous release's version bump on
-top of the intended one. It still merges cleanly, because patch-equivalent commits are dropped on
-rebase.
-
-Check with:
-
-```sh
-git fetch origin main develop                            # never check against stale refs
-git rev-parse origin/main^{tree} origin/develop^{tree}   # should match
-git merge-base origin/main origin/develop                # should equal origin/main
-```
-
-Fetch first every time. The whole safety argument for the force push below is "the trees are already
-identical", and a stale `origin/develop` can satisfy that check while the real branch has moved on —
-in which case the push discards commits.
-
-If the trees match but the merge-base is stale, reconcile `develop` to `main`. This needs a force
-push, so temporarily set `allow_force_pushes: true` and `enforce_admins: false` on `develop`, run
-`git push --force-with-lease origin origin/main:refs/heads/develop`, then restore both settings
-immediately. Only do this when the trees are already identical — it is a history fix, not a content
-change.
-
-A branch cut from `develop` *before* a reconciliation keeps the old commit SHAs and starts conflicting
-with it. Replant it with `git rebase --onto origin/develop <last-commit-shared-with-old-develop>`; the
-duplicated commits drop as patch-equivalent, and the tree hash should be unchanged afterwards.
-
-## Repository configuration
-
-Applied:
-
-- [x] `preview` environment, no required reviewer, deployment branches restricted to `main` and
-      `release/*`.
-- [x] `production` environment, with repository administrators as required reviewers.
-- [x] Obsolete environments `prereleases`, `cws-review`, `prerelease-site`, `production-site` and
-      `stable-releases` deleted.
-- [x] `cws-release-ready` removed from `main`'s required status checks. Nothing posts it any more,
-      so leaving it required would have blocked every pull request forever.
-- [x] `main`'s required status checks are `verify`, `extension / build`,
-      `docker / build (linux/amd64, ubuntu-latest, amd64)` and
-      `docker / build (linux/arm64, ubuntu-24.04-arm, arm64)`. `develop` matches.
-- [x] Labels `release/patch`, `release/minor` and `release/major` exist — they are the release
-      trigger. There is deliberately no `release/hotfix`: a hotfix is a `release/patch` on a pull
-      request whose head is a hotfix branch.
-- [x] Default workflow token permission is `read`.
-
-### Optional hardening: scope the credentials to environments
-
-All four secrets are currently repository secrets, which every job can read via `secrets: inherit`.
-The pipeline works as-is; the environments today provide the approval gate and the branch
-restriction, but not a credential boundary.
-
-To make them a real boundary, move the two publishing credentials into environments. This cannot be
-automated, because GitHub never discloses an existing secret's value — only someone holding the
-plaintext can re-enter it:
-
-```sh
-gh secret set CRX_PRIVATE_KEY --env preview < path/to/lurkloot.pem
-gh secret delete CRX_PRIVATE_KEY
-
-gh secret set CWS_SERVICE_ACCOUNT_JSON --env production < path/to/service-account.json
-gh secret delete CWS_SERVICE_ACCOUNT_JSON
-```
-
-Leave `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` at the repository level: the site deploys
-from both environments, so scoping them to one would break the other channel.
-
-Do this only when you have the plaintext to hand. Deleting a repository secret without having
-successfully set the environment copy breaks signing or publishing on the next release, and
-`CRX_PRIVATE_KEY` cannot be regenerated — losing it changes the extension ID.
+The Chrome Web Store intentionally trails the GitHub release while Google reviews the submission.
+There is no polling, cancellation, or rollback workflow.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -188,7 +188,7 @@ only then removes the conflicting classic protections. It refuses to run without
 `develop squash history` targets `develop` and requires:
 
 - pull requests merged with `squash` only for ordinary actors;
-- the same five checks and strict up-to-date policy;
+- the four ordinary validation/build checks and strict up-to-date policy;
 - no deletion or force push;
 - only the Lurkloot Release Sync App as an always-allowed bypass actor.
 

--- a/docs/github-apps/release-sync-manifest.json
+++ b/docs/github-apps/release-sync-manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Lurkloot Release Sync",
+  "url": "https://github.com/jamezrin/lurkloot",
+  "hook_attributes": {
+    "active": false
+  },
+  "public": false,
+  "default_permissions": {
+    "contents": "write",
+    "metadata": "read"
+  },
+  "default_events": []
+}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,4 +2,6 @@
 
 The canonical release runbook is [RELEASING.md](../RELEASING.md).
 
-It documents the `release/*` label that triggers **Prepare release**, the **Release** dispatch, the branch model and hotfixes, the release environments and approval, credentials, Chrome Web Store publication timing, and recovery.
+It documents label-driven candidate preparation, automatic publication after a merge-commit release
+PR, concurrent hotfixes, the protected direct `main` to `develop` sync, environments and credentials,
+the dedicated GitHub App and rulesets, Chrome Web Store timing, and recovery.

--- a/docs/superpowers/plans/2026-07-18-automatic-release-promotion.md
+++ b/docs/superpowers/plans/2026-07-18-automatic-release-promotion.md
@@ -8,6 +8,12 @@
 
 **Tech Stack:** GitHub Actions, Node 22/24 ESM, `node:test`, pnpm 11, WXT, Docker Buildx/GHCR, Chrome Web Store API v2, Cloudflare Pages, GitHub REST API.
 
+**Security hardening amendment:** Candidate signing tooling is prepared in a separate job from the
+trusted base ref and integrity-pinned lockfile. Generated release PRs receive required contexts on
+their head SHA from trusted orchestration. Stable Docker jobs export OCI archives before approval;
+all GHCR stable writes occur in the single production job and refuse to move an existing version
+digest. Candidate release creation recovers only an exact-SHA orphan tag.
+
 ## Global Constraints
 
 - Release labels are exactly `release/patch`, `release/minor`, and `release/major`.
@@ -534,4 +540,3 @@
   Apply and remove a release label on a test pull request, verify policy comments and candidate
   preparation, then close the generated candidate without merging. Confirm no stable tags, stable
   GHCR aliases, CWS revisions, or production deployments changed.
-

--- a/docs/superpowers/plans/2026-07-18-automatic-release-promotion.md
+++ b/docs/superpowers/plans/2026-07-18-automatic-release-promotion.md
@@ -1,0 +1,537 @@
+# Automatic Release Promotion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add committed release candidates with automatic previews, automatic stable publication on merge, merge-method rulesets, and protected direct `main` to `develop` synchronization.
+
+**Architecture:** Trusted Node ESM helpers decide label, version, candidate ownership, GitHub App authentication, and repository configuration. Reusable workflows keep candidate builds credential-free until isolated signing/publishing jobs, while the stable workflow rebuilds from merged `main`, publishes behind one production approval, and synchronizes `develop` with a dedicated App token.
+
+**Tech Stack:** GitHub Actions, Node 22/24 ESM, `node:test`, pnpm 11, WXT, Docker Buildx/GHCR, Chrome Web Store API v2, Cloudflare Pages, GitHub REST API.
+
+## Global Constraints
+
+- Release labels are exactly `release/patch`, `release/minor`, and `release/major`.
+- Stable version tags are immutable `vX.Y.Z`; mutable candidate tags are `candidate-vX.Y.Z`.
+- All seven workspace manifests and the changelog must agree before artifacts are built.
+- Candidate source never executes with repository write credentials or publishing secrets.
+- No inline JavaScript or TypeScript is permitted in workflow YAML.
+- Ordinary pull requests into `develop` squash; pull requests into `main` merge with a merge commit.
+- The general GitHub Actions App never bypasses branch protection.
+- `main` to `develop` synchronization uses a repository-scoped GitHub App configured only as a `develop` ruleset bypass actor.
+- The shared `next.lurkloot.pages.dev` deployment represents only the most recently completed candidate.
+
+---
+
+### Task 1: Release policy primitives
+
+**Files:**
+- Create: `scripts/release/pipeline.mjs`
+- Create: `scripts/release/pipeline.test.mjs`
+- Modify: `scripts/release/cli.mjs`
+- Modify: `scripts/release/cli.test.mjs`
+
+**Interfaces:**
+- Consumes: `latestVersion(tags)` and `nextVersion(current, bump)` from `scripts/release/version.mjs`.
+- Produces: `selectReleaseLabel(labels)`, `candidateTag(version)`, `candidateMarker(context)`, `parseCandidateMarker(body)`, and `validatePromotion(context)`.
+
+- [ ] **Step 1: Write failing policy tests**
+
+  Add tests proving zero labels select no release, one label selects its bump, multiple labels throw,
+  generated `release/*` heads are ignored as preparation sources, markers round-trip PR/version/head
+  identity, and promotion accepts `1.6.0` after either `1.5.0` or `1.5.1` but rejects `1.5.1` after
+  `1.6.0`.
+
+  ```javascript
+  test("selects exactly one recognized release label", () => {
+    assert.equal(selectReleaseLabel(["docs", "release/minor"]), "release/minor");
+    assert.equal(selectReleaseLabel(["docs"]), undefined);
+    assert.throws(
+      () => selectReleaseLabel(["release/patch", "release/minor"]),
+      /exactly one release label/,
+    );
+  });
+
+  test("validates a concurrent minor candidate after a patch release", () => {
+    assert.deepEqual(validatePromotion({ stableVersion: "1.5.1", version: "1.6.0", label: "release/minor" }), {
+      bump: "minor",
+      version: "1.6.0",
+    });
+    assert.throws(
+      () => validatePromotion({ stableVersion: "1.6.0", version: "1.5.1", label: "release/patch" }),
+      /expected 1\.6\.1/,
+    );
+  });
+  ```
+
+- [ ] **Step 2: Run the focused tests and confirm RED**
+
+  Run: `node --test scripts/release/pipeline.test.mjs`
+
+  Expected: failure because `scripts/release/pipeline.mjs` does not exist.
+
+- [ ] **Step 3: Implement the minimal policy module**
+
+  Implement stable SemVer validation through the existing version module, hidden candidate ownership
+  markers of the form `<!-- lurkloot-release-candidate:{...} -->`, and exact bump revalidation.
+  Expose a CLI command:
+
+  ```text
+  node scripts/release/cli.mjs policy --labels release/minor,docs --head develop --tags "v1.5.0"
+  label=release/minor
+  bump=minor
+  version=1.6.0
+  action=prepare
+  ```
+
+- [ ] **Step 4: Run policy and release tests and confirm GREEN**
+
+  Run: `node --test scripts/release/pipeline.test.mjs scripts/release/cli.test.mjs scripts/release/version.test.mjs`
+
+  Expected: all tests pass with zero failures.
+
+- [ ] **Step 5: Commit the policy boundary**
+
+  ```bash
+  git add scripts/release/pipeline.mjs scripts/release/pipeline.test.mjs scripts/release/cli.mjs scripts/release/cli.test.mjs
+  git commit -m "feat(release): add candidate policy primitives"
+  ```
+
+### Task 2: Idempotent GitHub candidate reconciliation
+
+**Files:**
+- Create: `scripts/release/github.mjs`
+- Create: `scripts/release/github.test.mjs`
+- Modify: `scripts/release/cli.mjs`
+
+**Interfaces:**
+- Consumes: candidate marker helpers from Task 1 and `releaseNotes()` from `scripts/release/notes.mjs`.
+- Produces: `GitHubClient`, `reconcilePrerelease(options)`, `retirePrerelease(options)`, and `upsertComment(options)`.
+
+- [ ] **Step 1: Write failing reconciliation tests**
+
+  Use a recording `fetchImpl` to prove that reconciliation creates a missing candidate tag and
+  prerelease, moves only an owned prerelease tag, clobbers named assets, updates one marked comment,
+  and refuses to modify a stable release or a marker owned by another PR.
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+  Run: `node --test scripts/release/github.test.mjs`
+
+  Expected: module-not-found failure for `scripts/release/github.mjs`.
+
+- [ ] **Step 3: Implement the REST client and CLI commands**
+
+  Add these commands without adding GitHub API logic to YAML:
+
+  ```text
+  cli.mjs publish-candidate --pr 132 --version 1.6.0 --sha abc --assets release-assets --notes notes.md
+  cli.mjs candidate-comment --pr 132 --version 1.6.0 --sha abc --state ready --url URL
+  cli.mjs retire-candidate --pr 132 --version 1.6.0
+  ```
+
+  The client must check live release/tag ownership before every write and use `GITHUB_TOKEN` only
+  from the environment.
+
+- [ ] **Step 4: Run candidate reconciliation tests and confirm GREEN**
+
+  Run: `node --test scripts/release/github.test.mjs scripts/release/pipeline.test.mjs scripts/release/cli.test.mjs`
+
+  Expected: all tests pass.
+
+- [ ] **Step 5: Commit GitHub reconciliation**
+
+  ```bash
+  git add scripts/release/github.mjs scripts/release/github.test.mjs scripts/release/cli.mjs
+  git commit -m "feat(release): reconcile candidate releases"
+  ```
+
+### Task 3: Trusted label preparation workflow
+
+**Files:**
+- Modify: `.github/workflows/prepare-release.yml`
+- Create: `scripts/release/workflows.test.mjs`
+- Modify: `scripts/release/cli.mjs`
+
+**Interfaces:**
+- Consumes: `policy` CLI output from Task 1.
+- Produces: a generated `release/X.Y.Z` branch and pull request carrying the selected release label,
+  plus outputs `version`, `release_pr`, and `release_sha` for candidate preparation.
+
+- [ ] **Step 1: Write failing structural workflow tests**
+
+  Assert that preparation uses `pull_request_target` for `labeled` and `unlabeled`, checks out base
+  tooling separately from candidate source, rejects forks and multiple release labels, ignores
+  generated release heads, never executes candidate scripts with a write token, and calls candidate
+  preparation after a successful branch push.
+
+- [ ] **Step 2: Run the workflow test and confirm RED**
+
+  Run: `node --test scripts/release/workflows.test.mjs`
+
+  Expected: assertions fail against the existing label-only `pull_request` workflow.
+
+- [ ] **Step 3: Refactor preparation around trusted tooling**
+
+  Use two checkout directories:
+
+  ```yaml
+  - uses: actions/checkout@v7
+    with:
+      ref: ${{ github.event.pull_request.base.sha }}
+      path: trusted
+      persist-credentials: false
+  - uses: actions/checkout@v7
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name }}
+      ref: ${{ github.event.pull_request.head.sha }}
+      path: candidate
+      fetch-depth: 0
+      persist-credentials: false
+  ```
+
+  Execute `node ../trusted/scripts/release/cli.mjs prepare-workspace` with `candidate` as the working
+  directory. Apply the recognized label to the generated release PR. On final-label removal, update
+  the sticky comment to `orphaned` without deleting anything.
+
+- [ ] **Step 4: Run workflow, policy, and CLI tests and confirm GREEN**
+
+  Run: `node --test scripts/release/workflows.test.mjs scripts/release/pipeline.test.mjs scripts/release/cli.test.mjs`
+
+  Expected: all tests pass.
+
+- [ ] **Step 5: Commit trusted preparation**
+
+  ```bash
+  git add .github/workflows/prepare-release.yml scripts/release/workflows.test.mjs scripts/release/cli.mjs
+  git commit -m "refactor(release): trust base tooling for preparation"
+  ```
+
+### Task 4: Candidate build and preview deployment
+
+**Files:**
+- Create: `.github/workflows/release-candidate.yml`
+- Create: `.github/workflows/build-release-candidate.yml`
+- Modify: `.github/workflows/build-docker.yml`
+- Modify: `.github/workflows/site-deploy.yml`
+- Modify: `scripts/release/workflows.test.mjs`
+
+**Interfaces:**
+- Consumes: committed `release/X.Y.Z` ref, PR number, selected release label, and candidate helpers.
+- Produces: signed extension artifact `candidate-extension-X.Y.Z`, GHCR tag
+  `candidate-X.Y.Z`, GitHub prerelease `candidate-vX.Y.Z`, shared preview site, and sticky status
+  comment.
+
+- [ ] **Step 1: Extend failing structural tests**
+
+  Assert that candidate verification and builds use read-only repository tokens; the signing job has
+  no candidate checkout; Docker receives separate `workspace_version` and `image_tag` inputs;
+  candidate publication never writes `latest`, `X`, `X.Y`, or `X.Y.Z`; and preview deployment uses
+  the candidate SHA while retaining the shared `prerelease` channel.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+  Run: `node --test scripts/release/workflows.test.mjs`
+
+  Expected: missing candidate workflows and Docker tag separation failures.
+
+- [ ] **Step 3: Add Docker tag separation**
+
+  Add `image_tag` as an optional reusable-workflow input. Continue using `version` only for workspace
+  overlay and use `${{ inputs.image_tag || inputs.version }}` for loaded and pushed image tags.
+
+- [ ] **Step 4: Add reusable candidate preparation**
+
+  `build-release-candidate.yml` must run `pnpm check`, call the existing extension builder with
+  `sign_crx: true`, call Docker with `image_tag: candidate-X.Y.Z`, publish the owned GitHub
+  prerelease only after verification/build success, and deploy the site preview. Concurrency is per
+  version except the site workflow's existing shared-channel cancellation.
+
+- [ ] **Step 5: Add the pull-request controller**
+
+  `release-candidate.yml` uses trusted `pull_request_target` workflow code for generated release PR
+  `opened`, `reopened`, and `synchronize` events, validates same-repository ownership and one release
+  label, then calls the reusable builder at the exact head SHA.
+
+- [ ] **Step 6: Run candidate and existing release tests and confirm GREEN**
+
+  Run: `node --test scripts/release/workflows.test.mjs scripts/release/*.test.mjs scripts/cws.test.mjs`
+
+  Expected: all tests pass.
+
+- [ ] **Step 7: Commit candidate previews**
+
+  ```bash
+  git add .github/workflows/release-candidate.yml .github/workflows/build-release-candidate.yml .github/workflows/build-docker.yml .github/workflows/site-deploy.yml scripts/release/workflows.test.mjs
+  git commit -m "feat(release): publish release candidate previews"
+  ```
+
+### Task 5: Dedicated App authentication and branch synchronization
+
+**Files:**
+- Create: `scripts/release/github-app.mjs`
+- Create: `scripts/release/github-app.test.mjs`
+- Create: `scripts/release/sync.mjs`
+- Create: `scripts/release/sync.test.mjs`
+- Modify: `scripts/release/cli.mjs`
+
+**Interfaces:**
+- Produces: `createAppJwt(options)`, `createRepositoryToken(options)`,
+  `synchronizationMode(graph)`, and CLI commands `app-token` and `sync-branches`.
+
+- [ ] **Step 1: Write failing App authentication tests**
+
+  Verify JWT claims (`iss`, `iat`, `exp`), repository installation lookup, one-hour token creation
+  with `contents: write`, explicit failure on missing App configuration, and masked GitHub output.
+
+- [ ] **Step 2: Write failing synchronization decision tests**
+
+  Cover `already-contained`, `fast-forward`, `merge`, and `conflict` outcomes using temporary Git
+  repositories. Assert that no remote ref changes before the supplied verification command succeeds.
+
+- [ ] **Step 3: Run focused tests and confirm RED**
+
+  Run: `node --test scripts/release/github-app.test.mjs scripts/release/sync.test.mjs`
+
+  Expected: module-not-found failures.
+
+- [ ] **Step 4: Implement short-lived App authentication**
+
+  Sign RS256 JWTs with Node's `crypto`, resolve `/repos/{owner}/{repo}/installation`, and request an
+  installation token limited to the repository and `contents: write`. Never print the private key or
+  unmasked token.
+
+- [ ] **Step 5: Implement verified synchronization**
+
+  Fetch fresh remote refs, create a temporary local integration branch from `origin/develop`, merge
+  `origin/main` with fast-forward when possible or `--no-ff` otherwise, run the exact verification
+  command supplied by the stable workflow, and push the verified commit to `refs/heads/develop`.
+  A merge conflict aborts and leaves the remote unchanged.
+
+- [ ] **Step 6: Run App, sync, and CLI tests and confirm GREEN**
+
+  Run: `node --test scripts/release/github-app.test.mjs scripts/release/sync.test.mjs scripts/release/cli.test.mjs`
+
+  Expected: all tests pass.
+
+- [ ] **Step 7: Commit synchronization tooling**
+
+  ```bash
+  git add scripts/release/github-app.mjs scripts/release/github-app.test.mjs scripts/release/sync.mjs scripts/release/sync.test.mjs scripts/release/cli.mjs
+  git commit -m "feat(release): add protected branch synchronization"
+  ```
+
+### Task 6: Automatic stable promotion with one production gate
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+- Modify: `.github/workflows/site-deploy.yml`
+- Create: `.github/actions/build-site/action.yml`
+- Create: `.github/actions/deploy-site/action.yml`
+- Modify: `scripts/release/workflows.test.mjs`
+
+**Interfaces:**
+- Consumes: merged release PR event or manual recovery dispatch, stable build artifacts, App token,
+  and production environment credentials.
+- Produces: immutable stable tag/release, stable GHCR aliases, CWS submission, production deployment,
+  candidate retirement, and synchronized `develop`.
+
+- [ ] **Step 1: Extend structural tests for stable promotion**
+
+  Require automatic `pull_request: closed` handling for merged `release/*` heads, retain
+  `workflow_dispatch`, rebuild from `main`, use one job referencing `production`, refuse tag moves,
+  deploy the site within that same production job, mint the dedicated App token, and never use the
+  general `GITHUB_TOKEN` for the `develop` push.
+
+- [ ] **Step 2: Run workflow tests and confirm RED**
+
+  Run: `node --test scripts/release/workflows.test.mjs`
+
+  Expected: existing dispatch-only workflow fails the new assertions.
+
+- [ ] **Step 3: Extract shared site actions**
+
+  Move the existing install/build/checksum operations into `build-site/action.yml` and the Wrangler
+  deployment into `deploy-site/action.yml`. Keep `site-deploy.yml` as the preview wrapper and reuse
+  both actions from stable promotion so production approval occurs once.
+
+- [ ] **Step 4: Add automatic merged-PR trigger and validation**
+
+  Resolve the version from `main`, validate the merged PR's one release label against the highest
+  preceding stable tag, and require the generated `release/X.Y.Z` head. Manual recovery resolves the
+  matching merged release PR through the GitHub API.
+
+- [ ] **Step 5: Publish and synchronize idempotently**
+
+  After stable GitHub/GHCR/CWS/site publication, retire only the matching owned candidate, mint the
+  App installation token from `RELEASE_SYNC_APP_ID` and `RELEASE_SYNC_APP_PRIVATE_KEY`, and run:
+
+  ```text
+  node scripts/release/cli.mjs sync-branches --remote authenticated-origin --verify "pnpm verify"
+  ```
+
+- [ ] **Step 6: Run workflow and release tests and confirm GREEN**
+
+  Run: `node --test scripts/release/workflows.test.mjs scripts/release/*.test.mjs scripts/cws.test.mjs`
+
+  Expected: all tests pass.
+
+- [ ] **Step 7: Commit automatic stable promotion**
+
+  ```bash
+  git add .github/workflows/release.yml .github/workflows/site-deploy.yml .github/actions/build-site/action.yml .github/actions/deploy-site/action.yml scripts/release/workflows.test.mjs
+  git commit -m "feat(release): promote merged release candidates"
+  ```
+
+### Task 7: Repository ruleset reconciler
+
+**Files:**
+- Create: `scripts/release/repository-config.mjs`
+- Create: `scripts/release/repository-config.test.mjs`
+- Modify: `scripts/release/cli.mjs`
+
+**Interfaces:**
+- Produces: `repositoryPatch()`, `mainRuleset()`, `developRuleset(syncAppId)`, and CLI command
+  `configure-repository --sync-app-id ID [--apply]`.
+
+- [ ] **Step 1: Write failing configuration tests**
+
+  Assert that repository merge methods enable merge+squash and disable rebase; `main` allows only
+  merge PRs; `develop` allows only squash PRs; both retain the four existing Actions status checks;
+  force pushes and deletions remain blocked; only the dedicated App bypasses `develop`; and the
+  GitHub Actions App ID `15368` never appears in a bypass list.
+
+- [ ] **Step 2: Run the test and confirm RED**
+
+  Run: `node --test scripts/release/repository-config.test.mjs`
+
+  Expected: module-not-found failure.
+
+- [ ] **Step 3: Implement dry-run and apply reconciliation**
+
+  Dry-run prints canonical JSON. Apply mode updates repository merge methods, creates or updates the
+  two active branch rulesets, reads them back for equality, and only then removes the conflicting
+  classic `main` and `develop` protections. It refuses `--apply` without a positive numeric App ID.
+
+- [ ] **Step 4: Run configuration tests and inspect dry-run output**
+
+  Run:
+
+  ```bash
+  node --test scripts/release/repository-config.test.mjs
+  node scripts/release/cli.mjs configure-repository --sync-app-id 12345
+  ```
+
+  Expected: tests pass; dry-run JSON contains two active rulesets and no Actions bypass.
+
+- [ ] **Step 5: Commit the repository reconciler**
+
+  ```bash
+  git add scripts/release/repository-config.mjs scripts/release/repository-config.test.mjs scripts/release/cli.mjs
+  git commit -m "feat(release): reconcile merge policy rulesets"
+  ```
+
+### Task 8: Runbook, App manifest, and full verification
+
+**Files:**
+- Create: `docs/github-apps/release-sync-manifest.json`
+- Modify: `RELEASING.md`
+- Modify: `AGENTS.md`
+- Modify: `docs/releases.md`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: every workflow, command, environment, and ruleset from Tasks 1-7.
+- Produces: owner setup instructions and root test coverage for all release modules.
+
+- [ ] **Step 1: Add the private App manifest**
+
+  Record the exact registration values:
+
+  ```json
+  {
+    "name": "Lurkloot Release Sync",
+    "url": "https://github.com/jamezrin/lurkloot",
+    "hook_attributes": { "active": false },
+    "public": false,
+    "default_permissions": { "contents": "write", "metadata": "read" },
+    "default_events": []
+  }
+  ```
+
+- [ ] **Step 2: Rewrite the release runbook**
+
+  Document label preparation, candidate refresh, parallel hotfix rules, merge-commit promotion,
+  automatic stable publication, candidate retirement, App creation/installation, production
+  environment secrets, ruleset dry-run/apply, conflict recovery, and one-time rollout order.
+
+- [ ] **Step 3: Include every release test in root verification**
+
+  Change `release:test` to `node --test scripts/release.test.mjs scripts/release/*.test.mjs` if needed
+  and ensure the new structural/configuration tests are included.
+
+- [ ] **Step 4: Run fresh full verification**
+
+  Run:
+
+  ```bash
+  pnpm check
+  pnpm build
+  pnpm build:firefox
+  git diff --check
+  ```
+
+  Expected: every command exits zero; release, CWS, workspace, extension, CLI, and site tests pass;
+  both production extension builds succeed; no whitespace errors are reported.
+
+- [ ] **Step 5: Commit documentation and verification wiring**
+
+  ```bash
+  git add docs/github-apps/release-sync-manifest.json RELEASING.md AGENTS.md docs/releases.md package.json
+  git commit -m "docs(release): document automatic promotion rollout"
+  ```
+
+### Task 9: Integrate and roll out safely
+
+**Files:**
+- No source changes unless verification identifies a defect.
+
+**Interfaces:**
+- Consumes: verified implementation branch and owner-provided GitHub App ID/private key.
+- Produces: `develop` containing the implementation and live repository settings ready for the next release.
+
+- [ ] **Step 1: Merge the implementation into local `develop`**
+
+  Fast-forward local `develop` to `ci/automate-release-promotion` and run `pnpm verify` again on the
+  integrated result.
+
+- [ ] **Step 2: Push `develop` without weakening protection**
+
+  Push through the currently permitted reviewed path if protection rejects a direct push. Do not
+  disable branch protection and do not add GitHub Actions as a bypass actor.
+
+- [ ] **Step 3: Register and install the dedicated App**
+
+  Use `docs/github-apps/release-sync-manifest.json`, install it only on `jamezrin/lurkloot`, generate
+  one private key, and record the numeric App ID.
+
+- [ ] **Step 4: Configure production secrets**
+
+  Store the App ID and complete PEM as `RELEASE_SYNC_APP_ID` and
+  `RELEASE_SYNC_APP_PRIVATE_KEY` on the `production` environment. Never store the private key as a
+  repository secret.
+
+- [ ] **Step 5: Dry-run and apply repository configuration**
+
+  ```bash
+  node scripts/release/cli.mjs configure-repository --sync-app-id "$RELEASE_SYNC_APP_ID"
+  node scripts/release/cli.mjs configure-repository --sync-app-id "$RELEASE_SYNC_APP_ID" --apply true
+  ```
+
+  Confirm the two rulesets through the GitHub API after apply.
+
+- [ ] **Step 6: Perform a credential-free rehearsal**
+
+  Apply and remove a release label on a test pull request, verify policy comments and candidate
+  preparation, then close the generated candidate without merging. Confirm no stable tags, stable
+  GHCR aliases, CWS revisions, or production deployments changed.
+

--- a/docs/superpowers/specs/2026-07-18-automatic-release-promotion-design.md
+++ b/docs/superpowers/specs/2026-07-18-automatic-release-promotion-design.md
@@ -86,14 +86,19 @@ A generated release pull request triggers candidate preparation on `opened`, `re
    request.
 6. Deploy the site to the shared `next` branch.
 7. Maintain one sticky release-status comment on the generated release pull request.
+8. Write the four validation contexts and a unique `release candidate / ready` context directly to
+   the generated PR head. This preserves required-check semantics when GitHub suppresses events
+   caused by the token that creates the PR.
 
 Candidate tags and releases are preview pointers, not provenance anchors. They may move only while
 the corresponding GitHub release remains a prerelease and retains matching ownership metadata.
 Stable tags are immutable.
 
-Candidate code builds in credential-free jobs. The signing job receives only normalized unsigned
-artifacts and a pinned signer, not a candidate checkout. The Docker publishing job receives verified
-OCI archives but does not execute them. Preview credentials live in the `preview` environment.
+Candidate code builds in credential-free jobs. A separate credential-free job prepares the signer
+from the trusted base ref and its integrity-pinned lockfile. The signing job receives only normalized
+unsigned artifacts and that signer bundle, not a candidate checkout. The Docker publishing job
+receives verified OCI archives but does not execute them. Preview credentials live in the `preview`
+environment.
 
 ## Stable promotion
 
@@ -101,11 +106,13 @@ The stable workflow reacts to a merged `release/*` pull request into `main` and 
 dispatch as an idempotent recovery entrypoint. It operates on the resulting `main` commit:
 
 1. Validate the committed version, release label, stable predecessor, and workspace metadata.
-2. Rebuild signed extension artifacts and both Docker architectures from `main`.
+2. Rebuild signed extension artifacts and export both Docker architectures as checksummed OCI
+   archives from `main`, without registry credentials.
 3. Pass the single `production` environment approval.
 4. Create `vX.Y.Z` at the merged `main` commit, refusing to move an existing tag.
 5. Create or update the stable GitHub release and upload verified artifacts.
-6. Publish GHCR `X.Y.Z`, `X.Y`, `X`, and `latest` aliases.
+6. Inside the production gate, publish GHCR `X.Y.Z`, `X.Y`, `X`, and `latest` aliases. Refuse to
+   replace an existing version-specific digest.
 7. Upload the Chrome ZIP and request `DEFAULT_PUBLISH`, which publishes after Google approval.
 8. Remove the matching candidate prerelease and candidate tag only after the stable GitHub release
    exists.
@@ -121,8 +128,8 @@ fails instead of overwriting or moving a stable object.
 Repository merge methods enable merge commits and squash merges and disable rebase merges.
 
 - The `main` ruleset permits only merge-commit pull request merges. It requires pull requests and
-  the existing verification checks, blocks force pushes and deletions, and does not require linear
-  history.
+  the existing verification checks plus `release candidate / ready`, blocks force pushes and
+  deletions, and does not require linear history.
 - The `develop` ruleset permits only squash pull request merges. It requires pull requests and the
   existing verification checks and blocks force pushes and deletions. Linear history is disabled
   because the dedicated synchronization App may add a merge commit.

--- a/docs/superpowers/specs/2026-07-18-automatic-release-promotion-design.md
+++ b/docs/superpowers/specs/2026-07-18-automatic-release-promotion-design.md
@@ -1,0 +1,176 @@
+# Automatic Release Promotion Design
+
+## Summary
+
+Lurkloot will keep committed `release/X.Y.Z` pull requests as the reviewed release boundary, add
+mutable preview deployments for those pull requests, and automatically publish the stable release
+when the release pull request is merged into `main`. Normal development pull requests into
+`develop` remain squash-only. Pull requests into `main` use merge commits so commits prepared on
+`develop` retain their SHAs. After publication, a dedicated repository-scoped GitHub App merges
+`main` directly back into `develop` without weakening branch protection for the general GitHub
+Actions identity.
+
+## Goals
+
+- Select patch, minor, or major releases by applying exactly one recognized release label to a
+  same-repository pull request targeting `main`.
+- Keep the version bump, changelog date, and all seven workspace manifest versions committed before
+  preview or stable artifacts are published.
+- Refresh a mutable GitHub prerelease, candidate GHCR image, and shared `next` site deployment on
+  every release pull request head change.
+- Publish the stable GitHub release, GHCR aliases, Chrome Web Store submission, and production site
+  automatically after the release pull request merges.
+- Support a patch hotfix candidate and a later minor or major candidate at the same time.
+- Preserve commit SHAs from release branches when they enter `main`.
+- Squash ordinary pull requests into `develop`.
+- Merge `main` directly into `develop` after a release with a narrowly scoped identity.
+- Keep orchestration logic in tested Node ESM programs instead of embedding JavaScript or
+  TypeScript in workflow YAML.
+
+## Non-goals
+
+- Displaying more than one site candidate. `next.lurkloot.pages.dev` represents the most recently
+  completed candidate deployment.
+- Uploading candidates to the Chrome Web Store. CWS receives only merged stable releases.
+- Automating Firefox Add-ons publication.
+- Cancelling a stable release or moving a stable tag.
+- Making GitHub Actions itself a branch-protection bypass actor.
+
+## Release identity and versioning
+
+The highest stable `vX.Y.Z` tag is the released version source. A recognized label derives the next
+version with ordinary SemVer arithmetic. The generated `release/X.Y.Z` branch contains the version
+bump in every workspace manifest and the dated changelog entry. The generated release pull request
+inherits the recognized release label so stable promotion can validate the requested bump again.
+
+Different resulting versions may coexist. For example, while `v1.5.0` is stable, `release/1.5.1`
+and `release/1.6.0` may both be open. A second pull request may not take ownership of an already-open
+release branch for the same version.
+
+After any intervening stable release, an older candidate must be brought up to date with `main` and
+rebuilt before it can merge. For example, after `1.5.1` ships, `1.6.0` remains the correct minor
+version, but its release branch must merge the new `main` so the hotfix is present. Required strict
+checks and the candidate check prevent promotion of the stale head. If the newer stable version
+makes the candidate version invalid, promotion fails and the candidate must be re-prepared under a
+new version.
+
+## Label lifecycle
+
+The trusted label controller reacts to `labeled` and `unlabeled` events on pull requests targeting
+`main`. It ignores generated `release/*` pull requests as preparation triggers.
+
+- Exactly one recognized label prepares or refreshes its release branch and pull request.
+- Two or more recognized labels post an explanatory pull request comment and fail without creating
+  or modifying a candidate.
+- Removing one label while another recognized label remains prepares the remaining selection.
+- Removing the final recognized label posts an orphan notice. It does not delete candidate artifacts
+  or branches because they may already be under review.
+- Fork pull requests are ineligible. On this public repository, GitHub's native repository roles
+  restrict label application; only the current administrator has triage-or-higher access.
+
+The controller checks out trusted release tooling from the base branch separately from candidate
+source. Candidate-controlled scripts never execute in the controller's write-token context.
+
+## Candidate preview
+
+A generated release pull request triggers candidate preparation on `opened`, `reopened`, and
+`synchronize`:
+
+1. Read and validate the committed version and release label without executing candidate code.
+2. Run the workspace checks and full repository verification with a read-only token.
+3. Build the normalized Chrome ZIP, Firefox ZIP, Firefox source ZIP, and signed CRX.
+4. Build both CLI container architectures and publish the mutable `candidate-X.Y.Z` GHCR tag. Never
+   move `latest`, `X`, `X.Y`, or the stable `X.Y.Z` tags.
+5. Create or refresh the GitHub prerelease attached to the explicitly mutable
+   `candidate-vX.Y.Z` tag. Refuse to take over a stable release or a candidate owned by another pull
+   request.
+6. Deploy the site to the shared `next` branch.
+7. Maintain one sticky release-status comment on the generated release pull request.
+
+Candidate tags and releases are preview pointers, not provenance anchors. They may move only while
+the corresponding GitHub release remains a prerelease and retains matching ownership metadata.
+Stable tags are immutable.
+
+Candidate code builds in credential-free jobs. The signing job receives only normalized unsigned
+artifacts and a pinned signer, not a candidate checkout. The Docker publishing job receives verified
+OCI archives but does not execute them. Preview credentials live in the `preview` environment.
+
+## Stable promotion
+
+The stable workflow reacts to a merged `release/*` pull request into `main` and retains a manual
+dispatch as an idempotent recovery entrypoint. It operates on the resulting `main` commit:
+
+1. Validate the committed version, release label, stable predecessor, and workspace metadata.
+2. Rebuild signed extension artifacts and both Docker architectures from `main`.
+3. Pass the single `production` environment approval.
+4. Create `vX.Y.Z` at the merged `main` commit, refusing to move an existing tag.
+5. Create or update the stable GitHub release and upload verified artifacts.
+6. Publish GHCR `X.Y.Z`, `X.Y`, `X`, and `latest` aliases.
+7. Upload the Chrome ZIP and request `DEFAULT_PUBLISH`, which publishes after Google approval.
+8. Remove the matching candidate prerelease and candidate tag only after the stable GitHub release
+   exists.
+9. Deploy the production site.
+10. Merge `main` directly into `develop` using the dedicated sync App after verifying the merged
+    tree. A fast-forward is preferred; otherwise an ordinary merge commit preserves ancestry.
+
+Every external mutation is idempotent. A matching existing state is a no-op; an identity mismatch
+fails instead of overwriting or moving a stable object.
+
+## Branch and merge policy
+
+Repository merge methods enable merge commits and squash merges and disable rebase merges.
+
+- The `main` ruleset permits only merge-commit pull request merges. It requires pull requests and
+  the existing verification checks, blocks force pushes and deletions, and does not require linear
+  history.
+- The `develop` ruleset permits only squash pull request merges. It requires pull requests and the
+  existing verification checks and blocks force pushes and deletions. Linear history is disabled
+  because the dedicated synchronization App may add a merge commit.
+- The synchronization App is the only bypass actor on the `develop` ruleset and has no bypass on
+  `main`.
+- The general GitHub Actions App is not a bypass actor.
+
+## Dedicated synchronization App
+
+The repository owner creates and installs a private GitHub App with repository `Contents: write`
+and `Metadata: read`, installed only on `jamezrin/lurkloot`. Its App ID and private key are stored as
+`RELEASE_SYNC_APP_ID` and `RELEASE_SYNC_APP_PRIVATE_KEY` in the protected `production` environment.
+The workflow mints a repository-scoped installation token that expires after one hour. The App is
+added to the `develop` ruleset bypass list and nowhere else.
+
+The sync program fetches fresh `main` and `develop`, exits successfully when `main` is already an
+ancestor of `develop`, fast-forwards when possible, and otherwise creates a merge commit. It runs
+`pnpm verify` on the resulting tree before pushing. A conflict or failed verification leaves both
+remote branches unchanged and fails the release run with recovery guidance.
+
+## Repository configuration and rollout
+
+Repository settings and rulesets are reconciled by a committed CLI using the GitHub REST API. The
+CLI supports a dry-run mode and requires the installed synchronization App ID before activating the
+new branch rules. Existing classic branch protections remain in place until the replacement rulesets
+have been created and inspected. The rollout removes conflicting classic protection only after the
+rulesets are active.
+
+The App itself cannot be created without an owner-authorized GitHub App registration. Until its App
+ID, installation, private key, environment secrets, and ruleset bypass are configured, the stable
+publishing workflow fails before attempting direct synchronization rather than falling back to the
+general Actions token or disabling protection.
+
+## Testing
+
+- Unit-test label cardinality, version derivation, generated-PR recognition, candidate ownership,
+  stable promotion validation, GitHub App JWT/token behavior, prerelease reconciliation, and sync
+  decisions.
+- Test workflow invariants structurally: untrusted jobs have read-only tokens, credentialed jobs do
+  not execute candidate source, stable tags cannot move, and the Actions App is not a bypass actor.
+- Run `pnpm check`, both extension production builds, release-script tests, and YAML parsing.
+- Exercise repository configuration in dry-run mode before applying it.
+
+## Recovery
+
+- Reapply the release label to retry preparation.
+- Push a conflict resolution to a stale release branch to rebuild its candidate.
+- Re-run the stable workflow manually on `main` after correcting an external failure.
+- If direct synchronization conflicts, merge `main` into `develop` locally with the dedicated App
+  credential or create a one-off reviewed synchronization PR; never disable branch protections.
+- Never move an existing stable tag. Prepare a new version when stable identity disagrees.

--- a/scripts/release/checks.mjs
+++ b/scripts/release/checks.mjs
@@ -1,0 +1,10 @@
+export const validationStatusContexts = [
+  "verify",
+  "extension / build",
+  "docker / build (linux/amd64, ubuntu-latest, amd64)",
+  "docker / build (linux/arm64, ubuntu-24.04-arm, arm64)",
+];
+
+export const candidateStatusContext = "release candidate / ready";
+
+export const requiredMainStatusContexts = [...validationStatusContexts, candidateStatusContext];

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -11,6 +11,7 @@ import { releasePolicy } from "./pipeline.mjs";
 import { GitHubClient, reconcilePrerelease, retirePrerelease, upsertComment } from "./github.mjs";
 import { createRepositoryToken } from "./github-app.mjs";
 import { syncBranches } from "./sync.mjs";
+import { applyRepositoryConfig, repositoryConfiguration } from "./repository-config.mjs";
 
 export function parseArgs(argv) {
   const values = {};
@@ -55,10 +56,16 @@ export function formatAppTokenOutput(token) {
   return `::add-mask::${token}\ntoken=${token}\n`;
 }
 
+export function configureApplyRequested({ apply }) {
+  if (apply === undefined || apply === "false") return false;
+  if (apply === "true") return true;
+  throw new Error("--apply must be true or false");
+}
+
 function githubClient() {
   return new GitHubClient({
     repository: process.env.GITHUB_REPOSITORY,
-    token: process.env.GITHUB_TOKEN,
+    token: process.env.GITHUB_TOKEN || process.env.GH_TOKEN,
   });
 }
 
@@ -128,6 +135,16 @@ const commands = {
   async "sync-branches"(values) {
     const result = await syncBranches({ remote: values.remote || "origin" });
     await emit(result);
+  },
+  async "configure-repository"(values) {
+    const syncAppId = Number(values["sync-app-id"]);
+    const configuration = repositoryConfiguration(syncAppId);
+    if (!configureApplyRequested(values)) {
+      process.stdout.write(`${JSON.stringify(configuration, null, 2)}\n`);
+      return;
+    }
+    await applyRepositoryConfig({ client: githubClient(), syncAppId });
+    process.stdout.write("repository release rulesets applied\n");
   },
   async "cws-release"(values) {
     const client = new ChromeWebStoreClient({

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
-import { appendFile, readFile, writeFile } from "node:fs/promises";
+import { appendFile, readFile, readdir, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
 import process from "node:process";
 import { changelogPath, checkWorkspace, prepareWorkspace } from "../release.mjs";
 import { latestVersion, nextVersion, parseManifestVersion } from "./version.mjs";
 import { releaseNotes } from "./notes.mjs";
 import { ChromeWebStoreClient, publishAction, serviceAccountToken, waitForUpload } from "../cws.mjs";
 import { releasePolicy } from "./pipeline.mjs";
+import { GitHubClient, reconcilePrerelease, retirePrerelease, upsertComment } from "./github.mjs";
 
 export function parseArgs(argv) {
   const values = {};
@@ -35,6 +37,25 @@ export function resolvePolicy({ labels = "", head = "", tags = "" }) {
   });
 }
 
+export function candidateStatus({ version, sha = "", state, url = "" }) {
+  const lines = [
+    `## Release candidate ${version}`,
+    "",
+    `- State: **${state}**`,
+  ];
+  if (sha) lines.push(`- Source: \`${sha.slice(0, 7)}\``);
+  if (url) lines.push(`- Candidate: ${url}`);
+  lines.push("- Site: https://next.lurkloot.pages.dev");
+  return lines.join("\n");
+}
+
+function githubClient() {
+  return new GitHubClient({
+    repository: process.env.GITHUB_REPOSITORY,
+    token: process.env.GITHUB_TOKEN,
+  });
+}
+
 async function emit(outputs) {
   const text = Object.entries(outputs).map(([key, value]) => `${key}=${value}`).join("\n");
   if (process.env.GITHUB_OUTPUT) await appendFile(process.env.GITHUB_OUTPUT, `${text}\n`);
@@ -56,6 +77,37 @@ const commands = {
   async notes(values) {
     const changelog = JSON.parse(await readFile(changelogPath, "utf8"));
     await writeFile(values.out, `${releaseNotes(changelog, values.version)}\n`);
+  },
+  async "publish-candidate"(values) {
+    const entries = await readdir(values.assets, { withFileTypes: true });
+    const assets = await Promise.all(entries
+      .filter((entry) => entry.isFile())
+      .map(async (entry) => ({
+        name: basename(entry.name),
+        bytes: await readFile(join(values.assets, entry.name)),
+      })));
+    await reconcilePrerelease({
+      client: githubClient(),
+      pr: Number(values.pr),
+      version: values.version,
+      sha: values.sha,
+      notes: await readFile(values.notes, "utf8"),
+      assets,
+    });
+  },
+  async "candidate-comment"(values) {
+    await upsertComment({
+      client: githubClient(),
+      pr: Number(values.pr),
+      body: candidateStatus(values),
+    });
+  },
+  async "retire-candidate"(values) {
+    await retirePrerelease({
+      client: githubClient(),
+      pr: Number(values.pr),
+      version: values.version,
+    });
   },
   async "cws-release"(values) {
     const client = new ChromeWebStoreClient({

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -9,6 +9,8 @@ import { releaseNotes } from "./notes.mjs";
 import { ChromeWebStoreClient, publishAction, serviceAccountToken, waitForUpload } from "../cws.mjs";
 import { releasePolicy } from "./pipeline.mjs";
 import { GitHubClient, reconcilePrerelease, retirePrerelease, upsertComment } from "./github.mjs";
+import { createRepositoryToken } from "./github-app.mjs";
+import { syncBranches } from "./sync.mjs";
 
 export function parseArgs(argv) {
   const values = {};
@@ -47,6 +49,10 @@ export function candidateStatus({ version, sha = "", state, url = "" }) {
   if (url) lines.push(`- Candidate: ${url}`);
   lines.push("- Site: https://next.lurkloot.pages.dev");
   return lines.join("\n");
+}
+
+export function formatAppTokenOutput(token) {
+  return `::add-mask::${token}\ntoken=${token}\n`;
 }
 
 function githubClient() {
@@ -108,6 +114,20 @@ const commands = {
       pr: Number(values.pr),
       version: values.version,
     });
+  },
+  async "app-token"() {
+    const result = await createRepositoryToken({
+      appId: process.env.RELEASE_SYNC_APP_ID,
+      privateKey: process.env.RELEASE_SYNC_APP_PRIVATE_KEY,
+      repository: process.env.GITHUB_REPOSITORY,
+    });
+    process.stdout.write(`::add-mask::${result.token}\n`);
+    if (process.env.GITHUB_OUTPUT) await appendFile(process.env.GITHUB_OUTPUT, `token=${result.token}\n`);
+    else process.stdout.write(`token=${result.token}\n`);
+  },
+  async "sync-branches"(values) {
+    const result = await syncBranches({ remote: values.remote || "origin" });
+    await emit(result);
   },
   async "cws-release"(values) {
     const client = new ChromeWebStoreClient({

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -8,7 +8,14 @@ import { latestVersion, nextVersion, parseManifestVersion } from "./version.mjs"
 import { releaseNotes } from "./notes.mjs";
 import { ChromeWebStoreClient, publishAction, serviceAccountToken, waitForUpload } from "../cws.mjs";
 import { releasePolicy } from "./pipeline.mjs";
-import { GitHubClient, reconcilePrerelease, retirePrerelease, upsertComment } from "./github.mjs";
+import {
+  GitHubClient,
+  reconcilePrerelease,
+  retirePrerelease,
+  setCandidateStatuses,
+  setCommitStatus,
+  upsertComment,
+} from "./github.mjs";
 import { createRepositoryToken } from "./github-app.mjs";
 import { syncBranches } from "./sync.mjs";
 import { applyRepositoryConfig, repositoryConfiguration } from "./repository-config.mjs";
@@ -113,6 +120,22 @@ const commands = {
       client: githubClient(),
       pr: Number(values.pr),
       body: candidateStatus(values),
+    });
+  },
+  async "commit-status"(values) {
+    await setCommitStatus({
+      client: githubClient(),
+      sha: values.sha,
+      state: values.state,
+      targetUrl: values["target-url"] ?? "",
+    });
+  },
+  async "candidate-checks"(values) {
+    await setCandidateStatuses({
+      client: githubClient(),
+      sha: values.sha,
+      state: values.state,
+      targetUrl: values["target-url"] ?? "",
     });
   },
   async "retire-candidate"(values) {

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -6,6 +6,7 @@ import { changelogPath, checkWorkspace, prepareWorkspace } from "../release.mjs"
 import { latestVersion, nextVersion, parseManifestVersion } from "./version.mjs";
 import { releaseNotes } from "./notes.mjs";
 import { ChromeWebStoreClient, publishAction, serviceAccountToken, waitForUpload } from "../cws.mjs";
+import { releasePolicy } from "./pipeline.mjs";
 
 export function parseArgs(argv) {
   const values = {};
@@ -26,6 +27,14 @@ export function resolveVersion({ tags, bump, version }) {
   return nextVersion(latestVersion(tags), bump);
 }
 
+export function resolvePolicy({ labels = "", head = "", tags = "" }) {
+  return releasePolicy({
+    labels: labels.split(",").map((label) => label.trim()).filter(Boolean),
+    head,
+    tags: tags.split(/\s+/).filter(Boolean),
+  });
+}
+
 async function emit(outputs) {
   const text = Object.entries(outputs).map(([key, value]) => `${key}=${value}`).join("\n");
   if (process.env.GITHUB_OUTPUT) await appendFile(process.env.GITHUB_OUTPUT, `${text}\n`);
@@ -33,6 +42,9 @@ async function emit(outputs) {
 }
 
 const commands = {
+  async policy(values) {
+    await emit(resolvePolicy(values));
+  },
   async "next-version"(values) {
     const tags = (values.tags ?? "").split(/\s+/).filter(Boolean);
     await emit({ version: resolveVersion({ tags, bump: values.bump, version: values.version ?? "" }) });

--- a/scripts/release/cli.test.mjs
+++ b/scripts/release/cli.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { candidateStatus, formatAppTokenOutput, parseArgs, resolvePolicy, resolveVersion } from "./cli.mjs";
+import { candidateStatus, configureApplyRequested, formatAppTokenOutput, parseArgs, resolvePolicy, resolveVersion } from "./cli.mjs";
 
 test("parses flags into a map", () => {
   assert.deepEqual(parseArgs(["--bump", "minor", "--version", "1.5.0"]), { bump: "minor", version: "1.5.0" });
@@ -46,4 +46,11 @@ test("renders candidate status with stable links", () => {
 
 test("masks an App token before exporting it", () => {
   assert.equal(formatAppTokenOutput("ghs_short"), "::add-mask::ghs_short\ntoken=ghs_short\n");
+});
+
+test("requires an explicit true value before applying repository settings", () => {
+  assert.equal(configureApplyRequested({}), false);
+  assert.equal(configureApplyRequested({ apply: "false" }), false);
+  assert.equal(configureApplyRequested({ apply: "true" }), true);
+  assert.throws(() => configureApplyRequested({ apply: "yes" }), /true or false/);
 });

--- a/scripts/release/cli.test.mjs
+++ b/scripts/release/cli.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { parseArgs, resolvePolicy, resolveVersion } from "./cli.mjs";
+import { candidateStatus, parseArgs, resolvePolicy, resolveVersion } from "./cli.mjs";
 
 test("parses flags into a map", () => {
   assert.deepEqual(parseArgs(["--bump", "minor", "--version", "1.5.0"]), { bump: "minor", version: "1.5.0" });
@@ -26,4 +26,20 @@ test("resolves release policy from comma-separated workflow inputs", () => {
     label: "release/minor",
     version: "1.6.0",
   });
+});
+
+test("renders candidate status with stable links", () => {
+  assert.equal(candidateStatus({
+    version: "1.6.0",
+    sha: "abcdef123456",
+    state: "ready",
+    url: "https://github.com/jamezrin/lurkloot/releases/tag/candidate-v1.6.0",
+  }), [
+    "## Release candidate 1.6.0",
+    "",
+    "- State: **ready**",
+    "- Source: `abcdef1`",
+    "- Candidate: https://github.com/jamezrin/lurkloot/releases/tag/candidate-v1.6.0",
+    "- Site: https://next.lurkloot.pages.dev",
+  ].join("\n"));
 });

--- a/scripts/release/cli.test.mjs
+++ b/scripts/release/cli.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { candidateStatus, parseArgs, resolvePolicy, resolveVersion } from "./cli.mjs";
+import { candidateStatus, formatAppTokenOutput, parseArgs, resolvePolicy, resolveVersion } from "./cli.mjs";
 
 test("parses flags into a map", () => {
   assert.deepEqual(parseArgs(["--bump", "minor", "--version", "1.5.0"]), { bump: "minor", version: "1.5.0" });
@@ -42,4 +42,8 @@ test("renders candidate status with stable links", () => {
     "- Candidate: https://github.com/jamezrin/lurkloot/releases/tag/candidate-v1.6.0",
     "- Site: https://next.lurkloot.pages.dev",
   ].join("\n"));
+});
+
+test("masks an App token before exporting it", () => {
+  assert.equal(formatAppTokenOutput("ghs_short"), "::add-mask::ghs_short\ntoken=ghs_short\n");
 });

--- a/scripts/release/cli.test.mjs
+++ b/scripts/release/cli.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { parseArgs, resolveVersion } from "./cli.mjs";
+import { parseArgs, resolvePolicy, resolveVersion } from "./cli.mjs";
 
 test("parses flags into a map", () => {
   assert.deepEqual(parseArgs(["--bump", "minor", "--version", "1.5.0"]), { bump: "minor", version: "1.5.0" });
@@ -13,4 +13,17 @@ test("an explicit version wins over the bump, otherwise the bump applies", () =>
   assert.throws(() => resolveVersion({ tags: ["v1.4.0"], bump: "", version: "" }), /bump must be/);
   assert.throws(() => resolveVersion({ tags: ["v1.4.0"], bump: "", version: "nope" }), /not stable SemVer/);
   assert.throws(() => resolveVersion({ tags: ["v1.4.0"], bump: "", version: "v2.0.0" }), /not stable SemVer/);
+});
+
+test("resolves release policy from comma-separated workflow inputs", () => {
+  assert.deepEqual(resolvePolicy({
+    labels: "docs,release/minor",
+    head: "develop",
+    tags: "v1.4.0 v1.5.0",
+  }), {
+    action: "prepare",
+    bump: "minor",
+    label: "release/minor",
+    version: "1.6.0",
+  });
 });

--- a/scripts/release/github-app.mjs
+++ b/scripts/release/github-app.mjs
@@ -1,0 +1,60 @@
+import { createSign } from "node:crypto";
+
+const apiOrigin = "https://api.github.com";
+
+function encode(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+export function createAppJwt({ appId, privateKey, now = Math.floor(Date.now() / 1000) }) {
+  if (!/^\d+$/.test(String(appId ?? ""))) throw new Error("GitHub App ID must be a positive integer");
+  if (!String(privateKey ?? "").includes("PRIVATE KEY")) throw new Error("GitHub App private key is required");
+  const unsigned = `${encode({ alg: "RS256", typ: "JWT" })}.${encode({
+    iat: now - 60,
+    exp: now + 540,
+    iss: String(appId),
+  })}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(unsigned);
+  return `${unsigned}.${signer.sign(privateKey).toString("base64url")}`;
+}
+
+async function request(fetchImpl, path, token, init = {}) {
+  const response = await fetchImpl(`${apiOrigin}${path}`, {
+    ...init,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2026-03-10",
+      ...init.headers,
+    },
+  });
+  const text = await response.text();
+  let body;
+  try { body = text ? JSON.parse(text) : undefined; } catch { body = text; }
+  if (!response.ok) throw new Error(`GitHub App API failed (${response.status}): ${body?.message ?? body ?? "unknown error"}`);
+  return body;
+}
+
+export async function createRepositoryToken({
+  appId,
+  privateKey,
+  repository,
+  fetchImpl = fetch,
+  now,
+}) {
+  const match = /^([^/]+)\/([^/]+)$/.exec(repository ?? "");
+  if (!match) throw new Error("repository must be owner/name");
+  const jwt = createAppJwt({ appId, privateKey, now });
+  const installation = await request(fetchImpl, `/repos/${repository}/installation`, jwt);
+  const token = await request(fetchImpl, `/app/installations/${installation.id}/access_tokens`, jwt, {
+    method: "POST",
+    body: JSON.stringify({
+      repositories: [match[2]],
+      permissions: { contents: "write" },
+    }),
+  });
+  if (!token?.token) throw new Error("GitHub App installation token response had no token");
+  return token;
+}

--- a/scripts/release/github-app.mjs
+++ b/scripts/release/github-app.mjs
@@ -7,7 +7,7 @@ function encode(value) {
 }
 
 export function createAppJwt({ appId, privateKey, now = Math.floor(Date.now() / 1000) }) {
-  if (!/^\d+$/.test(String(appId ?? ""))) throw new Error("GitHub App ID must be a positive integer");
+  if (!/^[1-9]\d*$/.test(String(appId ?? ""))) throw new Error("GitHub App ID must be a positive integer");
   if (!String(privateKey ?? "").includes("PRIVATE KEY")) throw new Error("GitHub App private key is required");
   const unsigned = `${encode({ alg: "RS256", typ: "JWT" })}.${encode({
     iat: now - 60,

--- a/scripts/release/github-app.test.mjs
+++ b/scripts/release/github-app.test.mjs
@@ -53,6 +53,7 @@ test("creates a repository-scoped contents-write installation token", async () =
 
 test("rejects missing or invalid App configuration", async () => {
   assert.throws(() => createAppJwt({ appId: "", privateKey: pem }), /App ID/);
+  assert.throws(() => createAppJwt({ appId: "0", privateKey: pem }), /positive integer/);
   await assert.rejects(
     createRepositoryToken({ appId: "12345", privateKey: "", repository: "jamezrin/lurkloot" }),
     /private key/,

--- a/scripts/release/github-app.test.mjs
+++ b/scripts/release/github-app.test.mjs
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { createAppJwt, createRepositoryToken } from "./github-app.mjs";
+
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const pem = privateKey.export({ type: "pkcs8", format: "pem" });
+
+function decode(segment) {
+  return JSON.parse(Buffer.from(segment, "base64url").toString("utf8"));
+}
+
+test("creates a short-lived GitHub App JWT", () => {
+  const token = createAppJwt({ appId: "12345", privateKey: pem, now: 1_700_000_000 });
+  const [header, payload, signature] = token.split(".");
+  assert.deepEqual(decode(header), { alg: "RS256", typ: "JWT" });
+  assert.deepEqual(decode(payload), {
+    iat: 1_699_999_940,
+    exp: 1_700_000_540,
+    iss: "12345",
+  });
+  assert.ok(signature.length > 100);
+});
+
+test("creates a repository-scoped contents-write installation token", async () => {
+  const calls = [];
+  const fetchImpl = async (url, init = {}) => {
+    calls.push({ url, init });
+    if (url.endsWith("/repos/jamezrin/lurkloot/installation")) {
+      return { ok: true, status: 200, json: async () => ({ id: 77 }), text: async () => JSON.stringify({ id: 77 }) };
+    }
+    return {
+      ok: true,
+      status: 201,
+      json: async () => ({ token: "ghs_short", expires_at: "2026-07-18T20:00:00Z" }),
+      text: async () => JSON.stringify({ token: "ghs_short", expires_at: "2026-07-18T20:00:00Z" }),
+    };
+  };
+  const result = await createRepositoryToken({
+    appId: "12345",
+    privateKey: pem,
+    repository: "jamezrin/lurkloot",
+    fetchImpl,
+    now: 1_700_000_000,
+  });
+  assert.equal(result.token, "ghs_short");
+  assert.deepEqual(JSON.parse(calls[1].init.body), {
+    repositories: ["lurkloot"],
+    permissions: { contents: "write" },
+  });
+  assert.match(calls[0].init.headers.authorization, /^Bearer /);
+});
+
+test("rejects missing or invalid App configuration", async () => {
+  assert.throws(() => createAppJwt({ appId: "", privateKey: pem }), /App ID/);
+  await assert.rejects(
+    createRepositoryToken({ appId: "12345", privateKey: "", repository: "jamezrin/lurkloot" }),
+    /private key/,
+  );
+});

--- a/scripts/release/github.mjs
+++ b/scripts/release/github.mjs
@@ -1,0 +1,168 @@
+import { candidateMarker, candidateTag, parseCandidateMarker } from "./pipeline.mjs";
+
+const apiOrigin = "https://api.github.com";
+const statusMarker = "<!-- lurkloot-release-status -->";
+
+export class GitHubClient {
+  constructor({ repository, token, fetchImpl = fetch }) {
+    if (!/^[^/]+\/[^/]+$/.test(repository ?? "")) throw new Error("GITHUB_REPOSITORY must be owner/name");
+    if (!token) throw new Error("GITHUB_TOKEN is required");
+    this.repository = repository;
+    this.token = token;
+    this.fetch = fetchImpl;
+  }
+
+  async request(path, { allowNotFound = false, body, headers, ...init } = {}) {
+    const url = path.startsWith("https://") ? path : `${apiOrigin}${path}`;
+    const response = await this.fetch(url, {
+      ...init,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${this.token}`,
+        "x-github-api-version": "2026-03-10",
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+        ...headers,
+      },
+      body: body === undefined || Buffer.isBuffer(body) ? body : JSON.stringify(body),
+    });
+    if (allowNotFound && response.status === 404) return undefined;
+    const text = await response.text();
+    let value;
+    if (text) {
+      try { value = JSON.parse(text); } catch { value = text; }
+    }
+    if (!response.ok) {
+      throw new Error(`GitHub API failed (${response.status}): ${value?.message ?? value ?? "unknown error"}`);
+    }
+    return value;
+  }
+
+  repoPath(path) {
+    return `/repos/${this.repository}${path}`;
+  }
+
+  ref(tag) {
+    return this.request(this.repoPath(`/git/ref/tags/${encodeURIComponent(tag)}`), { allowNotFound: true });
+  }
+
+  createRef(tag, sha) {
+    return this.request(this.repoPath("/git/refs"), {
+      method: "POST",
+      body: { ref: `refs/tags/${tag}`, sha },
+    });
+  }
+
+  updateRef(tag, sha) {
+    return this.request(this.repoPath(`/git/refs/tags/${encodeURIComponent(tag)}`), {
+      method: "PATCH",
+      body: { sha, force: true },
+    });
+  }
+
+  deleteRef(tag) {
+    return this.request(this.repoPath(`/git/refs/tags/${encodeURIComponent(tag)}`), {
+      method: "DELETE",
+      allowNotFound: true,
+    });
+  }
+
+  releaseByTag(tag) {
+    return this.request(this.repoPath(`/releases/tags/${encodeURIComponent(tag)}`), { allowNotFound: true });
+  }
+
+  createRelease(body) {
+    return this.request(this.repoPath("/releases"), { method: "POST", body });
+  }
+
+  updateRelease(id, body) {
+    return this.request(this.repoPath(`/releases/${id}`), { method: "PATCH", body });
+  }
+
+  deleteRelease(id) {
+    return this.request(this.repoPath(`/releases/${id}`), { method: "DELETE" });
+  }
+
+  deleteAsset(id) {
+    return this.request(this.repoPath(`/releases/assets/${id}`), { method: "DELETE" });
+  }
+
+  uploadAsset(uploadUrl, { name, bytes }) {
+    const base = uploadUrl.replace(/\{.*$/, "");
+    return this.request(`${base}?name=${encodeURIComponent(name)}`, {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: bytes,
+    });
+  }
+
+  comments(pr) {
+    return this.request(this.repoPath(`/issues/${pr}/comments`));
+  }
+
+  createComment(pr, body) {
+    return this.request(this.repoPath(`/issues/${pr}/comments`), { method: "POST", body: { body } });
+  }
+
+  updateComment(id, body) {
+    return this.request(this.repoPath(`/issues/comments/${id}`), { method: "PATCH", body: { body } });
+  }
+}
+
+function assertOwnedPrerelease(release, { pr, version }) {
+  const ownership = parseCandidateMarker(release.body);
+  if (!release.prerelease || ownership?.pr !== Number(pr) || ownership.version !== version) {
+    throw new Error(`refusing to modify candidate-v${version}: release is stable or owned by another pull request`);
+  }
+}
+
+function releaseBody({ notes, pr, version }) {
+  const marker = candidateMarker({ pr, version, head: `release/${version}` });
+  return [notes.trim(), marker].filter(Boolean).join("\n\n");
+}
+
+export async function reconcilePrerelease({ client, pr, version, sha, notes, assets }) {
+  const tag = candidateTag(version);
+  const [ref, existingRelease] = await Promise.all([client.ref(tag), client.releaseByTag(tag)]);
+  if (ref && !existingRelease) throw new Error(`refusing to move ${tag}: no owned prerelease proves its identity`);
+  if (existingRelease) assertOwnedPrerelease(existingRelease, { pr, version });
+
+  if (!ref) await client.createRef(tag, sha);
+  else if (ref.object?.sha !== sha) await client.updateRef(tag, sha);
+
+  const body = {
+    tag_name: tag,
+    name: `${version} candidate`,
+    body: releaseBody({ notes, pr, version }),
+    draft: false,
+    prerelease: true,
+    make_latest: "false",
+  };
+  const release = existingRelease
+    ? await client.updateRelease(existingRelease.id, body)
+    : await client.createRelease(body);
+  const existingAssets = new Map((release.assets ?? existingRelease?.assets ?? []).map((asset) => [asset.name, asset]));
+  for (const asset of assets) {
+    const existing = existingAssets.get(asset.name);
+    if (existing) await client.deleteAsset(existing.id);
+    await client.uploadAsset(release.upload_url ?? existingRelease.upload_url, asset);
+  }
+  return { release, tag };
+}
+
+export async function retirePrerelease({ client, pr, version }) {
+  const tag = candidateTag(version);
+  const release = await client.releaseByTag(tag);
+  if (!release) return "absent";
+  assertOwnedPrerelease(release, { pr, version });
+  await client.deleteRelease(release.id);
+  await client.deleteRef(tag);
+  return "retired";
+}
+
+export async function upsertComment({ client, pr, body }) {
+  const rendered = `${statusMarker}\n${body}`;
+  const comments = await client.comments(pr);
+  const existing = comments.find((comment) => comment.body?.startsWith(statusMarker));
+  if (existing) return client.updateComment(existing.id, rendered);
+  return client.createComment(pr, rendered);
+}

--- a/scripts/release/github.mjs
+++ b/scripts/release/github.mjs
@@ -154,8 +154,8 @@ export async function retirePrerelease({ client, pr, version }) {
   const release = await client.releaseByTag(tag);
   if (!release) return "absent";
   assertOwnedPrerelease(release, { pr, version });
-  await client.deleteRelease(release.id);
   await client.deleteRef(tag);
+  await client.deleteRelease(release.id);
   return "retired";
 }
 

--- a/scripts/release/github.mjs
+++ b/scripts/release/github.mjs
@@ -1,4 +1,5 @@
 import { candidateMarker, candidateTag, parseCandidateMarker } from "./pipeline.mjs";
+import { candidateStatusContext, requiredMainStatusContexts } from "./checks.mjs";
 
 const apiOrigin = "https://api.github.com";
 const statusMarker = "<!-- lurkloot-release-status -->";
@@ -106,6 +107,10 @@ export class GitHubClient {
   updateComment(id, body) {
     return this.request(this.repoPath(`/issues/comments/${id}`), { method: "PATCH", body: { body } });
   }
+
+  createStatus(sha, body) {
+    return this.request(this.repoPath(`/statuses/${encodeURIComponent(sha)}`), { method: "POST", body });
+  }
 }
 
 function assertOwnedPrerelease(release, { pr, version }) {
@@ -123,11 +128,13 @@ function releaseBody({ notes, pr, version }) {
 export async function reconcilePrerelease({ client, pr, version, sha, notes, assets }) {
   const tag = candidateTag(version);
   const [ref, existingRelease] = await Promise.all([client.ref(tag), client.releaseByTag(tag)]);
-  if (ref && !existingRelease) throw new Error(`refusing to move ${tag}: no owned prerelease proves its identity`);
+  if (ref && !existingRelease && ref.object?.sha !== sha) {
+    throw new Error(`refusing to recover ${tag}: it points to another commit`);
+  }
   if (existingRelease) assertOwnedPrerelease(existingRelease, { pr, version });
 
-  if (!ref) await client.createRef(tag, sha);
-  else if (ref.object?.sha !== sha) await client.updateRef(tag, sha);
+  if (existingRelease && !ref) await client.createRef(tag, sha);
+  else if (existingRelease && ref.object?.sha !== sha) await client.updateRef(tag, sha);
 
   const body = {
     tag_name: tag,
@@ -139,7 +146,7 @@ export async function reconcilePrerelease({ client, pr, version, sha, notes, ass
   };
   const release = existingRelease
     ? await client.updateRelease(existingRelease.id, body)
-    : await client.createRelease(body);
+    : await client.createRelease({ ...body, target_commitish: sha });
   const existingAssets = new Map((release.assets ?? existingRelease?.assets ?? []).map((asset) => [asset.name, asset]));
   for (const asset of assets) {
     const existing = existingAssets.get(asset.name);
@@ -147,6 +154,25 @@ export async function reconcilePrerelease({ client, pr, version, sha, notes, ass
     await client.uploadAsset(release.upload_url ?? existingRelease.upload_url, asset);
   }
   return { release, tag };
+}
+
+export async function setCommitStatus({ client, sha, state, targetUrl = "", context = candidateStatusContext }) {
+  const descriptions = {
+    pending: "Release candidate is building",
+    success: "Release candidate is ready",
+    failure: "Release candidate failed",
+  };
+  if (!descriptions[state]) throw new Error(`unsupported commit status: ${state}`);
+  return client.createStatus(sha, {
+    state,
+    context,
+    description: descriptions[state],
+    ...(targetUrl ? { target_url: targetUrl } : {}),
+  });
+}
+
+export async function setCandidateStatuses(options) {
+  return Promise.all(requiredMainStatusContexts.map((context) => setCommitStatus({ ...options, context })));
 }
 
 export async function retirePrerelease({ client, pr, version }) {

--- a/scripts/release/github.test.mjs
+++ b/scripts/release/github.test.mjs
@@ -115,5 +115,8 @@ test("retires only the matching owned prerelease", async () => {
   });
   const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
   await retirePrerelease({ client, pr: 132, version: "1.6.0" });
-  assert.deepEqual(routes.calls.slice(-2).map(({ method }) => method), ["DELETE", "DELETE"]);
+  assert.deepEqual(routes.calls.slice(-2).map(({ method, path }) => `${method} ${path}`), [
+    "DELETE /repos/jamezrin/lurkloot/git/refs/tags/candidate-v1.6.0",
+    "DELETE /repos/jamezrin/lurkloot/releases/12",
+  ]);
 });

--- a/scripts/release/github.test.mjs
+++ b/scripts/release/github.test.mjs
@@ -140,7 +140,9 @@ test("moves only an owned prerelease candidate", async () => {
   });
   const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
   await reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "new", notes: "notes", assets: [] });
-  assert.equal(routes.calls.some(({ path }) => path.endsWith("candidate-v1.6.0")), true);
+  assert.equal(routes.calls.some(({ method, path }) =>
+    method === "PATCH" &&
+    path === "/repos/jamezrin/lurkloot/git/refs/tags/candidate-v1.6.0"), true);
   const update = routes.calls.find(({ method, path }) => method === "PATCH" && path.endsWith("/releases/12"));
   assert.equal("target_commitish" in JSON.parse(update.init.body), false);
 });

--- a/scripts/release/github.test.mjs
+++ b/scripts/release/github.test.mjs
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { GitHubClient, reconcilePrerelease, retirePrerelease, upsertComment } from "./github.mjs";
+import { candidateMarker } from "./pipeline.mjs";
+
+function response(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() { return body; },
+    async text() { return body === undefined ? "" : JSON.stringify(body); },
+  };
+}
+
+function recordingFetch(routes) {
+  const calls = [];
+  const fetchImpl = async (url, init = {}) => {
+    const method = init.method ?? "GET";
+    const path = new URL(url).pathname;
+    calls.push({ method, path, init });
+    const key = `${method} ${path}`;
+    const result = routes[key];
+    if (!result) throw new Error(`unexpected request ${key}`);
+    return typeof result === "function" ? result({ url, init, calls }) : result;
+  };
+  return { calls, fetchImpl };
+}
+
+test("creates a missing owned candidate prerelease", async () => {
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
+    "POST /repos/jamezrin/lurkloot/git/refs": response(201, {}),
+    "POST /repos/jamezrin/lurkloot/releases": response(201, {
+      id: 12,
+      upload_url: "https://uploads.github.com/repos/jamezrin/lurkloot/releases/12/assets{?name,label}",
+      assets: [],
+    }),
+    "POST /repos/jamezrin/lurkloot/releases/12/assets": response(201, {}),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await reconcilePrerelease({
+    client,
+    pr: 132,
+    version: "1.6.0",
+    sha: "abc123",
+    notes: "## New\n- Candidate",
+    assets: [{ name: "lurkloot.zip", bytes: Buffer.from("zip") }],
+  });
+  assert.deepEqual(routes.calls.map(({ method, path }) => `${method} ${path}`), [
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0",
+    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0",
+    "POST /repos/jamezrin/lurkloot/git/refs",
+    "POST /repos/jamezrin/lurkloot/releases",
+    "POST /repos/jamezrin/lurkloot/releases/12/assets",
+  ]);
+});
+
+test("moves only an owned prerelease candidate", async () => {
+  const marker = candidateMarker({ pr: 132, version: "1.6.0", head: "release/1.6.0" });
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(200, { object: { sha: "old" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(200, {
+      id: 12,
+      prerelease: true,
+      body: marker,
+      upload_url: "https://uploads.github.com/repos/jamezrin/lurkloot/releases/12/assets{?name,label}",
+      assets: [],
+    }),
+    "PATCH /repos/jamezrin/lurkloot/git/refs/tags/candidate-v1.6.0": response(200, {}),
+    "PATCH /repos/jamezrin/lurkloot/releases/12": response(200, {
+      id: 12,
+      upload_url: "https://uploads.github.com/repos/jamezrin/lurkloot/releases/12/assets{?name,label}",
+      assets: [],
+    }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "new", notes: "notes", assets: [] });
+  assert.equal(routes.calls.some(({ path }) => path.endsWith("candidate-v1.6.0")), true);
+});
+
+test("refuses stable or foreign candidate releases", async () => {
+  for (const release of [
+    { id: 12, prerelease: false, body: "" },
+    { id: 12, prerelease: true, body: candidateMarker({ pr: 999, version: "1.6.0", head: "release/1.6.0" }) },
+  ]) {
+    const routes = recordingFetch({
+      "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(200, { object: { sha: "old" } }),
+      "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(200, release),
+    });
+    const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+    await assert.rejects(
+      reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "new", notes: "", assets: [] }),
+      /refusing to modify/,
+    );
+  }
+});
+
+test("updates one sticky release status comment", async () => {
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/issues/132/comments": response(200, [{ id: 7, body: "<!-- lurkloot-release-status -->\nold" }]),
+    "PATCH /repos/jamezrin/lurkloot/issues/comments/7": response(200, {}),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await upsertComment({ client, pr: 132, body: "ready" });
+  assert.equal(routes.calls.at(-1).method, "PATCH");
+});
+
+test("retires only the matching owned prerelease", async () => {
+  const marker = candidateMarker({ pr: 132, version: "1.6.0", head: "release/1.6.0" });
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(200, { id: 12, prerelease: true, body: marker }),
+    "DELETE /repos/jamezrin/lurkloot/releases/12": response(204),
+    "DELETE /repos/jamezrin/lurkloot/git/refs/tags/candidate-v1.6.0": response(204),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await retirePrerelease({ client, pr: 132, version: "1.6.0" });
+  assert.deepEqual(routes.calls.slice(-2).map(({ method }) => method), ["DELETE", "DELETE"]);
+});

--- a/scripts/release/github.test.mjs
+++ b/scripts/release/github.test.mjs
@@ -1,6 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { GitHubClient, reconcilePrerelease, retirePrerelease, upsertComment } from "./github.mjs";
+import {
+  GitHubClient,
+  reconcilePrerelease,
+  retirePrerelease,
+  setCandidateStatuses,
+  setCommitStatus,
+  upsertComment,
+} from "./github.mjs";
 import { candidateMarker } from "./pipeline.mjs";
 
 function response(status, body) {
@@ -30,7 +37,6 @@ test("creates a missing owned candidate prerelease", async () => {
   const routes = recordingFetch({
     "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
     "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
-    "POST /repos/jamezrin/lurkloot/git/refs": response(201, {}),
     "POST /repos/jamezrin/lurkloot/releases": response(201, {
       id: 12,
       upload_url: "https://uploads.github.com/repos/jamezrin/lurkloot/releases/12/assets{?name,label}",
@@ -50,9 +56,67 @@ test("creates a missing owned candidate prerelease", async () => {
   assert.deepEqual(routes.calls.map(({ method, path }) => `${method} ${path}`), [
     "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0",
     "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0",
-    "POST /repos/jamezrin/lurkloot/git/refs",
     "POST /repos/jamezrin/lurkloot/releases",
     "POST /repos/jamezrin/lurkloot/releases/12/assets",
+  ]);
+  const creation = routes.calls.find(({ method, path }) => method === "POST" && path.endsWith("/releases"));
+  assert.equal(JSON.parse(creation.init.body).target_commitish, "abc123");
+});
+
+test("recovers an exact-SHA candidate tag left without a release", async () => {
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(200, { object: { sha: "abc123" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
+    "POST /repos/jamezrin/lurkloot/releases": response(201, {
+      id: 12,
+      upload_url: "https://uploads.github.com/repos/jamezrin/lurkloot/releases/12/assets{?name,label}",
+      assets: [],
+    }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "abc123", notes: "notes", assets: [] });
+  assert.equal(routes.calls.some(({ path }) => path.endsWith("/git/refs")), false);
+});
+
+test("refuses an orphan candidate tag at another SHA", async () => {
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(200, { object: { sha: "foreign" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await assert.rejects(
+    reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "abc123", notes: "notes", assets: [] }),
+    /another commit/,
+  );
+});
+
+test("writes the candidate gate status to the requested commit", async () => {
+  const routes = recordingFetch({
+    "POST /repos/jamezrin/lurkloot/statuses/abc123": response(201, {}),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await setCommitStatus({ client, sha: "abc123", state: "success", targetUrl: "https://example.test/run" });
+  const body = JSON.parse(routes.calls[0].init.body);
+  assert.deepEqual(body, {
+    state: "success",
+    context: "release candidate / ready",
+    description: "Release candidate is ready",
+    target_url: "https://example.test/run",
+  });
+});
+
+test("writes every required context for a generated release pull request", async () => {
+  const routes = recordingFetch({
+    "POST /repos/jamezrin/lurkloot/statuses/abc123": response(201, {}),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await setCandidateStatuses({ client, sha: "abc123", state: "pending" });
+  assert.deepEqual(routes.calls.map(({ init }) => JSON.parse(init.body).context), [
+    "verify",
+    "extension / build",
+    "docker / build (linux/amd64, ubuntu-latest, amd64)",
+    "docker / build (linux/arm64, ubuntu-24.04-arm, arm64)",
+    "release candidate / ready",
   ]);
 });
 
@@ -77,6 +141,8 @@ test("moves only an owned prerelease candidate", async () => {
   const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
   await reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "new", notes: "notes", assets: [] });
   assert.equal(routes.calls.some(({ path }) => path.endsWith("candidate-v1.6.0")), true);
+  const update = routes.calls.find(({ method, path }) => method === "PATCH" && path.endsWith("/releases/12"));
+  assert.equal("target_commitish" in JSON.parse(update.init.body), false);
 });
 
 test("refuses stable or foreign candidate releases", async () => {

--- a/scripts/release/pipeline.mjs
+++ b/scripts/release/pipeline.mjs
@@ -3,7 +3,7 @@ import { latestVersion, nextVersion, parseManifestVersion } from "./version.mjs"
 export const recognizedReleaseLabels = ["release/patch", "release/minor", "release/major"];
 const recognized = new Set(recognizedReleaseLabels);
 const generatedHead = /^release\/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
-const markerPattern = /<!-- lurkloot-release-candidate:([^\n]+) -->/;
+const markerPattern = /<!-- lurkloot-release-candidate:([^\n]+) -->\s*$/;
 
 function labelNames(labels) {
   return (labels ?? []).map((label) => typeof label === "string" ? label : label.name);

--- a/scripts/release/pipeline.mjs
+++ b/scripts/release/pipeline.mjs
@@ -1,0 +1,69 @@
+import { latestVersion, nextVersion, parseManifestVersion } from "./version.mjs";
+
+export const recognizedReleaseLabels = ["release/patch", "release/minor", "release/major"];
+const recognized = new Set(recognizedReleaseLabels);
+const generatedHead = /^release\/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+const markerPattern = /<!-- lurkloot-release-candidate:([^\n]+) -->/;
+
+function labelNames(labels) {
+  return (labels ?? []).map((label) => typeof label === "string" ? label : label.name);
+}
+
+export function selectReleaseLabel(labels) {
+  const selected = labelNames(labels).filter((label) => recognized.has(label));
+  if (selected.length > 1) throw new Error("only one release label can be specified");
+  return selected[0];
+}
+
+export function isGeneratedReleaseHead(head) {
+  return generatedHead.test(head ?? "");
+}
+
+export function releasePolicy({ labels, head, tags }) {
+  if (isGeneratedReleaseHead(head)) return { action: "ignore" };
+  const label = selectReleaseLabel(labels);
+  if (!label) return { action: "orphan" };
+  const bump = label.slice("release/".length);
+  return {
+    action: "prepare",
+    bump,
+    label,
+    version: nextVersion(latestVersion(tags ?? []), bump),
+  };
+}
+
+export function candidateTag(version) {
+  parseManifestVersion(version);
+  return `candidate-v${version}`;
+}
+
+export function candidateMarker({ pr, version, head }) {
+  if (!Number.isInteger(Number(pr)) || Number(pr) < 1) throw new Error("candidate PR must be a positive integer");
+  parseManifestVersion(version);
+  if (!isGeneratedReleaseHead(head) || head !== `release/${version}`) {
+    throw new Error(`candidate head must be release/${version}`);
+  }
+  return `<!-- lurkloot-release-candidate:${JSON.stringify({ pr: Number(pr), version, head })} -->`;
+}
+
+export function parseCandidateMarker(body) {
+  const match = markerPattern.exec(body ?? "");
+  if (!match) return undefined;
+  try {
+    const value = JSON.parse(match[1]);
+    candidateMarker(value);
+    return value;
+  } catch {
+    throw new Error("candidate release has invalid ownership metadata");
+  }
+}
+
+export function validatePromotion({ stableVersion, version, label }) {
+  parseManifestVersion(stableVersion);
+  parseManifestVersion(version);
+  if (!recognized.has(label)) throw new Error(`unrecognized release label ${label ?? "none"}`);
+  const bump = label.slice("release/".length);
+  const expected = nextVersion(stableVersion, bump);
+  if (version !== expected) throw new Error(`${label} expected ${expected}, received ${version}`);
+  return { bump, version };
+}

--- a/scripts/release/pipeline.test.mjs
+++ b/scripts/release/pipeline.test.mjs
@@ -54,6 +54,17 @@ test("candidate ownership markers round trip", () => {
   assert.equal(candidateTag("1.6.0"), "candidate-v1.6.0");
 });
 
+test("uses only the final trailing candidate ownership marker", () => {
+  const spoofed = candidateMarker({ pr: 999, version: "1.6.0", head: "release/1.6.0" });
+  const canonical = candidateMarker({ pr: 132, version: "1.6.0", head: "release/1.6.0" });
+  assert.deepEqual(parseCandidateMarker(`${spoofed}\nnotes\n${canonical}\n`), {
+    pr: 132,
+    version: "1.6.0",
+    head: "release/1.6.0",
+  });
+  assert.equal(parseCandidateMarker(`${canonical}\nuser-controlled suffix`), undefined);
+});
+
 test("validates a concurrent minor candidate after a patch release", () => {
   assert.deepEqual(validatePromotion({
     stableVersion: "1.5.1",

--- a/scripts/release/pipeline.test.mjs
+++ b/scripts/release/pipeline.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  candidateMarker,
+  candidateTag,
+  isGeneratedReleaseHead,
+  parseCandidateMarker,
+  releasePolicy,
+  selectReleaseLabel,
+  validatePromotion,
+} from "./pipeline.mjs";
+
+test("selects exactly one recognized release label", () => {
+  assert.equal(selectReleaseLabel(["docs", "release/minor"]), "release/minor");
+  assert.equal(selectReleaseLabel(["docs"]), undefined);
+  assert.throws(
+    () => selectReleaseLabel(["release/patch", "release/minor"]),
+    /only one release label can be specified/,
+  );
+});
+
+test("recognizes only generated stable release heads", () => {
+  assert.equal(isGeneratedReleaseHead("release/1.6.0"), true);
+  assert.equal(isGeneratedReleaseHead("release/v1.6.0"), false);
+  assert.equal(isGeneratedReleaseHead("release/minor"), false);
+  assert.equal(isGeneratedReleaseHead("hotfix/login"), false);
+});
+
+test("derives preparation and orphan actions from live labels", () => {
+  assert.deepEqual(releasePolicy({
+    labels: ["release/minor"],
+    head: "develop",
+    tags: ["v1.5.0"],
+  }), {
+    action: "prepare",
+    bump: "minor",
+    label: "release/minor",
+    version: "1.6.0",
+  });
+  assert.deepEqual(releasePolicy({ labels: [], head: "develop", tags: ["v1.5.0"] }), {
+    action: "orphan",
+  });
+  assert.deepEqual(releasePolicy({ labels: ["release/minor"], head: "release/1.6.0", tags: ["v1.5.0"] }), {
+    action: "ignore",
+  });
+});
+
+test("candidate ownership markers round trip", () => {
+  const context = { pr: 132, version: "1.6.0", head: "release/1.6.0" };
+  const marker = candidateMarker(context);
+  assert.match(marker, /^<!-- lurkloot-release-candidate:/);
+  assert.deepEqual(parseCandidateMarker(`Candidate\n\n${marker}\n`), context);
+  assert.equal(parseCandidateMarker("ordinary release body"), undefined);
+  assert.equal(candidateTag("1.6.0"), "candidate-v1.6.0");
+});
+
+test("validates a concurrent minor candidate after a patch release", () => {
+  assert.deepEqual(validatePromotion({
+    stableVersion: "1.5.1",
+    version: "1.6.0",
+    label: "release/minor",
+  }), { bump: "minor", version: "1.6.0" });
+  assert.throws(
+    () => validatePromotion({ stableVersion: "1.6.0", version: "1.5.1", label: "release/patch" }),
+    /expected 1\.6\.1/,
+  );
+});

--- a/scripts/release/repository-config.mjs
+++ b/scripts/release/repository-config.mjs
@@ -1,4 +1,4 @@
-import { requiredMainStatusContexts } from "./checks.mjs";
+import { requiredMainStatusContexts, validationStatusContexts } from "./checks.mjs";
 
 const actionsAppId = 15368;
 
@@ -28,18 +28,18 @@ function pullRequestRule(mergeMethod) {
   };
 }
 
-function statusRule() {
+function statusRule(contexts) {
   return {
     type: "required_status_checks",
     parameters: {
       do_not_enforce_on_create: false,
       strict_required_status_checks_policy: true,
-      required_status_checks: requiredMainStatusContexts.map((context) => ({ context, integration_id: actionsAppId })),
+      required_status_checks: contexts.map((context) => ({ context, integration_id: actionsAppId })),
     },
   };
 }
 
-function branchRuleset({ name, branch, mergeMethod, bypass_actors = [] }) {
+function branchRuleset({ name, branch, mergeMethod, statusContexts, bypass_actors = [] }) {
   return {
     name,
     target: "branch",
@@ -50,7 +50,7 @@ function branchRuleset({ name, branch, mergeMethod, bypass_actors = [] }) {
       { type: "deletion" },
       { type: "non_fast_forward" },
       pullRequestRule(mergeMethod),
-      statusRule(),
+      statusRule(statusContexts),
     ],
   };
 }
@@ -60,6 +60,7 @@ export function mainRuleset() {
     name: "main release history",
     branch: "main",
     mergeMethod: "merge",
+    statusContexts: requiredMainStatusContexts,
   });
 }
 
@@ -70,6 +71,7 @@ export function developRuleset(syncAppId) {
     name: "develop squash history",
     branch: "develop",
     mergeMethod: "squash",
+    statusContexts: validationStatusContexts,
     bypass_actors: [{ actor_id: actorId, actor_type: "Integration", bypass_mode: "always" }],
   });
 }

--- a/scripts/release/repository-config.mjs
+++ b/scripts/release/repository-config.mjs
@@ -1,0 +1,130 @@
+const actionsAppId = 15368;
+const requiredChecks = [
+  "verify",
+  "extension / build",
+  "docker / build (linux/amd64, ubuntu-latest, amd64)",
+  "docker / build (linux/arm64, ubuntu-24.04-arm, arm64)",
+];
+
+export function repositoryPatch() {
+  return {
+    allow_merge_commit: true,
+    allow_squash_merge: true,
+    allow_rebase_merge: false,
+    merge_commit_title: "PR_TITLE",
+    merge_commit_message: "PR_BODY",
+    squash_merge_commit_title: "PR_TITLE",
+    squash_merge_commit_message: "PR_BODY",
+  };
+}
+
+function pullRequestRule(mergeMethod) {
+  return {
+    type: "pull_request",
+    parameters: {
+      allowed_merge_methods: [mergeMethod],
+      dismiss_stale_reviews_on_push: false,
+      require_code_owner_review: false,
+      require_last_push_approval: false,
+      required_approving_review_count: 0,
+      required_review_thread_resolution: false,
+    },
+  };
+}
+
+function statusRule() {
+  return {
+    type: "required_status_checks",
+    parameters: {
+      do_not_enforce_on_create: false,
+      strict_required_status_checks_policy: true,
+      required_status_checks: requiredChecks.map((context) => ({ context, integration_id: actionsAppId })),
+    },
+  };
+}
+
+function branchRuleset({ name, branch, mergeMethod, bypass_actors = [] }) {
+  return {
+    name,
+    target: "branch",
+    enforcement: "active",
+    bypass_actors,
+    conditions: { ref_name: { include: [`refs/heads/${branch}`], exclude: [] } },
+    rules: [
+      { type: "deletion" },
+      { type: "non_fast_forward" },
+      pullRequestRule(mergeMethod),
+      statusRule(),
+    ],
+  };
+}
+
+export function mainRuleset() {
+  return branchRuleset({
+    name: "main release history",
+    branch: "main",
+    mergeMethod: "merge",
+  });
+}
+
+export function developRuleset(syncAppId) {
+  const actorId = Number(syncAppId);
+  if (!Number.isInteger(actorId) || actorId < 1) throw new Error("sync App ID must be a positive integer");
+  return branchRuleset({
+    name: "develop squash history",
+    branch: "develop",
+    mergeMethod: "squash",
+    bypass_actors: [{ actor_id: actorId, actor_type: "Integration", bypass_mode: "always" }],
+  });
+}
+
+function comparableRuleset(value) {
+  return {
+    name: value.name,
+    target: value.target,
+    enforcement: value.enforcement,
+    bypass_actors: value.bypass_actors ?? [],
+    conditions: value.conditions,
+    rules: value.rules,
+  };
+}
+
+function assertRuleset(actual, expected) {
+  if (JSON.stringify(comparableRuleset(actual)) !== JSON.stringify(expected)) {
+    throw new Error(`ruleset ${expected.name} did not read back with the requested configuration`);
+  }
+}
+
+async function reconcileRuleset(client, existing, desired) {
+  if (existing) {
+    await client.request(client.repoPath(`/rulesets/${existing.id}`), { method: "PUT", body: desired });
+    return existing.id;
+  }
+  const created = await client.request(client.repoPath("/rulesets"), { method: "POST", body: desired });
+  return created.id;
+}
+
+export async function applyRepositoryConfig({ client, syncAppId }) {
+  const desired = [mainRuleset(), developRuleset(syncAppId)];
+  await client.request(client.repoPath(""), { method: "PATCH", body: repositoryPatch() });
+  const current = await client.request(client.repoPath("/rulesets"));
+  const ids = [];
+  for (const ruleset of desired) {
+    ids.push(await reconcileRuleset(client, current.find(({ name }) => name === ruleset.name), ruleset));
+  }
+  for (let index = 0; index < desired.length; index += 1) {
+    const actual = await client.request(client.repoPath(`/rulesets/${ids[index]}`));
+    assertRuleset(actual, desired[index]);
+  }
+  for (const branch of ["main", "develop"]) {
+    await client.request(client.repoPath(`/branches/${branch}/protection`), {
+      method: "DELETE",
+      allowNotFound: true,
+    });
+  }
+  return { repository: repositoryPatch(), rulesets: desired };
+}
+
+export function repositoryConfiguration(syncAppId) {
+  return { repository: repositoryPatch(), rulesets: [mainRuleset(), developRuleset(syncAppId)] };
+}

--- a/scripts/release/repository-config.mjs
+++ b/scripts/release/repository-config.mjs
@@ -1,10 +1,6 @@
+import { requiredMainStatusContexts } from "./checks.mjs";
+
 const actionsAppId = 15368;
-const requiredChecks = [
-  "verify",
-  "extension / build",
-  "docker / build (linux/amd64, ubuntu-latest, amd64)",
-  "docker / build (linux/arm64, ubuntu-24.04-arm, arm64)",
-];
 
 export function repositoryPatch() {
   return {
@@ -38,7 +34,7 @@ function statusRule() {
     parameters: {
       do_not_enforce_on_create: false,
       strict_required_status_checks_policy: true,
-      required_status_checks: requiredChecks.map((context) => ({ context, integration_id: actionsAppId })),
+      required_status_checks: requiredMainStatusContexts.map((context) => ({ context, integration_id: actionsAppId })),
     },
   };
 }

--- a/scripts/release/repository-config.test.mjs
+++ b/scripts/release/repository-config.test.mjs
@@ -7,6 +7,7 @@ const checks = [
   "extension / build",
   "docker / build (linux/amd64, ubuntu-latest, amd64)",
   "docker / build (linux/arm64, ubuntu-24.04-arm, arm64)",
+  "release candidate / ready",
 ];
 
 function rule(ruleset, type) {

--- a/scripts/release/repository-config.test.mjs
+++ b/scripts/release/repository-config.test.mjs
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { applyRepositoryConfig, developRuleset, mainRuleset, repositoryPatch } from "./repository-config.mjs";
+
+const checks = [
+  "verify",
+  "extension / build",
+  "docker / build (linux/amd64, ubuntu-latest, amd64)",
+  "docker / build (linux/arm64, ubuntu-24.04-arm, arm64)",
+];
+
+function rule(ruleset, type) {
+  return ruleset.rules.find((entry) => entry.type === type);
+}
+
+test("enables merge and squash while disabling repository-wide rebase", () => {
+  assert.deepEqual(repositoryPatch(), {
+    allow_merge_commit: true,
+    allow_squash_merge: true,
+    allow_rebase_merge: false,
+    merge_commit_title: "PR_TITLE",
+    merge_commit_message: "PR_BODY",
+    squash_merge_commit_title: "PR_TITLE",
+    squash_merge_commit_message: "PR_BODY",
+  });
+});
+
+test("main permits only merge commits and retains required checks", () => {
+  const ruleset = mainRuleset();
+  assert.deepEqual(ruleset.conditions.ref_name.include, ["refs/heads/main"]);
+  assert.deepEqual(ruleset.bypass_actors, []);
+  assert.deepEqual(rule(ruleset, "pull_request").parameters.allowed_merge_methods, ["merge"]);
+  assert.deepEqual(
+    rule(ruleset, "required_status_checks").parameters.required_status_checks.map(({ context }) => context),
+    checks,
+  );
+  assert.ok(rule(ruleset, "non_fast_forward"));
+  assert.ok(rule(ruleset, "deletion"));
+  assert.equal(rule(ruleset, "required_linear_history"), undefined);
+});
+
+test("develop permits squash PRs and only the dedicated App bypasses", () => {
+  const ruleset = developRuleset(98765);
+  assert.deepEqual(ruleset.conditions.ref_name.include, ["refs/heads/develop"]);
+  assert.deepEqual(ruleset.bypass_actors, [{
+    actor_id: 98765,
+    actor_type: "Integration",
+    bypass_mode: "always",
+  }]);
+  assert.deepEqual(rule(ruleset, "pull_request").parameters.allowed_merge_methods, ["squash"]);
+  assert.equal(JSON.stringify(ruleset.bypass_actors).includes("15368"), false);
+  assert.equal(rule(ruleset, "required_linear_history"), undefined);
+});
+
+test("rejects an invalid synchronization App ID", () => {
+  assert.throws(() => developRuleset(0), /positive integer/);
+  assert.throws(() => developRuleset("github-actions"), /positive integer/);
+});
+
+test("removes classic protection only after both rulesets read back", async () => {
+  const calls = [];
+  const desired = [mainRuleset(), developRuleset(98765)];
+  const client = {
+    repoPath: (path) => `/repos/jamezrin/lurkloot${path}`,
+    async request(path, init = {}) {
+      calls.push({ path, init });
+      if (path.endsWith("/rulesets") && !init.method) return [];
+      if (path.endsWith("/rulesets") && init.method === "POST") {
+        const index = calls.filter((call) => call.init.method === "POST").length - 1;
+        return { id: index + 10, ...desired[index] };
+      }
+      if (/\/rulesets\/1[01]$/.test(path)) return desired[Number(path.at(-1)) - 0];
+      return {};
+    },
+  };
+  await applyRepositoryConfig({ client, syncAppId: 98765 });
+  const deletes = calls.filter(({ init }) => init.method === "DELETE");
+  assert.deepEqual(deletes.map(({ path }) => path), [
+    "/repos/jamezrin/lurkloot/branches/main/protection",
+    "/repos/jamezrin/lurkloot/branches/develop/protection",
+  ]);
+  const lastRulesetRead = calls.map(({ path }) => path).findLastIndex((path) => path.includes("/rulesets/"));
+  const firstDelete = calls.findIndex(({ init }) => init.method === "DELETE");
+  assert.ok(lastRulesetRead < firstDelete);
+});

--- a/scripts/release/repository-config.test.mjs
+++ b/scripts/release/repository-config.test.mjs
@@ -49,6 +49,10 @@ test("develop permits squash PRs and only the dedicated App bypasses", () => {
     bypass_mode: "always",
   }]);
   assert.deepEqual(rule(ruleset, "pull_request").parameters.allowed_merge_methods, ["squash"]);
+  assert.deepEqual(
+    rule(ruleset, "required_status_checks").parameters.required_status_checks.map(({ context }) => context),
+    checks.slice(0, -1),
+  );
   assert.equal(JSON.stringify(ruleset.bypass_actors).includes("15368"), false);
   assert.equal(rule(ruleset, "required_linear_history"), undefined);
 });

--- a/scripts/release/sync.mjs
+++ b/scripts/release/sync.mjs
@@ -1,0 +1,57 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+
+async function git(cwd, ...args) {
+  return exec("git", args, { cwd });
+}
+
+async function isAncestor(cwd, ancestor, descendant) {
+  try {
+    await git(cwd, "merge-base", "--is-ancestor", ancestor, descendant);
+    return true;
+  } catch (error) {
+    if (error.code === 1) return false;
+    throw error;
+  }
+}
+
+async function defaultVerify(cwd) {
+  await exec("pnpm", ["verify"], { cwd });
+}
+
+export async function syncBranches({ cwd = process.cwd(), remote = "origin", verify = defaultVerify }) {
+  const main = `refs/remotes/${remote}/main`;
+  const develop = `refs/remotes/${remote}/develop`;
+  await git(cwd, "fetch", "--prune", remote,
+    `refs/heads/main:${main}`,
+    `refs/heads/develop:${develop}`);
+
+  if (await isAncestor(cwd, main, develop)) {
+    return { mode: "already-contained", sha: (await git(cwd, "rev-parse", develop)).stdout.trim() };
+  }
+
+  await git(cwd, "switch", "--detach", develop);
+  await git(cwd, "config", "user.name", "Lurkloot Release Sync[bot]");
+  await git(cwd, "config", "user.email", "release-sync@lurkloot.invalid");
+
+  let mode;
+  if (await isAncestor(cwd, develop, main)) {
+    await git(cwd, "merge", "--ff-only", main);
+    mode = "fast-forward";
+  } else {
+    try {
+      await git(cwd, "merge", "--no-ff", "--no-edit", main);
+    } catch (error) {
+      await git(cwd, "merge", "--abort").catch(() => {});
+      throw new Error(`main to develop synchronization conflict: ${error.stderr || error.message}`);
+    }
+    mode = "merge";
+  }
+
+  await verify(cwd);
+  const sha = (await git(cwd, "rev-parse", "HEAD")).stdout.trim();
+  await git(cwd, "push", remote, "HEAD:refs/heads/develop");
+  return { mode, sha };
+}

--- a/scripts/release/sync.mjs
+++ b/scripts/release/sync.mjs
@@ -18,6 +18,7 @@ async function isAncestor(cwd, ancestor, descendant) {
 }
 
 async function defaultVerify(cwd) {
+  await exec("pnpm", ["install", "--frozen-lockfile"], { cwd });
   await exec("pnpm", ["verify"], { cwd });
 }
 

--- a/scripts/release/sync.test.mjs
+++ b/scripts/release/sync.test.mjs
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { syncBranches } from "./sync.mjs";
+
+const exec = promisify(execFile);
+
+async function git(cwd, ...args) {
+  return exec("git", args, { cwd });
+}
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "lurkloot-sync-"));
+  const remote = join(root, "remote.git");
+  const seed = join(root, "seed");
+  await exec("git", ["init", "--bare", remote]);
+  await exec("git", ["clone", remote, seed]);
+  await git(seed, "config", "user.name", "Test");
+  await git(seed, "config", "user.email", "test@example.com");
+  await git(seed, "switch", "-c", "main");
+  await writeFile(join(seed, "shared.txt"), "base\n");
+  await git(seed, "add", "shared.txt");
+  await git(seed, "commit", "-m", "base");
+  await git(seed, "push", "origin", "main");
+  await git(seed, "switch", "-c", "develop");
+  await git(seed, "push", "origin", "develop");
+  return { root, remote, seed };
+}
+
+test("fast-forwards develop to verified main", async () => {
+  const { seed } = await fixture();
+  await git(seed, "switch", "main");
+  await writeFile(join(seed, "main.txt"), "released\n");
+  await git(seed, "add", "main.txt");
+  await git(seed, "commit", "-m", "release");
+  await git(seed, "push", "origin", "main");
+  let verified = false;
+  const result = await syncBranches({
+    cwd: seed,
+    verify: async () => { verified = true; },
+  });
+  assert.equal(result.mode, "fast-forward");
+  assert.equal(verified, true);
+  const main = (await git(seed, "rev-parse", "origin/main")).stdout.trim();
+  const develop = (await git(seed, "rev-parse", "origin/develop")).stdout.trim();
+  assert.equal(develop, main);
+});
+
+test("creates a verified merge when both branches advanced", async () => {
+  const { seed } = await fixture();
+  await git(seed, "switch", "main");
+  await writeFile(join(seed, "main.txt"), "released\n");
+  await git(seed, "add", "main.txt");
+  await git(seed, "commit", "-m", "release");
+  await git(seed, "push", "origin", "main");
+  await git(seed, "switch", "develop");
+  await writeFile(join(seed, "develop.txt"), "next\n");
+  await git(seed, "add", "develop.txt");
+  await git(seed, "commit", "-m", "next");
+  await git(seed, "push", "origin", "develop");
+  const result = await syncBranches({ cwd: seed, verify: async () => {} });
+  assert.equal(result.mode, "merge");
+  const parents = (await git(seed, "show", "-s", "--format=%P", result.sha)).stdout.trim().split(" ");
+  assert.equal(parents.length, 2);
+});
+
+test("leaves remote develop unchanged when a merge conflicts", async () => {
+  const { seed } = await fixture();
+  await git(seed, "switch", "main");
+  await writeFile(join(seed, "shared.txt"), "main\n");
+  await git(seed, "commit", "-am", "main edit");
+  await git(seed, "push", "origin", "main");
+  await git(seed, "switch", "develop");
+  await writeFile(join(seed, "shared.txt"), "develop\n");
+  await git(seed, "commit", "-am", "develop edit");
+  await git(seed, "push", "origin", "develop");
+  const before = (await git(seed, "rev-parse", "origin/develop")).stdout.trim();
+  let verified = false;
+  await assert.rejects(
+    syncBranches({ cwd: seed, verify: async () => { verified = true; } }),
+    /conflict/,
+  );
+  await git(seed, "fetch", "origin", "develop");
+  const after = (await git(seed, "rev-parse", "origin/develop")).stdout.trim();
+  assert.equal(after, before);
+  assert.equal(verified, false);
+});

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -6,6 +6,10 @@ async function workflow(name) {
   return readFile(new URL(`../../.github/workflows/${name}`, import.meta.url), "utf8");
 }
 
+async function action(name) {
+  return readFile(new URL(`../../.github/actions/${name}`, import.meta.url), "utf8");
+}
+
 test("release preparation uses trusted base tooling for label lifecycle events", async () => {
   const text = await workflow("prepare-release.yml");
   assert.match(text, /pull_request_target:/);
@@ -41,6 +45,16 @@ test("candidate workflow runs trusted orchestration for generated release pull r
   assert.doesNotMatch(candidate, /image_tag: latest/);
   assert.match(candidate, /publish-candidate/);
   assert.match(candidate, /channel: prerelease/);
+  assert.doesNotMatch(candidate, /secrets: inherit/);
+  assert.doesNotMatch(controller, /secrets: inherit/);
+});
+
+test("credentialed actions and reusable calls expose only explicit secrets", async () => {
+  const deploy = await action("deploy-site/action.yml");
+  const prepare = await workflow("prepare-release.yml");
+  assert.match(deploy, /cloudflare\/wrangler-action@[0-9a-f]{40}/);
+  assert.doesNotMatch(deploy, /cloudflare\/wrangler-action@v4/);
+  assert.doesNotMatch(prepare, /secrets: inherit/);
 });
 
 test("signed extension tooling is prepared only from a trusted ref", async () => {
@@ -71,6 +85,10 @@ test("stable promotion runs automatically with one production gate and a dedicat
   assert.doesNotMatch(text, /image_tag: \$\{\{ needs\.resolve\.outputs\.version \}\}\n\s+push: true/);
   assert.match(text, /Verify and publish immutable stable image/);
   assert.match(text, /refusing to move immutable image/);
+  assert.match(text, /mergeCommit/);
+  assert.match(text, /git checkout --detach "\$release_ref"/);
+  assert.match(text, /GIT_CONFIG_KEY_0/);
+  assert.doesNotMatch(text, /git remote set-url/);
   assert.match(text, /uses: \.\/\.github\/actions\/build-site/);
   assert.match(text, /uses: \.\/\.github\/actions\/deploy-site/);
   assert.match(text, /RELEASE_SYNC_APP_ID/);

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -60,7 +60,8 @@ test("credentialed actions and reusable calls expose only explicit secrets", asy
 test("signed extension tooling is prepared only from a trusted ref", async () => {
   const text = await workflow("build-extension.yml");
   assert.match(text, /prepare-signer:/);
-  assert.match(text, /ref: \$\{\{ inputs\.trusted_ref \|\| github\.sha \}\}/);
+  assert.match(text, /ref: \$\{\{ inputs\.trusted_ref \}\}/);
+  assert.match(text, /test -n "\$TRUSTED_REF"/);
   assert.match(text, /pnpm --filter lurkloot deploy --legacy --dev signer/);
   assert.match(text, /needs: \[build, prepare-signer\]/);
   assert.doesNotMatch(text, /if: inputs\.sign_crx && inputs\.version != ''/);

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -26,7 +26,12 @@ test("candidate workflow runs trusted orchestration for generated release pull r
   assert.match(controller, /types: \[opened, reopened, synchronize\]/);
   assert.match(controller, /startsWith\(github\.event\.pull_request\.head\.ref, 'release\/'\)/);
   assert.match(controller, /uses: \.\/\.github\/workflows\/build-release-candidate\.yml/);
+  assert.match(controller, /commit-status/);
+  assert.match(controller, /release candidate \/ ready/);
   assert.match(candidate, /permissions:\n\s+contents: read/);
+  assert.match(candidate, /trusted_ref:/);
+  assert.match(candidate, /statuses: write/);
+  assert.match(candidate, /candidate-checks/);
   assert.match(candidate, /pnpm check/);
   assert.match(candidate, /extension:\n\s+needs: verify/);
   assert.match(candidate, /docker:\n\s+needs: verify/);
@@ -35,6 +40,15 @@ test("candidate workflow runs trusted orchestration for generated release pull r
   assert.doesNotMatch(candidate, /image_tag: latest/);
   assert.match(candidate, /publish-candidate/);
   assert.match(candidate, /channel: prerelease/);
+});
+
+test("signed extension tooling is prepared only from a trusted ref", async () => {
+  const text = await workflow("build-extension.yml");
+  assert.match(text, /prepare-signer:/);
+  assert.match(text, /ref: \$\{\{ inputs\.trusted_ref \|\| github\.sha \}\}/);
+  assert.match(text, /pnpm --filter lurkloot deploy --legacy --dev signer/);
+  assert.match(text, /needs: \[build, prepare-signer\]/);
+  assert.doesNotMatch(text, /if: inputs\.sign_crx && inputs\.version != ''/);
 });
 
 test("docker separates workspace version overlays from image tags", async () => {
@@ -51,6 +65,10 @@ test("stable promotion runs automatically with one production gate and a dedicat
   assert.match(text, /github\.event\.pull_request\.merged/);
   assert.match(text, /startsWith\(github\.event\.pull_request\.head\.ref, 'release\/'\)/);
   assert.equal((text.match(/environment: production/g) ?? []).length, 1);
+  assert.match(text, /export_oci: true/);
+  assert.doesNotMatch(text, /image_tag: \$\{\{ needs\.resolve\.outputs\.version \}\}\n\s+push: true/);
+  assert.match(text, /Verify and publish immutable stable image/);
+  assert.match(text, /refusing to move immutable image/);
   assert.match(text, /uses: \.\/\.github\/actions\/build-site/);
   assert.match(text, /uses: \.\/\.github\/actions\/deploy-site/);
   assert.match(text, /RELEASE_SYNC_APP_ID/);

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -28,6 +28,7 @@ test("candidate workflow runs trusted orchestration for generated release pull r
   assert.match(controller, /uses: \.\/\.github\/workflows\/build-release-candidate\.yml/);
   assert.match(controller, /commit-status/);
   assert.match(controller, /release candidate \/ ready/);
+  assert.match(controller, /if: >-\n\s+!startsWith\(github\.event\.pull_request\.head\.ref, 'release\/'\)/);
   assert.match(candidate, /permissions:\n\s+contents: read/);
   assert.match(candidate, /trusted_ref:/);
   assert.match(candidate, /statuses: write/);
@@ -63,6 +64,7 @@ test("stable promotion runs automatically with one production gate and a dedicat
   assert.match(text, /pull_request:\n\s+types: \[closed\]/);
   assert.match(text, /workflow_dispatch:/);
   assert.match(text, /github\.event\.pull_request\.merged/);
+  assert.match(text, /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/);
   assert.match(text, /startsWith\(github\.event\.pull_request\.head\.ref, 'release\/'\)/);
   assert.equal((text.match(/environment: production/g) ?? []).length, 1);
   assert.match(text, /export_oci: true/);

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+async function workflow(name) {
+  return readFile(new URL(`../../.github/workflows/${name}`, import.meta.url), "utf8");
+}
+
+test("release preparation uses trusted base tooling for label lifecycle events", async () => {
+  const text = await workflow("prepare-release.yml");
+  assert.match(text, /pull_request_target:/);
+  assert.match(text, /types: \[labeled, unlabeled\]/);
+  assert.match(text, /head\.repo\.full_name == github\.repository/);
+  assert.match(text, /!startsWith\(github\.event\.pull_request\.head\.ref, 'release\/'\)/);
+  assert.match(text, /path: trusted/);
+  assert.match(text, /path: candidate/);
+  assert.match(text, /\.\.\/trusted\/scripts\/release\/cli\.mjs prepare-workspace/);
+  assert.match(text, /--add-label "\$LABEL"/);
+  assert.match(text, /uses: \.\/\.github\/workflows\/build-release-candidate\.yml/);
+});
+
+test("candidate workflow runs trusted orchestration for generated release pull requests", async () => {
+  const controller = await workflow("release-candidate.yml");
+  const candidate = await workflow("build-release-candidate.yml");
+  assert.match(controller, /pull_request_target:/);
+  assert.match(controller, /types: \[opened, reopened, synchronize\]/);
+  assert.match(controller, /startsWith\(github\.event\.pull_request\.head\.ref, 'release\/'\)/);
+  assert.match(controller, /uses: \.\/\.github\/workflows\/build-release-candidate\.yml/);
+  assert.match(candidate, /permissions:\n\s+contents: read/);
+  assert.match(candidate, /pnpm check/);
+  assert.match(candidate, /sign_crx: true/);
+  assert.match(candidate, /image_tag: candidate-\$\{\{ inputs\.version \}\}/);
+  assert.doesNotMatch(candidate, /image_tag: latest/);
+  assert.match(candidate, /publish-candidate/);
+  assert.match(candidate, /channel: prerelease/);
+});
+
+test("docker separates workspace version overlays from image tags", async () => {
+  const text = await workflow("build-docker.yml");
+  assert.match(text, /image_tag:/);
+  assert.match(text, /inputs\.image_tag \|\| inputs\.version \|\| 'validation'/);
+  assert.match(text, /IMAGE_TAG: \$\{\{ inputs\.image_tag \|\| inputs\.version \}\}/);
+});

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -41,3 +41,20 @@ test("docker separates workspace version overlays from image tags", async () => 
   assert.match(text, /inputs\.image_tag \|\| inputs\.version \|\| 'validation'/);
   assert.match(text, /IMAGE_TAG: \$\{\{ inputs\.image_tag \|\| inputs\.version \}\}/);
 });
+
+test("stable promotion runs automatically with one production gate and a dedicated sync token", async () => {
+  const text = await workflow("release.yml");
+  assert.match(text, /pull_request:\n\s+types: \[closed\]/);
+  assert.match(text, /workflow_dispatch:/);
+  assert.match(text, /github\.event\.pull_request\.merged/);
+  assert.match(text, /startsWith\(github\.event\.pull_request\.head\.ref, 'release\/'\)/);
+  assert.equal((text.match(/environment: production/g) ?? []).length, 1);
+  assert.match(text, /uses: \.\/\.github\/actions\/build-site/);
+  assert.match(text, /uses: \.\/\.github\/actions\/deploy-site/);
+  assert.match(text, /RELEASE_SYNC_APP_ID/);
+  assert.match(text, /RELEASE_SYNC_APP_PRIVATE_KEY/);
+  assert.match(text, /cli\.mjs app-token/);
+  assert.match(text, /cli\.mjs sync-branches/);
+  assert.match(text, /retire-candidate/);
+  assert.doesNotMatch(text, /gh pr create --base develop/);
+});

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -28,6 +28,8 @@ test("candidate workflow runs trusted orchestration for generated release pull r
   assert.match(controller, /uses: \.\/\.github\/workflows\/build-release-candidate\.yml/);
   assert.match(candidate, /permissions:\n\s+contents: read/);
   assert.match(candidate, /pnpm check/);
+  assert.match(candidate, /extension:\n\s+needs: verify/);
+  assert.match(candidate, /docker:\n\s+needs: verify/);
   assert.match(candidate, /sign_crx: true/);
   assert.match(candidate, /image_tag: candidate-\$\{\{ inputs\.version \}\}/);
   assert.doesNotMatch(candidate, /image_tag: latest/);


### PR DESCRIPTION
## Summary

- add trusted release candidate builds and automatic stable promotion
- support concurrent hotfix and normal release candidates
- add dedicated GitHub App authentication for protected main-to-develop synchronization
- codify merge policy rulesets: squash into develop, merge commits into main
- document the release design, implementation plan, rollout, credentials, and recovery

## Testing

- `pnpm verify`
- `git diff --check`
- release workflow tests: 43 passed
- Chrome Web Store tests: 17 passed
- CLI tests: 84 passed
- extension tests: 509 passed
- site tests: 3 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable site build/deploy composite actions, including SHA256 integrity verification and delegated preview/production site publishing.
  * Strengthened stable Docker publishing with immutable image/tag handling and an optional Docker `image_tag` override; improved release-candidate lifecycle with commit statuses, sticky comments, and candidate reconciliation.
  * Added release automation for repository merge rulesets and automated `main` → `develop` synchronization via a dedicated GitHub App.
* **Documentation**
  * Updated end-to-end release guides and added release promotion design/plan documentation.
* **Tests**
  * Expanded release automation unit tests and workflow validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->