### PR TITLE
docs(site): advertise Kick daily challenge claiming

### DIFF
--- a/packages/site/src/components/Coverage.astro
+++ b/packages/site/src/components/Coverage.astro
@@ -16,8 +16,8 @@ const platforms = [
     key: "kick",
     name: "Kick",
     blurb:
-      "Full Kick drops support, right in your browser. It follows live campaigns, picks the right channel for the reward you want, and claims it the moment it unlocks.",
-    points: ["Follows live Kick campaigns", "Picks the right channel for you", "Claims rewards automatically"],
+      "Full Kick drops support, right in your browser. It follows live campaigns, picks the right channel for the reward you want, and claims it the moment it unlocks — daily challenge cards included.",
+    points: ["Follows live Kick campaigns", "Picks the right channel for you", "Claims drops + daily challenges"],
   },
 ];
 

--- a/packages/site/src/components/Features.astro
+++ b/packages/site/src/components/Features.astro
@@ -85,8 +85,9 @@ const more = [
         <span class="kicker">Hands-off rewards</span>
         <h3>Claimed the instant it unlocks.</h3>
         <p>
-          Every drop — and, if you want, Twitch channel points — is claimed for you
-          automatically. You just open your inventory and find it already there.
+          Every drop is claimed for you automatically — along with Twitch channel points
+          and Kick's daily challenge cards, each on by default and switchable per platform.
+          You just open your inventory and find it already there.
         </p>
       </div>
       <div class="beat__lift reveal">

--- a/packages/site/src/faq.ts
+++ b/packages/site/src/faq.ts
@@ -37,7 +37,7 @@ export const faqItems: FaqItem[] = [
   },
   {
     q: "How does the auto-claim work?",
-    a: "When a drop becomes claimable, Lurkloot claims it for you automatically — including Twitch channel points if you enable that toggle. You can also turn on notifications so you know the moment a reward lands, and it tells you when all campaigns are exhausted.",
+    a: "When a drop becomes claimable, Lurkloot claims it for you automatically. The same goes for Twitch channel points and Kick's daily challenge cards, which are opened as soon as their watch-time goal is met — both are on by default, with a separate toggle per platform. You can also turn on notifications so you know the moment a reward lands, and it tells you when all campaigns are exhausted.",
   },
   {
     q: "Can I control which campaigns it prioritizes?",


### PR DESCRIPTION
## Summary

The landing page sold Kick as drops-only. The Twitch card already advertised channel points in three places, so Kick read as the lesser platform even though it now farms daily challenges too (#166, shipped in `f5adcae`). Outside the 1.7.0 changelog entry, the words "challenge" and "gamification" appeared nowhere in the site source.

- **`Coverage.astro`** — Kick blurb now ends `— daily challenge cards included`, mirroring Twitch's `— channel points included`, and the third bullet becomes `Claims drops + daily challenges` against Twitch's `Claims drops + channel points`. The two cards now have the same shape.
- **`Features.astro`** — the auto-claim beat mentions both reward types instead of Twitch's alone.
- **`faq.ts`** — same, plus what actually triggers a challenge claim.

Changelog deliberately untouched.

## Accuracy

Claims were checked against the implementation rather than written from the changelog:

- `claimChallenges()` in `packages/core/src/platforms/kick/index.ts:320` claims a challenge only when it is unclaimed and `progress >= threshold`, and the reward is a card with a rarity — hence "cards", and "as soon as their watch-time goal is met".
- `autoClaimChannelPoints` and `autoClaimChallenges` both default to `true` (`packages/shared/src/settings.ts:40,48`), so the old "if you enable that toggle" phrasing understated them. Now stated as on by default with a per-platform toggle, which matches `autoClaimChallengesFor` being Kick-only.

## Testing

- `pnpm build:site` — clean.
- `pnpm -r typecheck` — exit 0 across all 7 packages that define it (the site has no `typecheck` script; its Astro build is the gate).
- Rendered the built site and inspected it in a browser at 1280px and 390px:
  - Both platform cards stay equal height with three-line blurbs; bullet lists stay aligned.
  - At 390px the longest new bullet, `Claims drops + daily challenges`, still fits on one line inside the card.
  - The auto-claim beat copy goes from two lines to four and stays balanced against its visual.
  - The FAQ answer renders correctly in the expanded accordion.

No screenshots attached since `gh` can't upload images, but the layout checks above were done visually, not inferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product descriptions to clarify that auto-claim includes Twitch channel points and Kick daily challenge cards.
  * Clarified that these rewards are enabled by default, automatically opened when earned, and can be managed with separate per-platform toggles.
  * Updated the Kick platform details to mention daily challenge cards and their associated drops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->