### PR TITLE
fix(ci): resolve the repo for gh in prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -22,6 +22,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    # Both checkouts live in subdirectories, so the workspace root is not a git
+    # repository and gh cannot infer the repo from a remote.
+    env:
+      GH_REPO: ${{ github.repository }}
     outputs:
       action: ${{ steps.policy.outputs.action }}
       version: ${{ steps.policy.outputs.version }}


### PR DESCRIPTION
## Summary

`Prepare release` failed on #146 at the *Refuse to overwrite another pull request's release branch* step. The step name is misleading — no `release/1.6.0` pull request existed. The step failed on its own tooling:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Both checkouts in the `prepare` job use `path:` (`trusted/`, `candidate/`), so the workspace root is not a git repository. `gh pr list` had no remote to infer the repo from, and under `bash -e` the failed command substitution exited 1.

Setting `GH_REPO` at the job level fixes the guard plus three other steps that would have hit the same wall had they run: the two `gh pr comment` calls in *Resolve the live release policy* and *Report an orphaned candidate*, and the whole *Supersede the triggering pull request* step. Only the steps with `working-directory: candidate` worked, and only by accident.

`release.yml` checks out at the root, so its `gh` calls are unaffected. No other workflow has this pattern.

## Testing

- Reproduced locally: `gh pr list --head release/1.6.0 --state open --json body --jq '.[0].body // ""'` in a non-git directory fails with the identical error and exit 1; the same command with `GH_REPO` set exits 0.
- Workflow YAML parses and the job-level `env` resolves as expected.

`pull_request_target` loads the workflow from the base branch, so this needs to land on `main` before #146 is re-labelled.

Failing run: https://github.com/jamezrin/lurkloot/actions/runs/29664475440/job/88132491269