### PR TITLE
docs: require git worktrees for feature work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ stats-*.json
 # Local reference material (third-party projects, not part of this repo)
 references/
 
+# Per-branch git worktrees (see the Worktrees section in AGENTS.md)
+.worktrees/
+
 # Build / dist output
 artifacts/
 dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,28 @@ Use strict TypeScript and ES modules. Keep imports explicit and prefer `type` im
 
 Tests use Vitest in a Node environment with globals enabled and live in `packages/extension/tests/`. Add focused `*.test.ts` files matching the module being exercised, such as `scheduler.test.ts`, `parsers.test.ts`, or `version.test.ts`. Prefer deterministic unit tests with mocked adapters, browser APIs, or storage rather than live Twitch/Kick calls. Run `pnpm test` for test-only changes and `pnpm verify` before releases.
 
+## Worktrees
+
+**Always develop feature work in a git worktree under `.worktrees/`, never in the main checkout.**
+Multiple agent sessions run against this repository at once, and the main checkout is shared: doing
+feature work there lets concurrent sessions commit onto each other's branches. Create the worktree
+*before* the first edit, not after the branch already has commits on it.
+
+```bash
+git fetch origin develop
+git worktree add .worktrees/<short-kebab-case-description> -b <type>/<short-kebab-case-description> origin/develop
+cd .worktrees/<short-kebab-case-description>
+pnpm install --frozen-lockfile   # each worktree needs its own node_modules
+```
+
+Name the directory after the branch with the `<type>/` prefix dropped, so `feat/kick-daily-challenges`
+lives in `.worktrees/kick-daily-challenges`. Branch from `origin/develop` — it is the integration
+branch, and `main` runs ahead of it between releases. Leave the main checkout parked on `develop`.
+
+Run `git worktree list` before starting: if a worktree for the work already exists, use it rather
+than creating a second one. Remove a worktree with `git worktree remove .worktrees/<name>` once its
+branch is merged.
+
 ## Commit & Pull Request Guidelines
 
 Follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) using `<type>[optional scope]: <description>`. Use lowercase types and imperative, present-tense descriptions without a trailing period. Keep commits focused and use a scope when it adds useful context, such as `feat(popup): add schedule refresh button` or `fix(scheduler): refresh viewer counts`.


### PR DESCRIPTION
## Summary

Records the worktree convention this repository already follows in practice, and makes the ignore rule shared rather than local-only.

Two changes:

- **`AGENTS.md` gains a Worktrees section.** The convention was plainly visible — `git worktree list` shows a worktree per feature branch under `.worktrees/` — but it was written down nowhere, so a fresh agent session had no way to know beyond inferring it. This spells out the workflow and, more importantly, *why*: multiple sessions run against this repo concurrently and the main checkout is shared, so feature work there lets sessions commit onto each other's branches.
- **`.gitignore` gains `.worktrees/`.** It was already ignored via `.git/info/exclude`, which is local-only and never committed — so it worked on one machine and nowhere else.

## Why now

Two agent sessions working in the shared main checkout landed commits on each other's branches: an unrelated design doc and plan ended up on a feature branch mid-implementation. Both were recoverable (the commits were byte-identical duplicates of work already safe on the correct branch, so they could be dropped with a rebase), but nothing prevented it from happening again.

## Testing

Docs and ignore-rule only — no code paths touched.

- Verified the ignore pattern actually matches: created `.worktrees/probe/file.txt` and confirmed `git check-ignore -v` reports `.gitignore:22:.worktrees/` and `git status` stays clean.
- Confirmed the guidance is accurate against the repo: `origin/develop` is the integration branch (`main` runs ahead of it between releases), and each worktree needs its own `pnpm install`.

## Notes

`.claude/` sits in the same local-only exclude file and has the same problem, but it's deliberately left out of this PR — whether a shared `.claude/settings.json` should be committed is a separate judgement call from the personal `settings.local.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using separate Git worktrees during feature development.
  * Documented worktree setup, naming, installation, verification, and cleanup steps.

* **Chores**
  * Updated ignore rules so Git worktree directories are excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->