### PR TITLE
fix(release): render placeholder notes for a pending changelog entry

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -130,7 +130,7 @@ jobs:
         working-directory: candidate
         env:
           VERSION: ${{ inputs.version }}
-        run: node ../trusted/scripts/release/cli.mjs notes --version "$VERSION" --out ../notes.md
+        run: node ../trusted/scripts/release/cli.mjs notes --version "$VERSION" --out ../notes.md --pending true
       - name: Create or refresh the owned GitHub prerelease
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -71,6 +71,12 @@ export function configureApplyRequested({ apply }) {
   throw new Error("--apply must be true or false");
 }
 
+export function pendingNotesAllowed({ pending }) {
+  if (pending === undefined || pending === "false") return false;
+  if (pending === "true") return true;
+  throw new Error("--pending must be true or false");
+}
+
 function githubClient() {
   return new GitHubClient({
     repository: process.env.GITHUB_REPOSITORY,
@@ -98,7 +104,8 @@ const commands = {
   },
   async notes(values) {
     const changelog = JSON.parse(await readFile(changelogPath, "utf8"));
-    await writeFile(values.out, `${releaseNotes(changelog, values.version)}\n`);
+    const pending = pendingNotesAllowed(values);
+    await writeFile(values.out, `${releaseNotes(changelog, values.version, { pending })}\n`);
   },
   async "publish-candidate"(values) {
     const entries = await readdir(values.assets, { withFileTypes: true });

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -1,7 +1,10 @@
 const headings = [["new", "New"], ["improved", "Improved"], ["fixed", "Fixed"]];
 
-export function releaseNotes(changelog, version) {
+export function releaseNotes(changelog, version, { pending = false } = {}) {
   const entry = changelog.find((item) => item.version === version);
+  // A candidate is built before prepare-release writes the entry, so a missing one is expected
+  // there and must not block the preview; a real release still requires the written notes.
+  if (!entry && pending) return `_No changelog entry for ${version} yet._`;
   if (!entry) throw new Error(`no changelog entry for ${version}`);
   const sections = [];
   for (const [kind, heading] of headings) {

--- a/scripts/release/notes.test.mjs
+++ b/scripts/release/notes.test.mjs
@@ -26,3 +26,8 @@ test("omits empty groups and rejects an unknown version", () => {
   assert.equal(releaseNotes(changelog, "1.5.0"), ["## New", "- Older."].join("\n"));
   assert.throws(() => releaseNotes(changelog, "9.9.9"), /no changelog entry for 9\.9\.9/);
 });
+
+test("falls back to a placeholder for a version that has no entry yet", () => {
+  assert.equal(releaseNotes(changelog, "1.7.0", { pending: true }), "_No changelog entry for 1.7.0 yet._");
+  assert.equal(releaseNotes(changelog, "1.5.0", { pending: true }), ["## New", "- Older."].join("\n"));
+});


### PR DESCRIPTION
## Summary

`preview / publish` fails for every release candidate whose changelog entry has not been written yet — most recently [run 29688615742](https://github.com/jamezrin/lurkloot/actions/runs/29688615742/job/88197602391) with `release: no changelog entry for 1.7.0`, blocking #162.

The candidate is rendered from the PR head, but the entry for the next version only appears later, when `prepare-release` cuts the version bump (`scripts/release.mjs` inserts an empty entry then). So `releaseNotes` threw on a state that is normal for every candidate build, and the failure cascaded into `preview / gate`.

- `releaseNotes(changelog, version, { pending })` returns `_No changelog entry for X.Y.Z yet._` instead of throwing when the entry is missing.
- `notes` gains `--pending true|false`, parsed the same way as the existing `--apply` flag (`parseArgs` is pair-based, so the value is explicit).
- The candidate workflow passes `--pending true`.

`release.yml` stays strict on purpose: by then the release PR has merged and `checkWorkspace` has asserted the entry exists, so a throw there is a real problem, and publishing a blank release body would be worse than a retryable failure.

## Why this targets `main` and not `develop`

`prepare-release.yml` passes `trusted_ref: github.event.pull_request.base.sha` and runs the notes step from `../trusted/scripts/release/cli.mjs` — deliberately, per the comment on line 36, since `pull_request_target` hands out a write token. In the failing run that trusted ref was `4eafe1e`, i.e. `main`'s tip. The same fix on `develop` would therefore change nothing: the candidate keeps executing `main`'s copy of the script. No release label here — this is CI-only, so it takes the `non-release` path in `release-candidate.yml`, and `develop` picks it up through the usual `main` -> `develop` sync.

## Testing

- `pnpm release:test` on this branch — 70 passing, including the new cases covering the placeholder and that a real entry still takes precedence.
- Ran the CLI against the current `changelog.json`: `--pending true` writes the placeholder; without it the command still exits 1 with the same message.

## Not addressed

An entry that exists but has `changes: []` — exactly what `prepareWorkspace` creates — still renders an empty body in both paths, including the real release. Catching that belongs on the release PR check rather than at promote time, since failing at promote leaves a merged bump with no release. Happy to follow up if you want it.