### PR TITLE
fix(release): isolate the wrangler install from the repository

### DIFF
--- a/.github/actions/deploy-site/action.yml
+++ b/.github/actions/deploy-site/action.yml
@@ -19,9 +19,39 @@ runs:
     - shell: bash
       working-directory: ${{ inputs.directory }}
       run: sha256sum -c SITE_SHA256SUMS
+    # wrangler-action reuses an existing wrangler and otherwise installs one. The artifact directory
+    # holds only built files, so package-manager detection finds no lockfile, falls back to npm, and
+    # npm resolves the install by walking up to the repository root -- rewriting its package.json.
+    # That rewrite broke the develop synchronisation at the end of the 1.6.0 release. Give the
+    # install a scratch directory outside the repository and deploy the artifact by absolute path.
+    - id: wrangler
+      shell: bash
+      env:
+        SITE_MANIFEST: ${{ github.workspace }}/packages/site/package.json
+      run: |
+        scratch="$RUNNER_TEMP/wrangler-deploy"
+        mkdir -p "$scratch"
+        printf '{"name":"lurkloot-deploy","private":true}\n' > "$scratch/package.json"
+        echo "directory=$scratch" >> "$GITHUB_OUTPUT"
+        # One source of truth for the version: whatever the site package pins, Renovate keeps current.
+        version=$(node -p "require('$SITE_MANIFEST').devDependencies.wrangler")
+        test -n "$version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
     - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
       with:
         apiToken: ${{ inputs.api_token }}
         accountId: ${{ inputs.account_id }}
-        workingDirectory: ${{ inputs.directory }}
-        command: pages deploy . --project-name=lurkloot --branch=${{ inputs.channel == 'production' && 'main' || 'next' }}
+        wranglerVersion: ${{ steps.wrangler.outputs.version }}
+        workingDirectory: ${{ steps.wrangler.outputs.directory }}
+        command: pages deploy ${{ github.workspace }}/${{ inputs.directory }} --project-name=lurkloot --branch=${{ inputs.channel == 'production' && 'main' || 'next' }}
+    # The deploy must not have touched the repository. Catch a regression here rather than three
+    # steps later, where it surfaces as an unrelated git failure.
+    - shell: bash
+      run: |
+        git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+        dirty=$(git status --porcelain --untracked-files=no)
+        if [ -n "$dirty" ]; then
+          echo "site deployment modified tracked files:" >&2
+          printf '%s\n' "$dirty" >&2
+          exit 1
+        fi


### PR DESCRIPTION
## Summary

Follow-up to #160, which cleaned up *after* this rather than preventing it.

We already use `cloudflare/wrangler-action`, SHA-pinned to v4. The problem was how it was pointed at the work. `workingDirectory` was the artifact directory — built files only, no `package.json`, no lockfile. So the action's package-manager detection found no lockfile, fell back to npm, could not find wrangler, and ran an install that **walked up to the repository root and rewrote `package.json`**. That is what broke `git switch` during the `develop` synchronisation at the end of the 1.6.0 release.

Per the action's docs: *"If you omit `wranglerVersion` and Wrangler is already installed in your environment, the action uses the existing installation."* It had nothing to reuse, so it installed.

- The install now gets a scratch directory under `RUNNER_TEMP` with its own minimal `package.json`, so npm never reaches the repository. The artifact is deployed by absolute path instead.
- `wranglerVersion` is passed from `packages/site/package.json`, keeping one source of truth that Renovate already maintains, rather than letting the action pick a default.
- A closing step asserts the deploy left no tracked file modified, so a regression fails here with the offending paths instead of surfacing several steps later as an unrelated git error.

This also tightens the boundary the action already documents: the deploy step no longer needs anything from the repository tree at all.

## What I could not verify locally

The action's behaviour cannot be exercised outside CI. Two specifics worth a reviewer's eye:

- `wranglerVersion` receives the declared range `^4.103.0` rather than a resolved version. npm accepts that form; if the action requires an exact version this is where it would fail.
- The scratch-directory approach assumes npm confines the install to the nearest `package.json`, which is the documented behaviour.

Both fail safe: the `prerelease` channel deploys on every release candidate, so this runs against `next.lurkloot.pages.dev` well before it ever runs against production.

## Test Plan

- [x] `pnpm check` passes (exit 0)
- [x] `action.yml` parses; step order verified
- [x] Version expression resolves against the site manifest
- [ ] Proven by the next candidate's prerelease deploy

## Do not label this pull request

It targets `main`. A `release/*` label would make merging it cut a release branch off it.