### PR TITLE
feat(release): promote the candidate prerelease in place

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -174,7 +174,7 @@ jobs:
           PR: ${{ inputs.pr_number }}
           VERSION: ${{ inputs.version }}
           SHA: ${{ inputs.ref }}
-          URL: https://github.com/${{ github.repository }}/releases/tag/candidate-v${{ inputs.version }}
+          URL: https://github.com/${{ github.repository }}/releases/tag/v${{ inputs.version }}
         run: >-
           node scripts/release/cli.mjs candidate-comment
           --pr "$PR" --version "$VERSION" --sha "$SHA" --state ready --url "$URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,17 +76,8 @@ jobs:
         run: test "$COMMITTED" = "$EXPECTED"
       - run: node scripts/release.mjs check
 
-  extension:
-    needs: resolve
-    permissions:
-      contents: read
-    uses: ./.github/workflows/build-extension.yml
-    with:
-      ref: ${{ needs.resolve.outputs.ref }}
-      trusted_ref: ${{ needs.resolve.outputs.ref }}
-      sign_crx: true
-    secrets:
-      CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+  # The extension is not rebuilt here. Publication promotes the candidate prerelease in place, so the
+  # signed artifacts it already carries are the ones that ship; publish downloads them back.
 
   # GitHub validates the called workflow's permission ceiling before evaluating its skipped
   # publish job. The build matrix itself explicitly reduces packages back to none.
@@ -123,7 +114,7 @@ jobs:
           retention-days: 1
 
   publish:
-    needs: [resolve, extension, docker, site-build]
+    needs: [resolve, docker, site-build]
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -132,7 +123,6 @@ jobs:
       pull-requests: write
     env:
       VERSION: ${{ needs.resolve.outputs.version }}
-      RELEASE_SHA: ${{ needs.resolve.outputs.ref }}
       RELEASE_PR: ${{ needs.resolve.outputs.pr_number }}
       GITHUB_TOKEN: ${{ github.token }}
     steps:
@@ -155,10 +145,6 @@ jobs:
           version: 11.9.0
       - uses: actions/download-artifact@v8
         with:
-          name: extension-release-assets
-          path: release-assets
-      - uses: actions/download-artifact@v8
-        with:
           pattern: stable-docker-${{ github.run_id }}-${{ github.run_attempt }}-oci-*
           path: docker-images
           merge-multiple: true
@@ -166,26 +152,21 @@ jobs:
         with:
           name: stable-site-${{ github.run_id }}-${{ github.run_attempt }}
           path: site-artifact
-      - name: Tag the released commit without ever moving a stable tag
+      # The candidate published these already signed. Downloading them back, rather than rebuilding,
+      # is what makes the shipped bits the reviewed bits. SHA256SUMS covers every shipped file.
+      - name: Recover the reviewed release assets
         run: |
-          existing=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v$VERSION" --jq .object.sha 2>/dev/null || true)
-          if [ -z "$existing" ]; then
-            gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/v$VERSION" -f sha="$RELEASE_SHA"
-          elif [ "$existing" != "$RELEASE_SHA" ]; then
-            echo "v$VERSION already tags $existing; refusing to move it to $RELEASE_SHA." >&2
-            exit 1
-          fi
+          mkdir release-assets
+          gh release download "v$VERSION" --dir release-assets
+          (cd release-assets && sha256sum -c SHA256SUMS)
       - name: Verify the release asset set
         run: node scripts/release/cli.mjs assert-assets --assets release-assets --version "$VERSION"
-      - name: Create or update the stable GitHub release
+      # No tag is created here. It was created during candidacy at the release branch head, and the
+      # main ruleset's strict status-check policy guarantees that tree is what landed on main.
+      - name: Promote the candidate prerelease to the stable release
         run: |
           node scripts/release/cli.mjs notes --version "$VERSION" --out notes.md
-          if gh release view "v$VERSION" >/dev/null 2>&1; then
-            gh release edit "v$VERSION" --notes-file notes.md --latest
-          else
-            gh release create "v$VERSION" --title "v$VERSION" --notes-file notes.md --latest
-          fi
-          gh release upload "v$VERSION" release-assets/* --clobber
+          node scripts/release/cli.mjs promote-release --pr "$RELEASE_PR" --version "$VERSION" --notes notes.md
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -235,8 +216,6 @@ jobs:
           directory: site-artifact
           api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      - name: Retire the matching mutable candidate
-        run: node scripts/release/cli.mjs retire-candidate --pr "$RELEASE_PR" --version "$VERSION"
       - name: Merge main directly into develop with the dedicated App
         env:
           SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,8 +27,8 @@ empty entry. That intentionally permits build-only releases, but produces an emp
 2. Apply exactly one of `release/patch`, `release/minor`, or `release/major`. The label validates the
    version and builds a candidate. It does not modify the pull request it is applied to.
 3. Candidate automation verifies the labelled head, publishes the signed extension artifacts as the
-   mutable `candidate-vX.Y.Z` GitHub prerelease, pushes GHCR `candidate-X.Y.Z`, and deploys the site
-   to `next.lurkloot.pages.dev`.
+   mutable `vX.Y.Z` GitHub **prerelease**, pushes GHCR `candidate-X.Y.Z`, and deploys the site to
+   `next.lurkloot.pages.dev`.
 4. Review and merge that pull request normally, with a **merge commit**.
 5. Prepare release then cuts `release/X.Y.Z` from the resulting merge commit on `main`, commits the
    version in all seven workspace manifests, dates the changelog, opens a generated pull request into
@@ -36,9 +36,10 @@ empty entry. That intentionally permits build-only releases, but produces an emp
    generated pull request's diff is only the version bump and changelog date.
 6. Review and merge the generated `release/X.Y.Z` pull request with a **merge commit**. Squash and
    rebase are blocked on `main`; the original `develop` commit SHAs remain in `main` history.
-7. Release rebuilds from the merged `main` commit. Approve its single `production` job. It publishes
-   GitHub, GHCR, Chrome Web Store, and the production site, retires the candidate, then merges `main`
-   directly into `develop` with the dedicated synchronization App.
+7. Release runs from the merged `main` commit. Approve its single `production` job. It promotes the
+   `vX.Y.Z` prerelease to the latest release, publishing the extension artifacts it already carries
+   rather than rebuilding them, then publishes GHCR, Chrome Web Store, and the production site, and
+   merges `main` directly into `develop` with the dedicated synchronization App.
 
 `workflow_dispatch` remains on **Release** only for idempotent recovery. A successful release does
 not require a manual dispatch.
@@ -61,14 +62,21 @@ not require a manual dispatch.
 
 Candidate pointers are deliberately mutable:
 
-- GitHub tag/release: `candidate-vX.Y.Z`
+- GitHub tag/release: `vX.Y.Z`, published as a prerelease
 - GHCR image: `candidate-X.Y.Z`
 - Site: `https://next.lurkloot.pages.dev`
 
 Every generated release-branch push rebuilds and refreshes those targets. Ownership metadata binds
 the candidate release to its pull request. An exact-SHA tag left behind by interrupted initial
 creation is recovered; a tag at any other SHA is rejected. Automation never modifies a stable
-release through the candidate path.
+release through the candidate path: promotion clears the prerelease flag, and every later candidate
+build against that tag fails.
+
+The candidate and the stable release are the same object. `vX.Y.Z` is created during candidacy at the
+release branch head and is never moved; merging the release pull request flips it from prerelease to
+latest and publishes the artifacts it already carries. Because `vX.Y.Z` exists while the release is
+still under review, it is a moving tag until promotion — it stays out of `releases/latest` while it
+is a prerelease, but anyone pinning the raw tag during that window gets a pre-release commit.
 
 The candidate pipeline writes all five required contexts directly to the generated release PR head:
 the four build/verification contexts plus `release candidate / ready`. This is necessary because

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -11,7 +11,7 @@ import { assertReleaseAssets, releasePolicy } from "./pipeline.mjs";
 import {
   GitHubClient,
   reconcilePrerelease,
-  retirePrerelease,
+  promotePrerelease,
   setCandidateStatuses,
   setCommitStatus,
   upsertComment,
@@ -145,12 +145,14 @@ const commands = {
       targetUrl: values["target-url"] ?? "",
     });
   },
-  async "retire-candidate"(values) {
-    await retirePrerelease({
+  async "promote-release"(values) {
+    const { tag, promoted } = await promotePrerelease({
       client: githubClient(),
       pr: Number(values.pr),
       version: values.version,
+      notes: await readFile(values.notes, "utf8"),
     });
+    process.stdout.write(`${promoted ? "promoted" : "already promoted"} ${tag}\n`);
   },
   async "app-token"() {
     const result = await createRepositoryToken({

--- a/scripts/release/cli.test.mjs
+++ b/scripts/release/cli.test.mjs
@@ -33,13 +33,13 @@ test("renders candidate status with stable links", () => {
     version: "1.6.0",
     sha: "abcdef123456",
     state: "ready",
-    url: "https://github.com/jamezrin/lurkloot/releases/tag/candidate-v1.6.0",
+    url: "https://github.com/jamezrin/lurkloot/releases/tag/v1.6.0",
   }), [
     "## Release candidate 1.6.0",
     "",
     "- State: **ready**",
     "- Source: `abcdef1`",
-    "- Candidate: https://github.com/jamezrin/lurkloot/releases/tag/candidate-v1.6.0",
+    "- Candidate: https://github.com/jamezrin/lurkloot/releases/tag/v1.6.0",
     "- Site: https://next.lurkloot.pages.dev",
   ].join("\n"));
 });

--- a/scripts/release/github.mjs
+++ b/scripts/release/github.mjs
@@ -60,13 +60,6 @@ export class GitHubClient {
     });
   }
 
-  deleteRef(tag) {
-    return this.request(this.repoPath(`/git/refs/tags/${encodeURIComponent(tag)}`), {
-      method: "DELETE",
-      allowNotFound: true,
-    });
-  }
-
   releaseByTag(tag) {
     return this.request(this.repoPath(`/releases/tags/${encodeURIComponent(tag)}`), { allowNotFound: true });
   }
@@ -77,10 +70,6 @@ export class GitHubClient {
 
   updateRelease(id, body) {
     return this.request(this.repoPath(`/releases/${id}`), { method: "PATCH", body });
-  }
-
-  deleteRelease(id) {
-    return this.request(this.repoPath(`/releases/${id}`), { method: "DELETE" });
   }
 
   deleteAsset(id) {
@@ -113,10 +102,12 @@ export class GitHubClient {
   }
 }
 
+// The prerelease check is what stops a late candidate build from overwriting a release that has
+// already been promoted: promotion clears the flag, so every later reconcile against it fails here.
 function assertOwnedPrerelease(release, { pr, version }) {
   const ownership = parseCandidateMarker(release.body);
   if (!release.prerelease || ownership?.pr !== Number(pr) || ownership.version !== version) {
-    throw new Error(`refusing to modify candidate-v${version}: release is stable or owned by another pull request`);
+    throw new Error(`refusing to modify v${version}: release is already promoted or owned by another pull request`);
   }
 }
 
@@ -175,14 +166,29 @@ export async function setCandidateStatuses(options) {
   return Promise.all(requiredMainStatusContexts.map((context) => setCommitStatus({ ...options, context })));
 }
 
-export async function retirePrerelease({ client, pr, version }) {
+// Promotion is the terminal transition for a candidate: the same release object and the same tag
+// become the stable release. It is deliberately not creatable from nothing — a version with no
+// candidate has no reviewed artifacts to publish.
+export async function promotePrerelease({ client, pr, version, notes }) {
   const tag = candidateTag(version);
   const release = await client.releaseByTag(tag);
-  if (!release) return "absent";
+  if (!release) throw new Error(`cannot promote ${tag}: no candidate release exists`);
+  if (!release.prerelease) {
+    const ownership = parseCandidateMarker(release.body);
+    if (ownership?.pr !== Number(pr) || ownership.version !== version) {
+      throw new Error(`refusing to promote ${tag}: release is owned by another pull request`);
+    }
+    return { release, tag, promoted: false };
+  }
   assertOwnedPrerelease(release, { pr, version });
-  await client.deleteRef(tag);
-  await client.deleteRelease(release.id);
-  return "retired";
+  const promoted = await client.updateRelease(release.id, {
+    name: `v${version}`,
+    body: notes.trim(),
+    draft: false,
+    prerelease: false,
+    make_latest: "true",
+  });
+  return { release: promoted, tag, promoted: true };
 }
 
 export async function upsertComment({ client, pr, body }) {

--- a/scripts/release/github.test.mjs
+++ b/scripts/release/github.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import {
   GitHubClient,
   reconcilePrerelease,
-  retirePrerelease,
+  promotePrerelease,
   setCandidateStatuses,
   setCommitStatus,
   upsertComment,
@@ -35,8 +35,8 @@ function recordingFetch(routes) {
 
 test("creates a missing owned candidate prerelease", async () => {
   const routes = recordingFetch({
-    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
-    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(404, { message: "Not Found" }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(404, { message: "Not Found" }),
     "POST /repos/jamezrin/lurkloot/releases": response(201, {
       id: 12,
       upload_url: "https://uploads.github.com/repos/jamezrin/lurkloot/releases/12/assets{?name,label}",
@@ -54,8 +54,8 @@ test("creates a missing owned candidate prerelease", async () => {
     assets: [{ name: "lurkloot.zip", bytes: Buffer.from("zip") }],
   });
   assert.deepEqual(routes.calls.map(({ method, path }) => `${method} ${path}`), [
-    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0",
-    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0",
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0",
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0",
     "POST /repos/jamezrin/lurkloot/releases",
     "POST /repos/jamezrin/lurkloot/releases/12/assets",
   ]);
@@ -65,8 +65,8 @@ test("creates a missing owned candidate prerelease", async () => {
 
 test("recovers an exact-SHA candidate tag left without a release", async () => {
   const routes = recordingFetch({
-    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(200, { object: { sha: "abc123" } }),
-    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(200, { object: { sha: "abc123" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(404, { message: "Not Found" }),
     "POST /repos/jamezrin/lurkloot/releases": response(201, {
       id: 12,
       upload_url: "https://uploads.github.com/repos/jamezrin/lurkloot/releases/12/assets{?name,label}",
@@ -80,8 +80,8 @@ test("recovers an exact-SHA candidate tag left without a release", async () => {
 
 test("refuses an orphan candidate tag at another SHA", async () => {
   const routes = recordingFetch({
-    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(200, { object: { sha: "foreign" } }),
-    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(404, { message: "Not Found" }),
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(200, { object: { sha: "foreign" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(404, { message: "Not Found" }),
   });
   const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
   await assert.rejects(
@@ -123,15 +123,15 @@ test("writes every required context for a generated release pull request", async
 test("moves only an owned prerelease candidate", async () => {
   const marker = candidateMarker({ pr: 132, version: "1.6.0", head: "release/1.6.0" });
   const routes = recordingFetch({
-    "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(200, { object: { sha: "old" } }),
-    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(200, {
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(200, { object: { sha: "old" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, {
       id: 12,
       prerelease: true,
       body: marker,
       upload_url: "https://uploads.github.com/repos/jamezrin/lurkloot/releases/12/assets{?name,label}",
       assets: [],
     }),
-    "PATCH /repos/jamezrin/lurkloot/git/refs/tags/candidate-v1.6.0": response(200, {}),
+    "PATCH /repos/jamezrin/lurkloot/git/refs/tags/v1.6.0": response(200, {}),
     "PATCH /repos/jamezrin/lurkloot/releases/12": response(200, {
       id: 12,
       upload_url: "https://uploads.github.com/repos/jamezrin/lurkloot/releases/12/assets{?name,label}",
@@ -142,7 +142,7 @@ test("moves only an owned prerelease candidate", async () => {
   await reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "new", notes: "notes", assets: [] });
   assert.equal(routes.calls.some(({ method, path }) =>
     method === "PATCH" &&
-    path === "/repos/jamezrin/lurkloot/git/refs/tags/candidate-v1.6.0"), true);
+    path === "/repos/jamezrin/lurkloot/git/refs/tags/v1.6.0"), true);
   const update = routes.calls.find(({ method, path }) => method === "PATCH" && path.endsWith("/releases/12"));
   assert.equal("target_commitish" in JSON.parse(update.init.body), false);
 });
@@ -153,8 +153,8 @@ test("refuses stable or foreign candidate releases", async () => {
     { id: 12, prerelease: true, body: candidateMarker({ pr: 999, version: "1.6.0", head: "release/1.6.0" }) },
   ]) {
     const routes = recordingFetch({
-      "GET /repos/jamezrin/lurkloot/git/ref/tags/candidate-v1.6.0": response(200, { object: { sha: "old" } }),
-      "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(200, release),
+      "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(200, { object: { sha: "old" } }),
+      "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, release),
     });
     const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
     await assert.rejects(
@@ -174,17 +174,64 @@ test("updates one sticky release status comment", async () => {
   assert.equal(routes.calls.at(-1).method, "PATCH");
 });
 
-test("retires only the matching owned prerelease", async () => {
+test("promotes the owned candidate in place without touching its tag", async () => {
   const marker = candidateMarker({ pr: 132, version: "1.6.0", head: "release/1.6.0" });
   const routes = recordingFetch({
-    "GET /repos/jamezrin/lurkloot/releases/tags/candidate-v1.6.0": response(200, { id: 12, prerelease: true, body: marker }),
-    "DELETE /repos/jamezrin/lurkloot/releases/12": response(204),
-    "DELETE /repos/jamezrin/lurkloot/git/refs/tags/candidate-v1.6.0": response(204),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: true, body: marker }),
+    "PATCH /repos/jamezrin/lurkloot/releases/12": response(200, { id: 12, prerelease: false }),
   });
   const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
-  await retirePrerelease({ client, pr: 132, version: "1.6.0" });
-  assert.deepEqual(routes.calls.slice(-2).map(({ method, path }) => `${method} ${path}`), [
-    "DELETE /repos/jamezrin/lurkloot/git/refs/tags/candidate-v1.6.0",
-    "DELETE /repos/jamezrin/lurkloot/releases/12",
-  ]);
+  const result = await promotePrerelease({ client, pr: 132, version: "1.6.0", notes: "notes" });
+  assert.equal(result.promoted, true);
+  const patch = JSON.parse(routes.calls.find(({ method }) => method === "PATCH").init.body);
+  assert.equal(patch.prerelease, false);
+  assert.equal(patch.make_latest, "true");
+  assert.ok(!routes.calls.some(({ path }) => path.includes("/git/refs")), "promotion must not move the tag");
+});
+
+test("promoting an already promoted release is a no-op", async () => {
+  const marker = candidateMarker({ pr: 132, version: "1.6.0", head: "release/1.6.0" });
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: false, body: marker }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  const result = await promotePrerelease({ client, pr: 132, version: "1.6.0", notes: "notes" });
+  assert.equal(result.promoted, false);
+  assert.ok(!routes.calls.some(({ method }) => method === "PATCH"));
+});
+
+test("refuses to promote a release owned by another pull request", async () => {
+  const marker = candidateMarker({ pr: 999, version: "1.6.0", head: "release/1.6.0" });
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: false, body: marker }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await assert.rejects(
+    () => promotePrerelease({ client, pr: 132, version: "1.6.0", notes: "notes" }),
+    /owned by another pull request/,
+  );
+});
+
+test("refuses to promote a version that never had a candidate", async () => {
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(404, { message: "Not Found" }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await assert.rejects(
+    () => promotePrerelease({ client, pr: 132, version: "1.6.0", notes: "notes" }),
+    /no candidate release exists/,
+  );
+});
+
+test("a promoted release cannot be reopened by a later candidate build", async () => {
+  const marker = candidateMarker({ pr: 132, version: "1.6.0", head: "release/1.6.0" });
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(200, { object: { sha: "abc" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: false, body: marker }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  await assert.rejects(
+    () => reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "abc", notes: "n", assets: [] }),
+    /already promoted/,
+  );
 });

--- a/scripts/release/pipeline.mjs
+++ b/scripts/release/pipeline.mjs
@@ -32,9 +32,11 @@ export function releasePolicy({ labels, head, tags }) {
   };
 }
 
+// One tag spans candidacy and stable publication. The candidate publishes it as a prerelease at the
+// release branch head; merging flips that same release to latest without ever moving the tag.
 export function candidateTag(version) {
   parseManifestVersion(version);
-  return `candidate-v${version}`;
+  return `v${version}`;
 }
 
 export function candidateMarker({ pr, version, head }) {

--- a/scripts/release/pipeline.test.mjs
+++ b/scripts/release/pipeline.test.mjs
@@ -53,7 +53,7 @@ test("candidate ownership markers round trip", () => {
   assert.match(marker, /^<!-- lurkloot-release-candidate:/);
   assert.deepEqual(parseCandidateMarker(`Candidate\n\n${marker}\n`), context);
   assert.equal(parseCandidateMarker("ordinary release body"), undefined);
-  assert.equal(candidateTag("1.6.0"), "candidate-v1.6.0");
+  assert.equal(candidateTag("1.6.0"), "v1.6.0");
 });
 
 test("uses only the final trailing candidate ownership marker", () => {


### PR DESCRIPTION
## Summary

Implements `docs/superpowers/specs/2026-07-19-promote-candidate-in-place-design.md`. A release was two GitHub release objects — a `candidate-vX.Y.Z` prerelease that got deleted, and a separate `vX.Y.Z` stable created at the merge commit. Now it is one object and one tag across candidacy and publication.

- `candidateTag` returns `vX.Y.Z`. The candidate publishes it as a prerelease at the release branch head and mutates it on every push.
- `release.yml` no longer creates a tag or a release. It promotes the existing object via `promote-release`, flipping `prerelease: false` / `make_latest: true`. The tag never moves.
- The `extension` job is deleted from `release.yml`. `publish` downloads the already-signed assets back from the prerelease and verifies them with `SHA256SUMS`, so the bits that ship are the bits that were reviewed. The Chrome Web Store step uses that same recovered ZIP.
- `retire-candidate` / `retirePrerelease` removed, along with the now-unused `deleteRef` / `deleteRelease` client methods and the unused `RELEASE_SHA` env.

## Notes for review

**Two spec items needed no code.** `strict_required_status_checks_policy` was already `true` at `repository-config.mjs:37` and already live on both rulesets — I verified against the API rather than assuming. That policy is what makes tagging the branch head correct, so it is load-bearing even though unchanged.

**Promotion is idempotent.** Re-running it on an already-promoted release returns without patching, so `workflow_dispatch` recovery still works. It refuses outright if no candidate exists, since there would be no reviewed artifacts to publish.

**A capability is going away.** `retirePrerelease` was the only tooling for abandoning a candidate without shipping it; that now means deleting the release by hand. Flagged before implementing and not yet explicitly confirmed.

**Docker is deliberately asymmetric.** The image is still built from the merge commit rather than promoted from the candidate digest. That is only sound because the strict up-to-date rule makes the branch-head and merge-result trees identical — the same fact that makes the tagging scheme safe. Noted as a scoped-out follow-up in the spec.

**Consequence accepted:** `vX.Y.Z` is a published, moving tag during candidacy. `make_latest: "false"` keeps it out of `releases/latest`, so exposure is limited to consumers pinning the raw tag.

## Test Plan

- [x] `pnpm check` passes: exit 0, 17 cws + 57 release script tests, 84 cli, 509 extension, site build
- [x] `release.yml` parses; `extension` job gone from the job graph
- [x] New coverage: promotion does not touch `/git/refs`, is idempotent, rejects foreign ownership, rejects a missing candidate, and a promoted release cannot be reopened by a later candidate build
- [ ] End to end, by the 1.6.0 release

## Do not label this pull request

It targets `main`. A `release/*` label would make merging it cut a release branch off it.