### PR TITLE
docs(changelog): add 1.6.0 changes

### DIFF
--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "1.6.0",
+    "changes": [
+      {
+        "kind": "improved",
+        "text": "Compatibility settings now show what each option actually resolves to, grouped by platform, and say whether a value came from the selected profile or a manual override."
+      },
+      {
+        "kind": "fixed",
+        "text": "Long option names in settings dropdowns no longer squeeze setting titles into several lines."
+      }
+    ]
+  },
+  {
     "version": "1.5.0",
     "changes": [
       {


### PR DESCRIPTION
## Summary

Adds the undated `1.6.0` changelog entry for the two user-facing changes that landed on `develop` after the `v1.5.0` tag:

- **#143** — compatibility settings restructured around resolved values (`improved`)
- **#142** — select width cap in setting rows (`fixed`)

The remaining commits since `v1.5.0` are dependency bumps and release-pipeline work, so they get no entry.

Per `RELEASING.md`, the entry is at the top with no `date` — Prepare release stamps it when the `release/minor` label is applied. Version is `1.6.0` because #143 is a `feat`.

## Testing

`pnpm build:site` passes — the changelog kind validation in `src/changelog.ts` runs at build time and accepts the new entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Compatibility settings now show resolved option values by platform, including whether each value comes from a selected profile or a manual override.

* **Bug Fixes**
  * Long option names in settings dropdowns no longer wrap awkwardly or compress titles across multiple lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->