### PR TITLE
ci(release): rebuild the candidate on every push to a labelled head

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -2,7 +2,7 @@ name: Prepare release
 
 on:
   pull_request_target:
-    types: [labeled, unlabeled, closed]
+    types: [labeled, unlabeled, synchronize, closed]
     branches: [main]
 
 permissions:
@@ -15,12 +15,18 @@ concurrency:
 jobs:
   # A label only validates and previews. It never modifies the pull request it is applied to;
   # the release branch is cut once that pull request actually merges, by the cut job below.
+  # Pushes to a labelled head rebuild too, so the candidate always describes the commit that would
+  # be released rather than whichever commit happened to be current when the label went on.
   validate:
     if: >-
-      (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-      startsWith(github.event.label.name, 'release/') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      !startsWith(github.event.pull_request.head.ref, 'release/')
+      !startsWith(github.event.pull_request.head.ref, 'release/') &&
+      (
+      ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      startsWith(github.event.label.name, 'release/')) ||
+      (github.event.action == 'synchronize' &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'release/'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ Label a pull request into `main` with `release/patch`, `release/minor` or `relea
 validates the version and publishes mutable candidate artifacts; it does not modify the PR it is
 applied to. Merge that PR normally with a merge commit. Prepare release then cuts `release/X.Y.Z`
 from the resulting merge commit on `main`, commits the version, and opens its own PR into `main`
-whose diff is only the version bump. Candidate artifacts refresh on every release-branch push.
+whose diff is only the version bump. Candidate artifacts refresh on every push to a labelled head
+and on every release-branch push.
 
 Merge the generated release PR with a merge commit; **Release** starts automatically, publishes the
 GitHub release, GHCR aliases, Chrome Web Store submission and production site after one approval,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,7 +66,9 @@ Candidate pointers are deliberately mutable:
 - GHCR image: `candidate-X.Y.Z`
 - Site: `https://next.lurkloot.pages.dev`
 
-Every generated release-branch push rebuilds and refreshes those targets. Ownership metadata binds
+Every push to a labelled head rebuilds and refreshes those targets, as does every generated
+release-branch push, so the candidate always describes the commit that would be released rather
+than whichever commit was current when the label went on. Ownership metadata binds
 the candidate release to its pull request. An exact-SHA tag left behind by interrupted initial
 creation is recovered; a tag at any other SHA is rejected. Automation never modifies a stable
 release through the candidate path: promotion clears the prerelease flag, and every later candidate


### PR DESCRIPTION
## Summary

The candidate on a labelled pull request never followed the head. `prepare-release.yml` listened only on `[labeled, unlabeled, closed]`, so pushing commits to an already-labelled pull request rebuilt nothing.

#162 hit this directly: the `v1.7.0` prerelease was published at 16:11:15 from `0f9de542`, and the 1.7.0 changelog commit `94ff0f1a` landed at 16:13. The prerelease body still reads `_No changelog entry for 1.7.0 yet._`, and its artifacts are from the older commit too.

Nothing surfaced the staleness. `release-candidate.yml` *does* listen on `synchronize`, but its `preview` job requires a `release/*` head — so a labelled `develop` -> `main` pull request took the `non-release` path and stamped the commit status **green** without rebuilding. A workflow named "Refresh release candidate" going green on the changelog commit reads exactly like a refresh that happened.

- Add `synchronize` to the trigger.
- Admit it in `validate` when the pull request already carries a `release/*` label, using the same `contains(join(labels.*.name, ','), 'release/')` idiom the `cut` job uses.
- Update `AGENTS.md` and `RELEASING.md`, which both stated refresh-on-release-branch-push only.

No script change was needed: `reconcilePrerelease` force-moves the candidate tag (`updateRef` sends `force: true`) and deletes and re-uploads every asset, so body *and* artifacts follow the new head, including a non-fast-forward head after a `main` -> `develop` merge.

## Behavior

| Event | Before | After |
|---|---|---|
| `release/*` label applied | rebuild | rebuild |
| push to labelled head | **nothing** | rebuild |
| push to unlabelled PR | nothing | nothing |
| unrelated label (`bug`) applied | nothing | nothing |
| `release/*` head push | handled by `release-candidate.yml` | unchanged, still excluded |
| fork PR | excluded | excluded |

## Trust model — please review this bit

Adding `synchronize` to a `pull_request_target` workflow widens when head code runs alongside a write token and the `preview` environment secrets. The label stops being a one-time approval of a reviewed commit and becomes standing authorization for every later push to that branch.

The existing guards still hold: same-repo heads only (no forks), all privileged tooling runs from the `trusted` base-branch checkout, and `RELEASING.md` restricts label application to triage-or-higher. So anyone who could exploit this already has push access to `develop` **and** needs a maintainer-applied label. I judged that acceptable given the requirement, but it is a deliberate widening and worth your eyes.

Concurrency is left as `group: prepare-release, cancel-in-progress: false`. GitHub keeps only one pending run per group, so a burst of pushes settles on the newest commit, and a `closed` event can never cancel a `cut` mid-flight.

## Testing

Not covered by automated tests — per `AGENTS.md` this repository does not assert on workflow YAML. Verified by parsing the workflow and checking the folded `if` resolves to a single-line expression with the intended truth table across all six event shapes above. The real proof is the next push to #162, which should move the prerelease onto that commit and replace the placeholder body with the committed 1.7.0 notes.

## Targeting `main`

`pull_request_target` reads its workflow definition from the base branch, so this only takes effect once it is on `main` — same reason as #167. No release label here; it takes the `non-release` path.