### PR TITLE
fix(release): grant reusable docker permission ceiling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,13 @@ jobs:
     secrets:
       CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
 
+  # GitHub validates the called workflow's permission ceiling before evaluating its skipped
+  # publish job. The build matrix itself explicitly reduces packages back to none.
   docker:
     needs: resolve
     permissions:
       contents: read
+      packages: write
     uses: ./.github/workflows/build-docker.yml
     with:
       ref: ${{ needs.resolve.outputs.ref }}

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -83,6 +83,10 @@ test("stable promotion runs automatically with one production gate and a dedicat
   assert.match(text, /startsWith\(github\.event\.pull_request\.head\.ref, 'release\/'\)/);
   assert.equal((text.match(/environment: production/g) ?? []).length, 1);
   assert.match(text, /export_oci: true/);
+  assert.match(
+    text,
+    /docker:\n\s+needs: resolve\n\s+permissions:\n\s+contents: read\n\s+packages: write\n\s+uses: \.\/\.github\/workflows\/build-docker\.yml/,
+  );
   assert.doesNotMatch(text, /image_tag: \$\{\{ needs\.resolve\.outputs\.version \}\}\n\s+push: true/);
   assert.match(text, /Verify and publish immutable stable image/);
   assert.match(text, /refusing to move immutable image/);


### PR DESCRIPTION
## Summary

- grant the stable Docker reusable-workflow caller the compile-time `packages: write` ceiling GitHub requires
- retain `packages: none` on the build matrix, so release source code still cannot write to GHCR before approval
- add a regression assertion for the caller permission contract

## Testing

- `pnpm release:test` (50 tests)
- `actionlint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow permissions to support publishing Docker packages.
  * Added clarifying comments for workflow permission behavior.

* **Tests**
  * Expanded release workflow validation to confirm Docker build dependencies, permissions, and reusable workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->