### PR TITLE
fix(release): grant reusable docker permission ceiling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,13 @@ jobs:
     secrets:
       CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
 
+  # GitHub validates the called workflow's permission ceiling before evaluating its skipped
+  # publish job. The build matrix itself explicitly reduces packages back to none.
   docker:
     needs: resolve
     permissions:
       contents: read
+      packages: write
     uses: ./.github/workflows/build-docker.yml
     with:
       ref: ${{ needs.resolve.outputs.ref }}

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -83,6 +83,10 @@ test("stable promotion runs automatically with one production gate and a dedicat
   assert.match(text, /startsWith\(github\.event\.pull_request\.head\.ref, 'release\/'\)/);
   assert.equal((text.match(/environment: production/g) ?? []).length, 1);
   assert.match(text, /export_oci: true/);
+  assert.match(
+    text,
+    /docker:\n\s+needs: resolve\n\s+permissions:\n\s+contents: read\n\s+packages: write\n\s+uses: \.\/\.github\/workflows\/build-docker\.yml/,
+  );
   assert.doesNotMatch(text, /image_tag: \$\{\{ needs\.resolve\.outputs\.version \}\}\n\s+push: true/);
   assert.match(text, /Verify and publish immutable stable image/);
   assert.match(text, /refusing to move immutable image/);


### PR DESCRIPTION
## Summary

- satisfy GitHub reusable-workflow compile-time permission validation for the stable Docker build
- keep the source-executing build matrix at `packages: none`
- preserve the exact `develop` commit SHA in `main` via merge commit

This PR is intentionally not release-labelled.

## Testing

- `pnpm release:test` (50 tests)
- `actionlint`
- full PR validation