### PR TITLE
fix(release): drop the redundant release branch push trigger

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -4,20 +4,17 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
     branches: [main]
-  push:
-    branches: ['release/**']
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-candidate-controller-${{ github.event.pull_request.number || github.ref_name }}
+  group: release-candidate-controller-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   non-release:
     if: >-
-      github.event_name == 'pull_request_target' &&
       !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
@@ -42,7 +39,6 @@ jobs:
 
   resolve:
     if: >-
-      github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
@@ -92,60 +88,6 @@ jobs:
       trusted_ref: ${{ github.event.pull_request.base.sha }}
       version: ${{ needs.resolve.outputs.version }}
       pr_number: ${{ github.event.pull_request.number }}
-    secrets:
-      CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-  # A release branch push is the only candidate trigger that survives the release pull request being
-  # opened with GITHUB_TOKEN, which never dispatches workflow runs.
-  resolve-push:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      version: ${{ steps.identity.outputs.version }}
-      pr_number: ${{ steps.identity.outputs.pr_number }}
-      trusted_ref: ${{ steps.identity.outputs.trusted_ref }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 22
-      - id: identity
-        name: Match the committed release identity
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          version=${REF_NAME#release/}
-          test "$(node -p "require('./package.json').version")" = "$version"
-          release_pr=$(gh pr list --head "$REF_NAME" --base main --state open --limit 1 --json number --jq '.[0].number // ""')
-          test -n "$release_pr"
-          git fetch --no-tags origin main
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "pr_number=$release_pr" >> "$GITHUB_OUTPUT"
-          echo "trusted_ref=$(git rev-parse FETCH_HEAD)" >> "$GITHUB_OUTPUT"
-
-  preview-push:
-    needs: resolve-push
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-      statuses: write
-    uses: ./.github/workflows/build-release-candidate.yml
-    with:
-      ref: ${{ github.sha }}
-      trusted_ref: ${{ needs.resolve-push.outputs.trusted_ref }}
-      version: ${{ needs.resolve-push.outputs.version }}
-      pr_number: ${{ fromJSON(needs.resolve-push.outputs.pr_number) }}
     secrets:
       CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/superpowers/specs/2026-07-19-merge-first-release-flow-design.md
+++ b/docs/superpowers/specs/2026-07-19-merge-first-release-flow-design.md
@@ -215,3 +215,19 @@ End-to-end verification requires a real release cycle; `1.6.0` is the first one 
 `release/1.6.0` and its pull request [#148](https://github.com/jamezrin/lurkloot/pull/148) already exist,
 cut from `develop` under the old flow, and [#146](https://github.com/jamezrin/lurkloot/pull/146) is closed
 unmerged. Reconciling that state is a separate decision from this design and is not specified here.
+
+## Amendment, 2026-07-19: the push trigger was removed
+
+The `push` trigger on `release/**` described above was removed after one release cycle. It was added
+because a `GITHUB_TOKEN`-created pull request does not fire `opened`, so the release pull request
+would never receive its first candidate build. That gap is already closed by `cut` calling
+`build-release-candidate.yml` directly with the pull request number it just created.
+
+Every later push to the release branch also fires `pull_request_target: synchronize`, so both
+triggers started a build for the same commit. They carried different controller concurrency groups —
+keyed on the pull request number and on the ref name — so both were admitted, and only the inner
+`release-candidate-${version}` group cancelled one of them. The cancelled run's jobs then surfaced on
+the pull request as failing checks, on every release-branch push.
+
+The trigger covered no case that `cut` and `synchronize` do not already cover, so it was deleted
+rather than reconciled.


### PR DESCRIPTION
## Summary

Every push to a release branch produced a spurious set of failing checks on the release pull request — visible right now on #157 as `preview-push / verify`, `publish`, `gate`, `status` and `pending`.

They were not real failures. Run [29683297249](https://github.com/jamezrin/lurkloot/actions/runs/29683297249) was **cancelled**, and `gh pr checks` renders cancelled jobs as `fail`.

The cause is the `push` trigger on `release/**` added in #149. A push to the release branch also fires `pull_request_target: synchronize`, so two builds started for the same commit. Their controller concurrency groups differed — one keyed on the pull request number, one on the ref name — so both were admitted, and only the inner `release-candidate-${version}` group cancelled one.

The trigger covered no case that is not already covered. `cut` builds the initial candidate directly with the pull request number it just created, which was the actual fix for `GITHUB_TOKEN`-created pull requests not firing `opened`. Subsequent pushes fire `synchronize`. So the trigger is deleted rather than reconciled, along with the `resolve-push` / `preview-push` jobs and the `github.event_name` guards that only existed to keep the two paths apart.

The merge-first spec has an amendment recording why it went in and why it came out.

## Impact on #157

Not blocking — none of those contexts are required, so #157 is `MERGEABLE`/`UNSTABLE` and could merge as is. But the stale failed checks stay recorded on commit `750966f`. After this merges, one more push to `release/1.6.0` (merging `main` in) will re-run with only the pull request path and leave the checks clean.

## Test Plan

- [x] `pnpm release:test` passes (67 tests)
- [x] `release-candidate.yml` parses; trigger list is `['pull_request_target']` and the job graph is back to `non-release`, `resolve`, `preview`

## Do not label this pull request

It targets `main`. A `release/*` label would make merging it cut a release branch off it.