### PR TITLE
fix(release): validate sync credentials before publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,12 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+      - id: sync-token
+        name: Validate branch synchronization credentials before publication
+        env:
+          RELEASE_SYNC_APP_ID: ${{ secrets.RELEASE_SYNC_APP_ID }}
+          RELEASE_SYNC_APP_PRIVATE_KEY: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
+        run: node scripts/release/cli.mjs app-token
       - uses: pnpm/action-setup@v6
         with:
           version: 11.9.0
@@ -226,12 +232,6 @@ jobs:
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Retire the matching mutable candidate
         run: node scripts/release/cli.mjs retire-candidate --pr "$RELEASE_PR" --version "$VERSION"
-      - id: sync-token
-        name: Mint the dedicated branch synchronization token
-        env:
-          RELEASE_SYNC_APP_ID: ${{ secrets.RELEASE_SYNC_APP_ID }}
-          RELEASE_SYNC_APP_PRIVATE_KEY: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
-        run: node scripts/release/cli.mjs app-token
       - name: Merge main directly into develop with the dedicated App
         env:
           SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -96,6 +96,10 @@ test("stable promotion runs automatically with one production gate and a dedicat
   assert.match(text, /RELEASE_SYNC_APP_PRIVATE_KEY/);
   assert.match(text, /cli\.mjs app-token/);
   assert.match(text, /cli\.mjs sync-branches/);
+  assert.ok(
+    text.indexOf("cli.mjs app-token") < text.indexOf("Tag the released commit"),
+    "sync App credentials must be validated before stable publication starts",
+  );
   assert.match(text, /retire-candidate/);
   assert.doesNotMatch(text, /gh pr create --base develop/);
 });


### PR DESCRIPTION
## Summary

- validate the dedicated synchronization App before any stable release mutation
- fail safely when its credentials or installation are missing or invalid
- preserve the exact `develop` commit SHA in `main` via a merge commit

This PR is intentionally not release-labelled and does not publish a product release.

## Testing

- `pnpm release:test` (50 tests)
- `actionlint`
- full PR validation