### PR TITLE
fix(popup): cap select width in setting rows

### DIFF
--- a/packages/popup-ui/src/settingsControls.tsx
+++ b/packages/popup-ui/src/settingsControls.tsx
@@ -161,13 +161,14 @@ export function SelectSettingRow<T extends string>({ title, description, value, 
         <div className="text-[13px] font-medium text-zinc-800 dark:text-zinc-100">{title}</div>
         <div className="mt-0.5 text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{description}</div>
       </div>
-      <label className={cn("flex shrink-0 items-center rounded-lg border border-zinc-200 bg-white px-2 py-1 text-[11px] font-semibold text-zinc-500 focus-within:border-[var(--accent-ring)] dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400", disabled && "cursor-not-allowed")}>
+      <label className={cn("flex min-w-0 max-w-[45%] shrink-0 items-center rounded-lg border border-zinc-200 bg-white px-2 py-1 text-[11px] font-semibold text-zinc-500 focus-within:border-[var(--accent-ring)] dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400", disabled && "cursor-not-allowed")}>
         <select
           aria-label={title}
+          title={disabled ? disabledReason : options.find((option) => option.value === value)?.label}
           disabled={disabled}
           value={value}
           onChange={(event) => void onChange(event.target.value as T)}
-          className={cn("bg-transparent pr-1 outline-none", disabled && "cursor-not-allowed")}
+          className={cn("w-full truncate bg-transparent pr-1 outline-none", disabled && "cursor-not-allowed")}
         >
           {options.map((option) => (
             <option key={option.value} value={option.value}>{option.label}</option>


### PR DESCRIPTION
Fixes #141

## Summary

Some `<select>` controls in the advanced compatibility settings were wide enough to squeeze the setting title into wrapping over several lines.

**Root cause:** a native `<select>` sizes itself to its *longest option*, and the compatibility options append the raw adapter ID (`Spade heartbeat v1 (twitch-heartbeat-spade-v1)`). The wrapper in `SelectSettingRow` was `shrink-0` with no width cap, so in the 400px popup that control claimed 274px and left the title column 56px.

**Fix:** cap the control at `max-w-[45%]` with `min-w-0`, and let the select fill it with `w-full truncate`. Long option labels now ellipsize instead of driving layout. Added a `title` attribute so the full label is still reachable on hover when truncated (preserving `disabledReason` when the row is disabled).

## Testing

`pnpm check` passes clean — 593 tests, all workspace typechecks, site build.

The site demo doesn't normally render this component (its adapter omits the compat registry), so I temporarily wired the real `COMPATIBILITY_REGISTRY` into `PopupDemo.tsx` to drive the actual component at the real 400px popup width, then reverted that. Measuring the same five rows before and after:

| Row | Before (select / title) | After |
|---|---|---|
| Twitch heartbeat transport | 274px / 186x151 | 144px / 186x52 |
| Twitch inventory query | 232px / 98x86 | 144px / 186x52 |
| Kick claim-link handling | 199px / 131x86 | 144px / 186x52 |

Every title column is now a uniform 186x52 — one line, no wrap. Also verified the worst case by actually selecting `twitch-heartbeat-spade-v1`: the control stays 144px and the label ellipsizes to `Spade heartbeat v1 (…` rather than re-breaking the layout.

## Notes for review

- The change lands in the shared `SelectSettingRow`, so it also applies to the language/strategy selects in `settings.tsx`. Those have short labels and were visibly unaffected, but it is a shared component, not a compat-only fix.
- `45%` is a judgment call that reads well at 400px. An alternative worth considering: drop the `(id)` suffix from the option labels in `compatibilitySettings.tsx` — the IDs are already shown in the "Effective compatibility" block directly above — which would shorten labels at the source so the cap rarely engages.
- No screenshots attached here since reproducing required the temporary demo wiring described above; happy to attach the before/after captures if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved settings dropdown layout to better fit narrow spaces.
  * Added truncation for long option labels.
  * Added helpful hover text showing the selected option or why a control is disabled.
  * Updated the cursor appearance for disabled dropdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->