### PR TITLE
fix(release): normalize github ruleset readback

### DIFF
--- a/scripts/release/repository-config.mjs
+++ b/scripts/release/repository-config.mjs
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { requiredMainStatusContexts, validationStatusContexts } from "./checks.mjs";
 
 const actionsAppId = 15368;
@@ -83,12 +84,19 @@ function comparableRuleset(value) {
     enforcement: value.enforcement,
     bypass_actors: value.bypass_actors ?? [],
     conditions: value.conditions,
-    rules: value.rules,
+    rules: value.rules.map((rule) => {
+      if (rule.type !== "pull_request") return rule;
+      const parameters = { ...rule.parameters };
+      if (Array.isArray(parameters.required_reviewers) && parameters.required_reviewers.length === 0) {
+        delete parameters.required_reviewers;
+      }
+      return { ...rule, parameters };
+    }),
   };
 }
 
 function assertRuleset(actual, expected) {
-  if (JSON.stringify(comparableRuleset(actual)) !== JSON.stringify(expected)) {
+  if (!isDeepStrictEqual(comparableRuleset(actual), comparableRuleset(expected))) {
     throw new Error(`ruleset ${expected.name} did not read back with the requested configuration`);
   }
 }

--- a/scripts/release/repository-config.test.mjs
+++ b/scripts/release/repository-config.test.mjs
@@ -65,6 +65,12 @@ test("rejects an invalid synchronization App ID", () => {
 test("removes classic protection only after both rulesets read back", async () => {
   const calls = [];
   const desired = [mainRuleset(), developRuleset(98765)];
+  const readBack = desired.map((ruleset) => ({
+    ...ruleset,
+    rules: ruleset.rules.map((entry) => entry.type === "pull_request"
+      ? { ...entry, parameters: { ...entry.parameters, required_reviewers: [] } }
+      : entry),
+  }));
   const client = {
     repoPath: (path) => `/repos/jamezrin/lurkloot${path}`,
     async request(path, init = {}) {
@@ -74,7 +80,7 @@ test("removes classic protection only after both rulesets read back", async () =
         const index = calls.filter((call) => call.init.method === "POST").length - 1;
         return { id: index + 10, ...desired[index] };
       }
-      if (/\/rulesets\/1[01]$/.test(path)) return desired[Number(path.at(-1)) - 0];
+      if (/\/rulesets\/1[01]$/.test(path)) return readBack[Number(path.at(-1)) - 0];
       return {};
     },
   };


### PR DESCRIPTION
## Summary

- normalize GitHub-added empty reviewer defaults during ruleset verification
- use structural equality so API key ordering cannot cause false migration failures
- cover GitHub’s actual read-back representation with a regression test

## Testing

- `pnpm release:test` (50 tests)
- `actionlint`
- live repository migration completed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow reliability when validating repository rulesets.
  * Ruleset comparisons now correctly handle equivalent configurations returned by the repository service, including empty reviewer requirements.
  * Prevented valid post-synchronization configurations from being incorrectly reported as mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->