### PR TITLE
feat(popup): restructure compatibility settings around resolved values

### DIFF
--- a/packages/extension/tests/compatibilitySettingsView.test.tsx
+++ b/packages/extension/tests/compatibilitySettingsView.test.tsx
@@ -14,7 +14,15 @@ const labels: Record<string, string> = {
   compatibilityTwitchProfileDescription: "Twitch profile description",
   compatibilityKickProfileTitle: "Kick compatibility profile",
   compatibilityKickProfileDescription: "Kick profile description",
-  compatibilityEffectiveTitle: "Effective compatibility",
+  compatibilitySectionTitle: "Compatibility",
+  compatibilitySectionDescription: "Compatibility description",
+  compatibilityComponentProfile: "Profile",
+  compatibilityComponentHeartbeat: "Heartbeat transport",
+  compatibilityComponentInventory: "Inventory query",
+  compatibilityComponentClaim: "Claim handling",
+  compatibilityFromProfile: "From profile",
+  compatibilityOverridden: "Overridden",
+  compatibilityReplacedBy: "Replaced by $1",
   compatibilityExpertShow: "Show expert compatibility controls",
   compatibilityExpertHide: "Hide expert compatibility controls",
   compatibilityTwitchHeartbeatTitle: "Twitch heartbeat transport",
@@ -59,7 +67,14 @@ function mount(onChange = vi.fn()) {
       onChange(patch);
       setSettings((current) => applySettingsPatch(current, patch));
     };
-    return <I18nContext.Provider value={{ t: (key) => labels[key] ?? key, dir: "ltr", locale: "en" }}>
+    // Mirrors translateFromCatalogs so $1 placeholders resolve like they do in
+    // the real popup.
+    const translate = (key: string, substitutions?: string | string[]) => {
+      const template = labels[key] ?? key;
+      const values = Array.isArray(substitutions) ? substitutions : substitutions == null ? [] : [substitutions];
+      return values.reduce((text, value, index) => text.replaceAll(`$${index + 1}`, value), template);
+    };
+    return <I18nContext.Provider value={{ t: translate, dir: "ltr", locale: "en" }}>
       <CompatibilitySettings
         settings={settings.compatibility}
         registry={COMPATIBILITY_REGISTRY}
@@ -96,12 +111,41 @@ function choose(element: HTMLSelectElement, value: string): void {
 }
 
 describe("extension compatibility settings", () => {
-  it("labels every effective capability and uses localized option titles", () => {
+  it("groups capabilities per platform and shows what each one resolved to", () => {
     const { container } = mount();
-    for (const label of ["Twitch compatibility profile", "Twitch heartbeat transport", "Twitch inventory query", "Kick compatibility profile", "Kick claim-link handling"]) {
+    for (const label of ["Twitch", "Kick", "Profile", "Heartbeat transport", "Inventory query", "Claim handling"]) {
       expect(container.textContent).toContain(label);
     }
+    // The resolved id sits on the row itself rather than in a separate summary
+    // block, so "Automatic" always states what it actually picked.
+    for (const id of ["twitch-2026-07", "twitch-heartbeat-spade-v1", "twitch-inventory-v1", "kick-2026-07", "kick-claim-v2"]) {
+      expect(container.textContent).toContain(id);
+    }
+    // Full capability names stay as accessible names for the controls.
     expect(select(container, "Twitch compatibility profile").textContent).toContain("Twitch July 2026");
+  });
+
+  it("carries lifecycle into the option labels so the tradeoff is visible when choosing", () => {
+    const { container } = mount();
+    act(() => byText(container, "Show expert compatibility controls").click());
+    const heartbeat = select(container, "Twitch heartbeat transport");
+    const optionLabels = [...heartbeat.options].map((option) => option.textContent);
+    expect(optionLabels).toContain("Automatic");
+    expect(optionLabels).toContain("Spade heartbeat v1 · Recommended");
+    expect(optionLabels).toContain("GraphQL heartbeat v1 · Legacy");
+  });
+
+  it("attributes inherited values to the profile and flags explicit overrides", () => {
+    const { container } = mount();
+    expect(container.textContent).toContain("From profile");
+    expect(container.textContent).not.toContain("Overridden");
+
+    act(() => byText(container, "Show expert compatibility controls").click());
+    act(() => choose(select(container, "Twitch heartbeat transport"), "twitch-heartbeat-gql-v1"));
+
+    expect(container.textContent).toContain("Overridden");
+    // A legacy pick names its successor instead of silently going stale.
+    expect(container.textContent).toContain("Replaced by Spade heartbeat v1");
   });
 
   it("expands expert overrides, changes both platforms, and restores one atomic patch", () => {

--- a/packages/extension/tests/compatibilitySettingsView.test.tsx
+++ b/packages/extension/tests/compatibilitySettingsView.test.tsx
@@ -23,8 +23,6 @@ const labels: Record<string, string> = {
   compatibilityFromProfile: "From profile",
   compatibilityOverridden: "Overridden",
   compatibilityReplacedBy: "Replaced by $1",
-  compatibilityExpertShow: "Show expert compatibility controls",
-  compatibilityExpertHide: "Hide expert compatibility controls",
   compatibilityTwitchHeartbeatTitle: "Twitch heartbeat transport",
   compatibilityTwitchHeartbeatDescription: "Heartbeat description",
   compatibilityTwitchInventoryTitle: "Twitch inventory query",
@@ -61,7 +59,6 @@ function mount(onChange = vi.fn()) {
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   const container = document.getElementById("app")!;
   function Harness() {
-    const [expanded, setExpanded] = useState(false);
     const [settings, setSettings] = useState(DEFAULT_SETTINGS);
     const handleChange = (patch: SettingsPatch) => {
       onChange(patch);
@@ -80,8 +77,6 @@ function mount(onChange = vi.fn()) {
         registry={COMPATIBILITY_REGISTRY}
         resolution={resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" })}
         onChange={handleChange}
-        expertExpanded={expanded}
-        onExpertExpandedChange={setExpanded}
       />
     </I18nContext.Provider>;
   }
@@ -127,7 +122,6 @@ describe("extension compatibility settings", () => {
 
   it("carries lifecycle into the option labels so the tradeoff is visible when choosing", () => {
     const { container } = mount();
-    act(() => byText(container, "Show expert compatibility controls").click());
     const heartbeat = select(container, "Twitch heartbeat transport");
     const optionLabels = [...heartbeat.options].map((option) => option.textContent);
     expect(optionLabels).toContain("Automatic");
@@ -140,7 +134,6 @@ describe("extension compatibility settings", () => {
     expect(container.textContent).toContain("From profile");
     expect(container.textContent).not.toContain("Overridden");
 
-    act(() => byText(container, "Show expert compatibility controls").click());
     act(() => choose(select(container, "Twitch heartbeat transport"), "twitch-heartbeat-gql-v1"));
 
     expect(container.textContent).toContain("Overridden");
@@ -148,10 +141,9 @@ describe("extension compatibility settings", () => {
     expect(container.textContent).toContain("Replaced by Spade heartbeat v1");
   });
 
-  it("expands expert overrides, changes both platforms, and restores one atomic patch", () => {
+  it("overrides on both platforms without a disclosure step, and restores one atomic patch", () => {
     const { container, onChange } = mount();
     expect(container.querySelectorAll('input[type="text"]')).toHaveLength(0);
-    act(() => byText(container, "Show expert compatibility controls").click());
 
     expect([...select(container, "Twitch inventory query").options].map((option) => option.value)).toEqual(["auto", "twitch-inventory-v1"]);
 

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "تم استبداله بـ $1"
   },
-  "compatibilityExpertShow": {
-    "message": "إظهار عناصر التحكم المتقدمة"
-  },
-  "compatibilityExpertHide": {
-    "message": "إخفاء عناصر التحكم المتقدمة"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "نقل نبضات Twitch"
   },

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "اختر ملف Kick مضمنًا أو دع Lurkloot يختاره تلقائيًا."
   },
-  "compatibilityEffectiveTitle": {
-    "message": "التوافق الفعّال"
+  "compatibilitySectionTitle": {
+    "message": "التوافق"
+  },
+  "compatibilitySectionDescription": {
+    "message": "كيف يتواصل Lurkloot مع كل منصة. الوضع التلقائي يتبع الملف المضمَّن."
+  },
+  "compatibilityComponentProfile": {
+    "message": "الملف الشخصي"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "نقل نبضات المتابعة"
+  },
+  "compatibilityComponentInventory": {
+    "message": "استعلام المخزون"
+  },
+  "compatibilityComponentClaim": {
+    "message": "معالجة المطالبات"
+  },
+  "compatibilityFromProfile": {
+    "message": "من الملف الشخصي"
+  },
+  "compatibilityOverridden": {
+    "message": "تم التجاوز"
+  },
+  "compatibilityReplacedBy": {
+    "message": "تم استبداله بـ $1"
   },
   "compatibilityExpertShow": {
     "message": "إظهار عناصر التحكم المتقدمة"

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "Ersetzt durch $1"
   },
-  "compatibilityExpertShow": {
-    "message": "Expertenoptionen anzeigen"
-  },
-  "compatibilityExpertHide": {
-    "message": "Expertenoptionen ausblenden"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "Twitch-Heartbeat-Übertragung"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "Wähle ein mitgeliefertes Kick-Profil oder lass Lurkloot es automatisch auswählen."
   },
-  "compatibilityEffectiveTitle": {
-    "message": "Aktive Kompatibilität"
+  "compatibilitySectionTitle": {
+    "message": "Kompatibilität"
+  },
+  "compatibilitySectionDescription": {
+    "message": "Wie Lurkloot mit den einzelnen Plattformen kommuniziert. Automatisch folgt dem mitgelieferten Profil."
+  },
+  "compatibilityComponentProfile": {
+    "message": "Profil"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "Heartbeat-Übertragung"
+  },
+  "compatibilityComponentInventory": {
+    "message": "Inventarabfrage"
+  },
+  "compatibilityComponentClaim": {
+    "message": "Einlöse-Verarbeitung"
+  },
+  "compatibilityFromProfile": {
+    "message": "Aus dem Profil"
+  },
+  "compatibilityOverridden": {
+    "message": "Überschrieben"
+  },
+  "compatibilityReplacedBy": {
+    "message": "Ersetzt durch $1"
   },
   "compatibilityExpertShow": {
     "message": "Expertenoptionen anzeigen"

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "Choose a bundled Kick profile or let Lurkloot select it automatically."
   },
-  "compatibilityEffectiveTitle": {
-    "message": "Effective compatibility"
+  "compatibilitySectionTitle": {
+    "message": "Compatibility"
+  },
+  "compatibilitySectionDescription": {
+    "message": "How Lurkloot talks to each platform. Automatic follows the bundled profile."
+  },
+  "compatibilityComponentProfile": {
+    "message": "Profile"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "Heartbeat transport"
+  },
+  "compatibilityComponentInventory": {
+    "message": "Inventory query"
+  },
+  "compatibilityComponentClaim": {
+    "message": "Claim handling"
+  },
+  "compatibilityFromProfile": {
+    "message": "From profile"
+  },
+  "compatibilityOverridden": {
+    "message": "Overridden"
+  },
+  "compatibilityReplacedBy": {
+    "message": "Replaced by $1"
   },
   "compatibilityExpertShow": {
     "message": "Show expert compatibility controls"

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "Replaced by $1"
   },
-  "compatibilityExpertShow": {
-    "message": "Show expert compatibility controls"
-  },
-  "compatibilityExpertHide": {
-    "message": "Hide expert compatibility controls"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "Twitch heartbeat transport"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "Sustituido por $1"
   },
-  "compatibilityExpertShow": {
-    "message": "Mostrar controles avanzados"
-  },
-  "compatibilityExpertHide": {
-    "message": "Ocultar controles avanzados"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "Transporte de pulsos de Twitch"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "Elige un perfil de Kick incluido o deja que Lurkloot lo seleccione automáticamente."
   },
-  "compatibilityEffectiveTitle": {
-    "message": "Compatibilidad activa"
+  "compatibilitySectionTitle": {
+    "message": "Compatibilidad"
+  },
+  "compatibilitySectionDescription": {
+    "message": "Cómo se comunica Lurkloot con cada plataforma. El modo automático sigue el perfil incluido."
+  },
+  "compatibilityComponentProfile": {
+    "message": "Perfil"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "Transporte de latido"
+  },
+  "compatibilityComponentInventory": {
+    "message": "Consulta de inventario"
+  },
+  "compatibilityComponentClaim": {
+    "message": "Gestión de reclamaciones"
+  },
+  "compatibilityFromProfile": {
+    "message": "Del perfil"
+  },
+  "compatibilityOverridden": {
+    "message": "Anulado"
+  },
+  "compatibilityReplacedBy": {
+    "message": "Sustituido por $1"
   },
   "compatibilityExpertShow": {
     "message": "Mostrar controles avanzados"

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "Choisissez un profil Kick fourni ou laissez Lurkloot le sélectionner automatiquement."
   },
-  "compatibilityEffectiveTitle": {
-    "message": "Compatibilité active"
+  "compatibilitySectionTitle": {
+    "message": "Compatibilité"
+  },
+  "compatibilitySectionDescription": {
+    "message": "Comment Lurkloot communique avec chaque plateforme. Le mode automatique suit le profil fourni."
+  },
+  "compatibilityComponentProfile": {
+    "message": "Profil"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "Transport du signal de suivi"
+  },
+  "compatibilityComponentInventory": {
+    "message": "Requête d'inventaire"
+  },
+  "compatibilityComponentClaim": {
+    "message": "Gestion des réclamations"
+  },
+  "compatibilityFromProfile": {
+    "message": "Depuis le profil"
+  },
+  "compatibilityOverridden": {
+    "message": "Remplacé"
+  },
+  "compatibilityReplacedBy": {
+    "message": "Remplacé par $1"
   },
   "compatibilityExpertShow": {
     "message": "Afficher les options avancées"

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "Remplacé par $1"
   },
-  "compatibilityExpertShow": {
-    "message": "Afficher les options avancées"
-  },
-  "compatibilityExpertHide": {
-    "message": "Masquer les options avancées"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "Transport des pulsations Twitch"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "$1 द्वारा प्रतिस्थापित"
   },
-  "compatibilityExpertShow": {
-    "message": "विशेषज्ञ नियंत्रण दिखाएँ"
-  },
-  "compatibilityExpertHide": {
-    "message": "विशेषज्ञ नियंत्रण छिपाएँ"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "Twitch हार्टबीट ट्रांसपोर्ट"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "शामिल Kick प्रोफ़ाइल चुनें या Lurkloot को अपने आप चुनने दें।"
   },
-  "compatibilityEffectiveTitle": {
-    "message": "प्रभावी संगतता"
+  "compatibilitySectionTitle": {
+    "message": "संगतता"
+  },
+  "compatibilitySectionDescription": {
+    "message": "Lurkloot हर प्लेटफ़ॉर्म से कैसे संवाद करता है। स्वचालित मोड बंडल की गई प्रोफ़ाइल का पालन करता है।"
+  },
+  "compatibilityComponentProfile": {
+    "message": "प्रोफ़ाइल"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "हार्टबीट ट्रांसपोर्ट"
+  },
+  "compatibilityComponentInventory": {
+    "message": "इन्वेंट्री क्वेरी"
+  },
+  "compatibilityComponentClaim": {
+    "message": "क्लेम हैंडलिंग"
+  },
+  "compatibilityFromProfile": {
+    "message": "प्रोफ़ाइल से"
+  },
+  "compatibilityOverridden": {
+    "message": "अधिलेखित"
+  },
+  "compatibilityReplacedBy": {
+    "message": "$1 द्वारा प्रतिस्थापित"
   },
   "compatibilityExpertShow": {
     "message": "विशेषज्ञ नियंत्रण दिखाएँ"

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "Scegli un profilo Kick incluso o lascia che Lurkloot lo selezioni automaticamente."
   },
-  "compatibilityEffectiveTitle": {
-    "message": "Compatibilità attiva"
+  "compatibilitySectionTitle": {
+    "message": "Compatibilità"
+  },
+  "compatibilitySectionDescription": {
+    "message": "Come Lurkloot comunica con ogni piattaforma. La modalità automatica segue il profilo incluso."
+  },
+  "compatibilityComponentProfile": {
+    "message": "Profilo"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "Trasporto del heartbeat"
+  },
+  "compatibilityComponentInventory": {
+    "message": "Query dell'inventario"
+  },
+  "compatibilityComponentClaim": {
+    "message": "Gestione dei riscatti"
+  },
+  "compatibilityFromProfile": {
+    "message": "Dal profilo"
+  },
+  "compatibilityOverridden": {
+    "message": "Sovrascritto"
+  },
+  "compatibilityReplacedBy": {
+    "message": "Sostituito da $1"
   },
   "compatibilityExpertShow": {
     "message": "Mostra i controlli avanzati"

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "Sostituito da $1"
   },
-  "compatibilityExpertShow": {
-    "message": "Mostra i controlli avanzati"
-  },
-  "compatibilityExpertHide": {
-    "message": "Nascondi i controlli avanzati"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "Trasporto heartbeat di Twitch"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "Escolha um perfil da Kick incluído ou deixe o Lurkloot selecioná-lo automaticamente."
   },
-  "compatibilityEffectiveTitle": {
-    "message": "Compatibilidade ativa"
+  "compatibilitySectionTitle": {
+    "message": "Compatibilidade"
+  },
+  "compatibilitySectionDescription": {
+    "message": "Como o Lurkloot se comunica com cada plataforma. O modo automático segue o perfil incluído."
+  },
+  "compatibilityComponentProfile": {
+    "message": "Perfil"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "Transporte de heartbeat"
+  },
+  "compatibilityComponentInventory": {
+    "message": "Consulta de inventário"
+  },
+  "compatibilityComponentClaim": {
+    "message": "Tratamento de resgates"
+  },
+  "compatibilityFromProfile": {
+    "message": "Do perfil"
+  },
+  "compatibilityOverridden": {
+    "message": "Substituído"
+  },
+  "compatibilityReplacedBy": {
+    "message": "Substituído por $1"
   },
   "compatibilityExpertShow": {
     "message": "Mostrar controles avançados"

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "Substituído por $1"
   },
-  "compatibilityExpertShow": {
-    "message": "Mostrar controles avançados"
-  },
-  "compatibilityExpertHide": {
-    "message": "Ocultar controles avançados"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "Transporte de pulsos da Twitch"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "Заменено на $1"
   },
-  "compatibilityExpertShow": {
-    "message": "Показать расширенные настройки"
-  },
-  "compatibilityExpertHide": {
-    "message": "Скрыть расширенные настройки"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "Передача пульса Twitch"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "Выберите встроенный профиль Kick или разрешите Lurkloot выбрать его автоматически."
   },
-  "compatibilityEffectiveTitle": {
-    "message": "Активная совместимость"
+  "compatibilitySectionTitle": {
+    "message": "Совместимость"
+  },
+  "compatibilitySectionDescription": {
+    "message": "Как Lurkloot взаимодействует с каждой платформой. Автоматический режим следует встроенному профилю."
+  },
+  "compatibilityComponentProfile": {
+    "message": "Профиль"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "Транспорт heartbeat"
+  },
+  "compatibilityComponentInventory": {
+    "message": "Запрос инвентаря"
+  },
+  "compatibilityComponentClaim": {
+    "message": "Обработка получения наград"
+  },
+  "compatibilityFromProfile": {
+    "message": "Из профиля"
+  },
+  "compatibilityOverridden": {
+    "message": "Переопределено"
+  },
+  "compatibilityReplacedBy": {
+    "message": "Заменено на $1"
   },
   "compatibilityExpertShow": {
     "message": "Показать расширенные настройки"

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -717,8 +717,32 @@
   "compatibilityKickProfileDescription": {
     "message": "选择内置的 Kick 配置文件，或让 Lurkloot 自动选择。"
   },
-  "compatibilityEffectiveTitle": {
-    "message": "当前兼容性"
+  "compatibilitySectionTitle": {
+    "message": "兼容性"
+  },
+  "compatibilitySectionDescription": {
+    "message": "Lurkloot 与各平台通信的方式。自动模式会沿用内置配置方案。"
+  },
+  "compatibilityComponentProfile": {
+    "message": "配置方案"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "心跳传输方式"
+  },
+  "compatibilityComponentInventory": {
+    "message": "库存查询"
+  },
+  "compatibilityComponentClaim": {
+    "message": "领取处理"
+  },
+  "compatibilityFromProfile": {
+    "message": "来自配置方案"
+  },
+  "compatibilityOverridden": {
+    "message": "已覆盖"
+  },
+  "compatibilityReplacedBy": {
+    "message": "已由 $1 取代"
   },
   "compatibilityExpertShow": {
     "message": "显示专家控件"

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -744,12 +744,6 @@
   "compatibilityReplacedBy": {
     "message": "已由 $1 取代"
   },
-  "compatibilityExpertShow": {
-    "message": "显示专家控件"
-  },
-  "compatibilityExpertHide": {
-    "message": "隐藏专家控件"
-  },
   "compatibilityTwitchHeartbeatTitle": {
     "message": "Twitch 心跳传输"
   },

--- a/packages/popup-ui/src/compatibilitySettings.tsx
+++ b/packages/popup-ui/src/compatibilitySettings.tsx
@@ -1,11 +1,19 @@
 import React from "react";
 import type { CompatibilitySettings as CompatibilitySelections } from "@lurkloot/shared/models";
+import type { Platform } from "@lurkloot/shared/models";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
 import { ChevronDown, RotateCcw, TriangleAlert } from "lucide-react";
+import { PLATFORMS } from "./constants";
 import { useT } from "./context";
-import { SelectSettingRow } from "./settingsControls";
+import { SelectControl } from "./settingsControls";
 import { cn } from "./primitives";
-import type { CompatibilityLifecycle, PopupCompatibilityRegistry, PopupCompatibilityResolution } from "./types";
+import type {
+  CompatibilityLifecycle,
+  CompatibilityOptionMetadata,
+  PopupCompatibilityRegistry,
+  PopupCompatibilityResolution,
+  TFunction,
+} from "./types";
 
 export const AUTOMATIC_COMPATIBILITY_PATCH: SettingsPatch = Object.freeze({
   compatibility: Object.freeze({
@@ -31,30 +39,97 @@ const OPTION_TITLE_KEYS: Readonly<Record<string, string>> = Object.freeze({
   "kick-claim-v2": "compatibilityOptionKickClaimV2",
 });
 
+type OptionRecords = Readonly<Record<string, CompatibilityOptionMetadata>>;
+// "auto" means the row follows whatever the profile (or the resolver) picked.
+// Anything else is an explicit user override of that one component.
+type Selection = string;
+
+function optionTitle(translate: TFunction, id: string): string {
+  const titleKey = OPTION_TITLE_KEYS[id];
+  return titleKey ? translate(titleKey) : id;
+}
+
 function isOverridden(settings: CompatibilitySelections): boolean {
   return Object.values(settings.twitch).some((value) => value !== "auto")
     || Object.values(settings.kick).some((value) => value !== "auto");
 }
 
-function options(records: Readonly<Record<string, { id: string; hosts: readonly string[]; identities?: readonly string[] }>>, automatic: string, translate: (key: string) => string, webIdentity = false) {
+// Lifecycle rides along in the option label: a native <option> cannot carry a
+// badge, and the tradeoff between choices is exactly what you need at the
+// moment you open the dropdown.
+function options(records: OptionRecords, automatic: string, translate: TFunction, webIdentity = false) {
   return [
     { value: "auto", label: automatic },
     ...Object.values(records)
       .filter((item) => item.hosts.includes("extension") && (!webIdentity || item.identities?.includes("web")))
-      .map((item) => {
-        const titleKey = OPTION_TITLE_KEYS[item.id];
-        return { value: item.id, label: titleKey ? `${translate(titleKey)} (${item.id})` : item.id };
-      }),
+      .map((item) => ({
+        value: item.id,
+        label: `${optionTitle(translate, item.id)} · ${translate(LIFECYCLE_KEYS[item.lifecycle])}`,
+      })),
   ];
 }
 
 function LifecycleBadge({ lifecycle }: { lifecycle: CompatibilityLifecycle }) {
   const t = useT();
-  return <span className={cn("rounded-full px-1.5 py-0.5 text-[9px] font-semibold", lifecycle === "recommended" ? "bg-emerald-500/10 text-emerald-600" : lifecycle === "legacy" ? "bg-amber-500/10 text-amber-600" : "bg-violet-500/10 text-violet-600")}>{t(LIFECYCLE_KEYS[lifecycle])}</span>;
+  return <span className={cn("inline-flex items-center rounded-full px-1.5 py-0.5 text-[9px] font-semibold leading-none whitespace-nowrap", lifecycle === "recommended" ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400" : lifecycle === "legacy" ? "bg-amber-500/10 text-amber-600 dark:text-amber-400" : "bg-violet-500/10 text-violet-600 dark:text-violet-400")}>{t(LIFECYCLE_KEYS[lifecycle])}</span>;
 }
 
-function EffectiveItem({ label, id, lifecycle }: { label: string; id: string; lifecycle: CompatibilityLifecycle }) {
-  return <li className="flex items-center justify-between gap-2"><span className="min-w-0 text-[10px] text-zinc-600 dark:text-zinc-300"><span className="font-medium">{label}: </span><code>{id}</code></span><LifecycleBadge lifecycle={lifecycle} /></li>;
+function PlatformGroup({ platform, children }: { platform: Platform; children: React.ReactNode }) {
+  const details = PLATFORMS[platform];
+  return (
+    <div className="mt-3 first:mt-2">
+      <div className="mb-0.5 flex items-center gap-1.5">
+        <span className="flex h-4 w-4 items-center justify-center rounded text-[10px] font-black" style={{ backgroundColor: details.color, color: platform === "kick" ? "#07140a" : "#fff" }}>{details.mark}</span>
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">{details.label}</span>
+        <span className="h-px flex-1 bg-zinc-100 dark:bg-zinc-800/70" />
+      </div>
+      <div className="divide-y divide-zinc-100 dark:divide-zinc-800/70">{children}</div>
+    </div>
+  );
+}
+
+// One resolved component. The control and the value it produced sit together, so
+// "Automatic" always says what it actually resolved to.
+function CompatibilityRow({ title, ariaLabel, description, selection, resolvedId, metadata, options: rowOptions, onChange, editable, component }: {
+  title: string;
+  ariaLabel: string;
+  description: string;
+  selection: Selection;
+  resolvedId: string;
+  metadata?: CompatibilityOptionMetadata;
+  options: Array<{ value: string; label: string }>;
+  onChange(value: string): void | Promise<void>;
+  editable: boolean;
+  // Components inherit from the profile when left automatic; a profile row has
+  // nothing above it to inherit from.
+  component: boolean;
+}) {
+  const t = useT();
+  const automatic = selection === "auto";
+  const lifecycle = metadata?.lifecycle ?? "experimental";
+  const replacement = metadata?.replacement;
+  return (
+    <div className="py-2">
+      <div className="flex items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-[12px] font-medium text-zinc-800 dark:text-zinc-100">{title}</div>
+          {editable ? <div className="mt-0.5 text-[10px] leading-snug text-zinc-500 dark:text-zinc-400">{description}</div> : null}
+        </div>
+        {editable
+          ? <SelectControl label={ariaLabel} value={selection} options={rowOptions} onChange={onChange} />
+          : <span className="shrink-0 text-[10px] font-semibold text-zinc-400 dark:text-zinc-500">{t("compatibilityFromProfile")}</span>}
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1">
+        <span className="text-[11px] font-medium text-zinc-700 dark:text-zinc-200">{optionTitle(t, resolvedId)}</span>
+        <LifecycleBadge lifecycle={lifecycle} />
+        {automatic
+          ? (component && editable ? <span className="text-[10px] text-zinc-400 dark:text-zinc-500">{t("compatibilityFromProfile")}</span> : null)
+          : <span className="text-[10px] font-semibold text-amber-600 dark:text-amber-400">{t("compatibilityOverridden")}</span>}
+        <code className="w-full truncate text-[10px] text-zinc-400 dark:text-zinc-500">{resolvedId}</code>
+        {replacement ? <span className="w-full text-[10px] text-amber-600 dark:text-amber-400">{t("compatibilityReplacedBy", optionTitle(t, replacement))}</span> : null}
+      </div>
+    </div>
+  );
 }
 
 export function CompatibilitySettings({ settings, registry, resolution, onChange, expertExpanded, onExpertExpandedChange }: {
@@ -69,30 +144,87 @@ export function CompatibilitySettings({ settings, registry, resolution, onChange
   const automatic = t("compatibilityAutomatic");
   const effective = resolution.compatibility;
   const overridden = isOverridden(settings);
-  const lifecycle = (records: Readonly<Record<string, { lifecycle: CompatibilityLifecycle }>>, id: string) => records[id]?.lifecycle ?? "experimental";
+  const metadata = (records: OptionRecords, id: string) => records[id];
+
   return <div className="border-t border-zinc-100 py-2.5 dark:border-zinc-800/70">
-    <SelectSettingRow title={t("compatibilityTwitchProfileTitle")} description={t("compatibilityTwitchProfileDescription")} value={settings.twitch.profile} options={options(registry.twitch.profiles, automatic, t, true)} onChange={(profile) => onChange({ compatibility: { twitch: { profile } } })} />
-    <SelectSettingRow title={t("compatibilityKickProfileTitle")} description={t("compatibilityKickProfileDescription")} value={settings.kick.profile} options={options(registry.kick.profiles, automatic, t)} onChange={(profile) => onChange({ compatibility: { kick: { profile } } })} />
-    <div className="rounded-lg bg-zinc-50 p-2 dark:bg-zinc-900/60">
-      <div className="mb-1.5 text-[11px] font-semibold text-zinc-700 dark:text-zinc-200">{t("compatibilityEffectiveTitle")}</div>
-      <ul className="space-y-1">
-        <EffectiveItem label={t("compatibilityTwitchProfileTitle")} id={effective.twitch.profile} lifecycle={lifecycle(registry.twitch.profiles, effective.twitch.profile)} />
-        <EffectiveItem label={t("compatibilityTwitchHeartbeatTitle")} id={effective.twitch.heartbeat} lifecycle={lifecycle(registry.twitch.heartbeat, effective.twitch.heartbeat)} />
-        <EffectiveItem label={t("compatibilityTwitchInventoryTitle")} id={effective.twitch.inventory} lifecycle={lifecycle(registry.twitch.inventory, effective.twitch.inventory)} />
-        <EffectiveItem label={t("compatibilityKickProfileTitle")} id={effective.kick.profile} lifecycle={lifecycle(registry.kick.profiles, effective.kick.profile)} />
-        <EffectiveItem label={t("compatibilityKickClaimTitle")} id={effective.kick.claim} lifecycle={lifecycle(registry.kick.claim, effective.kick.claim)} />
-      </ul>
+    <div className="flex items-start gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="text-[13px] font-medium text-zinc-800 dark:text-zinc-100">{t("compatibilitySectionTitle")}</div>
+        <div className="mt-0.5 text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("compatibilitySectionDescription")}</div>
+      </div>
+      <span className={cn("shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold leading-none whitespace-nowrap", overridden ? "bg-amber-500/10 text-amber-600 dark:text-amber-400" : "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400")}>{overridden ? t("compatibilityOverridden") : automatic}</span>
     </div>
-    <button type="button" aria-expanded={expertExpanded} onClick={() => onExpertExpandedChange(!expertExpanded)} className="mt-2 flex w-full items-center justify-between rounded-lg px-1 py-1 text-[11px] font-semibold text-zinc-500">
+
+    <PlatformGroup platform="twitch">
+      <CompatibilityRow
+        title={t("compatibilityComponentProfile")}
+        ariaLabel={t("compatibilityTwitchProfileTitle")}
+        description={t("compatibilityTwitchProfileDescription")}
+        selection={settings.twitch.profile}
+        resolvedId={effective.twitch.profile}
+        metadata={metadata(registry.twitch.profiles, effective.twitch.profile)}
+        options={options(registry.twitch.profiles, automatic, t, true)}
+        onChange={(profile) => onChange({ compatibility: { twitch: { profile } } })}
+        editable
+        component={false}
+      />
+      <CompatibilityRow
+        title={t("compatibilityComponentHeartbeat")}
+        ariaLabel={t("compatibilityTwitchHeartbeatTitle")}
+        description={t("compatibilityTwitchHeartbeatDescription")}
+        selection={settings.twitch.heartbeatTransport}
+        resolvedId={effective.twitch.heartbeat}
+        metadata={metadata(registry.twitch.heartbeat, effective.twitch.heartbeat)}
+        options={options(registry.twitch.heartbeat, automatic, t, true)}
+        onChange={(heartbeatTransport) => onChange({ compatibility: { twitch: { heartbeatTransport } } })}
+        editable={expertExpanded}
+        component
+      />
+      <CompatibilityRow
+        title={t("compatibilityComponentInventory")}
+        ariaLabel={t("compatibilityTwitchInventoryTitle")}
+        description={t("compatibilityTwitchInventoryDescription")}
+        selection={settings.twitch.inventoryQueryVersion}
+        resolvedId={effective.twitch.inventory}
+        metadata={metadata(registry.twitch.inventory, effective.twitch.inventory)}
+        options={options(registry.twitch.inventory, automatic, t, true)}
+        onChange={(inventoryQueryVersion) => onChange({ compatibility: { twitch: { inventoryQueryVersion } } })}
+        editable={expertExpanded}
+        component
+      />
+    </PlatformGroup>
+
+    <PlatformGroup platform="kick">
+      <CompatibilityRow
+        title={t("compatibilityComponentProfile")}
+        ariaLabel={t("compatibilityKickProfileTitle")}
+        description={t("compatibilityKickProfileDescription")}
+        selection={settings.kick.profile}
+        resolvedId={effective.kick.profile}
+        metadata={metadata(registry.kick.profiles, effective.kick.profile)}
+        options={options(registry.kick.profiles, automatic, t)}
+        onChange={(profile) => onChange({ compatibility: { kick: { profile } } })}
+        editable
+        component={false}
+      />
+      <CompatibilityRow
+        title={t("compatibilityComponentClaim")}
+        ariaLabel={t("compatibilityKickClaimTitle")}
+        description={t("compatibilityKickClaimDescription")}
+        selection={settings.kick.claimLinkHandling}
+        resolvedId={effective.kick.claim}
+        metadata={metadata(registry.kick.claim, effective.kick.claim)}
+        options={options(registry.kick.claim, automatic, t)}
+        onChange={(claimLinkHandling) => onChange({ compatibility: { kick: { claimLinkHandling } } })}
+        editable={expertExpanded}
+        component
+      />
+    </PlatformGroup>
+
+    <button type="button" aria-expanded={expertExpanded} onClick={() => onExpertExpandedChange(!expertExpanded)} className="mt-2 flex w-full items-center justify-between rounded-lg px-1 py-1 text-[11px] font-semibold text-zinc-500 outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]">
       {t(expertExpanded ? "compatibilityExpertHide" : "compatibilityExpertShow")}<ChevronDown size={13} className={cn("transition-transform", expertExpanded && "rotate-180")} />
     </button>
-    {expertExpanded ? <div className="divide-y divide-zinc-100 dark:divide-zinc-800/70">
-      <SelectSettingRow title={t("compatibilityTwitchHeartbeatTitle")} description={t("compatibilityTwitchHeartbeatDescription")} value={settings.twitch.heartbeatTransport} options={options(registry.twitch.heartbeat, automatic, t, true)} onChange={(heartbeatTransport) => onChange({ compatibility: { twitch: { heartbeatTransport } } })} />
-      <SelectSettingRow title={t("compatibilityTwitchInventoryTitle")} description={t("compatibilityTwitchInventoryDescription")} value={settings.twitch.inventoryQueryVersion} options={options(registry.twitch.inventory, automatic, t, true)} onChange={(inventoryQueryVersion) => onChange({ compatibility: { twitch: { inventoryQueryVersion } } })} />
-      <SelectSettingRow title={t("compatibilityKickClaimTitle")} description={t("compatibilityKickClaimDescription")} value={settings.kick.claimLinkHandling} options={options(registry.kick.claim, automatic, t)} onChange={(claimLinkHandling) => onChange({ compatibility: { kick: { claimLinkHandling } } })} />
-      <div className="flex flex-wrap gap-1.5 py-2"><LifecycleBadge lifecycle="recommended" /><LifecycleBadge lifecycle="legacy" /><LifecycleBadge lifecycle="experimental" /></div>
-    </div> : null}
-    {overridden ? <div className="mt-2 flex items-start gap-1.5 rounded-lg bg-amber-500/10 p-2 text-[10px] text-amber-700 dark:text-amber-300"><TriangleAlert size={12} className="mt-0.5 shrink-0" /><span>{t("compatibilityOverrideWarning")}</span></div> : null}
-    <button type="button" disabled={!overridden} onClick={() => void onChange(AUTOMATIC_COMPATIBILITY_PATCH)} className="mt-2 flex items-center gap-1.5 rounded-lg border border-zinc-200 px-2 py-1 text-[11px] font-semibold text-zinc-500 disabled:opacity-40 dark:border-zinc-700"><RotateCcw size={12} />{t("compatibilityRestoreAutomatic")}</button>
+    {overridden ? <div className="mt-1 flex items-start gap-1.5 rounded-lg bg-amber-500/10 p-2 text-[10px] text-amber-700 dark:text-amber-300"><TriangleAlert size={12} className="mt-0.5 shrink-0" /><span>{t("compatibilityOverrideWarning")}</span></div> : null}
+    <button type="button" disabled={!overridden} onClick={() => void onChange(AUTOMATIC_COMPATIBILITY_PATCH)} className="mt-2 flex items-center gap-1.5 rounded-lg border border-zinc-200 px-2 py-1 text-[11px] font-semibold text-zinc-500 outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-40 dark:border-zinc-700"><RotateCcw size={12} />{t("compatibilityRestoreAutomatic")}</button>
   </div>;
 }

--- a/packages/popup-ui/src/compatibilitySettings.tsx
+++ b/packages/popup-ui/src/compatibilitySettings.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { CompatibilitySettings as CompatibilitySelections } from "@lurkloot/shared/models";
 import type { Platform } from "@lurkloot/shared/models";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
-import { ChevronDown, RotateCcw, TriangleAlert } from "lucide-react";
+import { RotateCcw, TriangleAlert } from "lucide-react";
 import { PLATFORMS } from "./constants";
 import { useT } from "./context";
 import { SelectControl } from "./settingsControls";
@@ -88,9 +88,9 @@ function PlatformGroup({ platform, children }: { platform: Platform; children: R
   );
 }
 
-// One resolved component. The control and the value it produced sit together, so
+// One resolved capability. The control and the value it produced sit together, so
 // "Automatic" always says what it actually resolved to.
-function CompatibilityRow({ title, ariaLabel, description, selection, resolvedId, metadata, options: rowOptions, onChange, editable, component }: {
+function CompatibilityRow({ title, ariaLabel, description, selection, resolvedId, metadata, options: rowOptions, onChange, component }: {
   title: string;
   ariaLabel: string;
   description: string;
@@ -99,7 +99,6 @@ function CompatibilityRow({ title, ariaLabel, description, selection, resolvedId
   metadata?: CompatibilityOptionMetadata;
   options: Array<{ value: string; label: string }>;
   onChange(value: string): void | Promise<void>;
-  editable: boolean;
   // Components inherit from the profile when left automatic; a profile row has
   // nothing above it to inherit from.
   component: boolean;
@@ -113,17 +112,15 @@ function CompatibilityRow({ title, ariaLabel, description, selection, resolvedId
       <div className="flex items-center gap-3">
         <div className="min-w-0 flex-1">
           <div className="text-[12px] font-medium text-zinc-800 dark:text-zinc-100">{title}</div>
-          {editable ? <div className="mt-0.5 text-[10px] leading-snug text-zinc-500 dark:text-zinc-400">{description}</div> : null}
+          <div className="mt-0.5 text-[10px] leading-snug text-zinc-500 dark:text-zinc-400">{description}</div>
         </div>
-        {editable
-          ? <SelectControl label={ariaLabel} value={selection} options={rowOptions} onChange={onChange} />
-          : <span className="shrink-0 text-[10px] font-semibold text-zinc-400 dark:text-zinc-500">{t("compatibilityFromProfile")}</span>}
+        <SelectControl label={ariaLabel} value={selection} options={rowOptions} onChange={onChange} />
       </div>
       <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1">
         <span className="text-[11px] font-medium text-zinc-700 dark:text-zinc-200">{optionTitle(t, resolvedId)}</span>
         <LifecycleBadge lifecycle={lifecycle} />
         {automatic
-          ? (component && editable ? <span className="text-[10px] text-zinc-400 dark:text-zinc-500">{t("compatibilityFromProfile")}</span> : null)
+          ? (component ? <span className="text-[10px] text-zinc-400 dark:text-zinc-500">{t("compatibilityFromProfile")}</span> : null)
           : <span className="text-[10px] font-semibold text-amber-600 dark:text-amber-400">{t("compatibilityOverridden")}</span>}
         <code className="w-full truncate text-[10px] text-zinc-400 dark:text-zinc-500">{resolvedId}</code>
         {replacement ? <span className="w-full text-[10px] text-amber-600 dark:text-amber-400">{t("compatibilityReplacedBy", optionTitle(t, replacement))}</span> : null}
@@ -132,13 +129,11 @@ function CompatibilityRow({ title, ariaLabel, description, selection, resolvedId
   );
 }
 
-export function CompatibilitySettings({ settings, registry, resolution, onChange, expertExpanded, onExpertExpandedChange }: {
+export function CompatibilitySettings({ settings, registry, resolution, onChange }: {
   settings: CompatibilitySelections;
   registry: PopupCompatibilityRegistry;
   resolution: PopupCompatibilityResolution;
   onChange(patch: SettingsPatch): void | Promise<void>;
-  expertExpanded: boolean;
-  onExpertExpandedChange(value: boolean): void;
 }) {
   const t = useT();
   const automatic = t("compatibilityAutomatic");
@@ -165,7 +160,6 @@ export function CompatibilitySettings({ settings, registry, resolution, onChange
         metadata={metadata(registry.twitch.profiles, effective.twitch.profile)}
         options={options(registry.twitch.profiles, automatic, t, true)}
         onChange={(profile) => onChange({ compatibility: { twitch: { profile } } })}
-        editable
         component={false}
       />
       <CompatibilityRow
@@ -177,7 +171,6 @@ export function CompatibilitySettings({ settings, registry, resolution, onChange
         metadata={metadata(registry.twitch.heartbeat, effective.twitch.heartbeat)}
         options={options(registry.twitch.heartbeat, automatic, t, true)}
         onChange={(heartbeatTransport) => onChange({ compatibility: { twitch: { heartbeatTransport } } })}
-        editable={expertExpanded}
         component
       />
       <CompatibilityRow
@@ -189,7 +182,6 @@ export function CompatibilitySettings({ settings, registry, resolution, onChange
         metadata={metadata(registry.twitch.inventory, effective.twitch.inventory)}
         options={options(registry.twitch.inventory, automatic, t, true)}
         onChange={(inventoryQueryVersion) => onChange({ compatibility: { twitch: { inventoryQueryVersion } } })}
-        editable={expertExpanded}
         component
       />
     </PlatformGroup>
@@ -204,7 +196,6 @@ export function CompatibilitySettings({ settings, registry, resolution, onChange
         metadata={metadata(registry.kick.profiles, effective.kick.profile)}
         options={options(registry.kick.profiles, automatic, t)}
         onChange={(profile) => onChange({ compatibility: { kick: { profile } } })}
-        editable
         component={false}
       />
       <CompatibilityRow
@@ -216,15 +207,11 @@ export function CompatibilitySettings({ settings, registry, resolution, onChange
         metadata={metadata(registry.kick.claim, effective.kick.claim)}
         options={options(registry.kick.claim, automatic, t)}
         onChange={(claimLinkHandling) => onChange({ compatibility: { kick: { claimLinkHandling } } })}
-        editable={expertExpanded}
         component
       />
     </PlatformGroup>
 
-    <button type="button" aria-expanded={expertExpanded} onClick={() => onExpertExpandedChange(!expertExpanded)} className="mt-2 flex w-full items-center justify-between rounded-lg px-1 py-1 text-[11px] font-semibold text-zinc-500 outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]">
-      {t(expertExpanded ? "compatibilityExpertHide" : "compatibilityExpertShow")}<ChevronDown size={13} className={cn("transition-transform", expertExpanded && "rotate-180")} />
-    </button>
-    {overridden ? <div className="mt-1 flex items-start gap-1.5 rounded-lg bg-amber-500/10 p-2 text-[10px] text-amber-700 dark:text-amber-300"><TriangleAlert size={12} className="mt-0.5 shrink-0" /><span>{t("compatibilityOverrideWarning")}</span></div> : null}
+    {overridden ? <div className="mt-3 flex items-start gap-1.5 rounded-lg bg-amber-500/10 p-2 text-[10px] text-amber-700 dark:text-amber-300"><TriangleAlert size={12} className="mt-0.5 shrink-0" /><span>{t("compatibilityOverrideWarning")}</span></div> : null}
     <button type="button" disabled={!overridden} onClick={() => void onChange(AUTOMATIC_COMPATIBILITY_PATCH)} className="mt-2 flex items-center gap-1.5 rounded-lg border border-zinc-200 px-2 py-1 text-[11px] font-semibold text-zinc-500 outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-40 dark:border-zinc-700"><RotateCcw size={12} />{t("compatibilityRestoreAutomatic")}</button>
   </div>;
 }

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -45,7 +45,6 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
 }) {
   const t = useT();
   const [platformTab, setPlatformTab] = useState<Platform>(initialPlatform);
-  const [compatibilityExpertExpanded, setCompatibilityExpertExpanded] = useState(false);
   const [exportArmed, setExportArmed] = useState(false);
   useEffect(() => setExportArmed(false), [exportConfirmationResetKey]);
   const set = (key: keyof ExtensionSettings) => (value: boolean) => onSettingsChange({ [key]: value } as SettingsPatch);
@@ -156,7 +155,7 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
       <SettingsSection title={t("advancedTitle")} description={t("advancedDescription")} icon={SlidersHorizontal}>
         <NumberSettingRow title={t("schedulerIntervalTitle")} description={t("schedulerIntervalDescription")} value={pollIntervalSeconds} min={30} max={3600} suffix={t("secondsSuffix")} onChange={(value) => onSettingsChange({ pollIntervalMinutes: value / 60 })} />
         <SettingRow title={t("diagnosticLoggingTitle")} description={t("diagnosticLoggingDescription")} checked={settings.diagnosticLogging} onChange={set("diagnosticLogging")} />
-        {compatibilityRegistry && compatibilityResolution ? <CompatibilitySettings settings={settings.compatibility} registry={compatibilityRegistry} resolution={compatibilityResolution} onChange={onSettingsChange} expertExpanded={compatibilityExpertExpanded} onExpertExpandedChange={setCompatibilityExpertExpanded} /> : null}
+        {compatibilityRegistry && compatibilityResolution ? <CompatibilitySettings settings={settings.compatibility} registry={compatibilityRegistry} resolution={compatibilityResolution} onChange={onSettingsChange} /> : null}
       </SettingsSection>
       {onExportCredentials && (
         <SettingsSection title={t("cliExportTitle")} description={t("cliExportDescription")} icon={Terminal}>

--- a/packages/popup-ui/src/settingsControls.tsx
+++ b/packages/popup-ui/src/settingsControls.tsx
@@ -146,6 +146,35 @@ export function ForgetExcludedCampaignsRow({ count, onForget }: { count: number;
   );
 }
 
+// The bare select control. A native <select> sizes itself to its longest option,
+// so it is capped and allowed to shrink; long labels ellipsize instead of
+// squeezing whatever sits beside it. The full label stays available on hover.
+export function SelectControl<T extends string>({ label, value, options, onChange, disabled = false, disabledReason }: {
+  label: string;
+  value: T;
+  options: Array<{ value: T; label: string }>;
+  onChange(value: T): void | Promise<void>;
+  disabled?: boolean;
+  disabledReason?: string;
+}) {
+  return (
+    <label className={cn("flex min-w-0 max-w-[45%] shrink-0 items-center rounded-lg border border-zinc-200 bg-white px-2 py-1 text-[11px] font-semibold text-zinc-500 focus-within:border-[var(--accent-ring)] dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400", disabled && "cursor-not-allowed")}>
+      <select
+        aria-label={label}
+        title={disabled ? disabledReason : options.find((option) => option.value === value)?.label}
+        disabled={disabled}
+        value={value}
+        onChange={(event) => void onChange(event.target.value as T)}
+        className={cn("w-full truncate bg-transparent pr-1 outline-none", disabled && "cursor-not-allowed")}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>{option.label}</option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
 export function SelectSettingRow<T extends string>({ title, description, value, options, onChange, disabled = false, disabledReason }: {
   title: string;
   description: string;
@@ -161,20 +190,7 @@ export function SelectSettingRow<T extends string>({ title, description, value, 
         <div className="text-[13px] font-medium text-zinc-800 dark:text-zinc-100">{title}</div>
         <div className="mt-0.5 text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{description}</div>
       </div>
-      <label className={cn("flex min-w-0 max-w-[45%] shrink-0 items-center rounded-lg border border-zinc-200 bg-white px-2 py-1 text-[11px] font-semibold text-zinc-500 focus-within:border-[var(--accent-ring)] dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400", disabled && "cursor-not-allowed")}>
-        <select
-          aria-label={title}
-          title={disabled ? disabledReason : options.find((option) => option.value === value)?.label}
-          disabled={disabled}
-          value={value}
-          onChange={(event) => void onChange(event.target.value as T)}
-          className={cn("w-full truncate bg-transparent pr-1 outline-none", disabled && "cursor-not-allowed")}
-        >
-          {options.map((option) => (
-            <option key={option.value} value={option.value}>{option.label}</option>
-          ))}
-        </select>
-      </label>
+      <SelectControl label={title} value={value} options={options} onChange={onChange} disabled={disabled} disabledReason={disabledReason} />
     </div>
   );
 }

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -9,6 +9,9 @@ export interface CompatibilityOptionMetadata {
   readonly lifecycle: CompatibilityLifecycle;
   readonly hosts: readonly string[];
   readonly identities?: readonly string[];
+  // Set on superseded options: the id that replaces this one. Surfaced so a
+  // legacy selection says what to move to.
+  readonly replacement?: string;
 }
 export interface PopupCompatibilityRegistry {
   readonly twitch: {


### PR DESCRIPTION
Stacked on #142 — base is `fix/compat-select-row-width`, so review that one first. Retarget to `develop` once #142 merges.

## Why

The section was counterintuitive for structural reasons, not cosmetic ones:

1. **The control and its result lived in two places.** You picked "Automatic" in a select; what it *resolved to* appeared in a separate "Effective compatibility" block below.
2. **That block listed five capabilities but only two controls were visible** until you expanded "expert" — it reported on rows you couldn't see.
3. **The profile→component hierarchy was invisible.** A profile bundles a heartbeat + inventory; the expert selects override what the profile chose. Nothing said so.
4. **Five identical selects reading "Automatic"**, none showing what they picked.
5. **Twitch and Kick were interleaved** rather than grouped.
6. **Lifecycle badges appeared everywhere except where you choose** — in the effective list and a floating legend, but not on the dropdown options.
7. **`replacement` metadata was never surfaced**, so a legacy pick never said what supersedes it.

## What changed

- **Resolved value folded into each row** — title, lifecycle badge and raw id sit on the control that produced them. "Automatic" now always states what it actually resolved to. The separate `compatibilityEffectiveTitle` block is gone.
- **Grouped by platform** with the existing `PLATFORMS` mark/colour convention already used in platform settings.
- **Provenance is explicit** — each component says `From profile` or `Overridden`; the section header carries an Automatic/Overridden pill.
- **Components stay read-only until expert mode.** The dangerous knobs remain gated, but their resolved state is always visible — that is what fixes the "reports on rows you can't see" problem.
- **Lifecycle moved into option labels** (`Spade heartbeat v1 · Recommended`), where the tradeoff matters at the moment of choosing. This also drops the raw `(id)` suffix that caused #141 in the first place.
- **Legacy picks name their successor** via the registry's `replacement` field (`Replaced by Spade heartbeat v1`).
- **`SelectControl` extracted** from `SelectSettingRow` so the width cap from #142 lives in one place and the compat rows reuse it.

Accessible names are unchanged: the controls keep the full capability names (`Twitch heartbeat transport`) as `aria-label` while the visible labels shorten to `Heartbeat transport` under the platform heading.

No change to the settings shape, the resolver, or `@lurkloot/core` — this is popup-ui plus copy.

## Testing

`pnpm check` passes — 511 extension tests (+2 net), all workspace typechecks, site build.

`compatibilitySettingsView.test.tsx` updated to the new IA, with new coverage for what the redesign introduces: resolved ids rendered per row, lifecycle carried into option labels, and `From profile` → `Overridden` + replacement hint when a legacy option is picked. The test's translate stub now performs `$1` substitution like `translateFromCatalogs` does, so the placeholder path is actually exercised.

Verified in the real component at the real 400px popup width by temporarily wiring the compat registry into the site demo (reverted before commit — the demo adapter omits it, so the section doesn't otherwise render there). Checked: default state, expert mode, an active override, dark mode via `prefers-color-scheme`, and Arabic RTL. No horizontal overflow in any of them (360px content in a 360px box).

## Please look at

- **The 9 new strings across 10 catalogs are machine-translated.** They pass the repo's parity and not-left-as-English checks, but the non-English wording wants a native review — particularly the German `Einlöse-Verarbeitung` and Russian `Обработка получения наград` for "Claim handling", which are the least idiomatic.
- **Registry `description` fields are still unused.** They are English-only literals in `@lurkloot/core`, so surfacing them would put untranslated text in a localized UI. I used the existing translated description keys instead — worth deciding if those descriptions should move into the catalogs.
- **`45%` select cap** inherited from #142 still applies; with the `(id)` suffix gone from option labels it now rarely engages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned compatibility settings with component-level options and clearer lifecycle information.
  * Added indicators showing whether settings come from a profile or are manually overridden.
  * Added replacement guidance for legacy options and a control to restore automatic settings.
  * Improved selection controls with consistent styling and helpful hover descriptions.

* **Documentation**
  * Updated compatibility terminology and translations across supported languages.

* **Tests**
  * Expanded coverage for platform grouping, lifecycle labels, overrides, replacements, and restoring automatic settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->