### PR TITLE
feat(core): accelerate Twitch reward handoff after a claim

### DIFF
--- a/docs/superpowers/plans/2026-07-19-twitch-claim-handoff.md
+++ b/docs/superpowers/plans/2026-07-19-twitch-claim-handoff.md
@@ -8,6 +8,22 @@
 
 **Tech Stack:** TypeScript, pnpm workspaces, Vitest (Node environment, globals enabled), React (popup UI), WXT (extension shell).
 
+> **As built — this plan was not followed exactly.** It is kept as the record of what was planned;
+> the spec describes the shipped design. Where they disagree, the spec is correct. Deviations:
+>
+> - `tick()` returns `ClaimedRewards` (reward ids per platform), not `Platform[]`. Task 4's contract
+>   is insufficient: seeding the "already claimed" set from the post-tick session marks the successor
+>   as claimed, and the loop never terminates.
+> - A fast path was added — when the triggering tick already selected the successor, the poll loop is
+>   skipped and only the heartbeat is brought forward.
+> - The `claimHandoffs` map is per-controller, not module-level, and its entry is reserved
+>   synchronously before the first await to close a duplicate-start and missed-abort race.
+> - The interval wait is capped at the remaining budget so a refresh cannot land past `maxSeconds`.
+> - The "nothing left" early exit covers `no_eligible_channel` as well as `campaign_ineligible`.
+> - `packages/cli/src/settings.ts` has its own explicit settings surface (interface, defaults, key
+>   allowlist, normalizer), so Task 8 required four edits there rather than the one templated line.
+> - `NumberSettingRow` gained a `disabled` prop, following `SelectSettingRow`'s existing pattern.
+
 **Conventions that apply to every task:**
 - Two-space indentation, double quotes, semicolons, camelCase functions/variables, `type` imports for types.
 - Conventional Commits, imperative mood, no trailing period.

--- a/docs/superpowers/plans/2026-07-19-twitch-claim-handoff.md
+++ b/docs/superpowers/plans/2026-07-19-twitch-claim-handoff.md
@@ -1,0 +1,1205 @@
+# Post-Claim Reward Handoff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a Twitch reward is claimed, run a bounded, abortable refresh loop that detects the next eligible reward and starts earning on it immediately, instead of waiting up to a minute for the fixed watch alarm.
+
+**Architecture:** A new `runClaimHandoff(platform)` in `packages/core/src/background/controller.ts` re-runs the existing scoped `tick([platform])` on a configurable interval until the session lands on a different reward, then fires one immediate tabless heartbeat. It runs outside the controller's state lock (each inner `tick()` takes the lock itself), is gated on a new `supportsPostClaimHandoff` adapter capability, and is bounded by a deadline computed once at start. Design: `docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md`.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Vitest (Node environment, globals enabled), React (popup UI), WXT (extension shell).
+
+**Conventions that apply to every task:**
+- Two-space indentation, double quotes, semicolons, camelCase functions/variables, `type` imports for types.
+- Conventional Commits, imperative mood, no trailing period.
+- Run tests with `pnpm test` from the repo root. To run a single file: `pnpm --filter @lurkloot/extension exec vitest run tests/<file> -t "<test name>"`.
+- `packages/core` must never import WXT or browser globals; `packages/extension/tests/coreBoundary.test.ts` enforces this.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `packages/shared/src/models.ts` | `EngineSettings` contract | Add 3 fields |
+| `packages/shared/src/settings.ts` | Defaults + normalization/clamping | Add 3 defaults, 3 merge lines |
+| `packages/core/src/platforms/adapter.ts` | `PlatformAdapter` contract | Add capability flag |
+| `packages/core/src/platforms/twitch/index.ts` | Twitch adapter | Declare capability |
+| `packages/core/src/background/controller.ts` | Handoff driver, abort map, triggers, `wait` dep | Main implementation |
+| `packages/cli/src/config.ts` | JSONC config template | Add 3 entries |
+| `packages/popup-ui/src/settings.tsx` | Advanced settings UI | Add 3 rows |
+| `packages/locales/messages/*.json` (10 files) | UI copy | Add 6 keys each |
+| `packages/extension/tests/settings.test.ts` | Clamping coverage | Add cases |
+| `packages/extension/tests/backgroundController.test.ts` | Handoff behavior coverage | Add suite |
+
+Tasks 1–2 are pure contract/settings work with no behavior. Task 3 adds the capability. Tasks 4–8 build the handoff incrementally, each with its own failing test first. Tasks 9–10 are configuration surfaces.
+
+---
+
+## Task 1: Engine settings fields, defaults, and clamping
+
+**Files:**
+- Modify: `packages/shared/src/models.ts:261`
+- Modify: `packages/shared/src/settings.ts:60`, `packages/shared/src/settings.ts:134`
+- Test: `packages/extension/tests/settings.test.ts:111`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/extension/tests/settings.test.ts`, add a new test after the existing `"clamps persisted numeric settings to browser-safe ranges"` test (which ends around line 118):
+
+```typescript
+  it("clamps post-claim handoff settings and defaults them when absent", () => {
+    expect(mergeSettings({}).postClaimHandoff).toBe(true);
+    expect(mergeSettings({}).postClaimHandoffIntervalSeconds).toBe(5);
+    expect(mergeSettings({}).postClaimHandoffMaxSeconds).toBe(45);
+
+    expect(mergeSettings({ postClaimHandoffIntervalSeconds: 0 }).postClaimHandoffIntervalSeconds).toBe(1);
+    expect(mergeSettings({ postClaimHandoffIntervalSeconds: 99 }).postClaimHandoffIntervalSeconds).toBe(30);
+    expect(mergeSettings({ postClaimHandoffMaxSeconds: 1 }).postClaimHandoffMaxSeconds).toBe(5);
+    expect(mergeSettings({ postClaimHandoffMaxSeconds: 999 }).postClaimHandoffMaxSeconds).toBe(120);
+
+    expect(mergeSettings({ postClaimHandoffIntervalSeconds: Number.NaN }).postClaimHandoffIntervalSeconds)
+      .toBe(DEFAULT_SETTINGS.postClaimHandoffIntervalSeconds);
+    expect(mergeSettings({ postClaimHandoffMaxSeconds: Number.NaN }).postClaimHandoffMaxSeconds)
+      .toBe(DEFAULT_SETTINGS.postClaimHandoffMaxSeconds);
+    expect(mergeSettings({ postClaimHandoff: false }).postClaimHandoff).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/settings.test.ts -t "clamps post-claim handoff"`
+
+Expected: FAIL. TypeScript will report that `postClaimHandoff` does not exist on the settings type.
+
+- [ ] **Step 3: Add the fields to the engine contract**
+
+In `packages/shared/src/models.ts`, replace lines 261-262:
+
+```typescript
+  offlineRetryLimit: number;
+  pollIntervalMinutes: number;
+```
+
+with:
+
+```typescript
+  offlineRetryLimit: number;
+  pollIntervalMinutes: number;
+  // Bounded post-claim handoff. After a reward is claimed, re-run discovery for
+  // that platform on this cadence until the next eligible reward appears, then
+  // transmit immediately instead of waiting for the fixed one-minute watch
+  // alarm. Only platforms whose adapter sets supportsPostClaimHandoff use it.
+  postClaimHandoff: boolean;
+  postClaimHandoffIntervalSeconds: number;
+  postClaimHandoffMaxSeconds: number;
+```
+
+- [ ] **Step 4: Add the defaults**
+
+In `packages/shared/src/settings.ts`, replace lines 60-61:
+
+```typescript
+  offlineRetryLimit: 3,
+  pollIntervalMinutes: 1,
+```
+
+with:
+
+```typescript
+  offlineRetryLimit: 3,
+  pollIntervalMinutes: 1,
+  postClaimHandoff: true,
+  // Nine refreshes at most, always finishing before the next one-minute watch
+  // alarm so the handoff and the alarm never contend for the same heartbeat.
+  postClaimHandoffIntervalSeconds: 5,
+  postClaimHandoffMaxSeconds: 45,
+```
+
+- [ ] **Step 5: Add the normalization**
+
+In `packages/shared/src/settings.ts`, replace line 136 (the `pollIntervalMinutes` line inside `mergeEngineSettings`) so the block reads:
+
+```typescript
+    // chrome.alarms floors periodInMinutes at 1, so sub-minute values are inert.
+    pollIntervalMinutes: clampNumber(value?.pollIntervalMinutes, 1, 60, DEFAULT_ENGINE_SETTINGS.pollIntervalMinutes),
+    postClaimHandoff: booleanOr(value?.postClaimHandoff, DEFAULT_ENGINE_SETTINGS.postClaimHandoff),
+    postClaimHandoffIntervalSeconds: clampInteger(value?.postClaimHandoffIntervalSeconds, 1, 30, DEFAULT_ENGINE_SETTINGS.postClaimHandoffIntervalSeconds),
+    postClaimHandoffMaxSeconds: clampInteger(value?.postClaimHandoffMaxSeconds, 5, 120, DEFAULT_ENGINE_SETTINGS.postClaimHandoffMaxSeconds),
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/settings.test.ts`
+
+Expected: PASS, all tests in the file.
+
+- [ ] **Step 7: Typecheck the workspace**
+
+Run: `pnpm typecheck`
+
+Expected: exit 0. If `packages/cli` fails because `DEFAULT_CLI_SETTINGS` is built from `DEFAULT_ENGINE_SETTINGS` by spread, no change is needed — it inherits the new fields. If it fails for another reason, fix it before committing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/shared/src/models.ts packages/shared/src/settings.ts packages/extension/tests/settings.test.ts
+git commit -m "feat(settings): add post-claim handoff engine settings"
+```
+
+---
+
+## Task 2: Adapter capability flag
+
+**Files:**
+- Modify: `packages/core/src/platforms/adapter.ts:56`
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/extension/tests/adapters.test.ts`, add this test inside the `describe("TwitchAdapter", ...)` block. Both adapters accept a bare fetcher (see line 666, `new TwitchAdapter(fetcher)`, and line 136, `new KickAdapter(fetcher)`), so reuse the `fetcher` fixture already in scope there:
+
+```typescript
+  it("declares the post-claim handoff capability for Twitch only", () => {
+    expect(new TwitchAdapter(fetcher).supportsPostClaimHandoff).toBe(true);
+    expect(new KickAdapter(fetcher).supportsPostClaimHandoff).toBeUndefined();
+  });
+```
+
+`KickAdapter` is already imported at line 3 of that file, so no new import is needed.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/adapters.test.ts -t "post-claim handoff capability"`
+
+Expected: FAIL — `supportsPostClaimHandoff` is not a property of `PlatformAdapter`.
+
+- [ ] **Step 3: Add the capability to the adapter contract**
+
+In `packages/core/src/platforms/adapter.ts`, after line 57 (`createTablessWatcher?(): TablessWatchController;`) and before the closing brace of `PlatformAdapter`:
+
+```typescript
+  // Whether a bounded post-claim refresh is worthwhile on this platform. Twitch
+  // only reveals the next reward in a campaign chain on a subsequent inventory
+  // read, so re-polling recovers watch time the fixed alarm would otherwise
+  // waste. Kick's tabless watcher holds a persistent viewer socket and paces
+  // its own sends, so it has no equivalent dead minute to recover.
+  supportsPostClaimHandoff?: boolean;
+```
+
+- [ ] **Step 4: Declare it on the Twitch adapter**
+
+In `packages/core/src/platforms/twitch/index.ts`, `supportsTabless = true;` is a plain class property on line 710. Add directly beneath it:
+
+```typescript
+  supportsPostClaimHandoff = true;
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/adapters.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/platforms/adapter.ts packages/core/src/platforms/twitch/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "feat(core): add post-claim handoff adapter capability"
+```
+
+---
+
+## Task 3: Injectable `wait` dependency
+
+The handoff sleeps between refreshes. Real `setTimeout` would make every test in Task 5 onward slow and flaky, so the delay becomes an injectable dependency first. This task adds it with no caller — Task 5 is the first consumer.
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts:106` (end of `BackgroundControllerDeps`)
+
+- [ ] **Step 1: Add the dependency to the interface**
+
+In `packages/core/src/background/controller.ts`, inside `BackgroundControllerDeps`, after the `stopPageContextTabs?` field (line 106) and before the closing brace:
+
+```typescript
+  // Delay used by the bounded post-claim handoff. Injected so tests can drive
+  // the loop deterministically instead of racing real timers. Resolves early
+  // (without throwing) when the signal aborts, so callers check `signal.aborted`
+  // after awaiting rather than catching.
+  wait?(ms: number, signal: AbortSignal): Promise<void>;
+```
+
+- [ ] **Step 2: Add the default implementation**
+
+In `packages/core/src/background/controller.ts`, immediately after the `createBackgroundController` function opens (after line 111, `const reportedCompatibilityWarnings = new Set<string>();`), add:
+
+```typescript
+  const wait: NonNullable<BackgroundControllerDeps<S>["wait"]> = deps.wait ?? ((ms, signal) => new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  }));
+```
+
+- [ ] **Step 3: Verify nothing broke**
+
+Run: `pnpm typecheck && pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts`
+
+Expected: typecheck exit 0; all existing controller tests PASS. The new `wait` is unused so far, which is expected. If your linter fails on the unused binding, leave the commit for Task 4 and continue — Task 4 consumes it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts
+git commit -m "refactor(core): inject the controller delay used by the claim handoff"
+```
+
+---
+
+## Task 4: `tick()` reports which platforms claimed
+
+The handoff needs to know a claim happened. `tick()` already runs inside `withEventCollector` and sees every emitted event, so it can collect the platforms that produced a `reward_claimed` activity event and return them. Its signature changes from `Promise<void>` to `Promise<Platform[]>`; all existing call sites ignore the value and keep compiling.
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts:359-401`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/extension/tests/backgroundController.test.ts`, add this test inside the top-level `describe("background controller", ...)` block:
+
+```typescript
+  it("reports the platforms that claimed a reward from tick", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: true });
+    env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
+
+    const claimed = await env.controller.tick();
+
+    expect(claimed).toEqual(["twitch"]);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts -t "reports the platforms that claimed"`
+
+Expected: FAIL — `claimed` is `undefined`, not `["twitch"]`.
+
+- [ ] **Step 3: Return claimed platforms from tick**
+
+In `packages/core/src/background/controller.ts`, change the `tick` signature on line 359 from:
+
+```typescript
+  async function tick(platforms?: Platform[], options?: { forcePaused?: boolean }): Promise<void> {
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+```
+
+to:
+
+```typescript
+  async function tick(platforms?: Platform[], options?: { forcePaused?: boolean }): Promise<Platform[]> {
+    const claimedPlatforms = new Set<Platform>();
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+```
+
+Inside that closure, the scheduler is invoked with an `emit` that is passed through to `runSchedulerTick`. Wrap it so claims are observed. Replace the `runSchedulerTick` call (lines 373-378) with:
+
+```typescript
+        const claimObservingEmit: EventEmitter = (event) => {
+          if (event.category === "activity" && event.code === "reward_claimed" && event.platform) {
+            claimedPlatforms.add(event.platform);
+          }
+          emit(event);
+        };
+        const result = await runSchedulerTick(state, settings, adapters, {
+          ...(platforms ? { platforms } : {}),
+          stopPageContextTabs: deps.stopPageContextTabs,
+          waitingClaimRewardIds: nextWaitingClaimRewardIds,
+          emit: claimObservingEmit,
+        });
+```
+
+In the `catch` block (line 385), the tick failed and any partial claim set is not actionable, so add as its first statement:
+
+```typescript
+        claimedPlatforms.clear();
+```
+
+Then change the end of the function (line 401) from:
+
+```typescript
+    }));
+  }
+```
+
+to:
+
+```typescript
+    }));
+    return [...claimedPlatforms];
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts`
+
+Expected: PASS, including all pre-existing controller tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(core): report claimed platforms from the scheduler tick"
+```
+
+---
+
+## Task 5: The bounded handoff loop
+
+This is the core of the feature: the loop, the abort map, the deadline, and the stop conditions. The immediate heartbeat is deliberately deferred to Task 6 so this task's tests isolate loop control from transmission.
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+- [ ] **Step 1: Add the test harness helper**
+
+In `packages/extension/tests/backgroundController.test.ts`, add this helper next to the existing `tablessEnv` helper (around line 1721). It gives tests a `wait` they advance by hand:
+
+```typescript
+  function manualWait() {
+    const pending: Array<() => void> = [];
+    const wait = vi.fn(async (_ms: number, signal: AbortSignal) => {
+      if (signal.aborted) return;
+      await new Promise<void>((resolve) => {
+        pending.push(resolve);
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    // Releases every currently-parked wait and yields so the loop can advance.
+    const flush = async () => {
+      for (const resolve of pending.splice(0)) resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+    return { wait, flush, get parked() { return pending.length; } };
+  }
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`harness` must accept the injected `wait`. First extend `harness`'s `overrides` parameter (line 55) from:
+
+```typescript
+  overrides: {
+    saveState?: (state: SchedulerState) => Promise<void>;
+    reportEvents?: (events: readonly EngineEvent[]) => Promise<void>;
+  } = {},
+```
+
+to:
+
+```typescript
+  overrides: {
+    saveState?: (state: SchedulerState) => Promise<void>;
+    reportEvents?: (events: readonly EngineEvent[]) => Promise<void>;
+    wait?: (ms: number, signal: AbortSignal) => Promise<void>;
+  } = {},
+```
+
+and add `wait: overrides.wait,` to the `deps` object literal (after `reportEvents`, around line 90).
+
+Then add this suite at the end of `describe("background controller", ...)`:
+
+```typescript
+  describe("post-claim handoff", () => {
+    // Twitch-only environment whose adapter opts into the handoff and whose
+    // campaign yields a claimable reward on the first pass.
+    function handoffEnv(overrides: Partial<ExtensionSettings> = {}) {
+      const timer = manualWait();
+      const env = harness({
+        ...DEFAULT_SETTINGS,
+        running: true,
+        autoClaim: true,
+        platform: {
+          ...DEFAULT_SETTINGS.platform,
+          kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false, watchQueueChannels: [] },
+        },
+        ...overrides,
+      }, { wait: timer.wait });
+      env.twitch.supportsPostClaimHandoff = true;
+      return { ...env, timer };
+    }
+
+    // A campaign whose first reward is claimable and whose second reward only
+    // becomes visible on a later inventory read — the exact Twitch behavior the
+    // handoff exists to absorb.
+    function chainedCampaign(revealSecond: boolean): DropCampaign {
+      const first: DropReward = { id: "reward-1", name: "First", requiredMinutes: 60, watchedMinutes: 60, status: "claimable" };
+      const second: DropReward = { id: "reward-2", name: "Second", requiredMinutes: 60, watchedMinutes: 0, status: "in_progress" };
+      return {
+        id: "twitch-campaign",
+        platform: "twitch",
+        name: "twitch campaign",
+        status: "active",
+        rewards: revealSecond ? [first, second] : [first],
+      };
+    }
+
+    it("starts earning the next reward before the next heartbeat alarm", async () => {
+      const env = handoffEnv();
+      let reveal = false;
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      reveal = true;
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.state.sessions.twitch.rewardId).toBe("reward-2");
+    });
+
+    it("stops at the deadline when no next reward appears", async () => {
+      const env = handoffEnv({ postClaimHandoffIntervalSeconds: 5, postClaimHandoffMaxSeconds: 15 });
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      for (let index = 0; index < 10; index += 1) await env.timer.flush();
+      await handoff;
+
+      // 15s budget at a 5s interval is three refreshes, never ten.
+      expect(env.timer.wait.mock.calls.length).toBeLessThanOrEqual(3);
+      expect(env.deps.createAlarm).not.toHaveBeenCalled();
+    });
+
+    it("exits early when the platform has no eligible reward left", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => []);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it("aborts in flight when farming stops", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      await Promise.resolve();
+      env.controller.abortClaimHandoffs();
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.parked).toBe(0);
+      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    });
+
+    it("does not run for a platform without the capability", async () => {
+      const env = handoffEnv();
+      env.twitch.supportsPostClaimHandoff = undefined;
+
+      await env.controller.runClaimHandoff("twitch");
+
+      expect(env.timer.wait).not.toHaveBeenCalled();
+    });
+
+    it("does not run when the setting is disabled", async () => {
+      const env = handoffEnv({ postClaimHandoff: false });
+
+      await env.controller.runClaimHandoff("twitch");
+
+      expect(env.timer.wait).not.toHaveBeenCalled();
+    });
+  });
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts -t "post-claim handoff"`
+
+Expected: FAIL — `env.controller.runClaimHandoff is not a function`.
+
+- [ ] **Step 4: Implement the handoff**
+
+In `packages/core/src/background/controller.ts`, add near the other module-level state (next to `stateMutation`, around line 65):
+
+```typescript
+// In-flight post-claim handoffs, one per platform. A claim arriving while a
+// handoff is already running for that platform is absorbed by the running loop
+// rather than starting a second one, which is what keeps the work bounded.
+const claimHandoffs = new Map<Platform, AbortController>();
+```
+
+Then add these two functions inside `createBackgroundController`, immediately after `runWatchHeartbeat` (after line 592):
+
+```typescript
+  // Aborts every in-flight handoff. Called when farming stops, when a settings
+  // session begins, and on runtime restart.
+  function abortClaimHandoffs(): void {
+    for (const controller of claimHandoffs.values()) controller.abort();
+    claimHandoffs.clear();
+  }
+
+  // Bounded post-claim handoff (see docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md).
+  // Re-runs a scoped tick on the configured cadence until the platform lands on
+  // a reward other than the ones just claimed, then hands off to the immediate
+  // heartbeat. Runs OUTSIDE the state lock: each inner tick() acquires the lock
+  // on its own, so a long handoff never blocks telemetry or user actions.
+  async function runClaimHandoff(platform: Platform): Promise<void> {
+    if (claimHandoffs.has(platform)) return;
+    const settings = await deps.loadSettings();
+    if (!settings.postClaimHandoff || !settings.running) return;
+    if (!settings.platform[platform].enabled) return;
+
+    const adapters = createAdapters(settings, () => undefined);
+    if (!adapters[platform].supportsPostClaimHandoff) return;
+
+    const before = await deps.loadState();
+    const claimedRewardIds = new Set<string>();
+    const startingRewardId = before.sessions[platform].rewardId;
+    if (startingRewardId) claimedRewardIds.add(startingRewardId);
+
+    const abort = new AbortController();
+    claimHandoffs.set(platform, abort);
+    // The deadline is computed once. A claim occurring inside the loop never
+    // extends it, so the worst case stays fixed at maxSeconds.
+    const deadline = Date.now() + settings.postClaimHandoffMaxSeconds * 1000;
+    const intervalMs = settings.postClaimHandoffIntervalSeconds * 1000;
+
+    try {
+      while (!abort.signal.aborted && Date.now() < deadline) {
+        await wait(intervalMs, abort.signal);
+        if (abort.signal.aborted) break;
+
+        const claimed = await tick([platform]);
+        for (const claimedPlatform of claimed) {
+          if (claimedPlatform !== platform) continue;
+          const rewardId = (await deps.loadState()).sessions[platform].rewardId;
+          if (rewardId) claimedRewardIds.add(rewardId);
+        }
+        if (abort.signal.aborted) break;
+
+        const session = (await deps.loadState()).sessions[platform];
+        if (session.status === "watching" && session.rewardId && !claimedRewardIds.has(session.rewardId)) {
+          await sendImmediateHeartbeat(platform, session);
+          return;
+        }
+        // Nothing eligible left on this platform: the chain is finished, so stop
+        // rather than burning the rest of the budget on identical refreshes.
+        if (session.status !== "watching" && session.reasonCode === "campaign_ineligible") return;
+      }
+    } finally {
+      if (claimHandoffs.get(platform) === abort) claimHandoffs.delete(platform);
+    }
+  }
+```
+
+Add a temporary stub for the heartbeat, which Task 6 replaces:
+
+```typescript
+  // Replaced with the real immediate heartbeat in Task 6.
+  async function sendImmediateHeartbeat(_platform: Platform, _session: WatchSession): Promise<void> {
+    return;
+  }
+```
+
+Finally, export both from the controller's return object (line 955), so it reads:
+
+```typescript
+  return {
+    ensureAlarm,
+    handleStartup,
+    handleTabRemoved,
+    handleMessage,
+    beginSettingsSession,
+    endSettingsSession,
+    captureTwitchIntegrity,
+    tick,
+    runWatchHeartbeat,
+    runClaimHandoff,
+    abortClaimHandoffs,
+  };
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts`
+
+Expected: PASS, including all pre-existing controller tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(core): add the bounded post-claim reward handoff loop"
+```
+
+---
+
+## Task 6: Immediate tabless heartbeat on success
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts` (replaces the Task 5 stub)
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these to the `describe("post-claim handoff", ...)` block. They need a tabless watcher, so they combine `handoffEnv` with the existing `fakeTablessWatcher` helper:
+
+```typescript
+    it("sends one immediate heartbeat when the next reward starts tablessly", async () => {
+      const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
+      const env = handoffEnv({ tablessMode: true });
+      env.twitch.supportsTabless = true;
+      env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
+      let reveal = false;
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      reveal = true;
+      await env.timer.flush();
+      await handoff;
+
+      expect(watcher.tick).toHaveBeenCalledTimes(1);
+      expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
+    });
+
+    it("skips the immediate heartbeat when one just landed on the same channel", async () => {
+      const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
+      const env = handoffEnv({ tablessMode: true });
+      env.twitch.supportsTabless = true;
+      env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
+      let reveal = false;
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+
+      // Establish the tabless session and land a heartbeat seconds ago.
+      await env.controller.tick();
+      await env.controller.runWatchHeartbeat();
+      watcher.tick.mockClear();
+
+      reveal = true;
+      const handoff = env.controller.runClaimHandoff("twitch");
+      await env.timer.flush();
+      await handoff;
+
+      expect(watcher.tick).not.toHaveBeenCalled();
+    });
+
+    it("sends no heartbeat when the next reward runs in a visible tab", async () => {
+      const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
+      const env = handoffEnv({ tablessMode: false });
+      env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
+      let reveal = false;
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      reveal = true;
+      await env.timer.flush();
+      await handoff;
+
+      expect(watcher.tick).not.toHaveBeenCalled();
+      // The tick that detected the successor already re-pointed the tab.
+      expect(env.state.sessions.twitch.rewardId).toBe("reward-2");
+      expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
+    });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts -t "immediate heartbeat"`
+
+Expected: FAIL — the stub sends nothing, so `watcher.tick` is never called in the first test.
+
+- [ ] **Step 3: Implement the immediate heartbeat**
+
+In `packages/core/src/background/controller.ts`, replace the Task 5 stub with:
+
+```typescript
+  // How recently a heartbeat must have landed for the handoff to consider the
+  // channel already covered. Half the fixed one-minute alarm period: long
+  // enough to suppress a genuine double-send, short enough that a real handoff
+  // still transmits.
+  const RECENT_HEARTBEAT_MS = 30_000;
+
+  // Transmits one heartbeat for a freshly-selected tabless target instead of
+  // waiting for the next watch alarm. A visible tab needs nothing: it earns
+  // progress continuously and the detecting tick already re-pointed it.
+  async function sendImmediateHeartbeat(platform: Platform, session: WatchSession): Promise<void> {
+    if (session.watchMode !== "tabless") return;
+    const watcher = tablessWatchers.get(platform);
+    if (!watcher) return;
+
+    // A channel switch always transmits: lastHeartbeatAt then refers to the
+    // previous target, so its recency says nothing about the new one.
+    const sameChannel = watcher.channelUrl != null && watcher.channelUrl === session.channel?.url;
+    const lastHeartbeatAt = session.lastHeartbeatAt ? Date.parse(session.lastHeartbeatAt) : Number.NaN;
+    const recent = !Number.isNaN(lastHeartbeatAt) && Date.now() - lastHeartbeatAt < RECENT_HEARTBEAT_MS;
+    if (sameChannel && recent) return;
+
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      let ok = false;
+      let message: string | undefined;
+      drainWatcherEvents(watcher, emit);
+      try {
+        const result = await watcher.tick(tablessWatchContext());
+        ok = result.ok;
+        message = result.message;
+      } catch (error) {
+        message = error instanceof Error ? error.message : "Post-claim heartbeat failed";
+      } finally {
+        drainWatcherEvents(watcher, emit);
+      }
+
+      const state = await deps.loadState();
+      const current = state.sessions[platform];
+      const nextState: SchedulerState = {
+        ...state,
+        sessions: {
+          ...state.sessions,
+          [platform]: {
+            ...current,
+            lastHeartbeatAt: new Date().toISOString(),
+            lastHeartbeatOk: ok,
+            heartbeatChecks: ok ? 0 : (current.heartbeatChecks ?? 0) + 1,
+          },
+        },
+      };
+      emit({
+        category: "diagnostic",
+        platform,
+        level: ok ? "debug" : "warn",
+        message: ok
+          ? "Post-claim handoff started the next reward without waiting for the watch alarm"
+          : message ?? "Post-claim heartbeat failed",
+      });
+      await persistAndReport(nextState, events);
+    }));
+  }
+```
+
+Note the lock discipline: `runClaimHandoff` holds no lock when it calls this, and `tick()` has already released its own, so acquiring here is safe and non-reentrant.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(core): transmit immediately when the post-claim handoff finds a reward"
+```
+
+---
+
+## Task 7: Wire the triggers and aborts
+
+The handoff exists but nothing starts it. This task connects it to automatic claims, manual claims, and the lifecycle events that must cancel it.
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts:289-360`, `:594-604`, `:804`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `describe("post-claim handoff", ...)` block:
+
+```typescript
+    it("starts a handoff after an automatic claim", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.tickAndHandOff();
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.wait).toHaveBeenCalled();
+    });
+
+    it("does not start a nested handoff for a claim inside a handoff", async () => {
+      const env = handoffEnv({ postClaimHandoffIntervalSeconds: 5, postClaimHandoffMaxSeconds: 15 });
+      // Every refresh yields another claimable reward, which would restart the
+      // deadline forever if nesting were allowed.
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      for (let index = 0; index < 10; index += 1) await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.wait.mock.calls.length).toBeLessThanOrEqual(3);
+    });
+
+    it("aborts running handoffs when a settings session begins", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      await Promise.resolve();
+      await env.controller.beginSettingsSession();
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.parked).toBe(0);
+    });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts -t "handoff"`
+
+Expected: FAIL — `env.controller.tickAndHandOff is not a function`.
+
+- [ ] **Step 3: Add the combined entry point**
+
+In `packages/core/src/background/controller.ts`, immediately after `runClaimHandoff`, add:
+
+```typescript
+  // The normal entry point for alarm- and message-driven ticks: run the tick,
+  // then hand off for every platform that claimed. Kept separate from tick() so
+  // the handoff's own inner ticks cannot recurse into another handoff.
+  async function tickAndHandOff(platforms?: Platform[]): Promise<void> {
+    const claimed = await tick(platforms);
+    for (const platform of claimed) await runClaimHandoff(platform);
+  }
+```
+
+Recursion is structurally impossible: `runClaimHandoff` calls `tick()`, never `tickAndHandOff()`, and its `claimHandoffs.has(platform)` guard rejects a second entry for the same platform.
+
+- [ ] **Step 4: Route the alarm and message paths through it**
+
+In `packages/core/src/background/controller.ts`, replace `await tick();` with `await tickAndHandOff();` at these call sites, which are the ones driven by the alarm or by user action:
+
+- line 330 (the alarm handler inside `handleMessage`/`handleAlarm`)
+- line 840 and line 854 (`if (settings.running) await tick();`)
+- line 860-861 (`tickAfterSave`) — becomes `await tickAndHandOff(message.tickAfterSavePlatforms);`
+- line 889-890 (`tickNow`)
+
+Leave these call sites on plain `tick()`:
+
+- lines 289-309 (`ensureAlarm` / `handleStartup`) — a restart should not fire a handoff.
+- line 590 (`runWatchHeartbeat`'s fallback tick) — a heartbeat fallback is not a claim.
+- line 596 (`beginSettingsSession`'s `forcePaused` tick) — this pauses, it does not claim.
+
+- [ ] **Step 5: Trigger from the manual claim path**
+
+The manual claim lives in `claimRewardNow` (line 714). Its `withStateLock(...)` closes on line 805 and is followed by `return snapshot();` on line 806, so the handoff goes between them — after the lock is released, never inside it.
+
+In `packages/core/src/background/controller.ts`, change the opening of `claimRewardNow` from:
+
+```typescript
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+```
+
+to:
+
+```typescript
+    let claimedManually = false;
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+```
+
+Inside the `try` block, line 751 reads `const claimed = await createAdapters(settings, emit)[message.platform].claimReward(campaign, reward);`. Directly beneath it add:
+
+```typescript
+        claimedManually = claimed;
+```
+
+Then change the end of the function from:
+
+```typescript
+      await persistAndReport(stateWithCampaigns, events);
+    }));
+    return snapshot();
+  }
+```
+
+to:
+
+```typescript
+      await persistAndReport(stateWithCampaigns, events);
+    }));
+    if (claimedManually) await runClaimHandoff(message.platform);
+    return snapshot();
+  }
+```
+
+- [ ] **Step 6: Abort on the lifecycle events**
+
+In `packages/core/src/background/controller.ts`:
+
+In `beginSettingsSession` (line 594), add `abortClaimHandoffs();` as its first statement:
+
+```typescript
+  async function beginSettingsSession(): Promise<void> {
+    abortClaimHandoffs();
+    settingsPauseCount += 1;
+    if (settingsPauseCount === 1) await tick(undefined, { forcePaused: true });
+  }
+```
+
+In `handleStartup` (line 304), add `abortClaimHandoffs();` alongside the existing watcher reset, so a restart leaves no orphaned loop.
+
+In the `setRunning` message handler (line 826), stopping farming must cancel any loop still refreshing. Change:
+
+```typescript
+    if (message.type === "setRunning") {
+      await updateStoredSettings({ running: message.running });
+      await tick();
+      return snapshot();
+    }
+```
+
+to:
+
+```typescript
+    if (message.type === "setRunning") {
+      if (!message.running) abortClaimHandoffs();
+      await updateStoredSettings({ running: message.running });
+      await tickAndHandOff();
+      return snapshot();
+    }
+```
+
+- [ ] **Step 7: Export `tickAndHandOff`**
+
+Add `tickAndHandOff,` to the controller's return object next to `tick`.
+
+- [ ] **Step 8: Run the full controller suite**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 9: Run the whole test suite and typecheck**
+
+Run: `pnpm test && pnpm typecheck`
+
+Expected: both exit 0. `coreBoundary.test.ts` must still pass — nothing added here imports a browser global.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(core): trigger the post-claim handoff from claim and lifecycle paths"
+```
+
+---
+
+## Task 8: CLI JSONC configuration
+
+**Files:**
+- Modify: `packages/cli/src/config.ts:59`
+- Test: `packages/cli/tests/` (whichever file asserts on `defaultConfigJsonc`)
+
+- [ ] **Step 1: Find the existing config test**
+
+Run: `grep -rn "defaultConfigJsonc" packages/cli/tests/`
+
+If a test parses the template, add an assertion there in Step 2. If none exists, skip to Step 3 — do not invent a new test file for a string template.
+
+- [ ] **Step 2: Add the assertion (only if a test exists)**
+
+```typescript
+  it("documents the post-claim handoff settings", () => {
+    const parsed = JSON.parse(stripJsonComments(defaultConfigJsonc()));
+    expect(parsed.settings.postClaimHandoff).toBe(true);
+    expect(parsed.settings.postClaimHandoffIntervalSeconds).toBe(5);
+    expect(parsed.settings.postClaimHandoffMaxSeconds).toBe(45);
+  });
+```
+
+Reuse whatever comment-stripping helper the existing test uses rather than adding a dependency.
+
+- [ ] **Step 3: Add the template entries**
+
+In `packages/cli/src/config.ts`, replace lines 57-59:
+
+```
+    "offlineRetryLimit": ${json(defaults.offlineRetryLimit)},
+    // How often campaign discovery and watch state are refreshed (1-60 minutes).
+    "pollIntervalMinutes": ${json(defaults.pollIntervalMinutes)},
+```
+
+with:
+
+```
+    "offlineRetryLimit": ${json(defaults.offlineRetryLimit)},
+    // How often campaign discovery and watch state are refreshed (1-60 minutes).
+    "pollIntervalMinutes": ${json(defaults.pollIntervalMinutes)},
+
+    // After claiming a reward, briefly re-check for the next one in the chain
+    // instead of waiting for the regular one-minute watch cycle. Twitch only.
+    "postClaimHandoff": ${json(defaults.postClaimHandoff)},
+    // Seconds between re-checks (1-30) and the total budget before giving up
+    // and falling back to the regular schedule (5-120).
+    "postClaimHandoffIntervalSeconds": ${json(defaults.postClaimHandoffIntervalSeconds)},
+    "postClaimHandoffMaxSeconds": ${json(defaults.postClaimHandoffMaxSeconds)},
+```
+
+- [ ] **Step 4: Verify the template is still valid JSONC**
+
+Run: `pnpm --filter @lurkloot/cli test` (or `pnpm test` if the CLI has no separate suite)
+
+Expected: PASS. If the CLI has no tests covering this, run `pnpm typecheck` and visually confirm the generated template parses by running the CLI's config-init path.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/config.ts packages/cli/tests/
+git commit -m "feat(cli): expose post-claim handoff settings in the config template"
+```
+
+---
+
+## Task 9: Locale strings
+
+Six new keys across all ten catalogs. `packages/extension/tests/i18n.test.ts` checks catalog parity, so a missing key in any one file fails the suite.
+
+**Files:**
+- Modify: `packages/locales/messages/en.json` and the nine other catalogs (`ar`, `de`, `es`, `fr`, `hi`, `it`, `pt_BR`, `ru`, `zh_CN`)
+
+- [ ] **Step 1: Add the English strings**
+
+In `packages/locales/messages/en.json`, next to the existing `schedulerIntervalTitle` block (line 419), add:
+
+```json
+  "postClaimHandoffTitle": {
+    "message": "Fast reward handoff"
+  },
+  "postClaimHandoffDescription": {
+    "message": "After claiming a drop, briefly check for the next reward in the campaign instead of waiting for the next scheduled cycle. Twitch only."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "Handoff check interval"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "How long to wait between checks for the next reward."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "Handoff time limit"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "Give up and return to the regular schedule after this long."
+  },
+```
+
+- [ ] **Step 2: Translate into the other nine catalogs**
+
+Add the same six keys to each of `ar.json`, `de.json`, `es.json`, `fr.json`, `hi.json`, `it.json`, `pt_BR.json`, `ru.json`, `zh_CN.json`, with translated `message` values. Match each file's existing key ordering and tone. Do not leave English text in a non-English catalog — `i18n.test.ts` will not catch that, but a reviewer will.
+
+- [ ] **Step 3: Verify catalog parity**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/i18n.test.ts`
+
+Expected: PASS. A failure here names the catalog and key that is missing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/locales/messages/
+git commit -m "feat(locales): add post-claim handoff settings copy"
+```
+
+---
+
+## Task 10: Advanced settings UI
+
+**Files:**
+- Modify: `packages/popup-ui/src/settings.tsx:155-158`
+
+- [ ] **Step 1: Add the rows**
+
+In `packages/popup-ui/src/settings.tsx`, inside the Advanced `SettingsSection`, after the existing `schedulerIntervalTitle` `NumberSettingRow` (line 156):
+
+```tsx
+        <SettingRow
+          title={t("postClaimHandoffTitle")}
+          description={t("postClaimHandoffDescription")}
+          checked={settings.postClaimHandoff}
+          onChange={set("postClaimHandoff")}
+        />
+        <NumberSettingRow
+          title={t("postClaimHandoffIntervalTitle")}
+          description={t("postClaimHandoffIntervalDescription")}
+          value={settings.postClaimHandoffIntervalSeconds}
+          min={1}
+          max={30}
+          suffix={t("secondsSuffix")}
+          disabled={!settings.postClaimHandoff}
+          onChange={(value) => onSettingsChange({ postClaimHandoffIntervalSeconds: value })}
+        />
+        <NumberSettingRow
+          title={t("postClaimHandoffMaxTitle")}
+          description={t("postClaimHandoffMaxDescription")}
+          value={settings.postClaimHandoffMaxSeconds}
+          min={5}
+          max={120}
+          suffix={t("secondsSuffix")}
+          disabled={!settings.postClaimHandoff}
+          onChange={(value) => onSettingsChange({ postClaimHandoffMaxSeconds: value })}
+        />
+```
+
+If `NumberSettingRow` does not accept a `disabled` prop, check how `adFocusMode` (line 149-152) handles `disabled` / `disabledReason` and follow that; if the primitive genuinely lacks the prop, add it to `packages/popup-ui/src/primitives.tsx` following `SettingRow`'s existing disabled handling.
+
+- [ ] **Step 2: Verify the settings patch accepts the new fields**
+
+Run: `grep -n "pollIntervalMinutes" packages/shared/src/settings.ts | grep -i patch`
+
+`applySettingsPatch` must pass the three new fields through. If it uses an explicit allowlist of patchable keys, add all three; if it spreads the patch, no change is needed.
+
+- [ ] **Step 3: Typecheck and build**
+
+Run: `pnpm typecheck && pnpm build:site`
+
+Expected: both exit 0. The site imports the real popup UI for its live demo, so a broken settings row fails the site build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/popup-ui/src/settings.tsx packages/shared/src/settings.ts
+git commit -m "feat(popup): add post-claim handoff controls to advanced settings"
+```
+
+---
+
+## Task 11: Full verification
+
+- [ ] **Step 1: Run the full check**
+
+Run: `pnpm check`
+
+Expected: exit 0 — script tests, workspace typechecks, extension tests, and the Astro site build all pass.
+
+- [ ] **Step 2: Run both browser builds**
+
+Run: `pnpm verify`
+
+Expected: exit 0. This is `pnpm check` plus the Chromium and Firefox production builds.
+
+- [ ] **Step 3: Confirm no new permissions**
+
+Run: `git diff origin/develop -- packages/extension/wxt.config.ts`
+
+Expected: empty. This feature adds no host permissions; a non-empty diff means something went wrong and must be explained in the PR.
+
+- [ ] **Step 4: Review the diff against the acceptance criteria**
+
+Run: `git diff origin/develop --stat`
+
+Confirm against issue #110: a new reward can begin before the next alarm (Task 6), the loop is bounded and abortable (Task 5), no duplicated claims or heartbeats (Task 5's nesting guard and Task 6's recency guard), failure falls back cleanly (Task 5 never touches alarms), and tests cover success, timeout, abort, no-next-reward, and visible-tab (Tasks 5–7).

--- a/docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md
+++ b/docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md
@@ -1,0 +1,206 @@
+# Accelerate Twitch Reward Handoff After a Claim
+
+**Date:** 2026-07-19
+
+Resolves [#110](https://github.com/jamezrin/lurkloot/issues/110). Related to [#106](https://github.com/jamezrin/lurkloot/issues/106).
+
+## Purpose
+
+When a Twitch reward is claimed, `runSchedulerTick` reconciles campaign state and picks the next
+watch target within the same tick. Two things still stall the chain:
+
+- Twitch's inventory may not yet report the next reward as active at the moment that tick reads
+  progress, so the scheduler sees no successor.
+- Even when the successor is chosen correctly, the first tabless heartbeat for it waits on the fixed
+  one-minute `WATCH_ALARM_NAME` alarm.
+
+Together these cost up to a minute of unearned watch time per reward in a campaign chain, and delay
+confirmation that the next reward has activated.
+
+This design adds a bounded, abortable post-claim handoff that re-polls for the successor and, once
+it appears, transmits immediately instead of waiting for the alarm.
+
+## Goals
+
+- Let a newly available next reward begin earning before the next regular heartbeat alarm.
+- Keep the refresh loop bounded in both cadence and total duration, and abortable at any point.
+- Make the retry interval and maximum duration configurable in Advanced Settings and CLI JSONC.
+- Fall back to unmodified alarm-driven scheduling whenever the handoff cannot confirm a successor.
+- Never duplicate claims or heartbeats as a result of the handoff.
+
+## Non-goals
+
+- Changing alarm cadence, or replacing alarm-driven scheduling in any way.
+- Implementing the handoff for Kick. Kick's tabless watcher holds a persistent viewer WebSocket and
+  self-paces its sends, so there is no equivalent minute of dead time to recover. See
+  `packages/core/src/core/tablessWatch.ts`.
+- Reloading or navigating a healthy visible watch tab.
+- Making every timing constant in the controller configurable.
+
+## Considered Approaches
+
+### Bounded loop of scoped `tick([platform])` — selected
+
+The handoff re-runs the existing scheduler tick for the claimed platform at the configured interval
+until the session lands on a different reward, then fires one immediate tabless heartbeat.
+
+A scoped tick already performs `discoverCampaigns()` + `readProgress()`, so this costs the same
+platform requests as a hand-rolled inventory poll while reusing eligibility filtering, claim
+guarding, target selection, and watcher reconciliation. Duplicate claims are prevented for free:
+`claimReadyRewards` only acts on rewards whose `status` is `"claimable"`, so a re-tick over
+already-claimed rewards is a no-op.
+
+### Lightweight inventory poll, then a single tick
+
+Poll `readProgress` directly in the loop and run one tick only after detecting a successor. Fewer
+state writes, but it reimplements eligibility detection outside the scheduler, where it can drift
+out of agreement with `isEligible` / `isRewardAvailableToEarn`.
+
+### A dedicated short-interval alarm
+
+Not viable. `chrome.alarms` clamps to a one-minute minimum, so it cannot express a five-second
+cadence — the exact constraint that motivated the fixed one-minute watch alarm in the first place.
+
+## Architecture
+
+### Adapter capability
+
+`PlatformAdapter` gains an optional capability flag alongside `supportsTabless`
+(`packages/core/src/platforms/adapter.ts:56`):
+
+```ts
+// Whether a bounded post-claim refresh is worthwhile on this platform. Twitch
+// only reveals the next reward in a campaign chain on a subsequent inventory
+// read, so re-polling recovers watch time the fixed alarm would waste.
+supportsPostClaimHandoff?: boolean;
+```
+
+The Twitch adapter sets it; Kick leaves it unset. The controller stays platform-neutral, per the
+`CLAUDE.md` rule that platform behavior lives behind `PlatformAdapter`.
+
+### Trigger
+
+`tick()` already runs inside `withEventCollector` and therefore observes every emitted event. It
+collects the platforms that produced a `reward_claimed` activity event
+(`packages/core/src/core/scheduler.ts:473`) and returns them, so its current `Promise<void>` becomes
+`Promise<Platform[]>`. The popup's manual-claim path
+(`packages/core/src/background/controller.ts:771`) triggers the handoff on the same basis.
+
+A handoff starts only when the platform's adapter declares `supportsPostClaimHandoff`, the settings
+enable it, and farming is running.
+
+### Driver
+
+`runClaimHandoff(platform)` runs **outside** the state lock. Each iteration's `tick()` acquires the
+lock on its own and releases it, which keeps a handoff from blocking telemetry writes, heartbeats,
+or user actions for its whole duration. This mirrors the existing arrangement in
+`runWatchHeartbeat`, which deliberately defers its trailing `tick()` until after its locked closure
+returns.
+
+A module-level `Map<Platform, AbortController>` tracks in-flight handoffs. Starting a handoff for a
+platform that already has one is a no-op rather than a restart.
+
+Loop shape, per iteration:
+
+1. Check `signal.aborted`; exit if set.
+2. `await deps.wait(intervalMs, signal)`.
+3. Check `signal.aborted`; exit if set.
+4. `await tick([platform])`.
+5. Evaluate stop conditions against the freshly persisted state.
+
+### Re-entrancy and boundedness
+
+A `reward_claimed` event emitted by a handoff's *own* tick does not start a nested handoff and does
+not extend the deadline. The deadline is computed once, when the handoff starts. This is what makes
+the "does not duplicate claims or watch heartbeats uncontrollably" criterion structural rather than
+incidental: the worst case is fixed at `ceil(maxSeconds / intervalSeconds)` ticks per handoff,
+regardless of how many rewards claim during it.
+
+### Stop conditions
+
+The loop ends on the first of:
+
+- **Success** — the platform session has `status === "watching"` and a `rewardId` that differs from
+  every reward id claimed so far in this handoff.
+- **Nothing left** — the tick produced no eligible reward for the platform (for example a session
+  reason code of `campaign_ineligible`). Exits early rather than burning the remaining budget.
+- **Deadline** — `maxSeconds` elapsed since the handoff started.
+- **Abort** — see below.
+
+### Abort
+
+The handoff aborts on farming stopped, the platform being disabled, `beginSettingsSession()`, and
+runtime restart. Abort is checked immediately before and after every await, so a stop request takes
+effect within one in-flight tick rather than at the next interval boundary.
+
+### Tail action
+
+On success:
+
+- **Tabless** (`session.watchMode === "tabless"`) — send one immediate heartbeat through the
+  platform's `TablessWatchController`. Skipped when a heartbeat already landed within the last 30
+  seconds **and** the watcher's `channelUrl` is unchanged, so the handoff and the one-minute alarm
+  cannot double-send to the same channel. A channel switch always transmits immediately, because the
+  session's `lastHeartbeatAt` then refers to the previous target.
+- **Visible tab** — nothing further. The tick that detected the successor has already re-pointed or
+  retained the tab, and a healthy tab earns progress continuously, so there is nothing to accelerate.
+
+On timeout, no-successor, or abort: emit a diagnostic and stop. Alarm scheduling is never touched by
+any path in this design, so every failure mode degrades to exactly today's behavior with state
+intact.
+
+### Testability
+
+`BackgroundControllerDeps` gains an optional `wait(ms, signal): Promise<void>`, defaulting to a
+`setTimeout`-based implementation. Tests inject a manually-advanced implementation and drive the
+loop deterministically, instead of coordinating fake timers against real promise scheduling.
+
+## Settings
+
+New `EngineSettings` fields (`packages/shared/src/models.ts:261`), with defaults and clamping in
+`packages/shared/src/settings.ts:60` and `:134`:
+
+| Field | Default | Clamp |
+| --- | --- | --- |
+| `postClaimHandoff` | `true` | boolean |
+| `postClaimHandoffIntervalSeconds` | `5` | 1–30 |
+| `postClaimHandoffMaxSeconds` | `45` | 5–120 |
+
+The defaults give at most nine inventory reads per claim and always finish before the next
+one-minute alarm, so the handoff and the alarm never contend.
+
+Enablement is an explicit boolean rather than an overloaded `postClaimHandoffMaxSeconds: 0`. A magic
+zero inside a `NumberSettingRow` reads as a bug to the user. The cost is a third row in an Advanced
+section that currently holds two.
+
+## Affected Files
+
+- `packages/core/src/platforms/adapter.ts` — `supportsPostClaimHandoff` capability flag.
+- `packages/core/src/platforms/twitch/index.ts` — declare the capability.
+- `packages/core/src/background/controller.ts` — `runClaimHandoff`, abort map, claimed-platform
+  return from `tick()`, manual-claim trigger, `deps.wait`.
+- `packages/shared/src/models.ts`, `packages/shared/src/settings.ts` — fields, defaults, clamps.
+- `packages/cli/src/config.ts:57` — JSONC template entries with explanatory comments.
+- `packages/popup-ui/src/settings.tsx:155` — one `SettingRow` toggle plus two `NumberSettingRow`s in
+  the Advanced section; interval and maximum are disabled while the toggle is off.
+- `packages/locales/messages/*.json` — six new keys across all ten catalogs.
+
+## Testing
+
+In `packages/extension/tests/backgroundController.test.ts`:
+
+- **Success** — successor appears mid-loop; exactly one immediate heartbeat is sent and the loop ends.
+- **Timeout** — no successor within `maxSeconds`; loop ends, alarms untouched, state uncorrupted.
+- **Abort** — farming stops mid-handoff; loop ends without a further tick or heartbeat.
+- **No next reward** — platform has nothing eligible; loop exits early rather than at the deadline.
+- **Visible tab** — successor detected in playback mode; the tick runs and no heartbeat is sent.
+- **No double heartbeat** — a recent heartbeat on an unchanged channel suppresses the immediate send.
+- **No nested handoff** — a claim occurring inside a handoff neither starts a second handoff nor
+  extends the original deadline.
+- **Unsupported platform** — Kick claims do not start a handoff.
+
+In the shared settings suite: clamping of out-of-range, missing, and non-numeric values for all three
+new fields.
+
+All coverage is engine-level. Consistent with the repository's standing decision not to assert on
+workflow YAML, nothing here tests `.github/workflows` content.

--- a/docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md
+++ b/docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md
@@ -81,10 +81,16 @@ The Twitch adapter sets it; Kick leaves it unset. The controller stays platform-
 ### Trigger
 
 `tick()` already runs inside `withEventCollector` and therefore observes every emitted event. It
-collects the platforms that produced a `reward_claimed` activity event
-(`packages/core/src/core/scheduler.ts:473`) and returns them, so its current `Promise<void>` becomes
-`Promise<Platform[]>`. The popup's manual-claim path
-(`packages/core/src/background/controller.ts:771`) triggers the handoff on the same basis.
+collects the `reward_claimed` activity events (`packages/core/src/core/scheduler.ts:473`) and returns
+the claimed reward ids keyed by platform, so its current `Promise<void>` becomes
+`Promise<ClaimedRewards>` where `ClaimedRewards = Partial<Record<Platform, string[]>>`. The popup's
+manual-claim path (`packages/core/src/background/controller.ts:771`) triggers the handoff on the same
+basis, passing the id it just claimed.
+
+The ids, not merely the platforms, are what the handoff needs: it recognises a successor as "the
+session is watching a reward that is not one of the ones just claimed". Deriving that from the
+session's own `rewardId` after the tick does not work, because by then the session already points at
+the successor — which would be recorded as claimed, and the loop would never terminate.
 
 A handoff starts only when the platform's adapter declares `supportsPostClaimHandoff`, the settings
 enable it, and farming is running.
@@ -97,16 +103,26 @@ or user actions for its whole duration. This mirrors the existing arrangement in
 `runWatchHeartbeat`, which deliberately defers its trailing `tick()` until after its locked closure
 returns.
 
-A module-level `Map<Platform, AbortController>` tracks in-flight handoffs. Starting a handoff for a
-platform that already has one is a no-op rather than a restart.
+A per-controller `Map<Platform, AbortController>` tracks in-flight handoffs. Starting a handoff for a
+platform that already has one is a no-op rather than a restart. The map entry is claimed
+**synchronously, before the first await**: registering it after the async setup would let two
+triggers past the duplicate guard into concurrent loops, and would let an `abortClaimHandoffs()`
+arriving mid-setup miss the handoff entirely. Everything after the reservation runs inside a `try`
+whose `finally` releases it.
+
+There is also a fast path before the loop. When the triggering tick already selected the successor,
+there is nothing to poll for, so the handoff skips straight to the immediate heartbeat.
 
 Loop shape, per iteration:
 
 1. Check `signal.aborted`; exit if set.
-2. `await deps.wait(intervalMs, signal)`.
-3. Check `signal.aborted`; exit if set.
+2. `await deps.wait(min(intervalMs, deadline - now), signal)` — capped at the remaining budget, so an
+   interval longer than what is left cannot push a refresh past the deadline.
+3. Check `signal.aborted` and the deadline; exit if either has passed.
 4. `await tick([platform])`.
-5. Evaluate stop conditions against the freshly persisted state.
+5. Check `signal.aborted`; exit if set.
+6. Load state, re-check `signal.aborted` (a cancellation during the load must not still transmit),
+   then evaluate stop conditions.
 
 ### Re-entrancy and boundedness
 
@@ -129,9 +145,11 @@ The loop ends on the first of:
 
 ### Abort
 
-The handoff aborts on farming stopped, the platform being disabled, `beginSettingsSession()`, and
-runtime restart. Abort is checked immediately before and after every await, so a stop request takes
-effect within one in-flight tick rather than at the next interval boundary.
+The handoff aborts on farming stopped, the platform being disabled, `beginSettingsSession()`,
+runtime restart, and CLI shutdown — the last of these before the transport is disposed, so a handoff
+cannot keep refreshing against disposed resources or hold the process open with a pending delay.
+Abort is checked immediately before and after every await, so a stop request takes effect within one
+in-flight tick rather than at the next interval boundary.
 
 ### Tail action
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -57,6 +57,14 @@ export function defaultConfigJsonc(): string {
     "offlineRetryLimit": ${json(defaults.offlineRetryLimit)},
     // How often campaign discovery and watch state are refreshed (1-60 minutes).
     "pollIntervalMinutes": ${json(defaults.pollIntervalMinutes)},
+
+    // After claiming a reward, briefly re-check for the next one in the chain
+    // instead of waiting for the regular one-minute watch cycle. Twitch only.
+    "postClaimHandoff": ${json(defaults.postClaimHandoff)},
+    // Seconds between re-checks (1-30) and the total budget before giving up
+    // and falling back to the regular schedule (5-120).
+    "postClaimHandoffIntervalSeconds": ${json(defaults.postClaimHandoffIntervalSeconds)},
+    "postClaimHandoffMaxSeconds": ${json(defaults.postClaimHandoffMaxSeconds)},
     "notifyRewardEarned": ${json(defaults.notifyRewardEarned)},
     "notifyNoDropsLeft": ${json(defaults.notifyNoDropsLeft)},
 

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -77,6 +77,10 @@ export async function runLoop(options: RunOptions): Promise<void> {
       stopped = true;
       logger.info(`Received ${signal}; shutting down`, "run");
       clearInterval(timer);
+      // Before disposing the transport: a post-claim handoff started by the last
+      // tick would otherwise keep refreshing against disposed resources, and its
+      // pending delay would hold the process open until the handoff's deadline.
+      controller.abortClaimHandoffs();
       await transport.dispose();
       resolveLoop();
     };

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -44,7 +44,7 @@ export async function runLoop(options: RunOptions): Promise<void> {
 
   const tickOnce = async () => {
     try {
-      await controller.tick();
+      await controller.tickAndHandOff();
       const state = await loadState(statePath);
       const waits = subscriptionWaitKeys([...state.campaigns.twitch, ...state.campaigns.kick]);
       for (const key of seenSubscriptionWaits) {

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -27,6 +27,11 @@ export interface CliSettings {
   watchQueueFallbackOnly: boolean;
   offlineRetryLimit: number;
   pollIntervalMinutes: number;
+  // Bounded post-claim refresh. Twitch-only in practice: the Kick adapter does
+  // not declare the capability. See EngineSettings.postClaimHandoff.
+  postClaimHandoff: boolean;
+  postClaimHandoffIntervalSeconds: number;
+  postClaimHandoffMaxSeconds: number;
   // Gate the controller's reward/no-drops notifications, which the CLI renders
   // as log lines (see runtime/run.ts createNotification).
   notifyRewardEarned: boolean;
@@ -49,6 +54,9 @@ export const DEFAULT_CLI_SETTINGS: CliSettings = {
   watchQueueFallbackOnly: DEFAULT_SETTINGS.watchQueueFallbackOnly,
   offlineRetryLimit: DEFAULT_SETTINGS.offlineRetryLimit,
   pollIntervalMinutes: DEFAULT_SETTINGS.pollIntervalMinutes,
+  postClaimHandoff: DEFAULT_SETTINGS.postClaimHandoff,
+  postClaimHandoffIntervalSeconds: DEFAULT_SETTINGS.postClaimHandoffIntervalSeconds,
+  postClaimHandoffMaxSeconds: DEFAULT_SETTINGS.postClaimHandoffMaxSeconds,
   notifyRewardEarned: DEFAULT_SETTINGS.notifyRewardEarned,
   notifyNoDropsLeft: DEFAULT_SETTINGS.notifyNoDropsLeft,
   platform: {
@@ -70,6 +78,9 @@ const CLI_SETTING_KEYS = new Set<string>([
   "watchQueueFallbackOnly",
   "offlineRetryLimit",
   "pollIntervalMinutes",
+  "postClaimHandoff",
+  "postClaimHandoffIntervalSeconds",
+  "postClaimHandoffMaxSeconds",
   // Accepted only so config parsing can surface the deprecation warning.
   // Runtime log filtering belongs to the global --log option and process logger.
   "enabledLogLevels",
@@ -184,6 +195,9 @@ export function parseCliSettings(raw: unknown): CliSettings {
     watchQueueFallbackOnly: booleanOr(v.watchQueueFallbackOnly, DEFAULT_CLI_SETTINGS.watchQueueFallbackOnly),
     offlineRetryLimit: clampInteger(v.offlineRetryLimit, 1, 10, DEFAULT_CLI_SETTINGS.offlineRetryLimit),
     pollIntervalMinutes: clampNumber(v.pollIntervalMinutes, 1, 60, DEFAULT_CLI_SETTINGS.pollIntervalMinutes),
+    postClaimHandoff: booleanOr(v.postClaimHandoff, DEFAULT_CLI_SETTINGS.postClaimHandoff),
+    postClaimHandoffIntervalSeconds: clampInteger(v.postClaimHandoffIntervalSeconds, 1, 30, DEFAULT_CLI_SETTINGS.postClaimHandoffIntervalSeconds),
+    postClaimHandoffMaxSeconds: clampInteger(v.postClaimHandoffMaxSeconds, 5, 120, DEFAULT_CLI_SETTINGS.postClaimHandoffMaxSeconds),
     notifyRewardEarned: booleanOr(v.notifyRewardEarned, DEFAULT_CLI_SETTINGS.notifyRewardEarned),
     notifyNoDropsLeft: booleanOr(v.notifyNoDropsLeft, DEFAULT_CLI_SETTINGS.notifyNoDropsLeft),
     platform: normalizePlatform(v.platform),

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -188,6 +188,15 @@ describe("loadConfig", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("documents the post-claim handoff settings in the template", () => {
+    // The round-trip above merges defaults, so an omitted key would still pass
+    // there. Assert the template itself carries them.
+    const template = defaultConfigJsonc();
+    expect(template).toContain("\"postClaimHandoff\":");
+    expect(template).toContain("\"postClaimHandoffIntervalSeconds\":");
+    expect(template).toContain("\"postClaimHandoffMaxSeconds\":");
+  });
 });
 
 describe("CLI config warning integration", () => {

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -191,11 +191,11 @@ describe("loadConfig", () => {
 
   it("documents the post-claim handoff settings in the template", () => {
     // The round-trip above merges defaults, so an omitted key would still pass
-    // there. Assert the template itself carries them.
+    // there. Assert the template itself carries them, with the rendered values.
     const template = defaultConfigJsonc();
-    expect(template).toContain("\"postClaimHandoff\":");
-    expect(template).toContain("\"postClaimHandoffIntervalSeconds\":");
-    expect(template).toContain("\"postClaimHandoffMaxSeconds\":");
+    expect(template).toContain(`"postClaimHandoff": ${DEFAULT_CLI_SETTINGS.postClaimHandoff}`);
+    expect(template).toContain(`"postClaimHandoffIntervalSeconds": ${DEFAULT_CLI_SETTINGS.postClaimHandoffIntervalSeconds}`);
+    expect(template).toContain(`"postClaimHandoffMaxSeconds": ${DEFAULT_CLI_SETTINGS.postClaimHandoffMaxSeconds}`);
   });
 });
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -27,6 +27,11 @@ const NOTHING_LEFT_REASON_CODES: WatchReasonCode[] = ["campaign_ineligible", "no
 function isNothingLeftToFarm(reasonCode: WatchReasonCode | undefined): boolean {
   return reasonCode != null && NOTHING_LEFT_REASON_CODES.includes(reasonCode);
 }
+// How recently a heartbeat must have landed for the post-claim handoff to treat
+// the channel as already covered. Half the fixed one-minute alarm period: long
+// enough to suppress a genuine double-send, short enough that a real handoff
+// still transmits.
+const RECENT_HEARTBEAT_MS = 30_000;
 const PLATFORMS: Platform[] = ["twitch", "kick"];
 const FARMING_STOP_REASON_CODES: Record<FarmingStopReason, true> = {
   automation_disabled: true,
@@ -706,9 +711,59 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
-  // Replaced with the real immediate heartbeat in the next commit.
-  async function sendImmediateHeartbeat(_platform: Platform, _session: WatchSession): Promise<void> {
-    return;
+  // Transmits one heartbeat for a freshly-selected tabless target instead of
+  // waiting for the next watch alarm. A visible tab needs nothing: it earns
+  // progress continuously and the detecting tick already re-pointed it.
+  async function sendImmediateHeartbeat(platform: Platform, session: WatchSession): Promise<void> {
+    if (session.watchMode !== "tabless") return;
+    const watcher = tablessWatchers.get(platform);
+    if (!watcher) return;
+
+    // A channel switch always transmits: lastHeartbeatAt then refers to the
+    // previous target, so its recency says nothing about the new one.
+    const sameChannel = watcher.channelUrl != null && watcher.channelUrl === session.channel?.url;
+    const lastHeartbeatAt = session.lastHeartbeatAt ? Date.parse(session.lastHeartbeatAt) : Number.NaN;
+    const recent = !Number.isNaN(lastHeartbeatAt) && Date.now() - lastHeartbeatAt < RECENT_HEARTBEAT_MS;
+    if (sameChannel && recent) return;
+
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      let ok = false;
+      let message: string | undefined;
+      drainWatcherEvents(watcher, emit);
+      try {
+        const result = await watcher.tick(tablessWatchContext());
+        ok = result.ok;
+        message = result.message;
+      } catch (error) {
+        message = error instanceof Error ? error.message : "Post-claim heartbeat failed";
+      } finally {
+        drainWatcherEvents(watcher, emit);
+      }
+
+      const state = await deps.loadState();
+      const current = state.sessions[platform];
+      const nextState: SchedulerState = {
+        ...state,
+        sessions: {
+          ...state.sessions,
+          [platform]: {
+            ...current,
+            lastHeartbeatAt: new Date().toISOString(),
+            lastHeartbeatOk: ok,
+            heartbeatChecks: ok ? 0 : (current.heartbeatChecks ?? 0) + 1,
+          },
+        },
+      };
+      emit({
+        category: "diagnostic",
+        platform,
+        level: ok ? "debug" : "warn",
+        message: ok
+          ? "Post-claim handoff started the next reward without waiting for the watch alarm"
+          : message ?? "Post-claim heartbeat failed",
+      });
+      await persistAndReport(nextState, events);
+    }));
   }
 
   async function beginSettingsSession(): Promise<void> {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -104,11 +104,32 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
   // Omitted in headless/test runs, where the scheduler forgets contexts from
   // state only (see runSchedulerTick / StopPageContextTabs).
   stopPageContextTabs?: StopPageContextTabs;
+  // Delay used by the bounded post-claim handoff. Injected so tests can drive
+  // the loop deterministically instead of racing real timers. Resolves early
+  // (without throwing) when the signal aborts, so callers check `signal.aborted`
+  // after awaiting rather than catching.
+  wait?(ms: number, signal: AbortSignal): Promise<void>;
 }
 
 export function createBackgroundController<S extends EngineSettings = EngineSettings>(deps: BackgroundControllerDeps<S>) {
   const reportedCompatibility = new Map<Platform, string>();
   const reportedCompatibilityWarnings = new Set<string>();
+
+  const wait: NonNullable<BackgroundControllerDeps<S>["wait"]> = deps.wait ?? ((ms, signal) => new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  }));
 
   const selectionFingerprint = (value: string): string => {
     let hash = 0x811c9dc5;

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -664,43 +664,55 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // on its own, so a long handoff never blocks telemetry or user actions.
   async function runClaimHandoff(platform: Platform, justClaimedRewardIds: readonly string[] = []): Promise<void> {
     if (claimHandoffs.has(platform)) return;
-    const settings = await deps.loadSettings();
-    if (!settings.postClaimHandoff || !settings.running) return;
-    if (!settings.platform[platform].enabled) return;
-
-    const adapters = createAdapters(settings, () => undefined);
-    if (!adapters[platform].supportsPostClaimHandoff) return;
-
-    const claimed = new Set(justClaimedRewardIds);
-    // A session is a successful handoff target when it is watching a reward
-    // other than the ones just claimed.
-    const isSuccessor = (session: WatchSession): boolean =>
-      session.status === "watching" && session.rewardId != null && !claimed.has(session.rewardId);
-
-    // The triggering tick may already have found the successor, in which case
-    // there is nothing to poll for — only a heartbeat to bring forward.
-    const before = await deps.loadState();
-    if (isSuccessor(before.sessions[platform])) {
-      await sendImmediateHeartbeat(platform, before.sessions[platform]);
-      return;
-    }
-
+    // Reserved synchronously, before the first await. Registering after the
+    // async setup would let two triggers past the guard into concurrent loops,
+    // and would let an abortClaimHandoffs() landing mid-setup miss this handoff
+    // entirely.
     const abort = new AbortController();
     claimHandoffs.set(platform, abort);
-    // The deadline is computed once. A claim occurring inside the loop never
-    // extends it, so the worst case stays fixed at maxSeconds.
-    const deadline = Date.now() + settings.postClaimHandoffMaxSeconds * 1000;
-    const intervalMs = settings.postClaimHandoffIntervalSeconds * 1000;
 
     try {
+      const settings = await deps.loadSettings();
+      if (abort.signal.aborted) return;
+      if (!settings.postClaimHandoff || !settings.running) return;
+      if (!settings.platform[platform].enabled) return;
+
+      const adapters = createAdapters(settings, () => undefined);
+      if (!adapters[platform].supportsPostClaimHandoff) return;
+
+      const claimed = new Set(justClaimedRewardIds);
+      // A session is a successful handoff target when it is watching a reward
+      // other than the ones just claimed.
+      const isSuccessor = (session: WatchSession): boolean =>
+        session.status === "watching" && session.rewardId != null && !claimed.has(session.rewardId);
+
+      // The triggering tick may already have found the successor, in which case
+      // there is nothing to poll for — only a heartbeat to bring forward.
+      const before = await deps.loadState();
+      if (abort.signal.aborted) return;
+      if (isSuccessor(before.sessions[platform])) {
+        await sendImmediateHeartbeat(platform, before.sessions[platform]);
+        return;
+      }
+
+      // The deadline is computed once. A claim occurring inside the loop never
+      // extends it, so the worst case stays fixed at maxSeconds.
+      const deadline = Date.now() + settings.postClaimHandoffMaxSeconds * 1000;
+      const intervalMs = settings.postClaimHandoffIntervalSeconds * 1000;
+
       while (!abort.signal.aborted && Date.now() < deadline) {
-        await wait(intervalMs, abort.signal);
-        if (abort.signal.aborted) break;
+        // Capped at the remaining budget, so an interval longer than what is
+        // left cannot push a refresh past the deadline.
+        await wait(Math.min(intervalMs, deadline - Date.now()), abort.signal);
+        if (abort.signal.aborted || Date.now() >= deadline) break;
 
         await tick([platform]);
         if (abort.signal.aborted) break;
 
         const session = (await deps.loadState()).sessions[platform];
+        // Re-checked after the load: a cancellation during it must not still
+        // transmit.
+        if (abort.signal.aborted) break;
         if (isSuccessor(session)) {
           await sendImmediateHeartbeat(platform, session);
           return;

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -16,6 +16,17 @@ export const ALARM_NAME = "lurkloot.tick";
 // of the (heavier, configurable) discovery tick. chrome.alarms clamps to a
 // 1-minute minimum, close enough to TwitchDropsMiner's 59s send cadence.
 export const WATCH_ALARM_NAME = "lurkloot.watch";
+// Reward ids claimed during one tick, per platform. The post-claim handoff needs
+// the ids (not just the platforms) so it can tell a genuine successor from the
+// reward that was just claimed.
+export type ClaimedRewards = Partial<Record<Platform, string[]>>;
+// Reasons a refreshed platform has nothing left to farm. Reaching one of these
+// means further refreshes would return the same answer, so the post-claim
+// handoff stops instead of spending the rest of its budget.
+const NOTHING_LEFT_REASON_CODES: WatchReasonCode[] = ["campaign_ineligible", "no_eligible_channel"];
+function isNothingLeftToFarm(reasonCode: WatchReasonCode | undefined): boolean {
+  return reasonCode != null && NOTHING_LEFT_REASON_CODES.includes(reasonCode);
+}
 const PLATFORMS: Platform[] = ["twitch", "kick"];
 const FARMING_STOP_REASON_CODES: Record<FarmingStopReason, true> = {
   automation_disabled: true,
@@ -114,6 +125,12 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
 export function createBackgroundController<S extends EngineSettings = EngineSettings>(deps: BackgroundControllerDeps<S>) {
   const reportedCompatibility = new Map<Platform, string>();
   const reportedCompatibilityWarnings = new Set<string>();
+  // In-flight post-claim handoffs, one per platform. A claim arriving while a
+  // handoff is already running for that platform is absorbed by the running
+  // loop rather than starting a second one, which is what keeps the work
+  // bounded. Per-controller, unlike the storage lock: these loops coordinate
+  // only with each other.
+  const claimHandoffs = new Map<Platform, AbortController>();
 
   const wait: NonNullable<BackgroundControllerDeps<S>["wait"]> = deps.wait ?? ((ms, signal) => new Promise<void>((resolve) => {
     if (signal.aborted) {
@@ -377,8 +394,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     });
   }
 
-  async function tick(platforms?: Platform[], options?: { forcePaused?: boolean }): Promise<Platform[]> {
-    const claimedPlatforms = new Set<Platform>();
+  async function tick(platforms?: Platform[], options?: { forcePaused?: boolean }): Promise<ClaimedRewards> {
+    const claimedRewards: ClaimedRewards = {};
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const storedSettings = await deps.loadSettings();
       const settings: S = options?.forcePaused || settingsPauseCount > 0
@@ -397,7 +414,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         // needs to know which platforms claimed.
         const claimObservingEmit: EventEmitter = (event) => {
           if (event.category === "activity" && event.code === "reward_claimed" && event.platform) {
-            claimedPlatforms.add(event.platform);
+            (claimedRewards[event.platform] ??= []).push(event.data.rewardId);
           }
           emit(event);
         };
@@ -415,7 +432,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         nextState = result.state;
       } catch (error) {
         // The tick was rolled back, so any partial claim set is not actionable.
-        claimedPlatforms.clear();
+        for (const key of Object.keys(claimedRewards) as Platform[]) delete claimedRewards[key];
         clearOperationalEvents(events);
         const detail = error instanceof Error ? error.message : "Scheduler tick failed";
         emit({ category: "activity", code: "interruption", level: "error", data: { reason: "platform_error", detail } });
@@ -431,7 +448,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         }
       }
     }));
-    return [...claimedPlatforms];
+    return claimedRewards;
   }
 
   async function handleTabRemoved(tabId: number): Promise<void> {
@@ -623,6 +640,75 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     for (const platform of fallbackPlatforms) {
       await tick([platform]);
     }
+  }
+
+  // Aborts every in-flight handoff. Called when farming stops, when a settings
+  // session begins, and on runtime restart.
+  function abortClaimHandoffs(): void {
+    for (const controller of claimHandoffs.values()) controller.abort();
+    claimHandoffs.clear();
+  }
+
+  // Bounded post-claim handoff (see docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md).
+  // Re-runs a scoped tick on the configured cadence until the platform lands on
+  // a reward other than the ones just claimed, then hands off to the immediate
+  // heartbeat. Runs OUTSIDE the state lock: each inner tick() acquires the lock
+  // on its own, so a long handoff never blocks telemetry or user actions.
+  async function runClaimHandoff(platform: Platform, justClaimedRewardIds: readonly string[] = []): Promise<void> {
+    if (claimHandoffs.has(platform)) return;
+    const settings = await deps.loadSettings();
+    if (!settings.postClaimHandoff || !settings.running) return;
+    if (!settings.platform[platform].enabled) return;
+
+    const adapters = createAdapters(settings, () => undefined);
+    if (!adapters[platform].supportsPostClaimHandoff) return;
+
+    const claimed = new Set(justClaimedRewardIds);
+    // A session is a successful handoff target when it is watching a reward
+    // other than the ones just claimed.
+    const isSuccessor = (session: WatchSession): boolean =>
+      session.status === "watching" && session.rewardId != null && !claimed.has(session.rewardId);
+
+    // The triggering tick may already have found the successor, in which case
+    // there is nothing to poll for — only a heartbeat to bring forward.
+    const before = await deps.loadState();
+    if (isSuccessor(before.sessions[platform])) {
+      await sendImmediateHeartbeat(platform, before.sessions[platform]);
+      return;
+    }
+
+    const abort = new AbortController();
+    claimHandoffs.set(platform, abort);
+    // The deadline is computed once. A claim occurring inside the loop never
+    // extends it, so the worst case stays fixed at maxSeconds.
+    const deadline = Date.now() + settings.postClaimHandoffMaxSeconds * 1000;
+    const intervalMs = settings.postClaimHandoffIntervalSeconds * 1000;
+
+    try {
+      while (!abort.signal.aborted && Date.now() < deadline) {
+        await wait(intervalMs, abort.signal);
+        if (abort.signal.aborted) break;
+
+        await tick([platform]);
+        if (abort.signal.aborted) break;
+
+        const session = (await deps.loadState()).sessions[platform];
+        if (isSuccessor(session)) {
+          await sendImmediateHeartbeat(platform, session);
+          return;
+        }
+        // Nothing eligible left on this platform: the chain is finished, so stop
+        // rather than burning the rest of the budget on identical refreshes.
+        if (session.status !== "watching" && isNothingLeftToFarm(session.reasonCode)) return;
+      }
+    } finally {
+      if (claimHandoffs.get(platform) === abort) claimHandoffs.delete(platform);
+    }
+  }
+
+  // Replaced with the real immediate heartbeat in the next commit.
+  async function sendImmediateHeartbeat(_platform: Platform, _session: WatchSession): Promise<void> {
+    return;
   }
 
   async function beginSettingsSession(): Promise<void> {
@@ -996,6 +1082,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     captureTwitchIntegrity,
     tick,
     runWatchHeartbeat,
+    runClaimHandoff,
+    abortClaimHandoffs,
   };
 }
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -377,7 +377,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     });
   }
 
-  async function tick(platforms?: Platform[], options?: { forcePaused?: boolean }): Promise<void> {
+  async function tick(platforms?: Platform[], options?: { forcePaused?: boolean }): Promise<Platform[]> {
+    const claimedPlatforms = new Set<Platform>();
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const storedSettings = await deps.loadSettings();
       const settings: S = options?.forcePaused || settingsPauseCount > 0
@@ -391,11 +392,20 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       let nextState: SchedulerState;
       try {
         const adapters = createAdapters(settings, emit);
+        // Observed here rather than returned by the scheduler: the controller
+        // already sees every emitted event, and the post-claim handoff only
+        // needs to know which platforms claimed.
+        const claimObservingEmit: EventEmitter = (event) => {
+          if (event.category === "activity" && event.code === "reward_claimed" && event.platform) {
+            claimedPlatforms.add(event.platform);
+          }
+          emit(event);
+        };
         const result = await runSchedulerTick(state, settings, adapters, {
           ...(platforms ? { platforms } : {}),
           stopPageContextTabs: deps.stopPageContextTabs,
           waitingClaimRewardIds: nextWaitingClaimRewardIds,
-          emit,
+          emit: claimObservingEmit,
         });
         const lifecycleEvents = farmingLifecycleEvents(state, result.state);
         for (const event of lifecycleEvents) emit(event);
@@ -404,6 +414,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         await reconcileTablessWatchers(result.state, settings, adapters, emit, platforms);
         nextState = result.state;
       } catch (error) {
+        // The tick was rolled back, so any partial claim set is not actionable.
+        claimedPlatforms.clear();
         clearOperationalEvents(events);
         const detail = error instanceof Error ? error.message : "Scheduler tick failed";
         emit({ category: "activity", code: "interruption", level: "error", data: { reason: "platform_error", detail } });
@@ -419,6 +431,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         }
       }
     }));
+    return [...claimedPlatforms];
   }
 
   async function handleTabRemoved(tabId: number): Promise<void> {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -677,7 +677,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       if (!settings.postClaimHandoff || !settings.running) return;
       if (!settings.platform[platform].enabled) return;
 
-      const adapters = createAdapters(settings, () => undefined);
+      // Deliberately bypasses the createAdapters() wrapper: that records every
+      // compatibility diagnostic it emits into the dedup caches, so probing
+      // through it with a no-op emit would mark a diagnostic as "already
+      // reported" without it ever reaching a sink, permanently suppressing it on
+      // the next genuine tick. This is a capability lookup, not a reporting
+      // context; the handoff's own tick() reports normally.
+      const { adapters } = deps.createAdapters(() => undefined, settings);
       if (!adapters[platform].supportsPostClaimHandoff) return;
 
       const claimed = new Set(justClaimedRewardIds);

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -337,6 +337,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function handleStartup(): Promise<void> {
+    // A restart kills the watchers a handoff would transmit through, so leave
+    // no loop running against them.
+    abortClaimHandoffs();
     const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
     await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
     await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
@@ -711,6 +714,16 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
+  // The normal entry point for alarm- and message-driven ticks: run the tick,
+  // then hand off for every platform that claimed. Kept separate from tick() so
+  // the handoff's own inner ticks cannot recurse into another handoff.
+  async function tickAndHandOff(platforms?: Platform[]): Promise<void> {
+    const claimed = await tick(platforms);
+    for (const platform of Object.keys(claimed) as Platform[]) {
+      await runClaimHandoff(platform, claimed[platform] ?? []);
+    }
+  }
+
   // Transmits one heartbeat for a freshly-selected tabless target instead of
   // waiting for the next watch alarm. A visible tab needs nothing: it earns
   // progress continuously and the detecting tick already re-pointed it.
@@ -767,6 +780,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function beginSettingsSession(): Promise<void> {
+    abortClaimHandoffs();
     settingsPauseCount += 1;
     if (settingsPauseCount === 1) await tick(undefined, { forcePaused: true });
   }
@@ -893,6 +907,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     // Hold the state lock across the whole load→persist so a concurrent tick or
     // telemetry write can't clobber the claimed-reward update. snapshot() runs
     // after the lock so it reflects the committed state.
+    let claimedManually = false;
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
       const campaigns = state.campaigns[message.platform];
@@ -924,6 +939,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       let stateWithCampaigns: SchedulerState;
       try {
         const claimed = await createAdapters(settings, emit)[message.platform].claimReward(campaign, reward);
+        claimedManually = claimed;
         const nextCampaigns = campaigns.map((item) => {
           if (item.id !== campaign.id) return item;
           const rewards = item.rewards.map((candidate) => candidate.id === reward.id && claimed
@@ -978,6 +994,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       }
       await persistAndReport(stateWithCampaigns, events);
     }));
+    // Outside the lock: runClaimHandoff ticks, which takes the lock itself.
+    if (claimedManually) await runClaimHandoff(message.platform, [message.rewardId]);
     return snapshot();
   }
 
@@ -999,8 +1017,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
 
     if (message.type === "setRunning") {
+      // Stopping must cancel any loop still refreshing in the background.
+      if (!message.running) abortClaimHandoffs();
       await updateStoredSettings({ running: message.running });
-      await tick();
+      await tickAndHandOff();
       return snapshot();
     }
 
@@ -1012,7 +1032,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           },
         },
       });
-      if (settings.running) await tick();
+      if (settings.running) await tickAndHandOff();
       return snapshot();
     }
 
@@ -1026,14 +1046,14 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       };
       if (message.enabled) patch.running = true;
       const settings = await updateStoredSettings(patch);
-      if (settings.running) await tick();
+      if (settings.running) await tickAndHandOff();
       return snapshot();
     }
 
     if (message.type === "saveSettings") {
       const settings = await updateStoredSettings(message.settingsPatch);
       if (message.tickAfterSave && settingsPauseCount === 0 && settings.running && hasEnabledPlatform(settings)) {
-        await tick(message.tickAfterSavePlatforms);
+        await tickAndHandOff(message.tickAfterSavePlatforms);
       }
       return snapshot();
     }
@@ -1062,7 +1082,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
 
     if (message.type === "tickNow") {
-      await tick();
+      await tickAndHandOff();
       return snapshot();
     }
   }
@@ -1136,6 +1156,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     endSettingsSession,
     captureTwitchIntegrity,
     tick,
+    tickAndHandOff,
     runWatchHeartbeat,
     runClaimHandoff,
     abortClaimHandoffs,

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -55,6 +55,12 @@ export interface PlatformAdapter {
   // the automatic fallback when heartbeats stop earning.
   supportsTabless?: boolean;
   createTablessWatcher?(): TablessWatchController;
+  // Whether a bounded post-claim refresh is worthwhile on this platform. Twitch
+  // only reveals the next reward in a campaign chain on a subsequent inventory
+  // read, so re-polling recovers watch time the fixed alarm would otherwise
+  // waste. Kick's tabless watcher holds a persistent viewer socket and paces
+  // its own sends, so it has no equivalent dead minute to recover.
+  supportsPostClaimHandoff?: boolean;
 }
 
 export interface PageFetcher {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -709,6 +709,11 @@ export class TwitchAdapter implements PlatformAdapter {
   // it keeps working even though the controller recreates adapters each tick.
   supportsTabless = true;
 
+  // Twitch reveals the next reward in a campaign chain only on a later
+  // inventory read, so a bounded post-claim refresh recovers watch time that
+  // would otherwise be lost waiting for the fixed one-minute watch alarm.
+  supportsPostClaimHandoff = true;
+
   createTablessWatcher(): TablessWatchController {
     return new TwitchWatcher(this.gqlTransport, this.options);
   }

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -204,7 +204,7 @@ export default defineBackground(() => {
 
   browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === ALARM_NAME) {
-      void controller.tick();
+      void controller.tickAndHandOff();
     } else if (alarm.name === WATCH_ALARM_NAME) {
       void controller.runWatchHeartbeat();
     }

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { PageFetcher } from "@lurkloot/core/adapter";
+import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
 import { createKickClaimCapability, createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/kick";
 import { KickWafBlockedError } from "@lurkloot/core/tabs";
 import { readFileSync } from "node:fs";
@@ -615,8 +615,13 @@ describe("TwitchAdapter", () => {
       throw new Error("unexpected fetch");
     });
 
-    expect(new TwitchAdapter(fetcher).supportsPostClaimHandoff).toBe(true);
-    expect(new KickAdapter(fetcher).supportsPostClaimHandoff).toBeUndefined();
+    // Read through the interface: the capability is optional there, and Kick's
+    // concrete class deliberately does not declare it at all.
+    const twitch: PlatformAdapter = new TwitchAdapter(fetcher);
+    const kick: PlatformAdapter = new KickAdapter(fetcher);
+
+    expect(twitch.supportsPostClaimHandoff).toBe(true);
+    expect(kick.supportsPostClaimHandoff).toBeUndefined();
   });
 
   it("discovers active dashboard campaigns through detail GQL and merges inventory progress", async () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -609,6 +609,16 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
 });
 
 describe("TwitchAdapter", () => {
+  it("declares the post-claim handoff capability for Twitch only", () => {
+    // Reading a capability must not touch the network.
+    const fetcher = jsonFetcher(() => {
+      throw new Error("unexpected fetch");
+    });
+
+    expect(new TwitchAdapter(fetcher).supportsPostClaimHandoff).toBe(true);
+    expect(new KickAdapter(fetcher).supportsPostClaimHandoff).toBeUndefined();
+  });
+
   it("discovers active dashboard campaigns through detail GQL and merges inventory progress", async () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -2207,6 +2207,73 @@ describe("background controller", () => {
       expect(env.timer.parked).toBe(0);
     });
 
+    it("does not start a second handoff while the first is still starting", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      // Both calls are made before either has finished its async setup.
+      const first = env.controller.runClaimHandoff("twitch", ["reward-1"]);
+      const second = env.controller.runClaimHandoff("twitch", ["reward-1"]);
+      await drainMicrotasks();
+      env.controller.abortClaimHandoffs();
+      await env.timer.flush();
+      await Promise.all([first, second]);
+
+      expect(env.timer.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it("honors an abort issued while the handoff is still starting", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
+      // Synchronously, before any setup await has resolved.
+      env.controller.abortClaimHandoffs();
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    });
+
+    it("never refreshes after the maximum duration has elapsed", async () => {
+      // A 30s interval against a 45s budget: a second full-length wait would
+      // land a refresh at 60s, past the deadline the setting promises.
+      const env = handoffEnv({ postClaimHandoffIntervalSeconds: 30, postClaimHandoffMaxSeconds: 45 });
+      // The session keeps watching the reward that was just claimed, so the loop
+      // never succeeds and never sees "nothing left" — only the deadline can end
+      // it. Without that, the early exit would mask any overshoot.
+      env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch")]);
+
+      const handoff = env.controller.runClaimHandoff("twitch", ["reward"]);
+      for (let index = 0; index < 5; index += 1) await env.timer.flush();
+      await handoff;
+
+      expect(env.twitch.discoverCampaigns).toHaveBeenCalledTimes(1);
+    });
+
+    it("sends no heartbeat when the abort lands while state is being read", async () => {
+      const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
+      const env = handoffEnv({ tablessMode: true });
+      env.twitch.supportsTabless = true;
+      env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(true)]);
+
+      await env.controller.tick();
+      watcher.tick.mockClear();
+
+      // Cancel at the moment the successor becomes visible to the handoff.
+      const loadState = env.deps.loadState.getMockImplementation()!;
+      env.deps.loadState.mockImplementation(async () => {
+        const state = await loadState();
+        if (state.sessions.twitch.rewardId === "reward-2") env.controller.abortClaimHandoffs();
+        return state;
+      });
+
+      await env.controller.runClaimHandoff("twitch", ["reward-1"]);
+
+      expect(watcher.tick).not.toHaveBeenCalled();
+    });
+
     it("sends no heartbeat when the next reward runs in a visible tab", async () => {
       const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
       const env = handoffEnv({ tablessMode: false });

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -2120,5 +2120,59 @@ describe("background controller", () => {
 
       expect(env.timer.wait).not.toHaveBeenCalled();
     });
+
+    it("sends one immediate heartbeat when the next reward starts tablessly", async () => {
+      const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
+      const env = handoffEnv({ tablessMode: true });
+      env.twitch.supportsTabless = true;
+      env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
+      let reveal = false;
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      reveal = true;
+      await env.timer.flush();
+      await handoff;
+
+      expect(watcher.tick).toHaveBeenCalledTimes(1);
+      expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
+    });
+
+    it("skips the immediate heartbeat when one just landed on the same channel", async () => {
+      const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
+      const env = handoffEnv({ tablessMode: true });
+      env.twitch.supportsTabless = true;
+      env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
+      // Both rewards visible from the start, so the triggering tick already
+      // selects the successor and the handoff takes its fast path.
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(true)]);
+
+      // Establish the tabless session and land a heartbeat seconds ago.
+      await env.controller.tick();
+      await env.controller.runWatchHeartbeat();
+      watcher.tick.mockClear();
+
+      await env.controller.runClaimHandoff("twitch", ["reward-1"]);
+
+      expect(watcher.tick).not.toHaveBeenCalled();
+    });
+
+    it("sends no heartbeat when the next reward runs in a visible tab", async () => {
+      const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
+      const env = handoffEnv({ tablessMode: false });
+      env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
+      let reveal = false;
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      reveal = true;
+      await env.timer.flush();
+      await handoff;
+
+      expect(watcher.tick).not.toHaveBeenCalled();
+      // The tick that detected the successor already re-pointed the tab.
+      expect(env.state.sessions.twitch.rewardId).toBe("reward-2");
+      expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ALARM_NAME, createBackgroundController } from "@lurkloot/core/controller";
 import { resolveCompatibility } from "@lurkloot/core";
 import type { ChannelCandidate, DropCampaign, DropReward, ExtensionSettings, Platform, SchedulerState } from "@lurkloot/shared/models";
@@ -54,6 +54,7 @@ function harness(
   overrides: {
     saveState?: (state: SchedulerState) => Promise<void>;
     reportEvents?: (events: readonly EngineEvent[]) => Promise<void>;
+    wait?: (ms: number, signal: AbortSignal) => Promise<void>;
   } = {},
 ) {
   let currentSettings = settings;
@@ -88,6 +89,7 @@ function harness(
       ...resolveCompatibility(nextSettings.compatibility, { host: "extension", twitchIdentity: "web" }),
     })),
     reportEvents: vi.fn(overrides.reportEvents ?? reportEvents),
+    wait: overrides.wait,
   };
 
   return {
@@ -1718,6 +1720,36 @@ describe("background controller", () => {
     return watcher;
   }
 
+  // Drains every pending microtask. setTimeout stays real under the Date-only
+  // fake timers these handoff tests install, so one turn of the macrotask queue
+  // is enough to let an async loop run to its next park.
+  const drainMicrotasks = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  // A `wait` the test releases by hand, so handoff loops advance
+  // deterministically instead of racing real timers.
+  function manualWait() {
+    const pending: Array<() => void> = [];
+    const wait = vi.fn(async (ms: number, signal: AbortSignal) => {
+      if (signal.aborted) return;
+      await new Promise<void>((resolve) => {
+        pending.push(resolve);
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      // The delay still consumes the handoff's time budget, so a loop driven
+      // entirely by flush() still reaches its deadline.
+      vi.setSystemTime(Date.now() + ms);
+    });
+    // Drain FIRST so the loop has actually parked — runClaimHandoff suspends on
+    // loadSettings well before it reaches its first wait, and releasing an empty
+    // queue would leave it parked forever.
+    const flush = async () => {
+      await drainMicrotasks();
+      for (const resolve of pending.splice(0)) resolve();
+      await drainMicrotasks();
+    };
+    return { wait, flush, get parked() { return pending.length; } };
+  }
+
   function tablessEnv(overrides: Partial<ExtensionSettings> = {}) {
     const env = harness({
       ...DEFAULT_SETTINGS,
@@ -1961,12 +1993,132 @@ describe("background controller", () => {
     expect(env.state.lastTickAt).toBeDefined();
   });
 
-  it("reports the platforms that claimed a reward from tick", async () => {
+  it("reports the reward ids claimed during a tick, per platform", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: true });
     env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
 
     const claimed = await env.controller.tick();
 
-    expect(claimed).toEqual(["twitch"]);
+    expect(claimed).toEqual({ twitch: ["reward"] });
+  });
+
+  describe("post-claim handoff", () => {
+    // Date only: the handoff's deadline is wall-clock based, but its delays are
+    // injected, so setTimeout must stay real for drainMicrotasks.
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Twitch-only environment whose adapter opts into the handoff.
+    function handoffEnv(overrides: Partial<ExtensionSettings> = {}) {
+      const timer = manualWait();
+      const env = harness({
+        ...DEFAULT_SETTINGS,
+        running: true,
+        autoClaim: true,
+        platform: {
+          ...DEFAULT_SETTINGS.platform,
+          kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false, watchQueueChannels: [] },
+        },
+        ...overrides,
+      }, { wait: timer.wait });
+      env.twitch.supportsPostClaimHandoff = true;
+      // Re-declare the getters: spreading `env` would evaluate them once and
+      // freeze the initial snapshot, so every assertion would read stale state.
+      return {
+        ...env,
+        timer,
+        get state() { return env.state; },
+        get settings() { return env.settings; },
+      };
+    }
+
+    // A campaign whose first reward is claimable and whose second reward only
+    // becomes visible on a later inventory read — the Twitch behavior the
+    // handoff exists to absorb.
+    function chainedCampaign(revealSecond: boolean): DropCampaign {
+      const first: DropReward = { id: "reward-1", name: "First", requiredMinutes: 60, watchedMinutes: 60, status: "claimable" };
+      const second: DropReward = { id: "reward-2", name: "Second", requiredMinutes: 60, watchedMinutes: 0, status: "in_progress" };
+      return {
+        id: "twitch-campaign",
+        platform: "twitch",
+        name: "twitch campaign",
+        status: "active",
+        rewards: revealSecond ? [first, second] : [first],
+      };
+    }
+
+    it("starts earning the next reward before the next heartbeat alarm", async () => {
+      const env = handoffEnv();
+      let reveal = false;
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      reveal = true;
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.state.sessions.twitch.rewardId).toBe("reward-2");
+    });
+
+    it("stops at the deadline when no next reward appears", async () => {
+      const env = handoffEnv({ postClaimHandoffIntervalSeconds: 5, postClaimHandoffMaxSeconds: 15 });
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      for (let index = 0; index < 10; index += 1) await env.timer.flush();
+      await handoff;
+
+      // A 15s budget at a 5s interval is three refreshes, never ten.
+      expect(env.timer.wait.mock.calls.length).toBeLessThanOrEqual(3);
+      expect(env.deps.createAlarm).not.toHaveBeenCalled();
+    });
+
+    it("exits early when the platform has no eligible reward left", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => []);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it("aborts in flight when farming stops", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch");
+      // Let the loop actually park before aborting, so this exercises an
+      // in-flight cancellation rather than a pre-start one.
+      await drainMicrotasks();
+      env.controller.abortClaimHandoffs();
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.parked).toBe(0);
+      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    });
+
+    it("does not run for a platform without the capability", async () => {
+      const env = handoffEnv();
+      env.twitch.supportsPostClaimHandoff = undefined;
+
+      await env.controller.runClaimHandoff("twitch");
+
+      expect(env.timer.wait).not.toHaveBeenCalled();
+    });
+
+    it("does not run when the setting is disabled", async () => {
+      const env = handoffEnv({ postClaimHandoff: false });
+
+      await env.controller.runClaimHandoff("twitch");
+
+      expect(env.timer.wait).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1960,4 +1960,13 @@ describe("background controller", () => {
     expect(env.state.manualWatch?.kick).toBeUndefined();
     expect(env.state.lastTickAt).toBeDefined();
   });
+
+  it("reports the platforms that claimed a reward from tick", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: true });
+    env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
+
+    const claimed = await env.controller.tick();
+
+    expect(claimed).toEqual(["twitch"]);
+  });
 });

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -2157,6 +2157,56 @@ describe("background controller", () => {
       expect(watcher.tick).not.toHaveBeenCalled();
     });
 
+    it("starts a handoff after an automatic claim", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.tickAndHandOff();
+      for (let index = 0; index < 12; index += 1) await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.wait).toHaveBeenCalled();
+    });
+
+    it("does not start a nested handoff for a claim inside a handoff", async () => {
+      const env = handoffEnv({ postClaimHandoffIntervalSeconds: 5, postClaimHandoffMaxSeconds: 15 });
+      // Every refresh yields another claimable reward, which would restart the
+      // deadline forever if a nested handoff were allowed.
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
+      for (let index = 0; index < 10; index += 1) await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.wait.mock.calls.length).toBeLessThanOrEqual(3);
+    });
+
+    it("aborts running handoffs when a settings session begins", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
+      await drainMicrotasks();
+      await env.controller.beginSettingsSession();
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.parked).toBe(0);
+    });
+
+    it("aborts running handoffs when farming is switched off", async () => {
+      const env = handoffEnv();
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
+      await drainMicrotasks();
+      await env.controller.handleMessage({ type: "setRunning", running: false });
+      await env.timer.flush();
+      await handoff;
+
+      expect(env.timer.parked).toBe(0);
+    });
+
     it("sends no heartbeat when the next reward runs in a visible tab", async () => {
       const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
       const env = handoffEnv({ tablessMode: false });

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -2113,6 +2113,23 @@ describe("background controller", () => {
       expect(env.timer.wait).not.toHaveBeenCalled();
     });
 
+    it("does not suppress compatibility diagnostics when probing the capability", async () => {
+      const env = handoffEnv();
+      // Bails right after the capability probe, which is the call that could
+      // poison the controller's compatibility dedup cache.
+      env.twitch.supportsPostClaimHandoff = undefined;
+
+      await env.controller.runClaimHandoff("twitch", ["reward-1"]);
+      await env.controller.tick();
+
+      const published = env.reportEvents.mock.calls.flatMap(([events]: [readonly EngineEvent[]]) => events);
+      expect(published).toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        platform: "twitch",
+        message: expect.stringContaining("Using compatibility profile"),
+      }));
+    });
+
     it("does not run when the setting is disabled", async () => {
       const env = handoffEnv({ postClaimHandoff: false });
 

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -117,6 +117,23 @@ describe("settings", () => {
     expect(mergeSettings({ offlineRetryLimit: Number.NaN }).offlineRetryLimit).toBe(DEFAULT_SETTINGS.offlineRetryLimit);
   });
 
+  it("clamps post-claim handoff settings and defaults them when absent", () => {
+    expect(mergeSettings({}).postClaimHandoff).toBe(true);
+    expect(mergeSettings({}).postClaimHandoffIntervalSeconds).toBe(5);
+    expect(mergeSettings({}).postClaimHandoffMaxSeconds).toBe(45);
+
+    expect(mergeSettings({ postClaimHandoffIntervalSeconds: 0 }).postClaimHandoffIntervalSeconds).toBe(1);
+    expect(mergeSettings({ postClaimHandoffIntervalSeconds: 99 }).postClaimHandoffIntervalSeconds).toBe(30);
+    expect(mergeSettings({ postClaimHandoffMaxSeconds: 1 }).postClaimHandoffMaxSeconds).toBe(5);
+    expect(mergeSettings({ postClaimHandoffMaxSeconds: 999 }).postClaimHandoffMaxSeconds).toBe(120);
+
+    expect(mergeSettings({ postClaimHandoffIntervalSeconds: Number.NaN }).postClaimHandoffIntervalSeconds)
+      .toBe(DEFAULT_SETTINGS.postClaimHandoffIntervalSeconds);
+    expect(mergeSettings({ postClaimHandoffMaxSeconds: Number.NaN }).postClaimHandoffMaxSeconds)
+      .toBe(DEFAULT_SETTINGS.postClaimHandoffMaxSeconds);
+    expect(mergeSettings({ postClaimHandoff: false }).postClaimHandoff).toBe(false);
+  });
+
   it("keeps diagnostic logging independent from the removed engine log-level setting", () => {
     expect(mergeSettings(undefined).diagnosticLogging).toBe(false);
     expect(mergeSettings({ diagnosticLogging: true }).diagnosticLogging).toBe(true);

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "مدى تكرار تحديث حالة الحملات والبثوث."
   },
+  "postClaimHandoffTitle": {
+    "message": "تسليم سريع للمكافآت"
+  },
+  "postClaimHandoffDescription": {
+    "message": "بعد المطالبة بمكافأة، يتحقق لفترة وجيزة من المكافأة التالية في الحملة بدلاً من انتظار الدورة المجدولة التالية. Twitch فقط."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "فاصل التحقق أثناء التسليم"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "مدة الانتظار بين عمليات التحقق من المكافأة التالية."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "الحد الزمني للتسليم"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "التوقف والعودة إلى الجدول المعتاد بعد هذه المدة."
+  },
   "secondsSuffix": {
     "message": "ث"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "Wie oft Kampagnen- und Streamerstatus aktualisiert werden."
   },
+  "postClaimHandoffTitle": {
+    "message": "Schnelle Belohnungsübergabe"
+  },
+  "postClaimHandoffDescription": {
+    "message": "Sucht nach dem Einlösen eines Drops kurz nach der nächsten Belohnung der Kampagne, statt auf den nächsten geplanten Zyklus zu warten. Nur für Twitch."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "Prüfintervall der Übergabe"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "Wie lange zwischen den Prüfungen auf die nächste Belohnung gewartet wird."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "Zeitlimit der Übergabe"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "Nach dieser Zeit aufgeben und zum regulären Zeitplan zurückkehren."
+  },
   "secondsSuffix": {
     "message": "Sek."
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "How often campaign and streamer status refreshes."
   },
+  "postClaimHandoffTitle": {
+    "message": "Fast reward handoff"
+  },
+  "postClaimHandoffDescription": {
+    "message": "After claiming a drop, briefly check for the next reward in the campaign instead of waiting for the next scheduled cycle. Twitch only."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "Handoff check interval"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "How long to wait between checks for the next reward."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "Handoff time limit"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "Give up and return to the regular schedule after this long."
+  },
   "secondsSuffix": {
     "message": "sec"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "Frecuencia con la que se actualizan campañas y streamers."
   },
+  "postClaimHandoffTitle": {
+    "message": "Traspaso rápido de recompensas"
+  },
+  "postClaimHandoffDescription": {
+    "message": "Después de reclamar un drop, busca brevemente la siguiente recompensa de la campaña en lugar de esperar al siguiente ciclo programado. Solo en Twitch."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "Intervalo de comprobación del traspaso"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "Cuánto esperar entre comprobaciones de la siguiente recompensa."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "Límite de tiempo del traspaso"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "Rendirse y volver a la programación normal después de este tiempo."
+  },
   "secondsSuffix": {
     "message": "s"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "Fréquence d’actualisation des campagnes et streamers."
   },
+  "postClaimHandoffTitle": {
+    "message": "Transfert rapide des récompenses"
+  },
+  "postClaimHandoffDescription": {
+    "message": "Après avoir réclamé un drop, recherche brièvement la récompense suivante de la campagne au lieu d’attendre le prochain cycle planifié. Twitch uniquement."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "Intervalle de vérification du transfert"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "Temps d’attente entre deux vérifications de la récompense suivante."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "Limite de temps du transfert"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "Abandonner et revenir au planning normal après ce délai."
+  },
   "secondsSuffix": {
     "message": "s"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "कैंपेन और streamer स्थिति कितनी बार refresh होती है।"
   },
+  "postClaimHandoffTitle": {
+    "message": "तेज़ इनाम हैंडऑफ़"
+  },
+  "postClaimHandoffDescription": {
+    "message": "ड्रॉप क्लेम करने के बाद, अगले निर्धारित चक्र की प्रतीक्षा करने के बजाय अभियान के अगले इनाम की थोड़ी देर जाँच करें। केवल Twitch।"
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "हैंडऑफ़ जाँच अंतराल"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "अगले इनाम की जाँच के बीच कितनी देर प्रतीक्षा करनी है।"
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "हैंडऑफ़ समय सीमा"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "इतने समय बाद छोड़ दें और नियमित शेड्यूल पर लौट आएँ।"
+  },
   "secondsSuffix": {
     "message": "सेक"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "Frequenza di aggiornamento di campagne e streamer."
   },
+  "postClaimHandoffTitle": {
+    "message": "Passaggio rapido delle ricompense"
+  },
+  "postClaimHandoffDescription": {
+    "message": "Dopo aver riscattato un drop, cerca brevemente la ricompensa successiva della campagna invece di attendere il ciclo programmato successivo. Solo Twitch."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "Intervallo di controllo del passaggio"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "Quanto attendere tra un controllo e l’altro della ricompensa successiva."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "Limite di tempo del passaggio"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "Rinuncia e torna alla pianificazione regolare dopo questo tempo."
+  },
   "secondsSuffix": {
     "message": "sec"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "Frequência de atualização de campanhas e streamers."
   },
+  "postClaimHandoffTitle": {
+    "message": "Transferência rápida de recompensas"
+  },
+  "postClaimHandoffDescription": {
+    "message": "Depois de resgatar um drop, procura brevemente pela próxima recompensa da campanha em vez de esperar pelo próximo ciclo agendado. Somente Twitch."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "Intervalo de verificação da transferência"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "Quanto tempo esperar entre as verificações da próxima recompensa."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "Limite de tempo da transferência"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "Desistir e voltar à programação regular depois desse tempo."
+  },
   "secondsSuffix": {
     "message": "s"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "Как часто обновляется статус кампаний и стримеров."
   },
+  "postClaimHandoffTitle": {
+    "message": "Быстрая передача награды"
+  },
+  "postClaimHandoffDescription": {
+    "message": "После получения дропа ненадолго проверяет следующую награду кампании вместо ожидания следующего запланированного цикла. Только для Twitch."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "Интервал проверки при передаче"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "Сколько ждать между проверками следующей награды."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "Ограничение времени передачи"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "Прекратить и вернуться к обычному расписанию по истечении этого времени."
+  },
   "secondsSuffix": {
     "message": "с"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -422,6 +422,24 @@
   "schedulerIntervalDescription": {
     "message": "活动和主播状态刷新的频率。"
   },
+  "postClaimHandoffTitle": {
+    "message": "快速奖励交接"
+  },
+  "postClaimHandoffDescription": {
+    "message": "领取掉宝后，短暂检查活动中的下一个奖励，而不是等待下一个计划周期。仅限 Twitch。"
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "交接检查间隔"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "两次检查下一个奖励之间的等待时间。"
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "交接时间上限"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "超过这段时间后放弃并返回常规计划。"
+  },
   "secondsSuffix": {
     "message": "秒"
   },

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -154,6 +154,34 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
       </SettingsSection>
       <SettingsSection title={t("advancedTitle")} description={t("advancedDescription")} icon={SlidersHorizontal}>
         <NumberSettingRow title={t("schedulerIntervalTitle")} description={t("schedulerIntervalDescription")} value={pollIntervalSeconds} min={30} max={3600} suffix={t("secondsSuffix")} onChange={(value) => onSettingsChange({ pollIntervalMinutes: value / 60 })} />
+        <SettingRow
+          title={t("postClaimHandoffTitle")}
+          description={t("postClaimHandoffDescription")}
+          checked={settings.postClaimHandoff}
+          onChange={set("postClaimHandoff")}
+        />
+        <NumberSettingRow
+          title={t("postClaimHandoffIntervalTitle")}
+          description={t("postClaimHandoffIntervalDescription")}
+          value={settings.postClaimHandoffIntervalSeconds}
+          min={1}
+          max={30}
+          suffix={t("secondsSuffix")}
+          disabled={!settings.postClaimHandoff}
+          disabledReason={t("postClaimHandoffDescription")}
+          onChange={(value) => onSettingsChange({ postClaimHandoffIntervalSeconds: value })}
+        />
+        <NumberSettingRow
+          title={t("postClaimHandoffMaxTitle")}
+          description={t("postClaimHandoffMaxDescription")}
+          value={settings.postClaimHandoffMaxSeconds}
+          min={5}
+          max={120}
+          suffix={t("secondsSuffix")}
+          disabled={!settings.postClaimHandoff}
+          disabledReason={t("postClaimHandoffDescription")}
+          onChange={(value) => onSettingsChange({ postClaimHandoffMaxSeconds: value })}
+        />
         <SettingRow title={t("diagnosticLoggingTitle")} description={t("diagnosticLoggingDescription")} checked={settings.diagnosticLogging} onChange={set("diagnosticLogging")} />
         {compatibilityRegistry && compatibilityResolution ? <CompatibilitySettings settings={settings.compatibility} registry={compatibilityRegistry} resolution={compatibilityResolution} onChange={onSettingsChange} /> : null}
       </SettingsSection>

--- a/packages/popup-ui/src/settingsControls.tsx
+++ b/packages/popup-ui/src/settingsControls.tsx
@@ -195,7 +195,7 @@ export function SelectSettingRow<T extends string>({ title, description, value, 
   );
 }
 
-export function NumberSettingRow({ title, description, value, min, max, suffix, onChange }: { title: string; description: string; value: number; min: number; max: number; suffix: string; onChange(value: number): void | Promise<void> }) {
+export function NumberSettingRow({ title, description, value, min, max, suffix, onChange, disabled = false, disabledReason }: { title: string; description: string; value: number; min: number; max: number; suffix: string; onChange(value: number): void | Promise<void>; disabled?: boolean; disabledReason?: string }) {
   const [draft, setDraft] = useState(String(value));
 
   useEffect(() => {
@@ -214,15 +214,16 @@ export function NumberSettingRow({ title, description, value, min, max, suffix, 
   }
 
   return (
-    <div className="flex items-center gap-3 py-2.5">
+    <div className={cn("flex items-center gap-3 py-2.5", disabled && "opacity-60")} title={disabled ? disabledReason : undefined}>
       <div className="min-w-0 flex-1">
         <div className="text-[13px] font-medium text-zinc-800 dark:text-zinc-100">{title}</div>
         <div className="mt-0.5 text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{description}</div>
       </div>
-      <label className="flex shrink-0 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2 py-1 text-[11px] font-semibold text-zinc-500 focus-within:border-[var(--accent-ring)] dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+      <label className={cn("flex shrink-0 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2 py-1 text-[11px] font-semibold text-zinc-500 focus-within:border-[var(--accent-ring)] dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400", disabled && "cursor-not-allowed")}>
         <input
           aria-label={title}
           type="number"
+          disabled={disabled}
           min={min}
           max={max}
           step={1}

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -260,6 +260,13 @@ export interface EngineSettings {
   excludedCampaignIds: string[];
   offlineRetryLimit: number;
   pollIntervalMinutes: number;
+  // Bounded post-claim handoff. After a reward is claimed, re-run discovery for
+  // that platform on this cadence until the next eligible reward appears, then
+  // transmit immediately instead of waiting for the fixed one-minute watch
+  // alarm. Only platforms whose adapter sets supportsPostClaimHandoff use it.
+  postClaimHandoff: boolean;
+  postClaimHandoffIntervalSeconds: number;
+  postClaimHandoffMaxSeconds: number;
 }
 
 // The browser extension's full settings schema: the engine contract plus the

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -59,6 +59,11 @@ export const DEFAULT_ENGINE_SETTINGS: EngineSettings = {
   excludedCampaignIds: [],
   offlineRetryLimit: 3,
   pollIntervalMinutes: 1,
+  postClaimHandoff: true,
+  // Nine refreshes at most, always finishing before the next one-minute watch
+  // alarm so the handoff and the alarm never contend for the same heartbeat.
+  postClaimHandoffIntervalSeconds: 5,
+  postClaimHandoffMaxSeconds: 45,
 };
 
 // The extension's full defaults: the engine contract plus the host-only knobs.
@@ -134,6 +139,9 @@ export function mergeEngineSettings(value: Partial<EngineSettings> | undefined):
     offlineRetryLimit: clampInteger(value?.offlineRetryLimit, 1, 10, DEFAULT_ENGINE_SETTINGS.offlineRetryLimit),
     // chrome.alarms floors periodInMinutes at 1, so sub-minute values are inert.
     pollIntervalMinutes: clampNumber(value?.pollIntervalMinutes, 1, 60, DEFAULT_ENGINE_SETTINGS.pollIntervalMinutes),
+    postClaimHandoff: booleanOr(value?.postClaimHandoff, DEFAULT_ENGINE_SETTINGS.postClaimHandoff),
+    postClaimHandoffIntervalSeconds: clampInteger(value?.postClaimHandoffIntervalSeconds, 1, 30, DEFAULT_ENGINE_SETTINGS.postClaimHandoffIntervalSeconds),
+    postClaimHandoffMaxSeconds: clampInteger(value?.postClaimHandoffMaxSeconds, 5, 120, DEFAULT_ENGINE_SETTINGS.postClaimHandoffMaxSeconds),
   };
 }
 


### PR DESCRIPTION
Closes #110.

## Summary

After a Twitch reward is claimed, the next reward in a campaign chain could wait up to a minute before earning resumed: Twitch often reveals the successor only on a later inventory read, and even once selected, its first tabless heartbeat waited on the fixed one-minute watch alarm.

This adds a bounded, abortable post-claim handoff that re-runs a scoped scheduler tick on a configurable cadence until the successor appears, then transmits immediately.

- **Adapter capability** — `supportsPostClaimHandoff` on `PlatformAdapter`, mirroring `supportsTabless`. Twitch opts in; Kick does not (its watcher holds a persistent viewer socket and paces its own sends, so there is no dead minute to recover).
- **Bounded loop** — deadline computed once at start, so a claim occurring *inside* a handoff neither nests nor extends it. Worst case is fixed at `ceil(maxSeconds / intervalSeconds)` ticks.
- **Fast path** — when the triggering tick already selected the successor, the poll loop is skipped and only the heartbeat is brought forward.
- **Reuse over reimplementation** — the loop re-runs the existing `tick()`, so eligibility, claim guarding, target selection and watcher reconciliation are not duplicated. Duplicate claims are structurally impossible: `claimReadyRewards` only acts on `status === "claimable"`.
- **No double heartbeats** — suppressed when one landed within 30s on an unchanged channel; a channel switch always transmits.
- **Alarms are never touched**, so every failure path degrades to exactly today's behavior.

Configurable in Advanced Settings and CLI JSONC: `postClaimHandoff` (default on), `postClaimHandoffIntervalSeconds` (5, clamped 1–30), `postClaimHandoffMaxSeconds` (45, clamped 5–120). The defaults give at most nine refreshes and always finish before the next alarm, so the two never contend.

Design and plan are committed under `docs/superpowers/`.

## Notable API change

`tick()` now returns `ClaimedRewards` (reward ids per platform) instead of `void`. The ids are required to distinguish a genuine successor from the reward just claimed — using the post-tick session id instead causes the loop to mark the successor as claimed and never terminate. A new `tickAndHandOff()` is the entry point for alarm- and message-driven ticks; `tick()` itself never triggers a handoff, which is what makes recursion structurally impossible.

## Test plan

- [x] `pnpm verify` passes (612 tests, both browser builds, site build)
- [x] Handoff coverage: success, deadline, abort in-flight, settings-session abort, farming-off abort, no-next-reward early exit, visible-tab, no-double-heartbeat, no nested handoff, capability gate, setting gate
- [x] Settings clamping covered for all three new fields
- [x] `wxt.config.ts` diff is empty — no new permissions
- [x] Popup rendering verified in the live demo (which mounts the real popup UI): enabled state shows the toggle plus `5 sec` / `45 sec`, matching the adjacent Scheduler interval row; turning the toggle off dims both dependent rows and sets `disabled` on their inputs, leaving Scheduler interval unaffected

## Note for reviewers

Touches `packages/cli/src/settings.ts`, which has concurrent in-flight work adding `MOVED_SETTING_KEYS`. Different regions, so it should merge cleanly, but whichever lands second should re-run `pnpm check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Twitch-only post-claim “fast handoff” that briefly rechecks after a reward claim to move to the next eligible reward.
  * On success in tabless mode, sends one immediate heartbeat with safeguards to prevent redundant sends.
* **Settings/Configuration**
  * Added advanced settings to enable the handoff and configure check interval and maximum duration (with defaults and clamping).
  * Updated CLI configuration to include the new handoff settings and improved shutdown to stop handoff activity cleanly.
* **Documentation**
  * Added design and verification documentation for the handoff flow.
* **Localization**
  * Added translated UI text for the feature and its timing controls.
* **Tests**
  * Expanded controller and settings tests to cover deterministic handoff behavior, abort/timeout cases, and value clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
