### PR TITLE
fix(release): scope candidate ownership to the release branch

### DIFF
--- a/scripts/release/github.mjs
+++ b/scripts/release/github.mjs
@@ -108,10 +108,18 @@ export class GitHubClient {
 
 // The prerelease check is what stops a late candidate build from overwriting a release that has
 // already been promoted: promotion clears the flag, so every later reconcile against it fails here.
-function assertOwnedPrerelease(release, { pr, version }) {
+// A candidate belongs to its release branch, not to whichever pull request published it first.
+// Merge-first has two legitimate publishers: the labelled source pull request builds the candidate
+// at label time, and the generated release pull request rebuilds and promotes it after the cut.
+// Scoping ownership to `head` lets the second take over from the first while still rejecting a
+// release for another version, an unmarked release, and anything already promoted.
+function assertOwnedPrerelease(release, { version }) {
   const ownership = parseCandidateMarker(release.body);
-  if (!release.prerelease || ownership?.pr !== Number(pr) || ownership.version !== version) {
-    throw new Error(`refusing to modify v${version}: release is already promoted or owned by another pull request`);
+  if (!release.prerelease) {
+    throw new Error(`refusing to modify v${version}: release is already promoted`);
+  }
+  if (ownership?.version !== version || ownership.head !== `release/${version}`) {
+    throw new Error(`refusing to modify v${version}: release does not belong to release/${version}`);
   }
 }
 
@@ -126,7 +134,7 @@ export async function reconcilePrerelease({ client, pr, version, sha, notes, ass
   if (ref && !existingRelease && ref.object?.sha !== sha) {
     throw new Error(`refusing to recover ${tag}: it points to another commit`);
   }
-  if (existingRelease) assertOwnedPrerelease(existingRelease, { pr, version });
+  if (existingRelease) assertOwnedPrerelease(existingRelease, { version });
 
   if (existingRelease && !ref) await client.createRef(tag, sha);
   else if (existingRelease && ref.object?.sha !== sha) await client.updateRef(tag, sha);
@@ -188,12 +196,12 @@ export async function promotePrerelease({ client, pr, version, notes }) {
   if (!release) throw new Error(`cannot promote ${tag}: no candidate release exists`);
   if (!release.prerelease) {
     const ownership = parseCandidateMarker(release.body);
-    if (ownership?.pr !== Number(pr) || ownership.version !== version) {
-      throw new Error(`refusing to promote ${tag}: release is owned by another pull request`);
+    if (ownership?.version !== version || ownership.head !== `release/${version}`) {
+      throw new Error(`refusing to promote ${tag}: release does not belong to release/${version}`);
     }
     return { release, tag, promoted: false };
   }
-  assertOwnedPrerelease(release, { pr, version });
+  assertOwnedPrerelease(release, { version });
   const promoted = await client.updateRelease(release.id, {
     name: `v${version}`,
     body: notes.trim(),

--- a/scripts/release/github.test.mjs
+++ b/scripts/release/github.test.mjs
@@ -151,7 +151,7 @@ test("moves only an owned prerelease candidate", async () => {
 test("refuses stable or foreign candidate releases", async () => {
   for (const release of [
     { id: 12, prerelease: false, body: "" },
-    { id: 12, prerelease: true, body: candidateMarker({ pr: 999, version: "1.6.0", head: "release/1.6.0" }) },
+    { id: 12, prerelease: true, body: candidateMarker({ pr: 999, version: "1.7.0", head: "release/1.7.0" }) },
   ]) {
     const routes = recordingFetch({
       "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(200, { object: { sha: "old" } }),
@@ -201,15 +201,15 @@ test("promoting an already promoted release is a no-op", async () => {
   assert.ok(!routes.calls.some(({ method }) => method === "PATCH"));
 });
 
-test("refuses to promote a release owned by another pull request", async () => {
-  const marker = candidateMarker({ pr: 999, version: "1.6.0", head: "release/1.6.0" });
+test("refuses to promote a release belonging to another release branch", async () => {
+  const marker = candidateMarker({ pr: 999, version: "1.7.0", head: "release/1.7.0" });
   const routes = recordingFetch({
     "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: false, body: marker }),
   });
   const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
   await assert.rejects(
     () => promotePrerelease({ client, pr: 132, version: "1.6.0", notes: "notes" }),
-    /owned by another pull request/,
+    /does not belong to release\/1\.6\.0/,
   );
 });
 
@@ -270,4 +270,54 @@ test("the candidate and the promoted release carry the same title", async () => 
 
   assert.equal(created.name, "v1.6.0");
   assert.equal(created.name, promoted.name);
+});
+
+test("the generated release pull request may take over its source pull request's candidate", async () => {
+  // Merge-first has two legitimate publishers for one candidate: the labelled source pull request
+  // at label time, then the generated release pull request after the cut. Ownership is scoped to
+  // the release branch, which both agree on, not to whichever pull request published first.
+  const marker = candidateMarker({ pr: 156, version: "1.6.0", head: "release/1.6.0" });
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(200, { object: { sha: "abc" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: true, body: marker, assets: [] }),
+    "PATCH /repos/jamezrin/lurkloot/releases/12": response(200, { id: 12, assets: [], upload_url: "https://uploads/{?name,label}" }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "t", fetchImpl: routes.fetchImpl });
+  await reconcilePrerelease({ client, pr: 157, version: "1.6.0", sha: "abc", notes: "n", assets: [] });
+  assert.ok(routes.calls.some(({ method }) => method === "PATCH"));
+});
+
+test("the generated release pull request may promote its source pull request's candidate", async () => {
+  const marker = candidateMarker({ pr: 156, version: "1.6.0", head: "release/1.6.0" });
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: true, body: marker }),
+    "PATCH /repos/jamezrin/lurkloot/releases/12": response(200, { id: 12 }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "t", fetchImpl: routes.fetchImpl });
+  assert.equal((await promotePrerelease({ client, pr: 157, version: "1.6.0", notes: "n" })).promoted, true);
+});
+
+test("a candidate for another version is still refused", async () => {
+  const marker = candidateMarker({ pr: 156, version: "1.7.0", head: "release/1.7.0" });
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(200, { object: { sha: "abc" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: true, body: marker }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "t", fetchImpl: routes.fetchImpl });
+  await assert.rejects(
+    () => reconcilePrerelease({ client, pr: 157, version: "1.6.0", sha: "abc", notes: "n", assets: [] }),
+    /does not belong to release\/1\.6\.0/,
+  );
+});
+
+test("a release with no ownership marker is refused", async () => {
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/git/ref/tags/v1.6.0": response(200, { object: { sha: "abc" } }),
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, { id: 12, prerelease: true, body: "hand written" }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "t", fetchImpl: routes.fetchImpl });
+  await assert.rejects(
+    () => reconcilePrerelease({ client, pr: 157, version: "1.6.0", sha: "abc", notes: "n", assets: [] }),
+    /does not belong to release\/1\.6\.0/,
+  );
 });


### PR DESCRIPTION
## Summary

Blocks 1.6.0. Run [29681984766](https://github.com/jamezrin/lurkloot/actions/runs/29681984766) failed with:

```
refusing to modify v1.6.0: release is already promoted or owned by another pull request
```

`v1.6.0` was published at label time by #156 (the develop→main PR), so its ownership marker reads `{"pr":156,...}`. After #156 merged, `cut` created #157 (`release/1.6.0`), and that PR's candidate build was rejected as an intruder.

The old flow had exactly one publisher per candidate — the release PR — so binding ownership to a PR number was sound. Merge-first has **two** legitimate publishers for the same candidate: the labelled source PR at label time, then the generated release PR after the cut. #149 changed the number of publishers without revisiting the guard.

Promotion would have failed the same way, since `release.yml` passes `RELEASE_PR=#157` into the identical check.

The marker already carries `head: "release/1.6.0"`, which both publishers agree on. Ownership is now scoped to that — a candidate belongs to its release, not to whichever PR published it first.

Still refused: a release already promoted (now with its own distinct message), a release whose marker names a different release branch, and a release with no marker at all.

## Test Plan

- [x] `pnpm check` passes: exit 0, 17 cws + 67 release script tests, 84 cli, 511 extension, site build
- [x] New: the generated release PR can take over and promote its source PR's candidate
- [x] New: a candidate for another version, and an unmarked release, are still refused
- [x] Two legacy tests rescoped — their "foreign PR on the same release branch" fixtures described behaviour that is now legitimate, so they assert a genuinely foreign release branch instead

## After merging

`release/1.6.0` (#157) needs its candidate rebuilt. Pushing to that branch triggers the build with `trusted_ref` at the fixed `main`; re-running the failed job would reuse the old tooling and fail again.

## Do not label this pull request

It targets `main`. A `release/*` label would make merging it cut a release branch off it.