### PR TITLE
fix(release): survive a dirty workspace when syncing develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,10 @@ jobs:
           export GIT_CONFIG_COUNT=1
           export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
           export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth"
+          # Publication dirties the workspace before this runs: the site deploy installs wrangler on
+          # demand, which rewrites package.json. Synchronization switches branches, so it aborts on a
+          # dirty tree. Everything is already published by now, so tracked edits are discarded.
+          git restore --staged --worktree -- .
           node scripts/release/cli.mjs sync-branches --remote origin
       - name: Report stable publication
         run: >-

--- a/scripts/release/sync.mjs
+++ b/scripts/release/sync.mjs
@@ -33,6 +33,12 @@ export async function syncBranches({ cwd = process.cwd(), remote = "origin", ver
     return { mode: "already-contained", sha: (await git(cwd, "rev-parse", develop)).stdout.trim() };
   }
 
+  // Switching branches aborts on modified tracked files, and the publish job that calls this has
+  // already run steps that can rewrite the workspace. Fail with the offending paths rather than a
+  // bare git abort. Untracked files are ignored: the job leaves downloaded artifacts lying around.
+  const dirty = (await git(cwd, "status", "--porcelain", "--untracked-files=no")).stdout.trim();
+  if (dirty) throw new Error(`refusing to synchronize with a dirty working tree:\n${dirty}`);
+
   await git(cwd, "switch", "--detach", develop);
   await git(cwd, "config", "user.name", "Lurkloot Release Sync[bot]");
   await git(cwd, "config", "user.email", "release-sync@lurkloot.invalid");

--- a/scripts/release/sync.test.mjs
+++ b/scripts/release/sync.test.mjs
@@ -89,3 +89,31 @@ test("leaves remote develop unchanged when a merge conflicts", async () => {
   assert.equal(after, before);
   assert.equal(verified, false);
 });
+
+test("refuses to synchronize when tracked files are modified", async () => {
+  // The publish job installs wrangler on demand during the site deploy, which rewrites package.json
+  // in the workspace this runs in. A bare git abort was hard to diagnose, so name the paths.
+  const { seed } = await fixture();
+  await git(seed, "switch", "main");
+  await writeFile(join(seed, "shared.txt"), "main\n");
+  await git(seed, "commit", "-am", "main edit");
+  await git(seed, "push", "origin", "main");
+  await git(seed, "switch", "--detach", "origin/main");
+  await writeFile(join(seed, "shared.txt"), "dirtied by a previous step\n");
+  await assert.rejects(
+    syncBranches({ cwd: seed, verify: async () => {} }),
+    /dirty working tree[\s\S]*shared\.txt/,
+  );
+});
+
+test("untracked files do not block synchronization", async () => {
+  const { seed } = await fixture();
+  await git(seed, "switch", "main");
+  await writeFile(join(seed, "shared.txt"), "main\n");
+  await git(seed, "commit", "-am", "main edit");
+  await git(seed, "push", "origin", "main");
+  await git(seed, "switch", "--detach", "origin/main");
+  await writeFile(join(seed, "notes.md"), "left behind by publication\n");
+  const result = await syncBranches({ cwd: seed, verify: async () => {} });
+  assert.equal(result.mode, "fast-forward");
+});


### PR DESCRIPTION
## Summary

The 1.6.0 release published successfully but its final step failed — run [29683874883](https://github.com/jamezrin/lurkloot/actions/runs/29683874883):

```
release: Command failed: git switch --detach refs/remotes/origin/develop
error: Your local changes to the following files would be overwritten by checkout:
	package.json
```

`deploy-site` runs `npx wrangler`, finds it missing (`npx canceled due to missing packages`), and installs it — rewriting `package.json` in the workspace. `syncBranches` then switches branches in that same workspace and aborts.

This is a pre-existing latent bug, not a regression from the merge-first work: the step ordering predates it. No release had previously reached this far under this workflow generation, so it had never been exercised.

- `release.yml` discards tracked edits immediately before synchronizing. Everything is published by that point, so there is nothing worth keeping.
- `syncBranches` now refuses a dirty tree with the offending paths named, instead of surfacing a bare git abort. Untracked files are ignored, since the publish job leaves downloaded artifacts around by design.

## Impact on 1.6.0

None outstanding. The release is complete: `v1.6.0` is Latest with all five assets, GHCR carries `1.6.0`/`1.6`/`1`/`latest`, the site deployed, and I completed the `main`→`develop` sync by hand — `develop` is at 1.6.0 and level with `main` (`7a1cd73`), verified with a full `pnpm verify` first, matching what the automation would have run.

## Test Plan

- [x] `pnpm check` passes (exit 0), `release.yml` parses
- [x] New: a modified tracked file is refused with the path named
- [x] New: untracked leftovers do not block synchronization

## Do not label this pull request

It targets `main`. A `release/*` label would make merging it cut a release branch off it.