### PR TITLE
fix(release): keep prerelease tags out of version derivation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -52,7 +52,8 @@ jobs:
         run: |
           labels=$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")
           tags=$(git -C trusted tag --list 'v*' | tr '\n' ' ')
-          if ! node trusted/scripts/release/cli.mjs policy --labels "$labels" --head "$HEAD_REF" --tags "$tags"; then
+          prereleases=$(node trusted/scripts/release/cli.mjs prerelease-tags)
+          if ! node trusted/scripts/release/cli.mjs policy --labels "$labels" --head "$HEAD_REF" --tags "$tags" --exclude "$prereleases"; then
             gh pr comment "$PR" --body "Release preparation is blocked: only one of \`release/patch\`, \`release/minor\`, or \`release/major\` may be applied."
             exit 1
           fi
@@ -114,10 +115,12 @@ jobs:
         name: Resolve the live release policy
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           labels=$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")
           tags=$(git tag --list 'v*' | tr '\n' ' ')
-          node scripts/release/cli.mjs policy --labels "$labels" --head "$HEAD_REF" --tags "$tags"
+          prereleases=$(node scripts/release/cli.mjs prerelease-tags)
+          node scripts/release/cli.mjs policy --labels "$labels" --head "$HEAD_REF" --tags "$tags" --exclude "$prereleases"
       - name: Refuse to overwrite another pull request's release branch
         env:
           VERSION: ${{ steps.policy.outputs.version }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -60,10 +60,13 @@ jobs:
         with:
           node-version: 22
       - id: policy
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           labels=$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")
           tags=$(git tag --list 'v*' | tr '\n' ' ')
-          node scripts/release/cli.mjs policy --labels "$labels" --head candidate-source --tags "$tags"
+          prereleases=$(node scripts/release/cli.mjs prerelease-tags)
+          node scripts/release/cli.mjs policy --labels "$labels" --head candidate-source --tags "$tags" --exclude "$prereleases"
       - name: Match the committed release identity
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,11 @@ jobs:
         env:
           LABELS: ${{ steps.metadata.outputs.labels }}
           VERSION: ${{ steps.metadata.outputs.version }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           tags=$(git tag --list 'v*' | grep -vx "v$VERSION" | tr '\n' ' ' || true)
-          node scripts/release/cli.mjs policy --labels "$LABELS" --head stable-source --tags "$tags"
+          prereleases=$(node scripts/release/cli.mjs prerelease-tags)
+          node scripts/release/cli.mjs policy --labels "$LABELS" --head stable-source --tags "$tags" --exclude "$prereleases"
       - name: Match the committed release version
         env:
           COMMITTED: ${{ steps.metadata.outputs.version }}

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -11,6 +11,7 @@ import { assertReleaseAssets, releasePolicy } from "./pipeline.mjs";
 import {
   GitHubClient,
   reconcilePrerelease,
+  prereleaseTags,
   promotePrerelease,
   setCandidateStatuses,
   setCommitStatus,
@@ -39,11 +40,12 @@ export function resolveVersion({ tags, bump, version }) {
   return nextVersion(latestVersion(tags), bump);
 }
 
-export function resolvePolicy({ labels = "", head = "", tags = "" }) {
+export function resolvePolicy({ labels = "", head = "", tags = "", exclude = "" }) {
   return releasePolicy({
     labels: labels.split(",").map((label) => label.trim()).filter(Boolean),
     head,
     tags: tags.split(/\s+/).filter(Boolean),
+    exclude: exclude.split(/\s+/).filter(Boolean),
   });
 }
 
@@ -144,6 +146,10 @@ const commands = {
       state: values.state,
       targetUrl: values["target-url"] ?? "",
     });
+  },
+  async "prerelease-tags"() {
+    const tags = await prereleaseTags({ client: githubClient() });
+    process.stdout.write(`${tags.join(" ")}\n`);
   },
   async "promote-release"(values) {
     const { tag, promoted } = await promotePrerelease({

--- a/scripts/release/cli.test.mjs
+++ b/scripts/release/cli.test.mjs
@@ -54,3 +54,12 @@ test("requires an explicit true value before applying repository settings", () =
   assert.equal(configureApplyRequested({ apply: "true" }), true);
   assert.throws(() => configureApplyRequested({ apply: "yes" }), /true or false/);
 });
+
+test("policy resolution accepts a space-separated exclusion list", () => {
+  assert.equal(resolvePolicy({
+    labels: "release/minor",
+    head: "develop",
+    tags: "v1.5.0 v1.6.0",
+    exclude: "v1.6.0",
+  }).version, "1.6.0");
+});

--- a/scripts/release/github.mjs
+++ b/scripts/release/github.mjs
@@ -60,6 +60,10 @@ export class GitHubClient {
     });
   }
 
+  releases() {
+    return this.request(this.repoPath("/releases?per_page=100"));
+  }
+
   releaseByTag(tag) {
     return this.request(this.repoPath(`/releases/tags/${encodeURIComponent(tag)}`), { allowNotFound: true });
   }
@@ -164,6 +168,13 @@ export async function setCommitStatus({ client, sha, state, targetUrl = "", cont
 
 export async function setCandidateStatuses(options) {
   return Promise.all(requiredMainStatusContexts.map((context) => setCommitStatus({ ...options, context })));
+}
+
+// The tags of every release still marked as a prerelease. These are candidates that have not been
+// promoted, so they must not count toward the next version derivation.
+export async function prereleaseTags({ client }) {
+  const releases = await client.releases();
+  return (releases ?? []).filter((release) => release.prerelease).map((release) => release.tag_name);
 }
 
 // Promotion is the terminal transition for a candidate: the same release object and the same tag

--- a/scripts/release/github.mjs
+++ b/scripts/release/github.mjs
@@ -133,7 +133,9 @@ export async function reconcilePrerelease({ client, pr, version, sha, notes, ass
 
   const body = {
     tag_name: tag,
-    name: `${version} candidate`,
+    // The title is the stable one from the outset. Promotion is a state change on the same release,
+    // so nothing about how it reads should differ between the prerelease and the final release.
+    name: `v${version}`,
     body: releaseBody({ notes, pr, version }),
     draft: false,
     prerelease: true,

--- a/scripts/release/github.test.mjs
+++ b/scripts/release/github.test.mjs
@@ -248,3 +248,26 @@ test("prerelease tags list only unpromoted candidates", async () => {
   const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
   assert.deepEqual(await prereleaseTags({ client }), ["v1.6.0"]);
 });
+
+test("the candidate and the promoted release carry the same title", async () => {
+  const marker = candidateMarker({ pr: 132, version: "1.6.0", head: "release/1.6.0" });
+  const create = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(404, { message: "Not Found" }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(404, { message: "Not Found" }),
+    "POST /repos/jamezrin/lurkloot/releases": response(201, { id: 12, upload_url: "https://uploads/{?name,label}", assets: [] }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "t", fetchImpl: create.fetchImpl });
+  await reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "abc", notes: "n", assets: [] });
+  const created = JSON.parse(create.calls.find(({ method }) => method === "POST").init.body);
+
+  const promote = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: true, body: marker }),
+    "PATCH /repos/jamezrin/lurkloot/releases/12": response(200, { id: 12 }),
+  });
+  const client2 = new GitHubClient({ repository: "jamezrin/lurkloot", token: "t", fetchImpl: promote.fetchImpl });
+  await promotePrerelease({ client: client2, pr: 132, version: "1.6.0", notes: "n" });
+  const promoted = JSON.parse(promote.calls.find(({ method }) => method === "PATCH").init.body);
+
+  assert.equal(created.name, "v1.6.0");
+  assert.equal(created.name, promoted.name);
+});

--- a/scripts/release/github.test.mjs
+++ b/scripts/release/github.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   GitHubClient,
   reconcilePrerelease,
+  prereleaseTags,
   promotePrerelease,
   setCandidateStatuses,
   setCommitStatus,
@@ -234,4 +235,16 @@ test("a promoted release cannot be reopened by a later candidate build", async (
     () => reconcilePrerelease({ client, pr: 132, version: "1.6.0", sha: "abc", notes: "n", assets: [] }),
     /already promoted/,
   );
+});
+
+test("prerelease tags list only unpromoted candidates", async () => {
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/releases": response(200, [
+      { tag_name: "v1.6.0", prerelease: true },
+      { tag_name: "v1.5.0", prerelease: false },
+      { tag_name: "v1.4.0", prerelease: false },
+    ]),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  assert.deepEqual(await prereleaseTags({ client }), ["v1.6.0"]);
 });

--- a/scripts/release/pipeline.mjs
+++ b/scripts/release/pipeline.mjs
@@ -19,16 +19,20 @@ export function isGeneratedReleaseHead(head) {
   return generatedHead.test(head ?? "");
 }
 
-export function releasePolicy({ labels, head, tags }) {
+// `exclude` carries the tags of releases that are still prereleases. A candidate publishes vX.Y.Z
+// before the version is final, so that tag sits in the stable namespace while it is only a
+// candidate; counting it would make the next derivation skip a version. See version.mjs.
+export function releasePolicy({ labels, head, tags, exclude = [] }) {
   if (isGeneratedReleaseHead(head)) return { action: "ignore" };
   const label = selectReleaseLabel(labels);
   if (!label) return { action: "orphan" };
   const bump = label.slice("release/".length);
+  const stableTags = (tags ?? []).filter((tag) => !exclude.includes(tag));
   return {
     action: "prepare",
     bump,
     label,
-    version: nextVersion(latestVersion(tags ?? []), bump),
+    version: nextVersion(latestVersion(stableTags), bump),
   };
 }
 

--- a/scripts/release/pipeline.test.mjs
+++ b/scripts/release/pipeline.test.mjs
@@ -116,3 +116,30 @@ test("asset assertion rejects a version mismatch", () => {
     /unexpected release asset: lurkloot-1\.5\.0-chrome\.crx/,
   );
 });
+
+test("a prerelease tag never influences the next version", () => {
+  // The candidate publishes vX.Y.Z as a prerelease before the version is final, so that tag is in
+  // the v* namespace while it is still a candidate. Counting it would skip a version.
+  assert.deepEqual(releasePolicy({
+    labels: ["release/minor"],
+    head: "develop",
+    tags: ["v1.4.0", "v1.5.0", "v1.6.0"],
+    exclude: ["v1.6.0"],
+  }), { action: "prepare", bump: "minor", label: "release/minor", version: "1.6.0" });
+});
+
+test("excluding nothing leaves the derivation unchanged", () => {
+  assert.equal(releasePolicy({
+    labels: ["release/minor"],
+    head: "develop",
+    tags: ["v1.4.0", "v1.5.0"],
+    exclude: [],
+  }).version, "1.6.0");
+});
+
+test("recomputing after the candidate tag exists is stable", () => {
+  // validate computes 1.6.0 and publishes the v1.6.0 prerelease; cut must reach the same answer.
+  const at = (tags) => releasePolicy({ labels: ["release/minor"], head: "develop", tags, exclude: ["v1.6.0"] }).version;
+  assert.equal(at(["v1.5.0"]), "1.6.0");
+  assert.equal(at(["v1.5.0", "v1.6.0"]), "1.6.0");
+});

--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -21,8 +21,10 @@ export function nextVersion(current, bump) {
   return `${major}.${minor}.${patch + 1}`;
 }
 
-// Staging candidates and prereleases must never influence the next version, so a leftover
-// candidate tag cannot skew a bump.
+// Staging candidates and prereleases must never influence the next version. This function only
+// filters by tag shape, and a candidate is now published as `vX.Y.Z`, which is stable-shaped — so
+// that guarantee lives in `releasePolicy`, which excludes the tags of unpromoted prereleases before
+// calling here. Do not rely on the tag name alone to keep a candidate out of a bump.
 export function latestVersion(tags) {
   const versions = tags.filter((tag) => stable.test(tag)).map(parseVersion);
   if (versions.length === 0) return "0.0.0";


### PR DESCRIPTION
## Summary

Regression from #151. Moving the candidate tag from `candidate-vX.Y.Z` into the `vX.Y.Z` namespace broke the invariant documented at `version.mjs:23-24` — that a candidate must never influence the next version. That invariant was enforced solely by the tag name failing the `stable` regex at `version.mjs:1`; renaming the tag silently removed the enforcement and left the comment claiming it still held.

Observed: the label-time build published the `v1.6.0` prerelease at 09:04, creating a real `v1.6.0` tag. When #146 merged a minute later, `cut` recomputed the version, now saw `v1.6.0` among the stable tags, and produced **1.7.0** (#154). 1.6.0 was skipped while still an unpromoted prerelease.

The version is derived twice — once at label time, once at cut time — and the first derivation was creating a tag that changed the second answer.

- `releasePolicy` takes an `exclude` list and drops those tags before deriving.
- New `prerelease-tags` CLI command and `prereleaseTags` helper return the tags of releases still marked prerelease.
- All four derivation sites pass the exclusion: `prepare-release.yml` (validate and cut), `release-candidate.yml`, `release.yml`.
- The `version.mjs` comment now states where the guarantee actually lives, so the next person doesn't trust the tag shape.

## Test Plan

- [x] `pnpm check` passes: exit 0, 17 cws + 62 release script tests, 84 cli, 511 extension, site build
- [x] All three workflows parse
- [x] Regression test: deriving with `['v1.4.0','v1.5.0','v1.6.0']` and `v1.6.0` excluded yields 1.6.0, not 1.7.0
- [x] Stability test: derivation returns 1.6.0 both before and after the candidate tag exists

## Follow-up not in this PR

`v1.6.0` currently tags `5dc509a`, the develop head from the label-time build, whose `package.json` says 1.5.0 — the tag names a commit that does not contain the version it claims. The post-merge candidate build was meant to re-point it and never ran. See the cleanup notes on #154.

## Do not label this pull request

It targets `main`. A `release/*` label would make merging it cut a release branch off it.