### PR TITLE
fix(release): validate sync credentials before publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,12 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+      - id: sync-token
+        name: Validate branch synchronization credentials before publication
+        env:
+          RELEASE_SYNC_APP_ID: ${{ secrets.RELEASE_SYNC_APP_ID }}
+          RELEASE_SYNC_APP_PRIVATE_KEY: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
+        run: node scripts/release/cli.mjs app-token
       - uses: pnpm/action-setup@v6
         with:
           version: 11.9.0
@@ -226,12 +232,6 @@ jobs:
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Retire the matching mutable candidate
         run: node scripts/release/cli.mjs retire-candidate --pr "$RELEASE_PR" --version "$VERSION"
-      - id: sync-token
-        name: Mint the dedicated branch synchronization token
-        env:
-          RELEASE_SYNC_APP_ID: ${{ secrets.RELEASE_SYNC_APP_ID }}
-          RELEASE_SYNC_APP_PRIVATE_KEY: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
-        run: node scripts/release/cli.mjs app-token
       - name: Merge main directly into develop with the dedicated App
         env:
           SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -96,6 +96,10 @@ test("stable promotion runs automatically with one production gate and a dedicat
   assert.match(text, /RELEASE_SYNC_APP_PRIVATE_KEY/);
   assert.match(text, /cli\.mjs app-token/);
   assert.match(text, /cli\.mjs sync-branches/);
+  assert.ok(
+    text.indexOf("cli.mjs app-token") < text.indexOf("Tag the released commit"),
+    "sync App credentials must be validated before stable publication starts",
+  );
   assert.match(text, /retire-candidate/);
   assert.doesNotMatch(text, /gh pr create --base develop/);
 });


### PR DESCRIPTION
## Summary

- mint and validate the dedicated synchronization App token before any stable release mutation
- reuse that short-lived token for the final direct `main` to `develop` synchronization
- add a workflow-structure regression test for the security boundary

## Testing

- `pnpm release:test` (50 tests)
- `actionlint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release workflow sequencing by validating branch synchronization credentials before publication steps begin.
  - Ensured branch synchronization credentials are available before the released commit is tagged.

- **Tests**
  - Added coverage to verify the release workflow performs credential validation before tagging the released commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->