### PR TITLE
ci(release): rebuild the candidate on every push to a labelled head

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -2,7 +2,7 @@ name: Prepare release
 
 on:
   pull_request_target:
-    types: [labeled, unlabeled, closed]
+    types: [labeled, unlabeled, synchronize, closed]
     branches: [main]
 
 permissions:
@@ -15,12 +15,18 @@ concurrency:
 jobs:
   # A label only validates and previews. It never modifies the pull request it is applied to;
   # the release branch is cut once that pull request actually merges, by the cut job below.
+  # Pushes to a labelled head rebuild too, so the candidate always describes the commit that would
+  # be released rather than whichever commit happened to be current when the label went on.
   validate:
     if: >-
-      (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-      startsWith(github.event.label.name, 'release/') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      !startsWith(github.event.pull_request.head.ref, 'release/')
+      !startsWith(github.event.pull_request.head.ref, 'release/') &&
+      (
+      ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      startsWith(github.event.label.name, 'release/')) ||
+      (github.event.action == 'synchronize' &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'release/'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ Label a pull request into `main` with `release/patch`, `release/minor` or `relea
 validates the version and publishes mutable candidate artifacts; it does not modify the PR it is
 applied to. Merge that PR normally with a merge commit. Prepare release then cuts `release/X.Y.Z`
 from the resulting merge commit on `main`, commits the version, and opens its own PR into `main`
-whose diff is only the version bump. Candidate artifacts refresh on every release-branch push.
+whose diff is only the version bump. Candidate artifacts refresh on every push to a labelled head
+and on every release-branch push.
 
 Merge the generated release PR with a merge commit; **Release** starts automatically, publishes the
 GitHub release, GHCR aliases, Chrome Web Store submission and production site after one approval,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,7 +66,9 @@ Candidate pointers are deliberately mutable:
 - GHCR image: `candidate-X.Y.Z`
 - Site: `https://next.lurkloot.pages.dev`
 
-Every generated release-branch push rebuilds and refreshes those targets. Ownership metadata binds
+Every push to a labelled head rebuilds and refreshes those targets, as does every generated
+release-branch push, so the candidate always describes the commit that would be released rather
+than whichever commit was current when the label went on. Ownership metadata binds
 the candidate release to its pull request. An exact-SHA tag left behind by interrupted initial
 creation is recovered; a tag at any other SHA is rejected. Automation never modifies a stable
 release through the candidate path: promotion clears the prerelease flag, and every later candidate


### PR DESCRIPTION
## Summary

Cherry-pick of #170 (`a724f30`) onto `develop`. #170 put the `synchronize` trigger on `main` only, and that turns out not to be enough.

## Why `main` alone did not work

After #170 merged to `main` at 16:24:49, the squash-merge of #172 pushed `d56cc407` to `develop` at 16:34:26 — a `synchronize` on #162, which carries `release/minor`. **No Prepare release run was created at all.** `Refresh release candidate` did run on that same event, so the event itself reached `pull_request_target` workflows; only this workflow ignored it.

The repository's default branch is `develop`, and `develop`'s `prepare-release.yml` still had `types: [labeled, unlabeled, closed]`. So the `on:` trigger that governs whether a run is created is read from `develop`, not from the pull request's base branch. The original failing run corroborates this: it logged `Uses: jamezrin/lurkloot/.github/workflows/build-release-candidate.yml@refs/heads/develop`.

Note this PR's head branch, the default branch, and the branch being fixed are all `develop`, so this evidence cannot distinguish "default branch" from "head branch" semantics. What it does establish unambiguously is that `main` alone is not sufficient.

This does **not** invalidate #167's targeting. Executed scripts genuinely do come from `main`: `build-release-candidate.yml` checks out `trusted` at `inputs.trusted_ref` (`= base.sha`) and runs `../trusted/scripts/release/cli.mjs`. Triggers and job `if` conditions come from `develop`; the scripts they execute come from `main`. Both branches need to carry this workflow, which is their steady state after a release sync anyway.

## Testing

Cherry-pick applied with an automatic merge in `prepare-release.yml` and `AGENTS.md` (`develop`'s `AGENTS.md` carries a Worktrees section `main` lacks). Verified after the fact that `types` is `[labeled, unlabeled, synchronize, closed]` and the folded `if` still resolves to a single-line expression. No workflow YAML tests, per `AGENTS.md`.

The real verification is the next push to `develop` after this merges, which should rebuild the `v1.7.0` candidate. Current stale baseline: target `0f9de542`, assets stamped 16:11, body `_No changelog entry for 1.7.0 yet._`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release candidates now refresh automatically whenever the labeled source changes, ensuring they reflect the latest releasable commit.
  * Release preparation now responds to pull request updates in addition to release-label changes.

* **Documentation**
  * Updated release guidance to clarify when candidate artifacts are rebuilt and how they track the commit that will be released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->