### PR TITLE
feat(scheduler): skip rewards that cannot finish

### DIFF
--- a/docs/superpowers/plans/2026-07-19-deadline-feasibility.md
+++ b/docs/superpowers/plans/2026-07-19-deadline-feasibility.md
@@ -1,0 +1,333 @@
+# Deadline Feasibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Skip watch rewards that cannot be completed before their earliest valid deadline, with one `-1..60` minute configuration shared by extension and CLI.
+
+**Architecture:** A pure evaluator in `@lurkloot/shared/rewards` owns all deadline arithmetic and returns typed data. The core scheduler uses it for selection and retention, while popup view models use it for localized presentation; settings normalization supplies the same default and range to both hosts.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Vitest, React, WXT, JSONC.
+
+## Global Constraints
+
+- `deadlineSafetyMarginMinutes` defaults to `5`.
+- `-1` disables feasibility filtering, `0` is strict feasibility, and `1..60` adds that many buffer minutes.
+- Missing or invalid deadlines preserve current farmability.
+- Exact equality is feasible and a one-millisecond shortage is infeasible.
+- Already-earned watch progress reduces remaining work.
+- Platform parsers and browser permissions remain unchanged.
+
+---
+
+### Task 1: Shared settings contract and normalization
+
+**Files:**
+- Modify: `packages/shared/src/models.ts`
+- Modify: `packages/shared/src/settings.ts`
+- Test: `packages/extension/tests/settings.test.ts`
+
+**Interfaces:**
+- Produces: `EngineSettings.deadlineSafetyMarginMinutes: number`
+- Produces: `DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes === 5`
+- Produces: normalization to an integer in `[-1, 60]`
+
+- [ ] **Step 1: Write the failing settings tests**
+
+Add assertions covering the default, `-1`, `0`, rounding, both clamps, and invalid fallback:
+
+```ts
+expect(DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes).toBe(5);
+expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -9 }).deadlineSafetyMarginMinutes).toBe(-1);
+expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -1 }).deadlineSafetyMarginMinutes).toBe(-1);
+expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 0 }).deadlineSafetyMarginMinutes).toBe(0);
+expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 4.6 }).deadlineSafetyMarginMinutes).toBe(5);
+expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 99 }).deadlineSafetyMarginMinutes).toBe(60);
+expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: Number.NaN }).deadlineSafetyMarginMinutes).toBe(5);
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm test -- settings.test.ts`
+
+Expected: FAIL because `deadlineSafetyMarginMinutes` is absent.
+
+- [ ] **Step 3: Implement the setting**
+
+Add `deadlineSafetyMarginMinutes: number` to `EngineSettings`, add `deadlineSafetyMarginMinutes: 5` to `DEFAULT_ENGINE_SETTINGS`, and normalize it in `mergeEngineSettings` with:
+
+```ts
+deadlineSafetyMarginMinutes: clampInteger(
+  value?.deadlineSafetyMarginMinutes,
+  -1,
+  60,
+  DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes,
+),
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pnpm test -- settings.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/models.ts packages/shared/src/settings.ts packages/extension/tests/settings.test.ts
+git commit -m "feat(settings): add deadline safety margin"
+```
+
+### Task 2: Pure reward feasibility evaluator
+
+**Files:**
+- Modify: `packages/shared/src/rewards.ts`
+- Create: `packages/extension/tests/rewardFeasibility.test.ts`
+
+**Interfaces:**
+- Produces: `RewardFeasibility` discriminated union with `disabled`, `unknown_deadline`, `feasible`, and `insufficient_time` kinds
+- Produces: `rewardFeasibility(campaign, reward, marginMinutes, now?): RewardFeasibility`
+- Produces: `isRewardDeadlineFeasible(...)` convenience predicate if it removes scheduler duplication
+
+- [ ] **Step 1: Write failing evaluator tests**
+
+Create fixed-time tests using `const now = Date.parse("2026-07-19T12:00:00.000Z")`. Cover disabled mode, exact equality, one millisecond short, partial progress, earliest of campaign/reward deadlines, invalid deadlines, and non-watch rewards. Assert structured fields for an insufficient result:
+
+```ts
+expect(rewardFeasibility(campaign, reward, 5, now)).toEqual({
+  kind: "insufficient_time",
+  deadline: "2026-07-19T12:34:59.999Z",
+  remainingMinutes: 30,
+  availableMilliseconds: 2_099_999,
+  marginMinutes: 5,
+});
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm test -- rewardFeasibility.test.ts`
+
+Expected: FAIL because `rewardFeasibility` is not exported.
+
+- [ ] **Step 3: Implement minimal evaluator**
+
+Use these public shapes and exact comparison:
+
+```ts
+export type RewardFeasibility =
+  | { kind: "disabled" }
+  | { kind: "not_applicable" }
+  | { kind: "unknown_deadline" }
+  | { kind: "feasible"; deadline: string; remainingMinutes: number; availableMilliseconds: number; marginMinutes: number }
+  | { kind: "insufficient_time"; deadline: string; remainingMinutes: number; availableMilliseconds: number; marginMinutes: number };
+
+const requiredMilliseconds = (remainingMinutes + marginMinutes) * 60_000;
+const kind = availableMilliseconds >= requiredMilliseconds ? "feasible" : "insufficient_time";
+```
+
+Return `disabled` before deadline parsing when the margin is `-1`; return `not_applicable` for claimed or non-watch rewards; select the minimum of valid campaign and reward timestamps; clamp remaining minutes to zero.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pnpm test -- rewardFeasibility.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/rewards.ts packages/extension/tests/rewardFeasibility.test.ts
+git commit -m "feat(core): evaluate reward deadline feasibility"
+```
+
+### Task 3: Scheduler selection, retention, and diagnostics
+
+**Files:**
+- Modify: `packages/core/src/core/scheduler.ts`
+- Test: `packages/extension/tests/scheduler.test.ts`
+
+**Interfaces:**
+- Consumes: `rewardFeasibility(campaign, reward, settings.deadlineSafetyMarginMinutes, now)`
+- Produces: scheduler decisions that never select an `insufficient_time` reward unless the setting is `-1`
+- Produces: diagnostic text containing reward, remaining minutes, available minutes, deadline, and margin
+
+- [ ] **Step 1: Write failing scheduler tests**
+
+Add fixed-clock tests with `vi.setSystemTime` proving that selection skips an infeasible in-progress reward for a feasible locked reward, rejects a campaign when all selectable watch rewards are infeasible, accepts exact equality, honors `-1`, and stops retaining a current session once its reward becomes infeasible. Assert the exclusion diagnostic contains `insufficient time`, the reward name, and `margin 5 minutes`.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm test -- scheduler.test.ts`
+
+Expected: FAIL because infeasible rewards remain selectable.
+
+- [ ] **Step 3: Integrate the evaluator**
+
+Change reward selection to accept settings and filter using one helper:
+
+```ts
+function isRewardFeasible(campaign: DropCampaign, reward: DropReward, settings: EngineSettings, now = Date.now()): boolean {
+  return rewardFeasibility(campaign, reward, settings.deadlineSafetyMarginMinutes, now).kind !== "insufficient_time";
+}
+```
+
+Use it in `activeReward`, `isEligible`, and current-session retention. Preserve in-progress-before-locked ordering among feasible rewards. Emit a diagnostic when infeasibility is the reason a candidate is skipped, formatting available minutes from `availableMilliseconds / 60_000` without using the rounded display value for decisions.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pnpm test -- scheduler.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/core/scheduler.ts packages/extension/tests/scheduler.test.ts
+git commit -m "feat(scheduler): skip rewards that cannot finish"
+```
+
+### Task 4: CLI configuration
+
+**Files:**
+- Modify: `packages/cli/src/settings.ts`
+- Modify: `packages/cli/src/config.ts`
+- Test: `packages/cli/tests/settings.test.ts`
+- Test: `packages/cli/tests/config.test.ts`
+
+**Interfaces:**
+- Produces: `CliSettings.deadlineSafetyMarginMinutes: number`
+- Produces: generated JSONC containing the setting and mode documentation
+- Produces: `toEngineSettings` forwarding the normalized value
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Assert that defaults include `5`, parsing accepts and normalizes `-1`, `0`, and out-of-range values, `toEngineSettings` forwards the field, and `defaultConfigJsonc()` includes:
+
+```jsonc
+// -1 disables deadline filtering; 0 uses exact feasibility; 1-60 adds a safety buffer.
+"deadlineSafetyMarginMinutes": 5,
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm --filter @lurkloot/cli test -- settings.test.ts config.test.ts`
+
+Expected: FAIL because the CLI rejects or omits the setting.
+
+- [ ] **Step 3: Implement CLI support**
+
+Add the field to `CliSettings`, `DEFAULT_CLI_SETTINGS`, `CLI_SETTING_KEYS`, the `parseCliSettings` return value using `clampInteger(..., -1, 60, ...)`, `toEngineSettings`, and the generated JSONC template with the exact explanatory comment.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pnpm --filter @lurkloot/cli test -- settings.test.ts config.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit without absorbing pre-existing edits**
+
+Inspect `git diff -- packages/cli/src/settings.ts`, stage only issue-108 hunks if unrelated edits remain, then:
+
+```bash
+git add packages/cli/src/config.ts packages/cli/tests/settings.test.ts packages/cli/tests/config.test.ts
+git commit -m "feat(cli): configure deadline safety margin"
+```
+
+### Task 5: Popup setting and insufficient-time explanation
+
+**Files:**
+- Modify: `packages/popup-ui/src/settings.tsx`
+- Modify: `packages/popup-ui/src/viewModels.ts`
+- Modify: `packages/popup-ui/src/types.ts`
+- Modify: `packages/popup-ui/src/drops.tsx`
+- Modify: `packages/popup-ui/src/Popup.tsx`
+- Modify: `packages/locales/messages/*.json`
+- Test: `packages/extension/tests/settingsView.test.tsx`
+- Test: `packages/extension/tests/subscriptionDropsView.test.ts`
+
+**Interfaces:**
+- Consumes: `rewardFeasibility`
+- Produces: `RewardView.ineligibilityReason?: "insufficient_time"`
+- Changes: `campaignViewFromCampaign(..., settings: Pick<ExtensionSettings, "deadlineSafetyMarginMinutes">, now?: number)`
+
+- [ ] **Step 1: Write failing popup tests**
+
+Assert the Advanced number control displays `5`, accepts `-1`, saves with `{ tickAfterSave: true }`, and shows localized Disabled/minutes semantics. Add a view-model/render test proving an infeasible watch reward receives `ineligibilityReason: "insufficient_time"` and renders `t("insufficientTimeRemaining")`; verify subscription rewards do not receive it.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm test -- settingsView.test.tsx subscriptionDropsView.test.ts`
+
+Expected: FAIL because the control and reason are absent.
+
+- [ ] **Step 3: Implement popup behavior**
+
+Add a `NumberSettingRow` under Advanced with `min={-1}`, `max={60}`, whole-minute values, and tick-after-save. Pass settings from `Popup.tsx` into `campaignViewFromCampaign`; map only evaluator kind `insufficient_time` to the new view field. Render a compact warning under watch progress. Add these English keys and translated equivalents to all catalogs:
+
+```json
+"deadlineSafetyMarginTitle": { "message": "Deadline safety margin" },
+"deadlineSafetyMarginDescription": { "message": "Set extra minutes required before farming a reward. Use -1 to disable deadline filtering." },
+"deadlineSafetyMarginDisabled": { "message": "Disabled" },
+"insufficientTimeRemaining": { "message": "Insufficient time remaining" }
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pnpm test -- settingsView.test.tsx subscriptionDropsView.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/popup-ui/src packages/locales/messages packages/extension/tests/settingsView.test.tsx packages/extension/tests/subscriptionDropsView.test.ts
+git commit -m "feat(popup): expose deadline feasibility controls"
+```
+
+### Task 6: Full verification and documentation consistency
+
+**Files:**
+- Modify if needed: `packages/cli/README.md`
+
+**Interfaces:**
+- Consumes: all prior task outputs
+- Produces: a verified extension and CLI implementation of issue #108
+
+- [ ] **Step 1: Document the CLI setting if the README enumerates settings**
+
+Add one concise entry with the exact `-1`, `0`, and `1..60` semantics; do not duplicate the generated JSONC reference unnecessarily.
+
+- [ ] **Step 2: Run focused suites**
+
+Run:
+
+```bash
+pnpm test -- rewardFeasibility.test.ts settings.test.ts scheduler.test.ts settingsView.test.tsx subscriptionDropsView.test.ts
+pnpm --filter @lurkloot/cli test -- settings.test.ts config.test.ts
+```
+
+Expected: all selected tests pass with zero failures.
+
+- [ ] **Step 3: Run full verification**
+
+Run: `pnpm verify`
+
+Expected: script tests, workspace typechecks, extension tests, Astro build, and both browser builds all exit successfully.
+
+- [ ] **Step 4: Review the final diff**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff --stat origin/develop...HEAD
+```
+
+Confirm no unrelated user changes are staged or committed and every acceptance criterion in the design spec maps to passing tests.
+
+- [ ] **Step 5: Commit any documentation-only remainder**
+
+```bash
+git add packages/cli/README.md
+git commit -m "docs(cli): document deadline safety margin"
+```

--- a/docs/superpowers/plans/2026-07-19-deadline-feasibility.md
+++ b/docs/superpowers/plans/2026-07-19-deadline-feasibility.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Skip watch rewards that cannot be completed before their earliest valid deadline, with one `-1..60` minute configuration shared by extension and CLI.
+**Goal:** Skip watch rewards that cannot be completed before their earliest valid deadline, with separate enablement and `0..60` minute margin settings shared by extension and CLI.
 
 **Architecture:** A pure evaluator in `@lurkloot/shared/rewards` owns all deadline arithmetic and returns typed data. The core scheduler uses it for selection and retention, while popup view models use it for localized presentation; settings normalization supplies the same default and range to both hosts.
 
@@ -10,8 +10,8 @@
 
 ## Global Constraints
 
-- `deadlineSafetyMarginMinutes` defaults to `5`.
-- `-1` disables feasibility filtering, `0` is strict feasibility, and `1..60` adds that many buffer minutes.
+- `skipUnfinishableRewards` defaults to `true` and controls whether filtering is enforced.
+- `deadlineSafetyMarginMinutes` defaults to `5`; `0` is strict feasibility and `1..60` adds that many buffer minutes.
 - Missing or invalid deadlines preserve current farmability.
 - Exact equality is feasible and a one-millisecond shortage is infeasible.
 - Already-earned watch progress reduces remaining work.
@@ -27,18 +27,20 @@
 - Test: `packages/extension/tests/settings.test.ts`
 
 **Interfaces:**
+- Produces: `EngineSettings.skipUnfinishableRewards: boolean`
 - Produces: `EngineSettings.deadlineSafetyMarginMinutes: number`
 - Produces: `DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes === 5`
-- Produces: normalization to an integer in `[-1, 60]`
+- Produces: boolean normalization plus an integer margin in `[0, 60]`
 
 - [ ] **Step 1: Write the failing settings tests**
 
-Add assertions covering the default, `-1`, `0`, rounding, both clamps, and invalid fallback:
+Add assertions covering both defaults, invalid booleans, `0`, rounding, both margin clamps, and invalid fallback:
 
 ```ts
 expect(DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes).toBe(5);
-expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -9 }).deadlineSafetyMarginMinutes).toBe(-1);
-expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -1 }).deadlineSafetyMarginMinutes).toBe(-1);
+expect(DEFAULT_ENGINE_SETTINGS.skipUnfinishableRewards).toBe(true);
+expect(mergeEngineSettings({ skipUnfinishableRewards: false }).skipUnfinishableRewards).toBe(false);
+expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -9 }).deadlineSafetyMarginMinutes).toBe(0);
 expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 0 }).deadlineSafetyMarginMinutes).toBe(0);
 expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 4.6 }).deadlineSafetyMarginMinutes).toBe(5);
 expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 99 }).deadlineSafetyMarginMinutes).toBe(60);
@@ -53,12 +55,12 @@ Expected: FAIL because `deadlineSafetyMarginMinutes` is absent.
 
 - [ ] **Step 3: Implement the setting**
 
-Add `deadlineSafetyMarginMinutes: number` to `EngineSettings`, add `deadlineSafetyMarginMinutes: 5` to `DEFAULT_ENGINE_SETTINGS`, and normalize it in `mergeEngineSettings` with:
+Add both fields to `EngineSettings`, add their defaults to `DEFAULT_ENGINE_SETTINGS`, normalize the toggle with `booleanOr`, and normalize the margin with:
 
 ```ts
 deadlineSafetyMarginMinutes: clampInteger(
   value?.deadlineSafetyMarginMinutes,
-  -1,
+  0,
   60,
   DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes,
 ),
@@ -85,15 +87,15 @@ git commit -m "feat(settings): add deadline safety margin"
 
 **Interfaces:**
 - Produces: `RewardFeasibility` discriminated union with `disabled`, `unknown_deadline`, `feasible`, and `insufficient_time` kinds
-- Produces: `rewardFeasibility(campaign, reward, marginMinutes, now?): RewardFeasibility`
+- Produces: `rewardFeasibility(campaign, reward, enabled, marginMinutes, now?): RewardFeasibility`
 - Produces: `isRewardDeadlineFeasible(...)` convenience predicate if it removes scheduler duplication
 
 - [ ] **Step 1: Write failing evaluator tests**
 
-Create fixed-time tests using `const now = Date.parse("2026-07-19T12:00:00.000Z")`. Cover disabled mode, exact equality, one millisecond short, partial progress, earliest of campaign/reward deadlines, invalid deadlines, and non-watch rewards. Assert structured fields for an insufficient result:
+Create fixed-time tests using `const now = Date.parse("2026-07-19T12:00:00.000Z")`. Cover disabled mode via the boolean flag, exact equality, one millisecond short, partial progress, earliest of campaign/reward deadlines, invalid deadlines, and non-watch rewards. Assert structured fields for an insufficient result:
 
 ```ts
-expect(rewardFeasibility(campaign, reward, 5, now)).toEqual({
+expect(rewardFeasibility(campaign, reward, true, 5, now)).toEqual({
   kind: "insufficient_time",
   deadline: "2026-07-19T12:34:59.999Z",
   remainingMinutes: 30,
@@ -124,7 +126,7 @@ const requiredMilliseconds = (remainingMinutes + marginMinutes) * 60_000;
 const kind = availableMilliseconds >= requiredMilliseconds ? "feasible" : "insufficient_time";
 ```
 
-Return `disabled` before deadline parsing when the margin is `-1`; return `not_applicable` for claimed or non-watch rewards; select the minimum of valid campaign and reward timestamps; clamp remaining minutes to zero.
+Return `disabled` before deadline parsing when the enabled flag is false; return `not_applicable` for claimed or non-watch rewards; select the minimum of valid campaign and reward timestamps; clamp remaining minutes to zero.
 
 - [ ] **Step 4: Verify GREEN**
 
@@ -146,13 +148,13 @@ git commit -m "feat(core): evaluate reward deadline feasibility"
 - Test: `packages/extension/tests/scheduler.test.ts`
 
 **Interfaces:**
-- Consumes: `rewardFeasibility(campaign, reward, settings.deadlineSafetyMarginMinutes, now)`
-- Produces: scheduler decisions that never select an `insufficient_time` reward unless the setting is `-1`
+- Consumes: `rewardFeasibility(campaign, reward, settings.skipUnfinishableRewards, settings.deadlineSafetyMarginMinutes, now)`
+- Produces: scheduler decisions that never select an `insufficient_time` reward while the toggle is enabled
 - Produces: diagnostic text containing reward, remaining minutes, available minutes, deadline, and margin
 
 - [ ] **Step 1: Write failing scheduler tests**
 
-Add fixed-clock tests with `vi.setSystemTime` proving that selection skips an infeasible in-progress reward for a feasible locked reward, rejects a campaign when all selectable watch rewards are infeasible, accepts exact equality, honors `-1`, and stops retaining a current session once its reward becomes infeasible. Assert the exclusion diagnostic contains `insufficient time`, the reward name, and `margin 5 minutes`.
+Add fixed-clock tests with `vi.setSystemTime` proving that selection skips an infeasible in-progress reward for a feasible locked reward, rejects a campaign when all selectable watch rewards are infeasible, accepts exact equality, honors a disabled toggle, and stops retaining a current session once its reward becomes infeasible. Assert the exclusion diagnostic contains `insufficient time`, the reward name, and `margin 5 minutes`.
 
 - [ ] **Step 2: Verify RED**
 
@@ -166,7 +168,7 @@ Change reward selection to accept settings and filter using one helper:
 
 ```ts
 function isRewardFeasible(campaign: DropCampaign, reward: DropReward, settings: EngineSettings, now = Date.now()): boolean {
-  return rewardFeasibility(campaign, reward, settings.deadlineSafetyMarginMinutes, now).kind !== "insufficient_time";
+  return rewardFeasibility(campaign, reward, settings.skipUnfinishableRewards, settings.deadlineSafetyMarginMinutes, now).kind !== "insufficient_time";
 }
 ```
 
@@ -194,16 +196,16 @@ git commit -m "feat(scheduler): skip rewards that cannot finish"
 - Test: `packages/cli/tests/config.test.ts`
 
 **Interfaces:**
-- Produces: `CliSettings.deadlineSafetyMarginMinutes: number`
+- Produces: `CliSettings.skipUnfinishableRewards: boolean` and `CliSettings.deadlineSafetyMarginMinutes: number`
 - Produces: generated JSONC containing the setting and mode documentation
 - Produces: `toEngineSettings` forwarding the normalized value
 
 - [ ] **Step 1: Write failing CLI tests**
 
-Assert that defaults include `5`, parsing accepts and normalizes `-1`, `0`, and out-of-range values, `toEngineSettings` forwards the field, and `defaultConfigJsonc()` includes:
+Assert that defaults include `true` and `5`, parsing accepts a disabled toggle and normalizes `0` and out-of-range margins, `toEngineSettings` forwards both fields, and `defaultConfigJsonc()` includes:
 
 ```jsonc
-// -1 disables deadline filtering; 0 uses exact feasibility; 1-60 adds a safety buffer.
+"skipUnfinishableRewards": true,
 "deadlineSafetyMarginMinutes": 5,
 ```
 
@@ -215,7 +217,7 @@ Expected: FAIL because the CLI rejects or omits the setting.
 
 - [ ] **Step 3: Implement CLI support**
 
-Add the field to `CliSettings`, `DEFAULT_CLI_SETTINGS`, `CLI_SETTING_KEYS`, the `parseCliSettings` return value using `clampInteger(..., -1, 60, ...)`, `toEngineSettings`, and the generated JSONC template with the exact explanatory comment.
+Add both fields to `CliSettings`, `DEFAULT_CLI_SETTINGS`, `CLI_SETTING_KEYS`, the `parseCliSettings` return value using `booleanOr` and `clampInteger(..., 0, 60, ...)`, `toEngineSettings`, and the generated JSONC template.
 
 - [ ] **Step 4: Verify GREEN**
 
@@ -247,11 +249,11 @@ git commit -m "feat(cli): configure deadline safety margin"
 **Interfaces:**
 - Consumes: `rewardFeasibility`
 - Produces: `RewardView.ineligibilityReason?: "insufficient_time"`
-- Changes: `campaignViewFromCampaign(..., settings: Pick<ExtensionSettings, "deadlineSafetyMarginMinutes">, now?: number)`
+- Changes: `campaignViewFromCampaign(..., settings: Pick<ExtensionSettings, "skipUnfinishableRewards" | "deadlineSafetyMarginMinutes">, now?: number)`
 
 - [ ] **Step 1: Write failing popup tests**
 
-Assert the Advanced number control displays `5`, accepts `-1`, saves with `{ tickAfterSave: true }`, and shows localized Disabled/minutes semantics. Add a view-model/render test proving an infeasible watch reward receives `ineligibilityReason: "insufficient_time"` and renders `t("insufficientTimeRemaining")`; verify subscription rewards do not receive it.
+Assert the Advanced toggle defaults on, the number control displays `5`, the margin input is disabled while the toggle is off, its value is preserved, and both controls save with `{ tickAfterSave: true }`. Add a view-model/render test proving a disabled toggle removes `ineligibilityReason`, while an enabled toggle marks an infeasible watch reward and renders `t("insufficientTimeRemaining")`.
 
 - [ ] **Step 2: Verify RED**
 
@@ -261,11 +263,13 @@ Expected: FAIL because the control and reason are absent.
 
 - [ ] **Step 3: Implement popup behavior**
 
-Add a `NumberSettingRow` under Advanced with `min={-1}`, `max={60}`, whole-minute values, and tick-after-save. Pass settings from `Popup.tsx` into `campaignViewFromCampaign`; map only evaluator kind `insufficient_time` to the new view field. Render a compact warning under watch progress. Add these English keys and translated equivalents to all catalogs:
+Add a `SettingRow` toggle followed by a `NumberSettingRow` with `min={0}`, `max={60}`, whole-minute values, `disabled={!settings.skipUnfinishableRewards}`, and tick-after-save. Pass both settings from `Popup.tsx` into `campaignViewFromCampaign`; map only evaluator kind `insufficient_time` to the new view field. Render a compact warning under watch progress. Add these English keys and translated equivalents to all catalogs:
 
 ```json
 "deadlineSafetyMarginTitle": { "message": "Deadline safety margin" },
-"deadlineSafetyMarginDescription": { "message": "Set extra minutes required before farming a reward. Use -1 to disable deadline filtering." },
+"skipUnfinishableRewardsTitle": { "message": "Skip rewards that cannot be completed" },
+"skipUnfinishableRewardsDescription": { "message": "Do not farm rewards when the remaining watch time exceeds their deadline." },
+"deadlineSafetyMarginDescription": { "message": "Set extra minutes required before farming a reward." },
 "deadlineSafetyMarginDisabled": { "message": "Disabled" },
 "insufficientTimeRemaining": { "message": "Insufficient time remaining" }
 ```
@@ -294,7 +298,7 @@ git commit -m "feat(popup): expose deadline feasibility controls"
 
 - [ ] **Step 1: Document the CLI setting if the README enumerates settings**
 
-Add one concise entry with the exact `-1`, `0`, and `1..60` semantics; do not duplicate the generated JSONC reference unnecessarily.
+Add one concise entry describing the enablement toggle and exact `0` and `1..60` margin semantics; do not duplicate the generated JSONC reference unnecessarily.
 
 - [ ] **Step 2: Run focused suites**
 

--- a/docs/superpowers/specs/2026-07-19-deadline-feasibility-design.md
+++ b/docs/superpowers/specs/2026-07-19-deadline-feasibility-design.md
@@ -38,7 +38,7 @@ The scheduler applies feasibility alongside existing reward availability and pre
 
 All scheduler paths that select or retain a reward use the same evaluator. This includes initial campaign selection, switching to a higher-priority reward, and deciding whether the current watch session remains valid. Disabling the toggle bypasses this filtering everywhere.
 
-The scheduler emits a specific diagnostic when a candidate is excluded. The message identifies the campaign and reward and reports the remaining watch minutes, available minutes, selected deadline, and configured margin. Existing generic `campaign_ineligible` session handling remains compatible, while the text explains the precise cause.
+The scheduler emits a specific diagnostic when a candidate is excluded. The message identifies the campaign and reward and reports the remaining watch minutes, available minutes, selected deadline, and configured margin. It tracks the currently infeasible reward identities separately from the campaign inventory fingerprint, so a clock-driven transition emits once even when campaign data is unchanged, while subsequent unchanged ticks remain deduplicated. Existing generic `campaign_ineligible` session handling remains compatible, while the text explains the precise cause.
 
 ## Popup and CLI Presentation
 

--- a/docs/superpowers/specs/2026-07-19-deadline-feasibility-design.md
+++ b/docs/superpowers/specs/2026-07-19-deadline-feasibility-design.md
@@ -1,0 +1,85 @@
+# Deadline Feasibility Design
+
+## Goal
+
+Prevent the extension and CLI from selecting watch rewards that cannot be completed before their deadline, while allowing users to disable the rule or configure a small scheduling buffer.
+
+## Configuration
+
+Add one engine-level setting named `deadlineSafetyMarginMinutes`:
+
+- `-1` disables deadline feasibility filtering and preserves current scheduling behavior.
+- `0` enables exact mathematical feasibility with no additional buffer.
+- Integers from `1` through `60` enable filtering with that many additional required minutes.
+
+The default is `5`. Settings normalization rounds finite values to the nearest integer and clamps them to the inclusive range `-1` through `60`. Missing, non-numeric, and non-finite values use the default.
+
+Because this is part of `EngineSettings`, the same value and behavior apply to the extension and CLI. The popup exposes it in Advanced settings and renders `-1` as “Disabled” rather than as an unexplained negative duration. The generated CLI JSONC configuration documents all three modes.
+
+## Feasibility Calculation
+
+Create one pure, shared feasibility evaluator for watch rewards. It accepts a campaign, reward, configured margin, and injectable current timestamp, and returns a structured result suitable for both scheduling and presentation.
+
+For an unearned watch reward:
+
+1. Calculate remaining watch minutes as `max(0, requiredMinutes - watchedMinutes)`.
+2. Parse the campaign deadline from `campaign.endsAt` and the reward deadline from `reward.availableUntil`.
+3. Ignore missing or invalid timestamps. If neither timestamp is valid, return an unknown-deadline result and keep the reward farmable.
+4. When both timestamps are valid, use the earlier one. This is the earliest applicable deadline.
+5. Calculate the required duration as the remaining watch minutes plus the configured safety margin.
+6. The reward is feasible when the time from `now` to the chosen deadline is greater than or equal to the required duration. Exact equality is feasible; any shortage is infeasible.
+
+When the setting is `-1`, the evaluator returns a disabled result and does not reject any reward. Claimed rewards and non-watch rewards are outside this rule and retain their existing behavior.
+
+Calculations use milliseconds internally so boundary behavior is deterministic. Human-facing messages may round durations for readability but do not influence the decision.
+
+## Scheduler Integration
+
+The scheduler applies feasibility alongside existing reward availability and precondition checks. It evaluates currently earnable rewards in the campaign using the existing preference for in-progress rewards before locked rewards, but skips infeasible candidates and continues looking for another earnable, feasible reward. A campaign is rejected for insufficient time only when it has no feasible watch reward that can currently be selected.
+
+All scheduler paths that select or retain a reward use the same evaluator. This includes initial campaign selection, switching to a higher-priority reward, and deciding whether the current watch session remains valid. Disabling the setting bypasses this filtering everywhere.
+
+The scheduler emits a specific diagnostic when a candidate is excluded. The message identifies the campaign and reward and reports the remaining watch minutes, available minutes, selected deadline, and configured margin. Existing generic `campaign_ineligible` session handling remains compatible, while the text explains the precise cause.
+
+## Popup and CLI Presentation
+
+The popup reuses the shared evaluator rather than duplicating deadline arithmetic. Affected rewards show an “Insufficient time remaining” explanation, and a campaign with no selectable feasible watch reward exposes the same reason in its UI state. This is derived at render time from current settings and the current clock, so time-sensitive status is not persisted into campaign data.
+
+The CLI continues to report scheduler decisions through its existing event and diagnostic pipeline. Its generated JSONC template includes `deadlineSafetyMarginMinutes` with comments explaining `-1`, `0`, and positive values. CLI settings validation recognizes and normalizes the field through the same contract used by the engine.
+
+All new user-facing popup copy is added to every locale catalog, following the repository’s existing localization fallback conventions.
+
+## Data and Error Handling
+
+No platform parser changes are required because normalized campaigns already expose `endsAt`, `availableUntil`, `requiredMinutes`, and `watchedMinutes`.
+
+Missing or malformed deadlines are treated as unknown rather than infeasible, preserving current behavior as required by the issue. Negative or over-complete remaining work is clamped to zero. An already-passed valid deadline remains infeasible unless the reward is already earned or the feature is disabled.
+
+The evaluator returns typed reason data instead of formatted UI strings. Each host formats that data for its own diagnostics or localized presentation.
+
+## Testing
+
+Deterministic unit tests use a fixed `now` value and cover:
+
+- exact equality between available and required duration;
+- a one-millisecond shortage;
+- partial progress reducing remaining work;
+- campaign-only and reward-only deadlines;
+- selecting the earlier valid campaign or reward deadline;
+- missing and invalid deadlines preserving farmability;
+- zero and positive safety margins;
+- `-1` disabling the rule;
+- skipping an infeasible preferred reward in favor of another feasible reward;
+- rejecting or stopping a campaign with no feasible selectable reward;
+- settings defaults, rounding, and `-1..60` clamping;
+- popup explanation and Advanced-setting behavior;
+- CLI JSONC generation and parsing.
+
+Relevant focused suites run first, followed by the repository’s full `pnpm verify` before completion.
+
+## Out of Scope
+
+- Predicting downtime, advertisements, stream endings, or platform-side progress lag beyond the configured fixed margin.
+- Combining simultaneous progress across platforms or campaigns.
+- Changing campaign priority ordering beyond excluding infeasible rewards.
+- Rejecting rewards when deadline data is unavailable or invalid.

--- a/docs/superpowers/specs/2026-07-19-deadline-feasibility-design.md
+++ b/docs/superpowers/specs/2026-07-19-deadline-feasibility-design.md
@@ -6,19 +6,18 @@ Prevent the extension and CLI from selecting watch rewards that cannot be comple
 
 ## Configuration
 
-Add one engine-level setting named `deadlineSafetyMarginMinutes`:
+Add two flat engine-level settings:
 
-- `-1` disables deadline feasibility filtering and preserves current scheduling behavior.
-- `0` enables exact mathematical feasibility with no additional buffer.
-- Integers from `1` through `60` enable filtering with that many additional required minutes.
+- `skipUnfinishableRewards` defaults to `true`. When `false`, deadline feasibility filtering is bypassed and current scheduling behavior is preserved.
+- `deadlineSafetyMarginMinutes` defaults to `5`. `0` enables exact mathematical feasibility with no additional buffer; integers from `1` through `60` add that many required minutes.
 
-The default is `5`. Settings normalization rounds finite values to the nearest integer and clamps them to the inclusive range `-1` through `60`. Missing, non-numeric, and non-finite values use the default.
+The boolean is normalized through the existing boolean setting helper. The margin rounds finite values to the nearest integer and clamps them to the inclusive range `0` through `60`. Missing, non-numeric, and non-finite values use the default.
 
-Because this is part of `EngineSettings`, the same value and behavior apply to the extension and CLI. The popup exposes it in Advanced settings and renders `-1` as “Disabled” rather than as an unexplained negative duration. The generated CLI JSONC configuration documents all three modes.
+Because both fields are part of `EngineSettings`, the same values and behavior apply to the extension and CLI. The popup exposes a toggle followed by the margin input in Advanced settings. Turning the toggle off disables the input without changing its stored value, so re-enabling restores the previous margin. The generated CLI JSONC configuration documents both fields separately.
 
 ## Feasibility Calculation
 
-Create one pure, shared feasibility evaluator for watch rewards. It accepts a campaign, reward, configured margin, and injectable current timestamp, and returns a structured result suitable for both scheduling and presentation.
+Create one pure, shared feasibility evaluator for watch rewards. It accepts a campaign, reward, enabled flag, configured margin, and injectable current timestamp, and returns a structured result suitable for both scheduling and presentation.
 
 For an unearned watch reward:
 
@@ -29,7 +28,7 @@ For an unearned watch reward:
 5. Calculate the required duration as the remaining watch minutes plus the configured safety margin.
 6. The reward is feasible when the time from `now` to the chosen deadline is greater than or equal to the required duration. Exact equality is feasible; any shortage is infeasible.
 
-When the setting is `-1`, the evaluator returns a disabled result and does not reject any reward. Claimed rewards and non-watch rewards are outside this rule and retain their existing behavior.
+When `skipUnfinishableRewards` is `false`, the evaluator returns a disabled result and does not reject any reward. Claimed rewards and non-watch rewards are outside this rule and retain their existing behavior.
 
 Calculations use milliseconds internally so boundary behavior is deterministic. Human-facing messages may round durations for readability but do not influence the decision.
 
@@ -37,7 +36,7 @@ Calculations use milliseconds internally so boundary behavior is deterministic. 
 
 The scheduler applies feasibility alongside existing reward availability and precondition checks. It evaluates currently earnable rewards in the campaign using the existing preference for in-progress rewards before locked rewards, but skips infeasible candidates and continues looking for another earnable, feasible reward. A campaign is rejected for insufficient time only when it has no feasible watch reward that can currently be selected.
 
-All scheduler paths that select or retain a reward use the same evaluator. This includes initial campaign selection, switching to a higher-priority reward, and deciding whether the current watch session remains valid. Disabling the setting bypasses this filtering everywhere.
+All scheduler paths that select or retain a reward use the same evaluator. This includes initial campaign selection, switching to a higher-priority reward, and deciding whether the current watch session remains valid. Disabling the toggle bypasses this filtering everywhere.
 
 The scheduler emits a specific diagnostic when a candidate is excluded. The message identifies the campaign and reward and reports the remaining watch minutes, available minutes, selected deadline, and configured margin. Existing generic `campaign_ineligible` session handling remains compatible, while the text explains the precise cause.
 
@@ -45,7 +44,7 @@ The scheduler emits a specific diagnostic when a candidate is excluded. The mess
 
 The popup reuses the shared evaluator rather than duplicating deadline arithmetic. Affected rewards show an “Insufficient time remaining” explanation, and a campaign with no selectable feasible watch reward exposes the same reason in its UI state. This is derived at render time from current settings and the current clock, so time-sensitive status is not persisted into campaign data.
 
-The CLI continues to report scheduler decisions through its existing event and diagnostic pipeline. Its generated JSONC template includes `deadlineSafetyMarginMinutes` with comments explaining `-1`, `0`, and positive values. CLI settings validation recognizes and normalizes the field through the same contract used by the engine.
+The CLI continues to report scheduler decisions through its existing event and diagnostic pipeline. Its generated JSONC template includes both `skipUnfinishableRewards` and `deadlineSafetyMarginMinutes`, with comments explaining that the toggle controls enforcement while the margin controls additional buffer. CLI settings validation recognizes and normalizes both fields through the same contract used by the engine.
 
 All new user-facing popup copy is added to every locale catalog, following the repository’s existing localization fallback conventions.
 
@@ -68,10 +67,10 @@ Deterministic unit tests use a fixed `now` value and cover:
 - selecting the earlier valid campaign or reward deadline;
 - missing and invalid deadlines preserving farmability;
 - zero and positive safety margins;
-- `-1` disabling the rule;
+- the boolean toggle disabling the rule while preserving the configured margin;
 - skipping an infeasible preferred reward in favor of another feasible reward;
 - rejecting or stopping a campaign with no feasible selectable reward;
-- settings defaults, rounding, and `-1..60` clamping;
+- settings defaults, boolean normalization, rounding, and `0..60` margin clamping;
 - popup explanation and Advanced-setting behavior;
 - CLI JSONC generation and parsing.
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -64,6 +64,8 @@ export function defaultConfigJsonc(): string {
     // and falling back to the regular schedule (5-120).
     "postClaimHandoffIntervalSeconds": ${json(defaults.postClaimHandoffIntervalSeconds)},
     "postClaimHandoffMaxSeconds": ${json(defaults.postClaimHandoffMaxSeconds)},
+    // -1 disables deadline filtering; 0 uses exact feasibility; 1-60 adds a safety buffer.
+    "deadlineSafetyMarginMinutes": ${json(defaults.deadlineSafetyMarginMinutes)},
     "notifyRewardEarned": ${json(defaults.notifyRewardEarned)},
     "notifyNoDropsLeft": ${json(defaults.notifyNoDropsLeft)},
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -64,7 +64,9 @@ export function defaultConfigJsonc(): string {
     // and falling back to the regular schedule (5-120).
     "postClaimHandoffIntervalSeconds": ${json(defaults.postClaimHandoffIntervalSeconds)},
     "postClaimHandoffMaxSeconds": ${json(defaults.postClaimHandoffMaxSeconds)},
-    // -1 disables deadline filtering; 0 uses exact feasibility; 1-60 adds a safety buffer.
+    // Skip rewards that cannot finish before their earliest valid deadline.
+    "skipUnfinishableRewards": ${json(defaults.skipUnfinishableRewards)},
+    // 0 uses exact feasibility; 1-60 adds a safety buffer.
     "deadlineSafetyMarginMinutes": ${json(defaults.deadlineSafetyMarginMinutes)},
     "notifyRewardEarned": ${json(defaults.notifyRewardEarned)},
     "notifyNoDropsLeft": ${json(defaults.notifyNoDropsLeft)},

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -31,6 +31,7 @@ export interface CliSettings {
   postClaimHandoff: boolean;
   postClaimHandoffIntervalSeconds: number;
   postClaimHandoffMaxSeconds: number;
+  deadlineSafetyMarginMinutes: number;
   // Gate the controller's reward/no-drops notifications, which the CLI renders
   // as log lines (see runtime/run.ts createNotification).
   notifyRewardEarned: boolean;
@@ -55,6 +56,7 @@ export const DEFAULT_CLI_SETTINGS: CliSettings = {
   postClaimHandoff: DEFAULT_SETTINGS.postClaimHandoff,
   postClaimHandoffIntervalSeconds: DEFAULT_SETTINGS.postClaimHandoffIntervalSeconds,
   postClaimHandoffMaxSeconds: DEFAULT_SETTINGS.postClaimHandoffMaxSeconds,
+  deadlineSafetyMarginMinutes: DEFAULT_SETTINGS.deadlineSafetyMarginMinutes,
   notifyRewardEarned: DEFAULT_SETTINGS.notifyRewardEarned,
   notifyNoDropsLeft: DEFAULT_SETTINGS.notifyNoDropsLeft,
   platform: {
@@ -78,6 +80,7 @@ const CLI_SETTING_KEYS = new Set<string>([
   "postClaimHandoff",
   "postClaimHandoffIntervalSeconds",
   "postClaimHandoffMaxSeconds",
+  "deadlineSafetyMarginMinutes",
   // Accepted only so config parsing can surface the deprecation warning.
   // Runtime log filtering belongs to the global --log option and process logger.
   "enabledLogLevels",
@@ -206,6 +209,12 @@ export function parseCliSettings(raw: unknown): CliSettings {
     postClaimHandoff: booleanOr(v.postClaimHandoff, DEFAULT_CLI_SETTINGS.postClaimHandoff),
     postClaimHandoffIntervalSeconds: clampInteger(v.postClaimHandoffIntervalSeconds, 1, 30, DEFAULT_CLI_SETTINGS.postClaimHandoffIntervalSeconds),
     postClaimHandoffMaxSeconds: clampInteger(v.postClaimHandoffMaxSeconds, 5, 120, DEFAULT_CLI_SETTINGS.postClaimHandoffMaxSeconds),
+    deadlineSafetyMarginMinutes: clampInteger(
+      v.deadlineSafetyMarginMinutes,
+      -1,
+      60,
+      DEFAULT_CLI_SETTINGS.deadlineSafetyMarginMinutes,
+    ),
     notifyRewardEarned: booleanOr(v.notifyRewardEarned, DEFAULT_CLI_SETTINGS.notifyRewardEarned),
     notifyNoDropsLeft: booleanOr(v.notifyNoDropsLeft, DEFAULT_CLI_SETTINGS.notifyNoDropsLeft),
     platform: normalizePlatform(v.platform),

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -31,6 +31,7 @@ export interface CliSettings {
   postClaimHandoff: boolean;
   postClaimHandoffIntervalSeconds: number;
   postClaimHandoffMaxSeconds: number;
+  skipUnfinishableRewards: boolean;
   deadlineSafetyMarginMinutes: number;
   // Gate the controller's reward/no-drops notifications, which the CLI renders
   // as log lines (see runtime/run.ts createNotification).
@@ -56,6 +57,7 @@ export const DEFAULT_CLI_SETTINGS: CliSettings = {
   postClaimHandoff: DEFAULT_SETTINGS.postClaimHandoff,
   postClaimHandoffIntervalSeconds: DEFAULT_SETTINGS.postClaimHandoffIntervalSeconds,
   postClaimHandoffMaxSeconds: DEFAULT_SETTINGS.postClaimHandoffMaxSeconds,
+  skipUnfinishableRewards: DEFAULT_SETTINGS.skipUnfinishableRewards,
   deadlineSafetyMarginMinutes: DEFAULT_SETTINGS.deadlineSafetyMarginMinutes,
   notifyRewardEarned: DEFAULT_SETTINGS.notifyRewardEarned,
   notifyNoDropsLeft: DEFAULT_SETTINGS.notifyNoDropsLeft,
@@ -80,6 +82,7 @@ const CLI_SETTING_KEYS = new Set<string>([
   "postClaimHandoff",
   "postClaimHandoffIntervalSeconds",
   "postClaimHandoffMaxSeconds",
+  "skipUnfinishableRewards",
   "deadlineSafetyMarginMinutes",
   // Accepted only so config parsing can surface the deprecation warning.
   // Runtime log filtering belongs to the global --log option and process logger.
@@ -209,9 +212,10 @@ export function parseCliSettings(raw: unknown): CliSettings {
     postClaimHandoff: booleanOr(v.postClaimHandoff, DEFAULT_CLI_SETTINGS.postClaimHandoff),
     postClaimHandoffIntervalSeconds: clampInteger(v.postClaimHandoffIntervalSeconds, 1, 30, DEFAULT_CLI_SETTINGS.postClaimHandoffIntervalSeconds),
     postClaimHandoffMaxSeconds: clampInteger(v.postClaimHandoffMaxSeconds, 5, 120, DEFAULT_CLI_SETTINGS.postClaimHandoffMaxSeconds),
+    skipUnfinishableRewards: booleanOr(v.skipUnfinishableRewards, DEFAULT_CLI_SETTINGS.skipUnfinishableRewards),
     deadlineSafetyMarginMinutes: clampInteger(
       v.deadlineSafetyMarginMinutes,
-      -1,
+      0,
       60,
       DEFAULT_CLI_SETTINGS.deadlineSafetyMarginMinutes,
     ),

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -183,6 +183,8 @@ describe("loadConfig", () => {
     try {
       const path = join(dir, "config.json");
       writeFileSync(path, defaultConfigJsonc());
+      expect(defaultConfigJsonc()).toContain("-1 disables deadline filtering; 0 uses exact feasibility; 1-60 adds a safety buffer.");
+      expect(defaultConfigJsonc()).toContain('"deadlineSafetyMarginMinutes": 5');
       expect(loadConfig(path).settings).toEqual(DEFAULT_CLI_SETTINGS);
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -183,7 +183,8 @@ describe("loadConfig", () => {
     try {
       const path = join(dir, "config.json");
       writeFileSync(path, defaultConfigJsonc());
-      expect(defaultConfigJsonc()).toContain("-1 disables deadline filtering; 0 uses exact feasibility; 1-60 adds a safety buffer.");
+      expect(defaultConfigJsonc()).toContain('"skipUnfinishableRewards": true');
+      expect(defaultConfigJsonc()).toContain("0 uses exact feasibility; 1-60 adds a safety buffer.");
       expect(defaultConfigJsonc()).toContain('"deadlineSafetyMarginMinutes": 5');
       expect(loadConfig(path).settings).toEqual(DEFAULT_CLI_SETTINGS);
     } finally {

--- a/packages/cli/tests/settings.test.ts
+++ b/packages/cli/tests/settings.test.ts
@@ -30,6 +30,10 @@ describe("parseCliSettings", () => {
     expect(parseCliSettings({ pollIntervalMinutes: 999 }).pollIntervalMinutes).toBe(60);
     expect(parseCliSettings({ offlineRetryLimit: 0 }).offlineRetryLimit).toBe(1);
     expect(parseCliSettings({ offlineRetryLimit: 99 }).offlineRetryLimit).toBe(10);
+    expect(parseCliSettings({ deadlineSafetyMarginMinutes: -9 }).deadlineSafetyMarginMinutes).toBe(-1);
+    expect(parseCliSettings({ deadlineSafetyMarginMinutes: -1 }).deadlineSafetyMarginMinutes).toBe(-1);
+    expect(parseCliSettings({ deadlineSafetyMarginMinutes: 0 }).deadlineSafetyMarginMinutes).toBe(0);
+    expect(parseCliSettings({ deadlineSafetyMarginMinutes: 99 }).deadlineSafetyMarginMinutes).toBe(60);
   });
 
   it("round-trips compatibility profile and expert selections", () => {
@@ -149,12 +153,14 @@ describe("toEngineSettings", () => {
       autoClaim: false,
       priorityMode: "lowest_availability",
       pollIntervalMinutes: 4,
+      deadlineSafetyMarginMinutes: -1,
       platform: { kick: { enabled: false } },
     });
     const engine = toEngineSettings(cli);
     expect(engine.autoClaim).toBe(false);
     expect(engine.priorityMode).toBe("lowest_availability");
     expect(engine.pollIntervalMinutes).toBe(4);
+    expect(engine.deadlineSafetyMarginMinutes).toBe(-1);
     expect(engine.platform.kick.enabled).toBe(false);
     expect(engine.compatibility).toEqual(cli.compatibility);
   });

--- a/packages/cli/tests/settings.test.ts
+++ b/packages/cli/tests/settings.test.ts
@@ -30,8 +30,7 @@ describe("parseCliSettings", () => {
     expect(parseCliSettings({ pollIntervalMinutes: 999 }).pollIntervalMinutes).toBe(60);
     expect(parseCliSettings({ offlineRetryLimit: 0 }).offlineRetryLimit).toBe(1);
     expect(parseCliSettings({ offlineRetryLimit: 99 }).offlineRetryLimit).toBe(10);
-    expect(parseCliSettings({ deadlineSafetyMarginMinutes: -9 }).deadlineSafetyMarginMinutes).toBe(-1);
-    expect(parseCliSettings({ deadlineSafetyMarginMinutes: -1 }).deadlineSafetyMarginMinutes).toBe(-1);
+    expect(parseCliSettings({ deadlineSafetyMarginMinutes: -9 }).deadlineSafetyMarginMinutes).toBe(0);
     expect(parseCliSettings({ deadlineSafetyMarginMinutes: 0 }).deadlineSafetyMarginMinutes).toBe(0);
     expect(parseCliSettings({ deadlineSafetyMarginMinutes: 99 }).deadlineSafetyMarginMinutes).toBe(60);
   });
@@ -153,14 +152,16 @@ describe("toEngineSettings", () => {
       autoClaim: false,
       priorityMode: "lowest_availability",
       pollIntervalMinutes: 4,
-      deadlineSafetyMarginMinutes: -1,
+      skipUnfinishableRewards: false,
+      deadlineSafetyMarginMinutes: 5,
       platform: { kick: { enabled: false } },
     });
     const engine = toEngineSettings(cli);
     expect(engine.autoClaim).toBe(false);
     expect(engine.priorityMode).toBe("lowest_availability");
     expect(engine.pollIntervalMinutes).toBe(4);
-    expect(engine.deadlineSafetyMarginMinutes).toBe(-1);
+    expect(engine.skipUnfinishableRewards).toBe(false);
+    expect(engine.deadlineSafetyMarginMinutes).toBe(5);
     expect(engine.platform.kick.enabled).toBe(false);
     expect(engine.compatibility).toEqual(cli.compatibility);
   });

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -514,7 +514,12 @@ export async function runSchedulerTick(
         emitDiagnostic(emit, platform, "debug", `${eligibleCount} of ${campaigns.length} campaigns eligible after filtering`);
         for (const campaign of campaigns) {
           for (const reward of campaign.rewards) {
-            const feasibility = rewardFeasibility(campaign, reward, settings.deadlineSafetyMarginMinutes);
+            const feasibility = rewardFeasibility(
+              campaign,
+              reward,
+              settings.skipUnfinishableRewards,
+              settings.deadlineSafetyMarginMinutes,
+            );
             if (feasibility.kind !== "insufficient_time") continue;
             const availableMinutes = feasibility.availableMilliseconds / 60_000;
             emit({
@@ -832,7 +837,12 @@ function isRewardRelevantNow(reward: DropReward): boolean {
 }
 
 function isRewardDeadlineFeasible(campaign: DropCampaign, reward: DropReward, settings: EngineSettings): boolean {
-  return rewardFeasibility(campaign, reward, settings.deadlineSafetyMarginMinutes).kind !== "insufficient_time";
+  return rewardFeasibility(
+    campaign,
+    reward,
+    settings.skipUnfinishableRewards,
+    settings.deadlineSafetyMarginMinutes,
+  ).kind !== "insufficient_time";
 }
 
 function campaignDiagnosticFingerprint(campaigns: readonly DropCampaign[]): string {

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -11,7 +11,7 @@ import type {
   WatchSession,
 } from "@lurkloot/shared/models";
 import { categoryListIndex } from "@lurkloot/shared/categories";
-import { isSubscriptionReward, isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
+import { isSubscriptionReward, isWatchReward, reconcileCampaignAfterClaims, rewardFeasibility } from "@lurkloot/shared/rewards";
 import { autoClaimChallengesFor, autoClaimChannelPointsFor } from "@lurkloot/shared/settings";
 import type { EngineEvent, EventEmitter, FarmingStopReason } from "@lurkloot/shared/events";
 import { currentManagedPageContextTabs, forgetManagedPageContextTabs, registerManagedPageContextTabs, type SchedulerManagedPageContexts } from "./tabs";
@@ -36,8 +36,11 @@ function challengePollDue(state: SchedulerState, platform: Platform, now: number
   return now - last >= CHALLENGE_POLL_INTERVAL_MS;
 }
 
-function activeReward(campaign: DropCampaign): DropReward | undefined {
-  const earnable = campaign.rewards.filter((reward) => reward.preconditionsMet !== false && isRewardAvailableToEarn(reward));
+function activeReward(campaign: DropCampaign, settings: EngineSettings): DropReward | undefined {
+  const earnable = campaign.rewards.filter((reward) =>
+    reward.preconditionsMet !== false
+    && isRewardAvailableToEarn(reward)
+    && isRewardDeadlineFeasible(campaign, reward, settings));
   return earnable.find((reward) => reward.status === "in_progress")
     ?? earnable.find((reward) => reward.status === "locked");
 }
@@ -77,7 +80,11 @@ function isEligible(campaign: DropCampaign, settings: EngineSettings): boolean {
   // reordered (campaignPriorities). Category curation is owned by the separate
   // per-platform "Farm all categories" filter above.
   if (settings.priorityMode === "priority_list_only" && !isInPriorityList(campaign, settings)) return false;
-  return campaign.rewards.some((reward) => reward.status !== "claimed" && reward.preconditionsMet !== false && isRewardRelevantNow(reward));
+  return campaign.rewards.some((reward) =>
+    reward.status !== "claimed"
+    && reward.preconditionsMet !== false
+    && isRewardRelevantNow(reward)
+    && (canClaimReward(reward) || isRewardDeadlineFeasible(campaign, reward, settings)));
 }
 
 function isInPriorityList(campaign: DropCampaign, settings: EngineSettings): boolean {
@@ -147,7 +154,7 @@ export async function chooseCampaignDecision(
   const subscriptionOnly = onlySubscriptionCampaigns(campaigns, settings);
 
   for (const campaign of sorted) {
-    const reward = activeReward(campaign);
+    const reward = activeReward(campaign, settings);
     if (!reward) continue;
 
     const excludedChannels = settings.platform[platform].excludedChannels ?? [];
@@ -235,6 +242,15 @@ function noEligibleCampaignReason(campaigns: DropCampaign[], settings: EngineSet
   }
   if (settings.priorityMode === "priority_list_only" && !notExcluded.some((campaign) => isInPriorityList(campaign, settings))) {
     return "No prioritized campaigns are eligible";
+  }
+  const relevantCampaigns = notExcluded.filter((campaign) => campaign.status === "active" && !hasCampaignEnded(campaign));
+  if (relevantCampaigns.length > 0 && relevantCampaigns.every((campaign) =>
+    campaign.rewards.some((reward) => reward.preconditionsMet !== false && isRewardAvailableToEarn(reward))
+    && !campaign.rewards.some((reward) =>
+      reward.preconditionsMet !== false
+      && isRewardAvailableToEarn(reward)
+      && isRewardDeadlineFeasible(campaign, reward, settings)))) {
+    return "Available rewards cannot be completed before their deadline";
   }
   return "No eligible campaigns";
 }
@@ -496,6 +512,28 @@ export async function runSchedulerTick(
         emitDiagnostic(emit, platform, "debug", `Campaign inventory changed (${campaigns.length} discovered)`);
         const eligibleCount = campaigns.filter((campaign) => isEligible(campaign, settings)).length;
         emitDiagnostic(emit, platform, "debug", `${eligibleCount} of ${campaigns.length} campaigns eligible after filtering`);
+        for (const campaign of campaigns) {
+          for (const reward of campaign.rewards) {
+            const feasibility = rewardFeasibility(campaign, reward, settings.deadlineSafetyMarginMinutes);
+            if (feasibility.kind !== "insufficient_time") continue;
+            const availableMinutes = feasibility.availableMilliseconds / 60_000;
+            emit({
+              category: "diagnostic",
+              platform,
+              level: "info",
+              code: "reward_insufficient_time",
+              message: `${campaign.name} / ${reward.name} has insufficient time: ${feasibility.remainingMinutes} watch minutes remain, ${availableMinutes.toFixed(2)} minutes are available before ${feasibility.deadline}, margin ${feasibility.marginMinutes} minutes`,
+              data: {
+                campaignId: campaign.id,
+                rewardId: reward.id,
+                remainingMinutes: feasibility.remainingMinutes,
+                availableMinutes,
+                deadline: feasibility.deadline,
+                marginMinutes: feasibility.marginMinutes,
+              },
+            });
+          }
+        }
       }
 
       if (settings.autoClaim) {
@@ -791,6 +829,10 @@ async function claimReadyRewards(
 
 function isRewardRelevantNow(reward: DropReward): boolean {
   return canClaimReward(reward) || isRewardAvailableToEarn(reward);
+}
+
+function isRewardDeadlineFeasible(campaign: DropCampaign, reward: DropReward, settings: EngineSettings): boolean {
+  return rewardFeasibility(campaign, reward, settings.deadlineSafetyMarginMinutes).kind !== "insufficient_time";
 }
 
 function campaignDiagnosticFingerprint(campaigns: readonly DropCampaign[]): string {

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -387,6 +387,7 @@ export async function runSchedulerTick(
     sessions: { ...state.sessions },
     managedWatchTabs: { ...state.managedWatchTabs },
     managedPageContextTabs: { ...state.managedPageContextTabs },
+    deadlineInfeasibleRewardIds: { ...state.deadlineInfeasibleRewardIds },
     lastTickAt: new Date().toISOString(),
   };
   const decisions: WatchDecision[] = [];
@@ -512,34 +513,44 @@ export async function runSchedulerTick(
         emitDiagnostic(emit, platform, "debug", `Campaign inventory changed (${campaigns.length} discovered)`);
         const eligibleCount = campaigns.filter((campaign) => isEligible(campaign, settings)).length;
         emitDiagnostic(emit, platform, "debug", `${eligibleCount} of ${campaigns.length} campaigns eligible after filtering`);
-        for (const campaign of campaigns) {
-          for (const reward of campaign.rewards) {
-            const feasibility = rewardFeasibility(
-              campaign,
-              reward,
-              settings.skipUnfinishableRewards,
-              settings.deadlineSafetyMarginMinutes,
-            );
-            if (feasibility.kind !== "insufficient_time") continue;
-            const availableMinutes = feasibility.availableMilliseconds / 60_000;
-            emit({
-              category: "diagnostic",
-              platform,
-              level: "info",
-              code: "reward_insufficient_time",
-              message: `${campaign.name} / ${reward.name} has insufficient time: ${feasibility.remainingMinutes} watch minutes remain, ${availableMinutes.toFixed(2)} minutes are available before ${feasibility.deadline}, margin ${feasibility.marginMinutes} minutes`,
-              data: {
-                campaignId: campaign.id,
-                rewardId: reward.id,
-                remainingMinutes: feasibility.remainingMinutes,
-                availableMinutes,
-                deadline: feasibility.deadline,
-                marginMinutes: feasibility.marginMinutes,
-              },
-            });
-          }
+      }
+
+      const previousInfeasibleRewardIds = new Set(state.deadlineInfeasibleRewardIds?.[platform]);
+      const currentInfeasibleRewardIds: string[] = [];
+      for (const campaign of campaigns) {
+        for (const reward of campaign.rewards) {
+          const feasibility = rewardFeasibility(
+            campaign,
+            reward,
+            settings.skipUnfinishableRewards,
+            settings.deadlineSafetyMarginMinutes,
+          );
+          if (feasibility.kind !== "insufficient_time") continue;
+          const diagnosticId = `${campaign.id}:${reward.id}`;
+          currentInfeasibleRewardIds.push(diagnosticId);
+          if (previousInfeasibleRewardIds.has(diagnosticId)) continue;
+          const availableMinutes = feasibility.availableMilliseconds / 60_000;
+          emit({
+            category: "diagnostic",
+            platform,
+            level: "info",
+            code: "reward_insufficient_time",
+            message: `${campaign.name} / ${reward.name} has insufficient time: ${feasibility.remainingMinutes} watch minutes remain, ${availableMinutes.toFixed(2)} minutes are available before ${feasibility.deadline}, margin ${feasibility.marginMinutes} minutes`,
+            data: {
+              campaignId: campaign.id,
+              rewardId: reward.id,
+              remainingMinutes: feasibility.remainingMinutes,
+              availableMinutes,
+              deadline: feasibility.deadline,
+              marginMinutes: feasibility.marginMinutes,
+            },
+          });
         }
       }
+      nextState.deadlineInfeasibleRewardIds = {
+        ...nextState.deadlineInfeasibleRewardIds,
+        [platform]: currentInfeasibleRewardIds,
+      };
 
       if (settings.autoClaim) {
         const claimResult = await claimReadyRewards(

--- a/packages/extension/tests/rewardFeasibility.test.ts
+++ b/packages/extension/tests/rewardFeasibility.test.ts
@@ -29,7 +29,7 @@ function campaign(rewards: DropReward[], patch: Partial<DropCampaign> = {}): Dro
 describe("reward deadline feasibility", () => {
   it("allows exact equality and accounts for existing progress plus margin", () => {
     const drop = reward({ availableUntil: "2026-07-19T12:35:00.000Z" });
-    expect(rewardFeasibility(campaign([drop]), drop, 5, now)).toEqual({
+    expect(rewardFeasibility(campaign([drop]), drop, true, 5, now)).toEqual({
       kind: "feasible",
       deadline: "2026-07-19T12:35:00.000Z",
       remainingMinutes: 30,
@@ -40,7 +40,7 @@ describe("reward deadline feasibility", () => {
 
   it("rejects a one-millisecond shortage", () => {
     const drop = reward({ availableUntil: "2026-07-19T12:34:59.999Z" });
-    expect(rewardFeasibility(campaign([drop]), drop, 5, now)).toEqual({
+    expect(rewardFeasibility(campaign([drop]), drop, true, 5, now)).toEqual({
       kind: "insufficient_time",
       deadline: "2026-07-19T12:34:59.999Z",
       remainingMinutes: 30,
@@ -51,24 +51,24 @@ describe("reward deadline feasibility", () => {
 
   it("uses the earliest valid campaign or reward deadline", () => {
     const drop = reward({ availableUntil: "2026-07-19T13:00:00.000Z" });
-    const result = rewardFeasibility(campaign([drop], { endsAt: "2026-07-19T12:29:00.000Z" }), drop, 0, now);
+    const result = rewardFeasibility(campaign([drop], { endsAt: "2026-07-19T12:29:00.000Z" }), drop, true, 0, now);
     expect(result).toMatchObject({ kind: "insufficient_time", deadline: "2026-07-19T12:29:00.000Z" });
   });
 
   it("keeps rewards farmable when deadlines are missing or invalid", () => {
     const drop = reward({ availableUntil: "not-a-date" });
-    expect(rewardFeasibility(campaign([drop], { endsAt: "also-invalid" }), drop, 5, now)).toEqual({ kind: "unknown_deadline" });
+    expect(rewardFeasibility(campaign([drop], { endsAt: "also-invalid" }), drop, true, 5, now)).toEqual({ kind: "unknown_deadline" });
   });
 
-  it("supports disabling the rule with -1", () => {
+  it("supports disabling the rule independently of the preserved margin", () => {
     const drop = reward({ availableUntil: "2020-01-01T00:00:00.000Z" });
-    expect(rewardFeasibility(campaign([drop]), drop, -1, now)).toEqual({ kind: "disabled" });
+    expect(rewardFeasibility(campaign([drop]), drop, false, 42, now)).toEqual({ kind: "disabled" });
   });
 
   it("does not apply to claimed or non-watch rewards", () => {
     const claimed = reward({ status: "claimed", availableUntil: "2020-01-01T00:00:00.000Z" });
     const subscription = reward({ requirement: "subscription", requiredMinutes: 0, requiredSubs: 1, availableUntil: "2020-01-01T00:00:00.000Z" });
-    expect(rewardFeasibility(campaign([claimed]), claimed, 5, now)).toEqual({ kind: "not_applicable" });
-    expect(rewardFeasibility(campaign([subscription]), subscription, 5, now)).toEqual({ kind: "not_applicable" });
+    expect(rewardFeasibility(campaign([claimed]), claimed, true, 5, now)).toEqual({ kind: "not_applicable" });
+    expect(rewardFeasibility(campaign([subscription]), subscription, true, 5, now)).toEqual({ kind: "not_applicable" });
   });
 });

--- a/packages/extension/tests/rewardFeasibility.test.ts
+++ b/packages/extension/tests/rewardFeasibility.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { DropCampaign, DropReward } from "@lurkloot/shared/models";
+import { rewardFeasibility } from "@lurkloot/shared/rewards";
+
+const now = Date.parse("2026-07-19T12:00:00.000Z");
+
+function reward(patch: Partial<DropReward> = {}): DropReward {
+  return {
+    id: "reward",
+    name: "Reward",
+    requiredMinutes: 60,
+    watchedMinutes: 30,
+    status: "in_progress",
+    ...patch,
+  };
+}
+
+function campaign(rewards: DropReward[], patch: Partial<DropCampaign> = {}): DropCampaign {
+  return {
+    id: "campaign",
+    platform: "twitch",
+    name: "Campaign",
+    status: "active",
+    rewards,
+    ...patch,
+  };
+}
+
+describe("reward deadline feasibility", () => {
+  it("allows exact equality and accounts for existing progress plus margin", () => {
+    const drop = reward({ availableUntil: "2026-07-19T12:35:00.000Z" });
+    expect(rewardFeasibility(campaign([drop]), drop, 5, now)).toEqual({
+      kind: "feasible",
+      deadline: "2026-07-19T12:35:00.000Z",
+      remainingMinutes: 30,
+      availableMilliseconds: 2_100_000,
+      marginMinutes: 5,
+    });
+  });
+
+  it("rejects a one-millisecond shortage", () => {
+    const drop = reward({ availableUntil: "2026-07-19T12:34:59.999Z" });
+    expect(rewardFeasibility(campaign([drop]), drop, 5, now)).toEqual({
+      kind: "insufficient_time",
+      deadline: "2026-07-19T12:34:59.999Z",
+      remainingMinutes: 30,
+      availableMilliseconds: 2_099_999,
+      marginMinutes: 5,
+    });
+  });
+
+  it("uses the earliest valid campaign or reward deadline", () => {
+    const drop = reward({ availableUntil: "2026-07-19T13:00:00.000Z" });
+    const result = rewardFeasibility(campaign([drop], { endsAt: "2026-07-19T12:29:00.000Z" }), drop, 0, now);
+    expect(result).toMatchObject({ kind: "insufficient_time", deadline: "2026-07-19T12:29:00.000Z" });
+  });
+
+  it("keeps rewards farmable when deadlines are missing or invalid", () => {
+    const drop = reward({ availableUntil: "not-a-date" });
+    expect(rewardFeasibility(campaign([drop], { endsAt: "also-invalid" }), drop, 5, now)).toEqual({ kind: "unknown_deadline" });
+  });
+
+  it("supports disabling the rule with -1", () => {
+    const drop = reward({ availableUntil: "2020-01-01T00:00:00.000Z" });
+    expect(rewardFeasibility(campaign([drop]), drop, -1, now)).toEqual({ kind: "disabled" });
+  });
+
+  it("does not apply to claimed or non-watch rewards", () => {
+    const claimed = reward({ status: "claimed", availableUntil: "2020-01-01T00:00:00.000Z" });
+    const subscription = reward({ requirement: "subscription", requiredMinutes: 0, requiredSubs: 1, availableUntil: "2020-01-01T00:00:00.000Z" });
+    expect(rewardFeasibility(campaign([claimed]), claimed, 5, now)).toEqual({ kind: "not_applicable" });
+    expect(rewardFeasibility(campaign([subscription]), subscription, 5, now)).toEqual({ kind: "not_applicable" });
+  });
+});

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -61,6 +61,69 @@ function adapter(platform: Platform, campaigns: DropCampaign[], candidates: Chan
 }
 
 describe("scheduler campaign selection", () => {
+  it("skips an infeasible in-progress reward for a feasible locked reward", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-19T12:00:00.000Z");
+    try {
+      const inProgress = { ...reward("in_progress"), id: "long", requiredMinutes: 60, watchedMinutes: 10 };
+      const locked = { ...reward("locked"), id: "short", requiredMinutes: 20, watchedMinutes: 0 };
+      const decision = await chooseCampaignDecision(
+        "twitch",
+        [campaign("timed", { endsAt: "2026-07-19T12:40:00.000Z", rewards: [inProgress, locked] })],
+        settings({ deadlineSafetyMarginMinutes: 5 }),
+        {
+          listCandidateChannels: vi.fn(async () => [channel("creator")]),
+          checkChannel: vi.fn(async (candidate) => ({ live: true, categoryMatches: true, candidate })),
+        },
+      );
+      expect(decision.action).toBe("watch");
+      expect(decision.reward?.id).toBe("short");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects a campaign when no watch reward can finish before its deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-19T12:00:00.000Z");
+    try {
+      const listCandidateChannels = vi.fn(async () => [channel("creator")]);
+      const decision = await chooseCampaignDecision(
+        "twitch",
+        [campaign("timed", { endsAt: "2026-07-19T12:44:59.999Z" })],
+        settings({ deadlineSafetyMarginMinutes: 5 }),
+        {
+          listCandidateChannels,
+          checkChannel: vi.fn(async (candidate) => ({ live: true, categoryMatches: true, candidate })),
+        },
+      );
+      expect(decision.action).toBe("idle");
+      expect(decision.reason).toContain("cannot be completed before their deadline");
+      expect(listCandidateChannels).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves current selection behavior when deadline filtering is disabled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-19T12:00:00.000Z");
+    try {
+      const decision = await chooseCampaignDecision(
+        "twitch",
+        [campaign("timed", { endsAt: "2026-07-19T12:01:00.000Z" })],
+        settings({ deadlineSafetyMarginMinutes: -1 }),
+        {
+          listCandidateChannels: vi.fn(async () => [channel("creator")]),
+          checkChannel: vi.fn(async (candidate) => ({ live: true, categoryMatches: true, candidate })),
+        },
+      );
+      expect(decision.action).toBe("watch");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses explicit priority before ending soonest", () => {
     const first = campaign("first", { endsAt: "2026-06-01T00:00:00.000Z" });
     const second = campaign("second", { endsAt: "2026-07-01T00:00:00.000Z" });
@@ -597,6 +660,36 @@ describe("scheduler tick", () => {
 
     expect(second.events.filter((event) => event.category === "diagnostic" && event.message.startsWith("Campaign decision:"))).toEqual([]);
     expect(second.events.filter((event) => event.category === "diagnostic" && event.message.includes("campaigns eligible"))).toEqual([]);
+  });
+
+  it("emits structured diagnostics for rewards excluded by deadline feasibility", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-19T12:00:00.000Z");
+    try {
+      const timed = campaign("drops", { endsAt: "2026-07-19T12:44:59.999Z" });
+      const result = await runSchedulerTick(
+        baseState,
+        settings({
+          deadlineSafetyMarginMinutes: 5,
+          platform: { twitch: { enabled: true, watchQueueChannels: [] }, kick: { enabled: false, watchQueueChannels: [] } },
+        }),
+        { twitch: adapter("twitch", [timed], []), kick: adapter("kick", [], []) },
+      );
+
+      expect(result.events).toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        code: "reward_insufficient_time",
+        data: expect.objectContaining({
+          campaignId: "drops",
+          rewardId: "reward-in_progress",
+          remainingMinutes: 40,
+          marginMinutes: 5,
+          deadline: "2026-07-19T12:44:59.999Z",
+        }),
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not classify a missing replacement reward as completed", async () => {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -692,6 +692,32 @@ describe("scheduler tick", () => {
     }
   });
 
+  it("emits a deadline diagnostic once when unchanged campaigns become infeasible over time", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-19T12:00:00.000Z");
+    try {
+      const timed = campaign("drops", { endsAt: "2026-07-19T12:50:00.000Z" });
+      const twitch = adapter("twitch", [timed], []);
+      const tickSettings = settings({
+        deadlineSafetyMarginMinutes: 5,
+        platform: { twitch: { enabled: true, watchQueueChannels: [] }, kick: { enabled: false, watchQueueChannels: [] } },
+      });
+      const tickAdapters = { twitch, kick: adapter("kick", [], []) };
+
+      const first = await runSchedulerTick(baseState, tickSettings, tickAdapters);
+      expect(first.events.filter((event) => event.code === "reward_insufficient_time")).toEqual([]);
+
+      vi.setSystemTime("2026-07-19T12:06:00.000Z");
+      const second = await runSchedulerTick(first.state, tickSettings, tickAdapters);
+      expect(second.events.filter((event) => event.code === "reward_insufficient_time")).toHaveLength(1);
+
+      const third = await runSchedulerTick(second.state, tickSettings, tickAdapters);
+      expect(third.events.filter((event) => event.code === "reward_insufficient_time")).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not classify a missing replacement reward as completed", async () => {
     const currentChannel = channel("creator");
     const twitch = adapter("twitch", [campaign("drops")], [currentChannel]);

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -112,7 +112,7 @@ describe("scheduler campaign selection", () => {
       const decision = await chooseCampaignDecision(
         "twitch",
         [campaign("timed", { endsAt: "2026-07-19T12:01:00.000Z" })],
-        settings({ deadlineSafetyMarginMinutes: -1 }),
+        settings({ skipUnfinishableRewards: false, deadlineSafetyMarginMinutes: 5 }),
         {
           listCandidateChannels: vi.fn(async () => [channel("creator")]),
           checkChannel: vi.fn(async (candidate) => ({ live: true, categoryMatches: true, candidate })),

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -134,6 +134,16 @@ describe("settings", () => {
     expect(mergeSettings({ postClaimHandoff: false }).postClaimHandoff).toBe(false);
   });
 
+  it("normalizes the deadline safety margin including the disabled sentinel", () => {
+    expect(DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes).toBe(5);
+    expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -9 }).deadlineSafetyMarginMinutes).toBe(-1);
+    expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -1 }).deadlineSafetyMarginMinutes).toBe(-1);
+    expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 0 }).deadlineSafetyMarginMinutes).toBe(0);
+    expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 4.6 }).deadlineSafetyMarginMinutes).toBe(5);
+    expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 99 }).deadlineSafetyMarginMinutes).toBe(60);
+    expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: Number.NaN }).deadlineSafetyMarginMinutes).toBe(5);
+  });
+
   it("keeps diagnostic logging independent from the removed engine log-level setting", () => {
     expect(mergeSettings(undefined).diagnosticLogging).toBe(false);
     expect(mergeSettings({ diagnosticLogging: true }).diagnosticLogging).toBe(true);

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -134,10 +134,12 @@ describe("settings", () => {
     expect(mergeSettings({ postClaimHandoff: false }).postClaimHandoff).toBe(false);
   });
 
-  it("normalizes the deadline safety margin including the disabled sentinel", () => {
+  it("normalizes deadline filtering enablement and its safety margin independently", () => {
+    expect(DEFAULT_ENGINE_SETTINGS.skipUnfinishableRewards).toBe(true);
     expect(DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes).toBe(5);
-    expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -9 }).deadlineSafetyMarginMinutes).toBe(-1);
-    expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -1 }).deadlineSafetyMarginMinutes).toBe(-1);
+    expect(mergeEngineSettings({ skipUnfinishableRewards: false }).skipUnfinishableRewards).toBe(false);
+    expect(mergeEngineSettings({ skipUnfinishableRewards: "no" } as never).skipUnfinishableRewards).toBe(true);
+    expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: -9 }).deadlineSafetyMarginMinutes).toBe(0);
     expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 0 }).deadlineSafetyMarginMinutes).toBe(0);
     expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 4.6 }).deadlineSafetyMarginMinutes).toBe(5);
     expect(mergeEngineSettings({ deadlineSafetyMarginMinutes: 99 }).deadlineSafetyMarginMinutes).toBe(60);

--- a/packages/extension/tests/settingsView.test.tsx
+++ b/packages/extension/tests/settingsView.test.tsx
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 describe("deadline feasibility setting", () => {
-  it("shows the shared value in Advanced settings and saves -1 immediately", () => {
+  function mountSettings(settings = DEFAULT_SETTINGS) {
     const { document, window } = parseHTML("<div id=app></div>");
     vi.stubGlobal("window", window);
     vi.stubGlobal("document", document);
@@ -26,9 +26,10 @@ describe("deadline feasibility setting", () => {
     const labels: Record<string, string> = {
       advancedTitle: "Advanced",
       deadlineSafetyMarginTitle: "Deadline safety margin",
-      deadlineSafetyMarginDescription: "Use -1 to disable deadline filtering.",
-      disabled: "Disabled",
+      deadlineSafetyMarginDescription: "Extra buffer minutes.",
       minutesSuffix: "min",
+      skipUnfinishableRewardsTitle: "Skip rewards that cannot be completed",
+      skipUnfinishableRewardsDescription: "Do not farm impossible rewards.",
     };
     const adapter = {} as PopupAdapter;
     const container = document.getElementById("app")!;
@@ -41,7 +42,7 @@ describe("deadline feasibility setting", () => {
             <SettingsView
               suggestions={{ twitch: [], kick: [] }}
               onSearchCategories={async () => []}
-              settings={DEFAULT_SETTINGS}
+              settings={settings}
               onSettingsChange={onSettingsChange}
               exportConfirmationResetKey={0}
             />
@@ -52,18 +53,25 @@ describe("deadline feasibility setting", () => {
 
     const advanced = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Advanced"));
     act(() => advanced?.click());
-    const input = container.querySelector('input[aria-label="Deadline safety margin"]') as HTMLInputElement;
-    expect(input.value).toBe("5");
+    return { container, onSettingsChange };
+  }
 
-    act(() => {
-      Object.defineProperty(input, "value", { configurable: true, value: "-1" });
-      input.dispatchEvent(new window.Event("input", { bubbles: true }));
-      input.dispatchEvent(new window.Event("change", { bubbles: true }));
-      input.dispatchEvent(new window.Event("focusout", { bubbles: true }));
-    });
+  it("defaults the toggle on and saves changes immediately", () => {
+    const { container, onSettingsChange } = mountSettings();
+    const toggle = container.querySelector('[role="switch"][aria-label="Skip rewards that cannot be completed"]') as HTMLButtonElement;
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+    act(() => toggle.click());
     expect(onSettingsChange).toHaveBeenCalledWith(
-      { deadlineSafetyMarginMinutes: -1 },
+      { skipUnfinishableRewards: false },
       { tickAfterSave: true },
     );
+  });
+
+  it("disables but preserves the margin input when filtering is off", () => {
+    const { container } = mountSettings({ ...DEFAULT_SETTINGS, skipUnfinishableRewards: false, deadlineSafetyMarginMinutes: 17 });
+    const input = container.querySelector('input[aria-label="Deadline safety margin"]') as HTMLInputElement;
+    expect(input.value).toBe("17");
+    expect(input.disabled).toBe(true);
   });
 });

--- a/packages/extension/tests/settingsView.test.tsx
+++ b/packages/extension/tests/settingsView.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
+import { I18nContext, PopupRuntimeContext } from "../../popup-ui/src/context";
+import { SettingsView } from "../../popup-ui/src/settings";
+import type { PopupAdapter } from "../../popup-ui/src/types";
+
+let root: Root | undefined;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+describe("deadline feasibility setting", () => {
+  it("shows the shared value in Advanced settings and saves -1 immediately", () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const onSettingsChange = vi.fn(async () => undefined);
+    const labels: Record<string, string> = {
+      advancedTitle: "Advanced",
+      deadlineSafetyMarginTitle: "Deadline safety margin",
+      deadlineSafetyMarginDescription: "Use -1 to disable deadline filtering.",
+      disabled: "Disabled",
+      minutesSuffix: "min",
+    };
+    const adapter = {} as PopupAdapter;
+    const container = document.getElementById("app")!;
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <PopupRuntimeContext.Provider value={{ adapter, preview: true }}>
+          <I18nContext.Provider value={{ t: (key) => labels[key] ?? key, dir: "ltr", locale: "en" }}>
+            <SettingsView
+              suggestions={{ twitch: [], kick: [] }}
+              onSearchCategories={async () => []}
+              settings={DEFAULT_SETTINGS}
+              onSettingsChange={onSettingsChange}
+              exportConfirmationResetKey={0}
+            />
+          </I18nContext.Provider>
+        </PopupRuntimeContext.Provider>,
+      );
+    });
+
+    const advanced = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Advanced"));
+    act(() => advanced?.click());
+    const input = container.querySelector('input[aria-label="Deadline safety margin"]') as HTMLInputElement;
+    expect(input.value).toBe("5");
+
+    act(() => {
+      Object.defineProperty(input, "value", { configurable: true, value: "-1" });
+      input.dispatchEvent(new window.Event("input", { bubbles: true }));
+      input.dispatchEvent(new window.Event("change", { bubbles: true }));
+      input.dispatchEvent(new window.Event("focusout", { bubbles: true }));
+    });
+    expect(onSettingsChange).toHaveBeenCalledWith(
+      { deadlineSafetyMarginMinutes: -1 },
+      { tickAfterSave: true },
+    );
+  });
+});

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -86,12 +86,20 @@ describe("subscription drop popup views", () => {
     };
 
     const view = campaignViewFromCampaign(source, 0, idleSession, false, {
+      skipUnfinishableRewards: true,
       deadlineSafetyMarginMinutes: 5,
       now: Date.parse("2026-07-19T12:00:00.000Z"),
     });
 
     expect(view.rewards[0].ineligibilityReason).toBe("insufficient_time");
     expect(renderDrops([view])).toContain("Insufficient time remaining");
+
+    const disabled = campaignViewFromCampaign(source, 0, idleSession, false, {
+      skipUnfinishableRewards: false,
+      deadlineSafetyMarginMinutes: 5,
+      now: Date.parse("2026-07-19T12:00:00.000Z"),
+    });
+    expect(disabled.rewards[0].ineligibilityReason).toBeUndefined();
   });
 
   it("preserves subscription rewards without fabricating progress", () => {

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -47,6 +47,7 @@ const testMessages: Record<string, string> = {
   excluded: "Excluded",
   excludeFromFarming: "Exclude from farming",
   farmingLabel: "Farming",
+  insufficientTimeRemaining: "Insufficient time remaining",
   notEarnableByWatching: "Not earnable by watching",
   qualifyingSubscriptionsRequired: "Requires $1 qualifying subscriptions",
   subscribedRefresh: "I've subscribed — refresh status",
@@ -78,6 +79,21 @@ function renderDrops(campaigns: CampaignView[], refreshing = false): string {
 }
 
 describe("subscription drop popup views", () => {
+  it("marks and explains watch rewards with insufficient time", () => {
+    const source = {
+      ...campaign("timed", [reward({ requirement: "watch", requiredMinutes: 60, watchedMinutes: 30, status: "in_progress" })]),
+      endsAt: "2026-07-19T12:34:59.999Z",
+    };
+
+    const view = campaignViewFromCampaign(source, 0, idleSession, false, {
+      deadlineSafetyMarginMinutes: 5,
+      now: Date.parse("2026-07-19T12:00:00.000Z"),
+    });
+
+    expect(view.rewards[0].ineligibilityReason).toBe("insufficient_time");
+    expect(renderDrops([view])).toContain("Insufficient time remaining");
+  });
+
   it("preserves subscription rewards without fabricating progress", () => {
     const source = campaign("subscription-only", [
       reward({ id: "subscribe-once", name: "Subscribe once", requirement: "subscription", requiredSubs: 1 }),

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "ث"
   },
+  "deadlineSafetyMarginTitle": { "message": "هامش أمان الموعد النهائي" },
+  "deadlineSafetyMarginDescription": { "message": "دقائق إضافية مطلوبة قبل جمع المكافأة. استخدم -1 لتعطيل تصفية الموعد النهائي." },
+  "disabled": { "message": "معطل" },
+  "minutesSuffix": { "message": "د" },
+  "insufficientTimeRemaining": { "message": "الوقت المتبقي غير كافٍ" },
   "automationSectionTitle": {
     "message": "الأتمتة"
   },

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -444,8 +444,10 @@
     "message": "ث"
   },
   "deadlineSafetyMarginTitle": { "message": "هامش أمان الموعد النهائي" },
-  "deadlineSafetyMarginDescription": { "message": "دقائق إضافية مطلوبة قبل جمع المكافأة. استخدم -1 لتعطيل تصفية الموعد النهائي." },
-  "disabled": { "message": "معطل" },
+  "deadlineSafetyMarginDescription": { "message": "دقائق إضافية مطلوبة قبل جمع المكافأة." },
+  "deadlineSafetyMarginDisabledReason": { "message": "فعّل تصفية الموعد النهائي لتغيير هامش الأمان." },
+  "skipUnfinishableRewardsTitle": { "message": "تخطي المكافآت التي لا يمكن إكمالها" },
+  "skipUnfinishableRewardsDescription": { "message": "لا تجمع المكافآت عندما يتجاوز وقت المشاهدة المتبقي الوقت المتاح قبل الموعد النهائي." },
   "minutesSuffix": { "message": "د" },
   "insufficientTimeRemaining": { "message": "الوقت المتبقي غير كافٍ" },
   "automationSectionTitle": {

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "Sek."
   },
+  "deadlineSafetyMarginTitle": { "message": "Sicherheitsmarge bis zum Ablauf" },
+  "deadlineSafetyMarginDescription": { "message": "Zusätzliche Minuten vor dem Farmen einer Belohnung. -1 deaktiviert den Fristfilter." },
+  "disabled": { "message": "Deaktiviert" },
+  "minutesSuffix": { "message": "Min." },
+  "insufficientTimeRemaining": { "message": "Nicht genügend Zeit verbleibend" },
   "automationSectionTitle": {
     "message": "Automatisierung"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -444,8 +444,10 @@
     "message": "Sek."
   },
   "deadlineSafetyMarginTitle": { "message": "Sicherheitsmarge bis zum Ablauf" },
-  "deadlineSafetyMarginDescription": { "message": "Zusätzliche Minuten vor dem Farmen einer Belohnung. -1 deaktiviert den Fristfilter." },
-  "disabled": { "message": "Deaktiviert" },
+  "deadlineSafetyMarginDescription": { "message": "Zusätzliche Minuten vor dem Farmen einer Belohnung." },
+  "deadlineSafetyMarginDisabledReason": { "message": "Aktiviere den Fristfilter, um die Sicherheitsmarge zu ändern." },
+  "skipUnfinishableRewardsTitle": { "message": "Nicht abschließbare Belohnungen überspringen" },
+  "skipUnfinishableRewardsDescription": { "message": "Belohnungen nicht farmen, wenn die verbleibende Wiedergabezeit die Frist überschreitet." },
   "minutesSuffix": { "message": "Min." },
   "insufficientTimeRemaining": { "message": "Nicht genügend Zeit verbleibend" },
   "automationSectionTitle": {

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -444,8 +444,10 @@
     "message": "sec"
   },
   "deadlineSafetyMarginTitle": { "message": "Deadline safety margin" },
-  "deadlineSafetyMarginDescription": { "message": "Extra minutes required before farming a reward. Use -1 to disable deadline filtering." },
-  "disabled": { "message": "Disabled" },
+  "deadlineSafetyMarginDescription": { "message": "Extra minutes required before farming a reward." },
+  "deadlineSafetyMarginDisabledReason": { "message": "Enable deadline filtering to change the safety margin." },
+  "skipUnfinishableRewardsTitle": { "message": "Skip rewards that cannot be completed" },
+  "skipUnfinishableRewardsDescription": { "message": "Do not farm rewards when their remaining watch time exceeds the time before their deadline." },
   "minutesSuffix": { "message": "min" },
   "insufficientTimeRemaining": { "message": "Insufficient time remaining" },
   "automationSectionTitle": {

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "sec"
   },
+  "deadlineSafetyMarginTitle": { "message": "Deadline safety margin" },
+  "deadlineSafetyMarginDescription": { "message": "Extra minutes required before farming a reward. Use -1 to disable deadline filtering." },
+  "disabled": { "message": "Disabled" },
+  "minutesSuffix": { "message": "min" },
+  "insufficientTimeRemaining": { "message": "Insufficient time remaining" },
   "automationSectionTitle": {
     "message": "Automation"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -444,8 +444,10 @@
     "message": "s"
   },
   "deadlineSafetyMarginTitle": { "message": "Margen de seguridad del plazo" },
-  "deadlineSafetyMarginDescription": { "message": "Minutos adicionales requeridos antes de farmear una recompensa. Usa -1 para desactivar el filtro de plazos." },
-  "disabled": { "message": "Desactivado" },
+  "deadlineSafetyMarginDescription": { "message": "Minutos adicionales requeridos antes de farmear una recompensa." },
+  "deadlineSafetyMarginDisabledReason": { "message": "Activa el filtro de plazos para cambiar el margen de seguridad." },
+  "skipUnfinishableRewardsTitle": { "message": "Omitir recompensas que no se pueden completar" },
+  "skipUnfinishableRewardsDescription": { "message": "No farmear recompensas cuyo tiempo de visionado restante supere el plazo disponible." },
   "minutesSuffix": { "message": "min." },
   "insufficientTimeRemaining": { "message": "No queda tiempo suficiente" },
   "automationSectionTitle": {

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "s"
   },
+  "deadlineSafetyMarginTitle": { "message": "Margen de seguridad del plazo" },
+  "deadlineSafetyMarginDescription": { "message": "Minutos adicionales requeridos antes de farmear una recompensa. Usa -1 para desactivar el filtro de plazos." },
+  "disabled": { "message": "Desactivado" },
+  "minutesSuffix": { "message": "min." },
+  "insufficientTimeRemaining": { "message": "No queda tiempo suficiente" },
   "automationSectionTitle": {
     "message": "Automatización"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -444,8 +444,10 @@
     "message": "s"
   },
   "deadlineSafetyMarginTitle": { "message": "Marge de sécurité avant échéance" },
-  "deadlineSafetyMarginDescription": { "message": "Minutes supplémentaires requises avant de farmer une récompense. Utilisez -1 pour désactiver le filtre." },
-  "disabled": { "message": "Désactivé" },
+  "deadlineSafetyMarginDescription": { "message": "Minutes supplémentaires requises avant de farmer une récompense." },
+  "deadlineSafetyMarginDisabledReason": { "message": "Activez le filtre des échéances pour modifier la marge." },
+  "skipUnfinishableRewardsTitle": { "message": "Ignorer les récompenses impossibles à terminer" },
+  "skipUnfinishableRewardsDescription": { "message": "Ne pas farmer une récompense si le temps de visionnage restant dépasse son échéance." },
   "minutesSuffix": { "message": "min." },
   "insufficientTimeRemaining": { "message": "Temps restant insuffisant" },
   "automationSectionTitle": {

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "s"
   },
+  "deadlineSafetyMarginTitle": { "message": "Marge de sécurité avant échéance" },
+  "deadlineSafetyMarginDescription": { "message": "Minutes supplémentaires requises avant de farmer une récompense. Utilisez -1 pour désactiver le filtre." },
+  "disabled": { "message": "Désactivé" },
+  "minutesSuffix": { "message": "min." },
+  "insufficientTimeRemaining": { "message": "Temps restant insuffisant" },
   "automationSectionTitle": {
     "message": "Automatisation"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -444,8 +444,10 @@
     "message": "सेक"
   },
   "deadlineSafetyMarginTitle": { "message": "समय-सीमा सुरक्षा मार्जिन" },
-  "deadlineSafetyMarginDescription": { "message": "इनाम फ़ार्म करने से पहले आवश्यक अतिरिक्त मिनट। फ़िल्टर बंद करने के लिए -1 का उपयोग करें।" },
-  "disabled": { "message": "अक्षम" },
+  "deadlineSafetyMarginDescription": { "message": "इनाम फ़ार्म करने से पहले आवश्यक अतिरिक्त मिनट।" },
+  "deadlineSafetyMarginDisabledReason": { "message": "सुरक्षा मार्जिन बदलने के लिए समय-सीमा फ़िल्टर सक्षम करें।" },
+  "skipUnfinishableRewardsTitle": { "message": "पूरा न हो सकने वाले इनाम छोड़ें" },
+  "skipUnfinishableRewardsDescription": { "message": "जब बचा हुआ देखने का समय समय-सीमा से अधिक हो तो इनाम फ़ार्म न करें।" },
   "minutesSuffix": { "message": "मिनट" },
   "insufficientTimeRemaining": { "message": "पर्याप्त समय शेष नहीं" },
   "automationSectionTitle": {

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "सेक"
   },
+  "deadlineSafetyMarginTitle": { "message": "समय-सीमा सुरक्षा मार्जिन" },
+  "deadlineSafetyMarginDescription": { "message": "इनाम फ़ार्म करने से पहले आवश्यक अतिरिक्त मिनट। फ़िल्टर बंद करने के लिए -1 का उपयोग करें।" },
+  "disabled": { "message": "अक्षम" },
+  "minutesSuffix": { "message": "मिनट" },
+  "insufficientTimeRemaining": { "message": "पर्याप्त समय शेष नहीं" },
   "automationSectionTitle": {
     "message": "ऑटोमेशन"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -444,8 +444,10 @@
     "message": "sec"
   },
   "deadlineSafetyMarginTitle": { "message": "Margine di sicurezza della scadenza" },
-  "deadlineSafetyMarginDescription": { "message": "Minuti aggiuntivi richiesti prima di farmare una ricompensa. Usa -1 per disattivare il filtro." },
-  "disabled": { "message": "Disattivato" },
+  "deadlineSafetyMarginDescription": { "message": "Minuti aggiuntivi richiesti prima di farmare una ricompensa." },
+  "deadlineSafetyMarginDisabledReason": { "message": "Attiva il filtro delle scadenze per modificare il margine." },
+  "skipUnfinishableRewardsTitle": { "message": "Salta le ricompense impossibili da completare" },
+  "skipUnfinishableRewardsDescription": { "message": "Non farmare ricompense se il tempo di visione restante supera la scadenza." },
   "minutesSuffix": { "message": "min." },
   "insufficientTimeRemaining": { "message": "Tempo rimanente insufficiente" },
   "automationSectionTitle": {

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "sec"
   },
+  "deadlineSafetyMarginTitle": { "message": "Margine di sicurezza della scadenza" },
+  "deadlineSafetyMarginDescription": { "message": "Minuti aggiuntivi richiesti prima di farmare una ricompensa. Usa -1 per disattivare il filtro." },
+  "disabled": { "message": "Disattivato" },
+  "minutesSuffix": { "message": "min." },
+  "insufficientTimeRemaining": { "message": "Tempo rimanente insufficiente" },
   "automationSectionTitle": {
     "message": "Automazione"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -444,8 +444,10 @@
     "message": "s"
   },
   "deadlineSafetyMarginTitle": { "message": "Margem de segurança do prazo" },
-  "deadlineSafetyMarginDescription": { "message": "Minutos extras antes de farmar uma recompensa. Use -1 para desativar o filtro de prazo." },
-  "disabled": { "message": "Desativado" },
+  "deadlineSafetyMarginDescription": { "message": "Minutos extras antes de farmar uma recompensa." },
+  "deadlineSafetyMarginDisabledReason": { "message": "Ative o filtro de prazo para alterar a margem de segurança." },
+  "skipUnfinishableRewardsTitle": { "message": "Pular recompensas que não podem ser concluídas" },
+  "skipUnfinishableRewardsDescription": { "message": "Não farmar recompensas quando o tempo restante de exibição ultrapassar o prazo." },
   "minutesSuffix": { "message": "min." },
   "insufficientTimeRemaining": { "message": "Tempo restante insuficiente" },
   "automationSectionTitle": {

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "s"
   },
+  "deadlineSafetyMarginTitle": { "message": "Margem de segurança do prazo" },
+  "deadlineSafetyMarginDescription": { "message": "Minutos extras antes de farmar uma recompensa. Use -1 para desativar o filtro de prazo." },
+  "disabled": { "message": "Desativado" },
+  "minutesSuffix": { "message": "min." },
+  "insufficientTimeRemaining": { "message": "Tempo restante insuficiente" },
   "automationSectionTitle": {
     "message": "Automação"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "с"
   },
+  "deadlineSafetyMarginTitle": { "message": "Запас времени до окончания" },
+  "deadlineSafetyMarginDescription": { "message": "Дополнительные минуты перед фармом награды. -1 отключает фильтр сроков." },
+  "disabled": { "message": "Отключено" },
+  "minutesSuffix": { "message": "мин" },
+  "insufficientTimeRemaining": { "message": "Недостаточно оставшегося времени" },
   "automationSectionTitle": {
     "message": "Автоматизация"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -444,8 +444,10 @@
     "message": "с"
   },
   "deadlineSafetyMarginTitle": { "message": "Запас времени до окончания" },
-  "deadlineSafetyMarginDescription": { "message": "Дополнительные минуты перед фармом награды. -1 отключает фильтр сроков." },
-  "disabled": { "message": "Отключено" },
+  "deadlineSafetyMarginDescription": { "message": "Дополнительные минуты перед фармом награды." },
+  "deadlineSafetyMarginDisabledReason": { "message": "Включите фильтр сроков, чтобы изменить запас времени." },
+  "skipUnfinishableRewardsTitle": { "message": "Пропускать награды, которые нельзя завершить" },
+  "skipUnfinishableRewardsDescription": { "message": "Не фармить награды, если оставшееся время просмотра превышает доступный срок." },
   "minutesSuffix": { "message": "мин" },
   "insufficientTimeRemaining": { "message": "Недостаточно оставшегося времени" },
   "automationSectionTitle": {

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -444,8 +444,10 @@
     "message": "秒"
   },
   "deadlineSafetyMarginTitle": { "message": "截止时间安全余量" },
-  "deadlineSafetyMarginDescription": { "message": "开始获取奖励前需额外预留的分钟数。设为 -1 可关闭截止时间筛选。" },
-  "disabled": { "message": "已禁用" },
+  "deadlineSafetyMarginDescription": { "message": "开始获取奖励前需额外预留的分钟数。" },
+  "deadlineSafetyMarginDisabledReason": { "message": "启用截止时间筛选后才能修改安全余量。" },
+  "skipUnfinishableRewardsTitle": { "message": "跳过无法完成的奖励" },
+  "skipUnfinishableRewardsDescription": { "message": "当剩余观看时间超过截止前可用时间时，不再获取该奖励。" },
   "minutesSuffix": { "message": "分钟" },
   "insufficientTimeRemaining": { "message": "剩余时间不足" },
   "automationSectionTitle": {

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -443,6 +443,11 @@
   "secondsSuffix": {
     "message": "秒"
   },
+  "deadlineSafetyMarginTitle": { "message": "截止时间安全余量" },
+  "deadlineSafetyMarginDescription": { "message": "开始获取奖励前需额外预留的分钟数。设为 -1 可关闭截止时间筛选。" },
+  "disabled": { "message": "已禁用" },
+  "minutesSuffix": { "message": "分钟" },
+  "insufficientTimeRemaining": { "message": "剩余时间不足" },
   "automationSectionTitle": {
     "message": "自动化"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -482,7 +482,13 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const rawCampaigns = sortCampaignsForPopup(snapshot.state.campaigns[platform].filter((campaign) => isCampaignVisible(campaign, settings, excludedIds)), settings);
   const session = snapshot.state.sessions[platform];
   const sessionChannel = channelViewFromSession(session);
-  const campaigns = rawCampaigns.map((campaign, index) => campaignViewFromCampaign(campaign, index, session, excludedIds.has(campaign.id)));
+  const campaigns = rawCampaigns.map((campaign, index) => campaignViewFromCampaign(
+    campaign,
+    index,
+    session,
+    excludedIds.has(campaign.id),
+    { deadlineSafetyMarginMinutes: settings.deadlineSafetyMarginMinutes },
+  ));
   const games = gameItemsFromCampaigns(snapshot.state.campaigns[platform], t);
   // Categories that currently have active drop campaigns, surfaced as one-tap
   // "Has active drops" suggestions in the category filter editor (zero network).

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -487,7 +487,10 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
     index,
     session,
     excludedIds.has(campaign.id),
-    { deadlineSafetyMarginMinutes: settings.deadlineSafetyMarginMinutes },
+    {
+      skipUnfinishableRewards: settings.skipUnfinishableRewards,
+      deadlineSafetyMarginMinutes: settings.deadlineSafetyMarginMinutes,
+    },
   ));
   const games = gameItemsFromCampaigns(snapshot.state.campaigns[platform], t);
   // Categories that currently have active drop campaigns, surfaced as one-tap

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -424,6 +424,11 @@ function RewardTile({ reward }: { reward: RewardView }) {
             </span>
             <span className="tabular">{formatMinutes(reward.requiredMinutes)}</span>
           </div>
+          {reward.ineligibilityReason === "insufficient_time" ? (
+            <div className="mt-1 text-[10px] font-semibold leading-tight text-amber-600 dark:text-amber-400">
+              {t("insufficientTimeRemaining")}
+            </div>
+          ) : null}
         </>
       ) : reward.requirement === "subscription" ? (
         <div className="space-y-1 text-[10px] leading-tight text-zinc-500 dark:text-zinc-400">

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -187,14 +187,22 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
           disabledReason={t("postClaimHandoffDescription")}
           onChange={(value) => onSettingsChange({ postClaimHandoffMaxSeconds: value })}
         />
+        <SettingRow
+          title={t("skipUnfinishableRewardsTitle")}
+          description={t("skipUnfinishableRewardsDescription")}
+          checked={settings.skipUnfinishableRewards}
+          onChange={(value) => onSettingsChange({ skipUnfinishableRewards: value }, { tickAfterSave: true })}
+        />
         <NumberSettingRow
           title={t("deadlineSafetyMarginTitle")}
           description={t("deadlineSafetyMarginDescription")}
           value={settings.deadlineSafetyMarginMinutes}
-          min={-1}
+          min={0}
           max={60}
-          suffix={settings.deadlineSafetyMarginMinutes === -1 ? t("disabled") : t("minutesSuffix")}
+          suffix={t("minutesSuffix")}
           onChange={(value) => onSettingsChange({ deadlineSafetyMarginMinutes: value }, { tickAfterSave: true })}
+          disabled={!settings.skipUnfinishableRewards}
+          disabledReason={t("deadlineSafetyMarginDisabledReason")}
         />
         <SettingRow title={t("diagnosticLoggingTitle")} description={t("diagnosticLoggingDescription")} checked={settings.diagnosticLogging} onChange={set("diagnosticLogging")} />
         {compatibilityRegistry && compatibilityResolution ? <CompatibilitySettings settings={settings.compatibility} registry={compatibilityRegistry} resolution={compatibilityResolution} onChange={onSettingsChange} /> : null}

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -187,6 +187,15 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
           disabledReason={t("postClaimHandoffDescription")}
           onChange={(value) => onSettingsChange({ postClaimHandoffMaxSeconds: value })}
         />
+        <NumberSettingRow
+          title={t("deadlineSafetyMarginTitle")}
+          description={t("deadlineSafetyMarginDescription")}
+          value={settings.deadlineSafetyMarginMinutes}
+          min={-1}
+          max={60}
+          suffix={settings.deadlineSafetyMarginMinutes === -1 ? t("disabled") : t("minutesSuffix")}
+          onChange={(value) => onSettingsChange({ deadlineSafetyMarginMinutes: value }, { tickAfterSave: true })}
+        />
         <SettingRow title={t("diagnosticLoggingTitle")} description={t("diagnosticLoggingDescription")} checked={settings.diagnosticLogging} onChange={set("diagnosticLogging")} />
         {compatibilityRegistry && compatibilityResolution ? <CompatibilitySettings settings={settings.compatibility} registry={compatibilityRegistry} resolution={compatibilityResolution} onChange={onSettingsChange} /> : null}
       </SettingsSection>

--- a/packages/popup-ui/src/settingsControls.tsx
+++ b/packages/popup-ui/src/settingsControls.tsx
@@ -229,7 +229,7 @@ export function NumberSettingRow({ title, description, value, min, max, suffix, 
           step={1}
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
-          onBlur={() => commit()}
+          onBlur={(event) => commit(event.currentTarget.value)}
           onKeyDown={(event) => {
             if (event.key === "Enter") event.currentTarget.blur();
           }}

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -55,6 +55,7 @@ export type RewardView = {
   tint: string;
   imageUrl?: string;
   claimGuidance?: ClaimGuidance;
+  ineligibilityReason?: "insufficient_time";
 };
 export type CampaignLifecycleState = "upcoming" | "expired" | "finished";
 

--- a/packages/popup-ui/src/viewModels.ts
+++ b/packages/popup-ui/src/viewModels.ts
@@ -136,7 +136,7 @@ export function campaignViewFromCampaign(
   index: number,
   session: WatchSession,
   excluded: boolean,
-  feasibility?: { deadlineSafetyMarginMinutes: number; now?: number },
+  feasibility?: { skipUnfinishableRewards: boolean; deadlineSafetyMarginMinutes: number; now?: number },
 ): CampaignView {
   return {
     id: campaign.id,
@@ -162,7 +162,13 @@ export function campaignViewFromCampaign(
         : reward.status === "claimed" ? 100 : undefined;
       const claimGuidance = safeClaimGuidance(reward.claimGuidance ?? campaign.claimGuidance);
       const deadlineFeasibility = feasibility
-        ? rewardFeasibility(campaign, reward, feasibility.deadlineSafetyMarginMinutes, feasibility.now)
+        ? rewardFeasibility(
+            campaign,
+            reward,
+            feasibility.skipUnfinishableRewards,
+            feasibility.deadlineSafetyMarginMinutes,
+            feasibility.now,
+          )
         : undefined;
       return {
         id: reward.id,

--- a/packages/popup-ui/src/viewModels.ts
+++ b/packages/popup-ui/src/viewModels.ts
@@ -5,6 +5,7 @@ import {
   campaignHasWatchRewards,
   isWatchReward,
   rewardRequirementType,
+  rewardFeasibility,
 } from "@lurkloot/shared/rewards";
 import { CAMPAIGN_TINTS, GAME_ACCENTS, NO_CATEGORY_ACCENT, REWARD_TINTS } from "./constants";
 import { initials } from "./format";
@@ -130,7 +131,13 @@ function rewardComplete(reward: RewardView): boolean {
   return reward.obtained || (reward.progress ?? 0) >= 100;
 }
 
-export function campaignViewFromCampaign(campaign: DropCampaign, index: number, session: WatchSession, excluded: boolean): CampaignView {
+export function campaignViewFromCampaign(
+  campaign: DropCampaign,
+  index: number,
+  session: WatchSession,
+  excluded: boolean,
+  feasibility?: { deadlineSafetyMarginMinutes: number; now?: number },
+): CampaignView {
   return {
     id: campaign.id,
     gameId: gameId(campaign),
@@ -154,6 +161,9 @@ export function campaignViewFromCampaign(campaign: DropCampaign, index: number, 
         ? Math.min(100, (Math.min(reward.watchedMinutes, reward.requiredMinutes) / reward.requiredMinutes) * 100)
         : reward.status === "claimed" ? 100 : undefined;
       const claimGuidance = safeClaimGuidance(reward.claimGuidance ?? campaign.claimGuidance);
+      const deadlineFeasibility = feasibility
+        ? rewardFeasibility(campaign, reward, feasibility.deadlineSafetyMarginMinutes, feasibility.now)
+        : undefined;
       return {
         id: reward.id,
         name: reward.name,
@@ -166,6 +176,7 @@ export function campaignViewFromCampaign(campaign: DropCampaign, index: number, 
         tint: REWARD_TINTS[rewardIndex % REWARD_TINTS.length],
         imageUrl: campaign.platform === "kick" ? kickRewardImageUrl(reward.imageUrl) : reward.imageUrl,
         claimGuidance,
+        ineligibilityReason: deadlineFeasibility?.kind === "insufficient_time" ? "insufficient_time" : undefined,
       };
     }),
     hasWatchRewards: campaignHasWatchRewards(campaign),

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -281,6 +281,7 @@ export interface EngineSettings {
   postClaimHandoff: boolean;
   postClaimHandoffIntervalSeconds: number;
   postClaimHandoffMaxSeconds: number;
+  deadlineSafetyMarginMinutes: number;
 }
 
 // The browser extension's full settings schema: the engine contract plus the

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -315,6 +315,7 @@ export interface SchedulerState {
   // would never survive to the next one.
   gamification?: Partial<Record<Platform, { lastCheckedAt: string }>>;
   campaigns: Record<Platform, DropCampaign[]>;
+  deadlineInfeasibleRewardIds?: Partial<Record<Platform, string[]>>;
   lastTickAt?: string;
   // ISO timestamp recorded once by the background on install; drives the
   // time-based rate/review nudge. Undefined means "unknown" (pre-feature state).

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -281,6 +281,7 @@ export interface EngineSettings {
   postClaimHandoff: boolean;
   postClaimHandoffIntervalSeconds: number;
   postClaimHandoffMaxSeconds: number;
+  skipUnfinishableRewards: boolean;
   deadlineSafetyMarginMinutes: number;
 }
 

--- a/packages/shared/src/rewards.ts
+++ b/packages/shared/src/rewards.ts
@@ -12,6 +12,47 @@ export function rewardRequirementType(reward: RequirementFields): RewardRequirem
 export const isWatchReward = (reward: RequirementFields): boolean => rewardRequirementType(reward) === "watch";
 export const isSubscriptionReward = (reward: RequirementFields): boolean => rewardRequirementType(reward) === "subscription";
 
+export type RewardFeasibility =
+  | { kind: "disabled" }
+  | { kind: "not_applicable" }
+  | { kind: "unknown_deadline" }
+  | { kind: "feasible"; deadline: string; remainingMinutes: number; availableMilliseconds: number; marginMinutes: number }
+  | { kind: "insufficient_time"; deadline: string; remainingMinutes: number; availableMilliseconds: number; marginMinutes: number };
+
+export function rewardFeasibility(
+  campaign: Pick<DropCampaign, "endsAt">,
+  reward: DropReward,
+  marginMinutes: number,
+  now = Date.now(),
+): RewardFeasibility {
+  if (marginMinutes === -1) return { kind: "disabled" };
+  if (!isWatchReward(reward) || reward.status === "claimed" || reward.status === "claimable") {
+    return { kind: "not_applicable" };
+  }
+
+  const deadlines = [campaign.endsAt, reward.availableUntil]
+    .flatMap((deadline) => {
+      if (!deadline) return [];
+      const timestamp = Date.parse(deadline);
+      return Number.isNaN(timestamp) ? [] : [{ deadline, timestamp }];
+    })
+    .sort((left, right) => left.timestamp - right.timestamp);
+  const earliest = deadlines[0];
+  if (!earliest) return { kind: "unknown_deadline" };
+
+  const remainingMinutes = Math.max(0, reward.requiredMinutes - reward.watchedMinutes);
+  const availableMilliseconds = earliest.timestamp - now;
+  const requiredMilliseconds = (remainingMinutes + marginMinutes) * 60_000;
+  const kind = availableMilliseconds >= requiredMilliseconds ? "feasible" : "insufficient_time";
+  return {
+    kind,
+    deadline: earliest.deadline,
+    remainingMinutes,
+    availableMilliseconds,
+    marginMinutes,
+  };
+}
+
 export function isWaitingSubscriptionReward(reward: DropReward, now = Date.now()): boolean {
   if (!isSubscriptionReward(reward)) return false;
   if (reward.status !== "locked" && reward.status !== "in_progress") return false;

--- a/packages/shared/src/rewards.ts
+++ b/packages/shared/src/rewards.ts
@@ -22,10 +22,11 @@ export type RewardFeasibility =
 export function rewardFeasibility(
   campaign: Pick<DropCampaign, "endsAt">,
   reward: DropReward,
+  enabled: boolean,
   marginMinutes: number,
   now = Date.now(),
 ): RewardFeasibility {
-  if (marginMinutes === -1) return { kind: "disabled" };
+  if (!enabled) return { kind: "disabled" };
   if (!isWatchReward(reward) || reward.status === "claimed" || reward.status === "claimable") {
     return { kind: "not_applicable" };
   }

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -68,6 +68,7 @@ export const DEFAULT_ENGINE_SETTINGS: EngineSettings = {
   // alarm so the handoff and the alarm never contend for the same heartbeat.
   postClaimHandoffIntervalSeconds: 5,
   postClaimHandoffMaxSeconds: 45,
+  skipUnfinishableRewards: true,
   deadlineSafetyMarginMinutes: 5,
 };
 
@@ -154,9 +155,10 @@ export function mergeEngineSettings(value: Partial<EngineSettings> | undefined):
     postClaimHandoff: booleanOr(value?.postClaimHandoff, DEFAULT_ENGINE_SETTINGS.postClaimHandoff),
     postClaimHandoffIntervalSeconds: clampInteger(value?.postClaimHandoffIntervalSeconds, 1, 30, DEFAULT_ENGINE_SETTINGS.postClaimHandoffIntervalSeconds),
     postClaimHandoffMaxSeconds: clampInteger(value?.postClaimHandoffMaxSeconds, 5, 120, DEFAULT_ENGINE_SETTINGS.postClaimHandoffMaxSeconds),
+    skipUnfinishableRewards: booleanOr(value?.skipUnfinishableRewards, DEFAULT_ENGINE_SETTINGS.skipUnfinishableRewards),
     deadlineSafetyMarginMinutes: clampInteger(
       value?.deadlineSafetyMarginMinutes,
-      -1,
+      0,
       60,
       DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes,
     ),

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -68,6 +68,7 @@ export const DEFAULT_ENGINE_SETTINGS: EngineSettings = {
   // alarm so the handoff and the alarm never contend for the same heartbeat.
   postClaimHandoffIntervalSeconds: 5,
   postClaimHandoffMaxSeconds: 45,
+  deadlineSafetyMarginMinutes: 5,
 };
 
 // The extension's full defaults: the engine contract plus the host-only knobs.
@@ -153,6 +154,12 @@ export function mergeEngineSettings(value: Partial<EngineSettings> | undefined):
     postClaimHandoff: booleanOr(value?.postClaimHandoff, DEFAULT_ENGINE_SETTINGS.postClaimHandoff),
     postClaimHandoffIntervalSeconds: clampInteger(value?.postClaimHandoffIntervalSeconds, 1, 30, DEFAULT_ENGINE_SETTINGS.postClaimHandoffIntervalSeconds),
     postClaimHandoffMaxSeconds: clampInteger(value?.postClaimHandoffMaxSeconds, 5, 120, DEFAULT_ENGINE_SETTINGS.postClaimHandoffMaxSeconds),
+    deadlineSafetyMarginMinutes: clampInteger(
+      value?.deadlineSafetyMarginMinutes,
+      -1,
+      60,
+      DEFAULT_ENGINE_SETTINGS.deadlineSafetyMarginMinutes,
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary

- add a shared deadline-feasibility evaluator used by the farming engine and popup
- skip rewards that cannot accumulate their remaining watch time before the earliest valid campaign or reward deadline
- add separate `skipUnfinishableRewards` and `deadlineSafetyMarginMinutes` settings to the Advanced popup settings and CLI JSONC configuration
- preserve the configured margin while filtering is disabled, and disable the margin input in the UI until filtering is enabled again
- surface structured scheduler diagnostics and a popup warning when rewards are skipped

## Why

Rewards that are technically available can still be impossible to finish before their deadline. Avoiding those rewards keeps the farming queue focused on rewards that can still be earned, while the explicit toggle lets users restore the previous behavior when desired.

## Configuration

- `skipUnfinishableRewards`: defaults to `true`; set to `false` to disable deadline-feasibility filtering
- `deadlineSafetyMarginMinutes`: defaults to `5`; `0` uses exact feasibility and values from `1` to `60` add a safety buffer

## Testing

- `pnpm verify`
- 565 extension tests
- 90 CLI tests
- all workspace typechecks
- Astro site build
- Chromium and Firefox production extension builds

## Screenshots

Not included: the popup behavior is covered by focused React DOM tests.

Closes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deadline feasibility controls: “skip unfinishable rewards” and a configurable “deadline safety margin” (0–60).
  * Scheduler/popup now apply the rule and show an “Insufficient time remaining” explanation for watch rewards that can’t be completed in time.
  * Exposed the same settings in the CLI, including generated config template support.
* **Bug Fixes**
  * Scheduler filters out deadline-infeasible watch rewards and emits structured, de-duplicated “insufficient time” diagnostics.
* **Documentation**
  * Added an end-to-end implementation plan and detailed design spec for deadline feasibility.
* **Tests**
  * Added coverage for feasibility rules, settings normalization, and UI/CLI messaging.
* **Chores**
  * Improved numeric setting blur behavior in the popup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->