### PR TITLE
refactor: add versioned settings migration framework

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ The popup and content scripts do not call adapters directly. They send typed run
 
 ## Settings Model
 
-`mergeSettings` in `@lurkloot/shared/settings` is the source of truth for defaults, migrations, and persisted-setting normalization. It fills missing keys from `DEFAULT_SETTINGS`, clamps numeric values, normalizes channel/category/campaign lists, and removes duplicate list entries.
+`mergeSettings` in `@lurkloot/shared/settings` is the source of truth for defaults and persisted-setting normalization. It fills missing keys from `DEFAULT_SETTINGS`, clamps numeric values, normalizes channel/category/campaign lists, and removes duplicate list entries. It reads only current property names; legacy shapes are handled beforehand by the migration registry (see [Settings Migrations](#settings-migrations)).
 
 Important setting groups:
 
@@ -50,6 +50,46 @@ Important setting groups:
 - Notifications: `notifyRewardEarned`, `notifyNoDropsLeft`.
 
 The popup normalizes snapshots before rendering and normalizes patches before saving, so older stored settings get current defaults before they drive UI toggles.
+
+## Settings Migrations
+
+`packages/shared/src/settingsSchema.ts` is the only place legacy settings shapes
+are transformed. Both hosts call `migrateSettings(raw)` on the raw persisted
+payload and pass the result to normalization (`mergeSettings` in the extension,
+`parseCliSettings` in the CLI). Migration and normalization are deliberately
+separate: clamping and defaulting would erase the raw property information the
+deprecation diagnostics depend on.
+
+A stored document carries a reserved `schemaVersion`; an unversioned document is
+version 0. `migrateSettings` applies every migration from the stored version up
+to `CURRENT_SETTINGS_SCHEMA_VERSION`, returning the migrated payload, a `changed`
+flag, and structured diagnostics. A version newer than this build supports throws
+`UnsupportedSettingsVersionError`, and neither host writes after that error.
+
+Extension storage is upgraded automatically: `loadSettings` writes the canonical
+envelope once when `changed` is true, under the settings lock. The CLI's JSONC
+file is never rewritten, so its diagnostics surface as startup warnings that
+repeat until the user edits the file.
+
+To add version N+1:
+
+1. Increment `CURRENT_SETTINGS_SCHEMA_VERSION`.
+2. Add exactly one pure `N` → `N+1` entry to `MIGRATIONS`. It receives a deep
+   clone it owns outright, so it may mutate that object freely, but it must not
+   reach outside it or log.
+3. Emit a diagnostic for every deprecated or removed property it recognizes,
+   with the full dotted path and the replacement path when one exists.
+4. When an old and a current representation coexist, the current one wins and
+   the deprecated one still produces a diagnostic. Migrations never inspect
+   value types, so a wrong-typed current value is left for normalization to
+   default rather than falling back to the legacy value.
+5. Add fixtures to `packages/extension/tests/settingsMigrations.test.ts` for
+   version N input, mixed old/current input, and the fully migrated output.
+6. Update `defaultConfigJsonc()` in `packages/cli/src/config.ts` when public
+   property names change.
+
+Released migrations are never edited except to fix a data-loss defect. A later
+semantic change gets a new version and a new migration.
 
 ## Scheduler Flow
 

--- a/docs/superpowers/plans/2026-07-20-settings-schema-migrations.md
+++ b/docs/superpowers/plans/2026-07-20-settings-schema-migrations.md
@@ -1,0 +1,1166 @@
+# Versioned Settings Migrations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the scattered inline legacy-settings fallbacks with one ordered, versioned migration registry in `@lurkloot/shared` that both the extension and the CLI run before normalization.
+
+**Architecture:** A new `packages/shared/src/settingsSchema.ts` owns `CURRENT_SETTINGS_SCHEMA_VERSION`, an ordered migration registry, and `migrateSettings(raw)`. Migration and normalization are separate phases: hosts call `migrateSettings` on the raw persisted payload, then pass the migrated payload to the existing `mergeSettings` / `parseCliSettings`. The extension stores a flat settings document with a reserved `schemaVersion` property and writes back once when a migration ran; the CLI migrates in memory only and re-warns on every startup.
+
+**Tech Stack:** TypeScript 7 (strict, ESM), pnpm workspaces, Vitest (node environment, globals enabled), WXT, jsonc-parser.
+
+## Global Constraints
+
+- Migrations are pure: they must not mutate their input and must be deterministic.
+- Running the full pipeline on a current-version document is a no-op that writes nothing.
+- The CLI configuration file is never rewritten, reformatted, or backed up.
+- Current property names always win over deprecated aliases; the deprecated alias still produces a diagnostic.
+- Migration functions never log. Hosts format and route diagnostics.
+- No defaults, clamps, or farming behavior change in this work.
+- `schemaVersion` is reserved metadata: it is stripped before producing `ExtensionSettings` / `CliSettings` and is not a member of either type.
+
+## Design Decisions (resolved before planning)
+
+- Migration 1 absorbs **every** existing inline legacy fallback, not just the Idle Watchlist aliases: `watchQueueFallbackOnly`, `platform.<p>.watchQueueChannels`, top-level `autoClaimChannelPoints`, and `verboseLogging`.
+- Because top-level `autoClaimChannelPoints` becomes a registered alias, the CLI **accepts it with a deprecation warning** instead of hard-erroring. `MOVED_SETTING_KEYS` is deleted.
+- `enabledLogLevels` is out of scope. It is a deprecated-and-ignored CLI knob with no replacement, not a shape migration; it keeps its existing dedicated warning in `packages/cli/src/config.ts`.
+- The legacy `gamePriority` key stays intentionally un-migrated (see the comment above `normalizeCategorySelections`).
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `packages/shared/src/settingsSchema.ts` (new) | Version constant, diagnostic/result types, error type, ordered registry, `migrateSettings`, `withSchemaVersion`. |
+| `packages/shared/package.json` | Add the `./settingsSchema` export. |
+| `packages/shared/src/settings.ts` | Drop `currentOrLegacy` and all inline legacy reads; normalize only current names. |
+| `packages/extension/src/core/storage.ts` | Migrate → normalize → conditional write-back under the settings lock; stamp `schemaVersion` on every write. |
+| `packages/cli/src/settings.ts` | Migrate before validation; drop legacy allowlist entries and `MOVED_SETTING_KEYS`; return diagnostics. |
+| `packages/cli/src/config.ts` | Format diagnostics into `warnings`; add `schemaVersion` to the generated template. |
+| `docs/architecture.md` | "Adding a settings migration" section. |
+
+---
+
+### Task 1: Shared schema module — versions, types, and errors
+
+**Files:**
+- Create: `packages/shared/src/settingsSchema.ts`
+- Modify: `packages/shared/package.json`
+- Test: `packages/extension/tests/settingsMigrations.test.ts` (new)
+
+**Interfaces:**
+- Consumes: an arbitrary persisted value (`unknown`).
+- Produces: `SettingsMigrationResult`, `UnsupportedSettingsVersionError`, `CURRENT_SETTINGS_SCHEMA_VERSION`.
+
+- [ ] **Step 1: Add the package export**
+
+In `packages/shared/package.json`, add to `exports` after the `"./settings"` line:
+
+```json
+    "./settingsSchema": "./src/settingsSchema.ts",
+```
+
+- [ ] **Step 2: Write the failing version-handling tests**
+
+Create `packages/extension/tests/settingsMigrations.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  CURRENT_SETTINGS_SCHEMA_VERSION,
+  SETTINGS_SCHEMA_VERSION_KEY,
+  UnsupportedSettingsVersionError,
+  migrateSettings,
+  withSchemaVersion,
+} from "@lurkloot/shared/settingsSchema";
+
+describe("settings schema versions", () => {
+  it("treats an unversioned object as version 0", () => {
+    const result = migrateSettings({ autoClaim: false });
+    expect(result.fromVersion).toBe(0);
+    expect(result.toVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    expect(result.changed).toBe(true);
+  });
+
+  it("treats a missing or non-object payload as an empty version 0 document", () => {
+    for (const raw of [undefined, null, "nope", 42, ["a"]]) {
+      const result = migrateSettings(raw);
+      expect(result.settings).toEqual({});
+      expect(result.fromVersion).toBe(0);
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+
+  it("is a no-op for a current-version document", () => {
+    const stored = withSchemaVersion({ autoClaim: false });
+    const result = migrateSettings(stored);
+    expect(result.changed).toBe(false);
+    expect(result.fromVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.settings).toEqual({ autoClaim: false });
+  });
+
+  it("strips the reserved schemaVersion property from the migrated payload", () => {
+    const result = migrateSettings(withSchemaVersion({ autoClaim: true }));
+    expect(result.settings).not.toHaveProperty(SETTINGS_SCHEMA_VERSION_KEY);
+  });
+
+  it("never mutates its input", () => {
+    const stored = { watchQueueFallbackOnly: false, platform: { twitch: { watchQueueChannels: ["A"] } } };
+    const snapshot = structuredClone(stored);
+    migrateSettings(stored);
+    expect(stored).toEqual(snapshot);
+  });
+
+  it("is idempotent when re-run on its own output", () => {
+    const first = migrateSettings({ watchQueueFallbackOnly: false });
+    const second = migrateSettings(withSchemaVersion(first.settings));
+    expect(second.settings).toEqual(first.settings);
+    expect(second.changed).toBe(false);
+  });
+
+  it("rejects a future schema version", () => {
+    const future = CURRENT_SETTINGS_SCHEMA_VERSION + 1;
+    expect(() => migrateSettings({ [SETTINGS_SCHEMA_VERSION_KEY]: future }))
+      .toThrow(UnsupportedSettingsVersionError);
+    try {
+      migrateSettings({ [SETTINGS_SCHEMA_VERSION_KEY]: future });
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnsupportedSettingsVersionError);
+      expect((error as UnsupportedSettingsVersionError).version).toBe(future);
+      expect((error as UnsupportedSettingsVersionError).reason).toBe("future");
+    }
+  });
+
+  it("rejects a malformed schema version", () => {
+    for (const version of [-1, 1.5, Number.NaN, "1", null]) {
+      expect(() => migrateSettings({ [SETTINGS_SCHEMA_VERSION_KEY]: version }))
+        .toThrow(UnsupportedSettingsVersionError);
+    }
+  });
+
+  it("stamps the current version with withSchemaVersion", () => {
+    expect(withSchemaVersion({ autoClaim: true })).toEqual({
+      autoClaim: true,
+      [SETTINGS_SCHEMA_VERSION_KEY]: CURRENT_SETTINGS_SCHEMA_VERSION,
+    });
+  });
+
+  it("upgrades a version 0 document all the way to the current version", () => {
+    // Guards sequential application: whatever CURRENT_SETTINGS_SCHEMA_VERSION
+    // becomes, entering at 0 must land on it. The contiguity of the registry
+    // itself is asserted at module load, so a missing step throws on import
+    // rather than letting a host write a half-migrated document.
+    expect(migrateSettings({}).toVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    expect(migrateSettings({}).fromVersion).toBe(0);
+  });
+
+  it("enters at every intermediate version without skipping steps", () => {
+    // Re-migrating from each supported version must converge on the same
+    // document as migrating the whole way from 0.
+    const target = migrateSettings({ autoClaim: false }).settings;
+    for (let version = 0; version <= CURRENT_SETTINGS_SCHEMA_VERSION; version += 1) {
+      const result = migrateSettings({ ...target, [SETTINGS_SCHEMA_VERSION_KEY]: version });
+      expect(result.settings).toEqual(target);
+      expect(result.toVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension test -- settingsMigrations`
+Expected: FAIL — `Failed to resolve import "@lurkloot/shared/settingsSchema"`.
+
+- [ ] **Step 4: Implement the schema module skeleton**
+
+Create `packages/shared/src/settingsSchema.ts`. Migration 1's body is a stub here; Task 2 fills it in.
+
+```ts
+// The single authority for versioned settings-shape migrations. Both hosts run
+// `migrateSettings` on their raw persisted payload *before* normalization: the
+// raw property information is what makes accurate deprecation diagnostics
+// possible, and defaulting or clamping would erase it.
+//
+// See docs/architecture.md ("Adding a settings migration") before adding one.
+
+// Incremented for every semantic settings-shape migration.
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 1;
+
+// Reserved metadata stored alongside the settings properties. It is stripped
+// before any runtime EngineSettings/ExtensionSettings/CliSettings value is
+// produced, so it never appears in those types.
+export const SETTINGS_SCHEMA_VERSION_KEY = "schemaVersion";
+
+export type SettingsMigrationDiagnosticCode = "deprecated_property" | "moved_property";
+
+export interface SettingsMigrationDiagnostic {
+  // Stable across releases; hosts may route on it.
+  code: SettingsMigrationDiagnosticCode;
+  // Dotted path relative to the settings object, e.g. "platform.twitch.watchQueueChannels".
+  path: string;
+  // Dotted replacement path, when the property has one.
+  replacement?: string;
+  // Host-neutral text. Hosts add their own prefix (the CLI prepends "settings.").
+  message: string;
+}
+
+export interface SettingsMigrationResult {
+  // The migrated raw payload, without the reserved version property.
+  settings: Record<string, unknown>;
+  fromVersion: number;
+  toVersion: number;
+  // True when the stored document was not already at the current version, i.e.
+  // when a host should persist the canonical result.
+  changed: boolean;
+  diagnostics: SettingsMigrationDiagnostic[];
+}
+
+export class UnsupportedSettingsVersionError extends Error {
+  readonly version: unknown;
+  readonly supported: number;
+  readonly reason: "future" | "invalid";
+
+  constructor(version: unknown, reason: "future" | "invalid") {
+    super(reason === "future"
+      ? `Settings schema version ${String(version)} is newer than this build supports (${CURRENT_SETTINGS_SCHEMA_VERSION})`
+      : `Settings schema version ${String(version)} is not a non-negative integer`);
+    this.name = "UnsupportedSettingsVersionError";
+    this.version = version;
+    this.supported = CURRENT_SETTINGS_SCHEMA_VERSION;
+    this.reason = reason;
+  }
+}
+
+type Diagnose = (diagnostic: SettingsMigrationDiagnostic) => void;
+
+interface SettingsMigration {
+  // The version this migration produces. MIGRATIONS[i].to === i + 1.
+  to: number;
+  // Receives a deep clone it owns outright, so it may mutate freely.
+  migrate: (raw: Record<string, unknown>, diagnose: Diagnose) => Record<string, unknown>;
+}
+
+// Ordered registry. Entry i upgrades version i to version i + 1. Never edit a
+// released migration except to fix data loss; add a new version instead.
+const MIGRATIONS: SettingsMigration[] = [
+  { to: 1, migrate: (raw) => raw },
+];
+
+if (MIGRATIONS.length !== CURRENT_SETTINGS_SCHEMA_VERSION
+  || MIGRATIONS.some((migration, index) => migration.to !== index + 1)) {
+  throw new Error("Settings migration registry is not a contiguous 1..CURRENT_SETTINGS_SCHEMA_VERSION sequence");
+}
+
+export function withSchemaVersion<T extends object>(settings: T): T & { schemaVersion: number } {
+  return { ...settings, [SETTINGS_SCHEMA_VERSION_KEY]: CURRENT_SETTINGS_SCHEMA_VERSION } as T & { schemaVersion: number };
+}
+
+export function migrateSettings(raw: unknown): SettingsMigrationResult {
+  const source = isPlainObject(raw) ? raw : {};
+  const fromVersion = readVersion(source);
+  const { [SETTINGS_SCHEMA_VERSION_KEY]: _version, ...rest } = source;
+
+  const diagnostics: SettingsMigrationDiagnostic[] = [];
+  const seen = new Set<string>();
+  const diagnose: Diagnose = (diagnostic) => {
+    const key = `${diagnostic.code}:${diagnostic.path}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    diagnostics.push(diagnostic);
+  };
+
+  let settings = structuredClone(rest) as Record<string, unknown>;
+  for (const migration of MIGRATIONS.slice(fromVersion)) {
+    settings = migration.migrate(settings, diagnose);
+  }
+
+  return {
+    settings,
+    fromVersion,
+    toVersion: CURRENT_SETTINGS_SCHEMA_VERSION,
+    changed: fromVersion !== CURRENT_SETTINGS_SCHEMA_VERSION,
+    diagnostics,
+  };
+}
+
+function readVersion(source: Record<string, unknown>): number {
+  if (!Object.hasOwn(source, SETTINGS_SCHEMA_VERSION_KEY)) return 0;
+  const version = source[SETTINGS_SCHEMA_VERSION_KEY];
+  if (typeof version !== "number" || !Number.isInteger(version) || version < 0) {
+    throw new UnsupportedSettingsVersionError(version, "invalid");
+  }
+  if (version > CURRENT_SETTINGS_SCHEMA_VERSION) {
+    throw new UnsupportedSettingsVersionError(version, "future");
+  }
+  return version;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension test -- settingsMigrations`
+Expected: PASS (11 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/settingsSchema.ts packages/shared/package.json packages/extension/tests/settingsMigrations.test.ts
+git commit -m "feat(shared): add versioned settings schema module"
+```
+
+---
+
+### Task 2: Migration 1 — consolidate every legacy alias
+
+**Files:**
+- Modify: `packages/shared/src/settingsSchema.ts` (the `MIGRATIONS` entry added in Task 1)
+- Test: `packages/extension/tests/settingsMigrations.test.ts`
+
+**Interfaces:**
+- Consumes: a version 0 raw payload.
+- Produces: a version 1 raw payload plus `deprecated_property` / `moved_property` diagnostics.
+
+Migration 1 recognizes exactly five legacy shapes:
+
+| Legacy path | Current path | Code |
+| --- | --- | --- |
+| `watchQueueFallbackOnly` | `idleWatchlistFallbackOnly` | `deprecated_property` |
+| `platform.twitch.watchQueueChannels` | `platform.twitch.idleWatchlistChannels` | `deprecated_property` |
+| `platform.kick.watchQueueChannels` | `platform.kick.idleWatchlistChannels` | `deprecated_property` |
+| `verboseLogging` | `diagnosticLogging` | `deprecated_property` |
+| `autoClaimChannelPoints` | `platform.twitch.autoClaimChannelPoints` | `moved_property` |
+
+- [ ] **Step 1: Write the failing migration tests**
+
+Append to `packages/extension/tests/settingsMigrations.test.ts`:
+
+```ts
+describe("migration 1: legacy aliases", () => {
+  it("renames the Watch Queue properties", () => {
+    const result = migrateSettings({
+      watchQueueFallbackOnly: false,
+      platform: {
+        twitch: { watchQueueChannels: ["Legacy"] },
+        kick: { watchQueueChannels: ["KickLegacy"] },
+      },
+    });
+    expect(result.settings).toEqual({
+      idleWatchlistFallbackOnly: false,
+      platform: {
+        twitch: { idleWatchlistChannels: ["Legacy"] },
+        kick: { idleWatchlistChannels: ["KickLegacy"] },
+      },
+    });
+    expect(result.settings).not.toHaveProperty("watchQueueFallbackOnly");
+  });
+
+  it("moves a top-level autoClaimChannelPoints onto platform.twitch", () => {
+    const result = migrateSettings({ autoClaimChannelPoints: false });
+    expect(result.settings).toEqual({ platform: { twitch: { autoClaimChannelPoints: false } } });
+    expect(result.diagnostics).toContainEqual({
+      code: "moved_property",
+      path: "autoClaimChannelPoints",
+      replacement: "platform.twitch.autoClaimChannelPoints",
+      message: "autoClaimChannelPoints moved to platform.twitch.autoClaimChannelPoints",
+    });
+  });
+
+  it("renames verboseLogging to diagnosticLogging", () => {
+    expect(migrateSettings({ verboseLogging: true }).settings).toEqual({ diagnosticLogging: true });
+    expect(migrateSettings({ verboseLogging: false }).settings).toEqual({ diagnosticLogging: false });
+  });
+
+  it("keeps a non-boolean legacy value verbatim so normalization decides", () => {
+    // mergeSettings applies booleanOr afterwards; the migration only reshapes.
+    expect(migrateSettings({ autoClaimChannelPoints: "yes" }).settings)
+      .toEqual({ platform: { twitch: { autoClaimChannelPoints: "yes" } } });
+  });
+
+  it("lets the current property win while still reporting the deprecated one", () => {
+    const result = migrateSettings({
+      idleWatchlistFallbackOnly: true,
+      watchQueueFallbackOnly: false,
+      diagnosticLogging: false,
+      verboseLogging: true,
+      autoClaimChannelPoints: false,
+      platform: {
+        twitch: { idleWatchlistChannels: [], watchQueueChannels: ["legacy"], autoClaimChannelPoints: true },
+        kick: { idleWatchlistChannels: ["new"], watchQueueChannels: ["legacy"] },
+      },
+    });
+    expect(result.settings).toEqual({
+      idleWatchlistFallbackOnly: true,
+      diagnosticLogging: false,
+      platform: {
+        twitch: { idleWatchlistChannels: [], autoClaimChannelPoints: true },
+        kick: { idleWatchlistChannels: ["new"] },
+      },
+    });
+    expect(result.diagnostics.map((d) => d.path)).toEqual([
+      "watchQueueFallbackOnly",
+      "verboseLogging",
+      "autoClaimChannelPoints",
+      "platform.twitch.watchQueueChannels",
+      "platform.kick.watchQueueChannels",
+    ]);
+  });
+
+  it("emits a stable, deduplicated diagnostic per deprecated property", () => {
+    const result = migrateSettings({ watchQueueFallbackOnly: false });
+    expect(result.diagnostics).toEqual([{
+      code: "deprecated_property",
+      path: "watchQueueFallbackOnly",
+      replacement: "idleWatchlistFallbackOnly",
+      message: "watchQueueFallbackOnly is deprecated; use idleWatchlistFallbackOnly",
+    }]);
+  });
+
+  it("reports nothing for a payload that only uses current names", () => {
+    const result = migrateSettings({
+      idleWatchlistFallbackOnly: true,
+      platform: { twitch: { idleWatchlistChannels: ["a"] } },
+    });
+    expect(result.diagnostics).toEqual([]);
+    expect(result.changed).toBe(true); // unversioned input still gets stamped
+  });
+
+  it("leaves unrelated and malformed platform blocks alone", () => {
+    expect(migrateSettings({ platform: "nope", other: 1 }).settings).toEqual({ platform: "nope", other: 1 });
+    expect(migrateSettings({ platform: { twitch: null } }).settings).toEqual({ platform: { twitch: null } });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension test -- settingsMigrations`
+Expected: FAIL — the stub migration returns its input, so the rename assertions fail.
+
+- [ ] **Step 3: Implement migration 1**
+
+In `packages/shared/src/settingsSchema.ts`, replace the stub registry with the real one and add the helpers below it:
+
+```ts
+// Migration 1 consolidates every legacy shape that predates the registry: the
+// Idle Watchlist rename (PR #177), the pre-split top-level channel-points
+// toggle, and the verboseLogging rename. Diagnostics are emitted in a fixed
+// order so host warnings are stable across runs.
+const MIGRATIONS: SettingsMigration[] = [
+  { to: 1, migrate: migrateToV1 },
+];
+
+function migrateToV1(raw: Record<string, unknown>, diagnose: Diagnose): Record<string, unknown> {
+  renameProperty(raw, "watchQueueFallbackOnly", "idleWatchlistFallbackOnly", "", diagnose);
+  renameProperty(raw, "verboseLogging", "diagnosticLogging", "", diagnose);
+
+  if (Object.hasOwn(raw, "autoClaimChannelPoints")) {
+    const legacy = raw.autoClaimChannelPoints;
+    delete raw.autoClaimChannelPoints;
+    diagnose({
+      code: "moved_property",
+      path: "autoClaimChannelPoints",
+      replacement: "platform.twitch.autoClaimChannelPoints",
+      message: "autoClaimChannelPoints moved to platform.twitch.autoClaimChannelPoints",
+    });
+    const twitch = ensurePlatformBlock(raw, "twitch");
+    if (twitch && !Object.hasOwn(twitch, "autoClaimChannelPoints")) {
+      twitch.autoClaimChannelPoints = legacy;
+    }
+  }
+
+  for (const platform of ["twitch", "kick"] as const) {
+    const block = platformBlock(raw, platform);
+    if (!block) continue;
+    renameProperty(block, "watchQueueChannels", "idleWatchlistChannels", `platform.${platform}.`, diagnose);
+  }
+
+  return raw;
+}
+
+// Drops the legacy key and reports it. The current key wins when both exist,
+// including when its value is `false` or an empty array.
+function renameProperty(
+  owner: Record<string, unknown>,
+  legacyKey: string,
+  currentKey: string,
+  pathPrefix: string,
+  diagnose: Diagnose,
+): void {
+  if (!Object.hasOwn(owner, legacyKey)) return;
+  const legacy = owner[legacyKey];
+  delete owner[legacyKey];
+  diagnose({
+    code: "deprecated_property",
+    path: `${pathPrefix}${legacyKey}`,
+    replacement: `${pathPrefix}${currentKey}`,
+    message: `${pathPrefix}${legacyKey} is deprecated; use ${pathPrefix}${currentKey}`,
+  });
+  if (!Object.hasOwn(owner, currentKey)) owner[currentKey] = legacy;
+}
+
+function platformBlock(raw: Record<string, unknown>, platform: string): Record<string, unknown> | undefined {
+  const platforms = raw.platform;
+  if (!isPlainObject(platforms)) return undefined;
+  const block = platforms[platform];
+  return isPlainObject(block) ? block : undefined;
+}
+
+// Creates `platform.<name>` only when it is safe to do so; a malformed block is
+// left untouched so validation can report it verbatim.
+function ensurePlatformBlock(raw: Record<string, unknown>, platform: string): Record<string, unknown> | undefined {
+  if (!Object.hasOwn(raw, "platform")) raw.platform = {};
+  const platforms = raw.platform;
+  if (!isPlainObject(platforms)) return undefined;
+  if (!Object.hasOwn(platforms, platform)) platforms[platform] = {};
+  const block = platforms[platform];
+  return isPlainObject(block) ? block : undefined;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension test -- settingsMigrations`
+Expected: PASS (19 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/settingsSchema.ts packages/extension/tests/settingsMigrations.test.ts
+git commit -m "feat(shared): add the first settings schema migration"
+```
+
+---
+
+### Task 3: Strip inline legacy handling from normalization
+
+**Files:**
+- Modify: `packages/shared/src/settings.ts:100-206` (`mergeEngineSettings`, `currentOrLegacy`, `mergeSettings`)
+- Test: `packages/extension/tests/settings.test.ts`
+
+**Interfaces:**
+- `mergeEngineSettings` / `mergeSettings` keep their signatures but now only read current property names.
+
+- [ ] **Step 1: Move the legacy assertions out of the normalization tests**
+
+In `packages/extension/tests/settings.test.ts`, delete the four legacy cases now covered by `settingsMigrations.test.ts`:
+- the `watchQueueFallbackOnly` / `watchQueueChannels` migration and precedence tests around lines 37-60,
+- `"migrates the legacy verboseLogging flag"` (lines 186-189),
+- `"migrates a legacy top-level autoClaimChannelPoints onto platform.twitch"` and the precedence/strip/non-boolean cases (lines 302-326).
+
+Keep `"defaults autoClaimChannelPoints on for Twitch"` (line 298) and the `enabledLogLevels` cases (lines 182-183) — those assert normalization, not migration.
+
+Replace them with one test proving normalization no longer reads legacy names:
+
+```ts
+it("ignores legacy property names, which the migration registry handles first", () => {
+  const merged = mergeSettings({
+    watchQueueFallbackOnly: false,
+    verboseLogging: true,
+    autoClaimChannelPoints: false,
+    platform: { ...DEFAULT_SETTINGS.platform, twitch: { ...DEFAULT_SETTINGS.platform.twitch, watchQueueChannels: ["legacy"] } },
+  } as never);
+  expect(merged.idleWatchlistFallbackOnly).toBe(DEFAULT_SETTINGS.idleWatchlistFallbackOnly);
+  expect(merged.diagnosticLogging).toBe(false);
+  expect(merged.platform.twitch.autoClaimChannelPoints).toBe(true);
+  expect(merged.platform.twitch.idleWatchlistChannels).toEqual([]);
+  expect(merged).not.toHaveProperty("watchQueueFallbackOnly");
+});
+```
+
+- [ ] **Step 2: Run the tests to verify the new one fails**
+
+Run: `pnpm --filter @lurkloot/extension test -- settings.test`
+Expected: FAIL — `mergeSettings` still honors the legacy names, so `idleWatchlistFallbackOnly` is `false` and `diagnosticLogging` is `true`.
+
+- [ ] **Step 3: Remove the inline fallbacks**
+
+In `packages/shared/src/settings.ts`:
+
+Delete the `legacyChannelPoints` line (105) and its comment (103-104), and delete the entire `currentOrLegacy` helper (175-181).
+
+Replace the `idleWatchlistFallbackOnly` entry (114-117) with:
+
+```ts
+    idleWatchlistFallbackOnly: booleanOr(value?.idleWatchlistFallbackOnly, DEFAULT_ENGINE_SETTINGS.idleWatchlistFallbackOnly),
+```
+
+Replace both `idleWatchlistChannels` entries (124-126 and 137-139) with the direct reads:
+
+```ts
+        idleWatchlistChannels: normalizeChannelList(platform?.twitch?.idleWatchlistChannels),
+```
+
+```ts
+        idleWatchlistChannels: normalizeChannelList(platform?.kick?.idleWatchlistChannels),
+```
+
+Replace the `autoClaimChannelPoints` entry (130-133) with:
+
+```ts
+        autoClaimChannelPoints: booleanOr(platform?.twitch?.autoClaimChannelPoints, DEFAULT_ENGINE_SETTINGS.platform.twitch.autoClaimChannelPoints),
+```
+
+Replace the `mergeSettings` preamble (186-189) with nothing, and change the `diagnosticLogging` entry (204) to:
+
+```ts
+    diagnosticLogging: booleanOr(value?.diagnosticLogging, DEFAULT_SETTINGS.diagnosticLogging),
+```
+
+Add this comment directly above `mergeEngineSettings` (before line 98's existing comment block):
+
+```ts
+// Legacy property names are not read here. Hosts run migrateSettings() from
+// @lurkloot/shared/settingsSchema on the raw payload first; by the time a value
+// reaches normalization it only carries current names.
+```
+
+- [ ] **Step 4: Run the full extension suite**
+
+Run: `pnpm --filter @lurkloot/extension test`
+Expected: `settings.test.ts` PASSes. `storageSettingsMigration.test.ts` FAILs — that is expected and fixed in Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/settings.ts packages/extension/tests/settings.test.ts
+git commit -m "refactor(shared): read only current names during settings normalization"
+```
+
+---
+
+### Task 4: Extension storage runs migration under the settings lock
+
+**Files:**
+- Modify: `packages/extension/src/core/storage.ts:32-67` and `:117-130`
+- Test: `packages/extension/tests/storageSettingsMigration.test.ts`
+
+**Interfaces:**
+- Consumes: `browser.storage.local` key `settings`, holding a flat document of settings properties plus `schemaVersion`.
+- Produces: `ExtensionSettings` from `loadSettings`; every write emits `withSchemaVersion(settings)`.
+
+`loadSettings` reads, migrates, normalizes and — only when `changed` — writes back, all while holding `withSettingsStorageLock`, so a migration write can never clobber a concurrent save. A future version throws out of `loadSettings` without writing.
+
+- [ ] **Step 1: Rewrite the storage migration tests**
+
+Replace the body of `packages/extension/tests/storageSettingsMigration.test.ts` after the `vi.mock` block with:
+
+```ts
+import { loadSettings, resetStorage, saveSettings } from "../src/core/storage";
+import { CURRENT_SETTINGS_SCHEMA_VERSION, UnsupportedSettingsVersionError, withSchemaVersion } from "@lurkloot/shared/settingsSchema";
+import { DEFAULT_SETTINGS, mergeSettings } from "@lurkloot/shared/settings";
+
+describe("settings storage migration", () => {
+  beforeEach(() => {
+    get.mockReset();
+    set.mockReset();
+    set.mockResolvedValue(undefined);
+  });
+
+  it("writes a legacy document back once, using current keys and the current version", async () => {
+    get.mockResolvedValue({
+      settings: {
+        watchQueueFallbackOnly: false,
+        platform: {
+          twitch: { watchQueueChannels: ["Legacy"] },
+          kick: { watchQueueChannels: ["KickLegacy"] },
+        },
+      },
+    });
+
+    const settings = await loadSettings();
+
+    expect(settings.idleWatchlistFallbackOnly).toBe(false);
+    expect(settings.platform.twitch.idleWatchlistChannels).toEqual(["legacy"]);
+    expect(set).toHaveBeenCalledTimes(1);
+    const written = set.mock.calls[0]?.[0].settings;
+    expect(written).toEqual(withSchemaVersion(settings));
+    expect(written.schemaVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    expect(written).not.toHaveProperty("watchQueueFallbackOnly");
+    expect(written.platform.twitch).not.toHaveProperty("watchQueueChannels");
+  });
+
+  it("stamps an unversioned document that already uses current keys", async () => {
+    get.mockResolvedValue({
+      settings: { idleWatchlistFallbackOnly: true, platform: { twitch: { idleWatchlistChannels: ["current"] } } },
+    });
+
+    await loadSettings();
+
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set.mock.calls[0]?.[0].settings.schemaVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+  });
+
+  it("does not write when storage is already at the current version", async () => {
+    get.mockResolvedValue({ settings: withSchemaVersion(DEFAULT_SETTINGS) });
+
+    await loadSettings();
+
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("still returns usable settings when the write-back fails, and retries on the next load", async () => {
+    get.mockResolvedValue({
+      settings: { watchQueueFallbackOnly: false, platform: { twitch: { watchQueueChannels: ["Legacy"] } } },
+    });
+    set.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    await expect(loadSettings()).resolves.toMatchObject({
+      idleWatchlistFallbackOnly: false,
+      platform: { twitch: { idleWatchlistChannels: ["legacy"] } },
+    });
+    expect(set).toHaveBeenCalledTimes(1);
+
+    set.mockResolvedValue(undefined);
+    await loadSettings();
+    expect(set).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a future schema version without writing", async () => {
+    get.mockResolvedValue({ settings: { schemaVersion: CURRENT_SETTINGS_SCHEMA_VERSION + 1, autoClaim: false } });
+
+    await expect(loadSettings()).rejects.toThrow(UnsupportedSettingsVersionError);
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("emits the current version on an ordinary save", async () => {
+    await saveSettings(DEFAULT_SETTINGS);
+    expect(set).toHaveBeenCalledWith({ settings: withSchemaVersion(DEFAULT_SETTINGS) });
+  });
+
+  it("emits the current version on reset", async () => {
+    await resetStorage();
+    expect(set.mock.calls[0]?.[0].settings).toEqual(withSchemaVersion(DEFAULT_SETTINGS));
+  });
+
+  it("serializes a migration write with a concurrent settings save", async () => {
+    let finishMigration: (() => void) | undefined;
+    const migrationPending = new Promise<void>((resolve) => {
+      finishMigration = resolve;
+    });
+    get.mockResolvedValue({
+      settings: { watchQueueFallbackOnly: false, platform: { twitch: { watchQueueChannels: ["Legacy"] } } },
+    });
+    set.mockImplementationOnce(() => migrationPending).mockResolvedValue(undefined);
+
+    const migration = loadSettings();
+    await vi.waitFor(() => expect(set).toHaveBeenCalledTimes(1));
+
+    const current = mergeSettings({ idleWatchlistFallbackOnly: true });
+    const save = saveSettings(current);
+
+    expect(set).toHaveBeenCalledTimes(1);
+    finishMigration?.();
+    await migration;
+    await save;
+    expect(set).toHaveBeenCalledTimes(2);
+    expect(set.mock.calls[1]?.[0]).toEqual({ settings: withSchemaVersion(current) });
+  });
+});
+```
+
+Note the `resetStorage` test needs `clearActivityEvents` mocked. Add this alongside the existing `vi.mock("wxt/browser", ...)` at the top of the file:
+
+```ts
+vi.mock("../src/core/activityStorage", () => ({
+  clearActivityEvents: vi.fn().mockResolvedValue(undefined),
+  importLegacyActivityEvents: vi.fn().mockResolvedValue(undefined),
+}));
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension test -- storageSettingsMigration`
+Expected: FAIL — writes carry no `schemaVersion` and the future-version case resolves instead of rejecting.
+
+- [ ] **Step 3: Rewire storage.ts**
+
+In `packages/extension/src/core/storage.ts`:
+
+Add to the imports:
+
+```ts
+import { migrateSettings, withSchemaVersion } from "@lurkloot/shared/settingsSchema";
+```
+
+Replace `loadSettings` and delete `hasLegacyWatchQueueSettings` entirely (lines 32-61):
+
+```ts
+// Reads, migrates, normalizes and — only when the stored document was not
+// already at the current schema version — persists the canonical envelope, all
+// under the settings lock so a migration write can never overwrite a newer
+// concurrent save. A future schema version throws without writing rather than
+// replacing data this build does not understand.
+export async function loadSettings(): Promise<ExtensionSettings> {
+  return withSettingsStorageLock(async () => {
+    const data = await browser.storage.local.get(SETTINGS_KEY);
+    const migration = migrateSettings(data[SETTINGS_KEY]);
+    const settings = mergeSettings(migration.settings as Partial<ExtensionSettings>);
+    if (migration.changed) {
+      try {
+        await browser.storage.local.set({ [SETTINGS_KEY]: withSchemaVersion(settings) });
+      } catch {
+        // Startup continues on the canonical in-memory settings. The stored
+        // document is untouched, so the next load retries the same migration.
+      }
+    }
+    return settings;
+  });
+}
+```
+
+Replace `saveSettings` (63-67):
+
+```ts
+export async function saveSettings(settings: ExtensionSettings): Promise<void> {
+  await withSettingsStorageLock(async () => {
+    await browser.storage.local.set({ [SETTINGS_KEY]: withSchemaVersion(settings) });
+  });
+}
+```
+
+In `resetStorage` (117-123), the settings write must take the settings lock too — today it only takes the state lock. Replace the first block with:
+
+```ts
+  await withSettingsStorageLock(async () => {
+    await browser.storage.local.set({ [SETTINGS_KEY]: withSchemaVersion(DEFAULT_SETTINGS) });
+  });
+  await withStateStorageLock(async () => {
+    await browser.storage.local.set({ [STATE_KEY]: DEFAULT_STATE });
+  });
+```
+
+- [ ] **Step 4: Run the full extension suite**
+
+Run: `pnpm --filter @lurkloot/extension test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/extension/src/core/storage.ts packages/extension/tests/storageSettingsMigration.test.ts
+git commit -m "feat(extension): migrate stored settings through the shared registry"
+```
+
+---
+
+### Task 5: CLI migrates in memory and warns every startup
+
+**Files:**
+- Modify: `packages/cli/src/settings.ts:74-100`, `:110-138`, `:144-231`, `:249-286`
+- Modify: `packages/cli/src/config.ts:32-115`, `:136-158`
+- Test: `packages/cli/tests/settings.test.ts`, `packages/cli/tests/config.test.ts`
+
+**Interfaces:**
+- `parseCliSettings(raw)` keeps returning `CliSettings`. A new `parseCliSettingsWithDiagnostics(raw)` returns `{ settings: CliSettings; diagnostics: SettingsMigrationDiagnostic[] }`; `parseCliSettings` delegates to it and discards the diagnostics so existing call sites and tests keep working.
+- `parseConfig` formats each diagnostic into `CliConfig.warnings` as `settings.<path> is deprecated; use settings.<replacement>`.
+
+- [ ] **Step 1: Write the failing CLI tests**
+
+In `packages/cli/tests/settings.test.ts`, replace the two legacy Watch Queue tests (lines 5-25) and the `autoClaimChannelPoints` moved-key test (lines 121-124) with:
+
+```ts
+import { parseCliSettingsWithDiagnostics } from "../src/settings";
+
+it("migrates legacy Watch Queue settings and reports them", () => {
+  const { settings, diagnostics } = parseCliSettingsWithDiagnostics({
+    watchQueueFallbackOnly: false,
+    platform: { twitch: { watchQueueChannels: [" Legacy ", "legacy"] } },
+  });
+  expect(settings.idleWatchlistFallbackOnly).toBe(false);
+  expect(settings.platform.twitch.idleWatchlistChannels).toEqual(["legacy"]);
+  expect(settings).not.toHaveProperty("watchQueueFallbackOnly");
+  expect(diagnostics.map((d) => d.path)).toEqual(["watchQueueFallbackOnly", "platform.twitch.watchQueueChannels"]);
+});
+
+it("prefers current keys over legacy ones", () => {
+  const settings = parseCliSettings({
+    idleWatchlistFallbackOnly: true,
+    watchQueueFallbackOnly: false,
+    platform: {
+      twitch: { idleWatchlistChannels: [], watchQueueChannels: ["legacy"] },
+      kick: { idleWatchlistChannels: ["new"], watchQueueChannels: ["legacy"] },
+    },
+  });
+  expect(settings.idleWatchlistFallbackOnly).toBe(true);
+  expect(settings.platform.twitch.idleWatchlistChannels).toEqual([]);
+  expect(settings.platform.kick.idleWatchlistChannels).toEqual(["new"]);
+});
+
+it("accepts a deprecated top-level autoClaimChannelPoints instead of erroring", () => {
+  const { settings, diagnostics } = parseCliSettingsWithDiagnostics({ autoClaimChannelPoints: false });
+  expect(settings.platform.twitch.autoClaimChannelPoints).toBe(false);
+  expect(diagnostics.map((d) => d.path)).toEqual(["autoClaimChannelPoints"]);
+});
+
+it("still rejects unknown keys that are not registered aliases", () => {
+  expect(() => parseCliSettings({ nonsense: 1 })).toThrow(/unknown CLI setting "nonsense"/);
+});
+
+it("still rejects extension-only keys", () => {
+  expect(() => parseCliSettings({ muteFarmingTabs: true }))
+    .toThrow(/"muteFarmingTabs" is an extension-only setting/);
+});
+
+it("accepts schemaVersion at the root of settings without exposing it", () => {
+  const settings = parseCliSettings({ schemaVersion: 1, autoClaim: false });
+  expect(settings.autoClaim).toBe(false);
+  expect(settings).not.toHaveProperty("schemaVersion");
+});
+
+it("rejects a future schema version", () => {
+  expect(() => parseCliSettings({ schemaVersion: 999 })).toThrow(/newer than this build supports/);
+});
+```
+
+In `packages/cli/tests/config.test.ts`, add:
+
+```ts
+it("warns with the full deprecated and replacement paths", () => {
+  const config = parseConfig({
+    settings: { watchQueueFallbackOnly: false, platform: { kick: { watchQueueChannels: ["a"] } } },
+  }, CONFIG_PATH);
+  expect(config.warnings).toContain("settings.watchQueueFallbackOnly is deprecated; use settings.idleWatchlistFallbackOnly");
+  expect(config.warnings).toContain("settings.platform.kick.watchQueueChannels is deprecated; use settings.platform.kick.idleWatchlistChannels");
+});
+
+it("warns about a moved property with its destination path", () => {
+  const config = parseConfig({ settings: { autoClaimChannelPoints: false } }, CONFIG_PATH);
+  expect(config.warnings).toContain("settings.autoClaimChannelPoints moved to settings.platform.twitch.autoClaimChannelPoints");
+});
+
+it("repeats the warnings on every independent load", () => {
+  const raw = { settings: { watchQueueFallbackOnly: false } };
+  expect(parseConfig(raw, CONFIG_PATH).warnings).toEqual(parseConfig(raw, CONFIG_PATH).warnings);
+});
+
+it("emits no migration warnings for a current config", () => {
+  expect(parseConfig({ settings: { schemaVersion: 1, autoClaim: true } }, CONFIG_PATH).warnings).toEqual([]);
+});
+
+it("generates a template that carries the current schema version", () => {
+  expect(defaultConfigJsonc()).toContain(`"schemaVersion": ${CURRENT_SETTINGS_SCHEMA_VERSION}`);
+  expect(parseConfig(parseJsonc(defaultConfigJsonc()), CONFIG_PATH).warnings).toEqual([]);
+});
+```
+
+Add the imports that test file needs: `defaultConfigJsonc` from `../src/config`, `CURRENT_SETTINGS_SCHEMA_VERSION` from `@lurkloot/shared/settingsSchema`, and `parse as parseJsonc` from `jsonc-parser`.
+
+Also add a test proving the file is never touched:
+
+```ts
+it("never rewrites the config file while migrating", () => {
+  const dir = mkdtempSync(join(tmpdir(), "lurkloot-config-"));
+  const path = join(dir, "config.jsonc");
+  writeFileSync(path, '{ "settings": { "watchQueueFallbackOnly": false } }\n');
+  const before = readFileSync(path, "utf8");
+  const beforeStat = statSync(path).mtimeMs;
+
+  const config = loadConfig(path);
+
+  expect(config.settings.idleWatchlistFallbackOnly).toBe(false);
+  expect(readFileSync(path, "utf8")).toBe(before);
+  expect(statSync(path).mtimeMs).toBe(beforeStat);
+  rmSync(dir, { recursive: true, force: true });
+});
+```
+
+with `mkdtempSync, readFileSync, rmSync, statSync, writeFileSync` from `node:fs`, `tmpdir` from `node:os`, `join` from `node:path`, and `loadConfig` from `../src/config`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/cli test`
+Expected: FAIL — `parseCliSettingsWithDiagnostics` does not exist.
+
+- [ ] **Step 3: Rewire the CLI settings parser**
+
+In `packages/cli/src/settings.ts`:
+
+Add the import:
+
+```ts
+import { migrateSettings, type SettingsMigrationDiagnostic } from "@lurkloot/shared/settingsSchema";
+```
+
+Remove the legacy aliases from `CLI_SETTING_KEYS` — delete the `"watchQueueFallbackOnly",` line (80). Remove `"watchQueueChannels"` from both `CLI_PLATFORM_KEYS` sets (98-99). The migration deletes those names before validation runs, so allowlisting them here would be dead code.
+
+Delete `MOVED_SETTING_KEYS` (126-130) and simplify `describeOffender` (132-138) to:
+
+```ts
+function describeOffender(key: string): string {
+  return EXTENSION_ONLY_KEYS.has(key)
+    ? `"${key}" is an extension-only setting with no effect in the CLI; remove it`
+    : `unknown CLI setting "${key}"`;
+}
+```
+
+Delete the local `currentOrLegacy` helper (280-286).
+
+Change the `idleWatchlistFallbackOnly` entry (210-213) to:
+
+```ts
+    idleWatchlistFallbackOnly: booleanOr(v.idleWatchlistFallbackOnly, DEFAULT_CLI_SETTINGS.idleWatchlistFallbackOnly),
+```
+
+Change the `idleWatchlistChannels` entry inside `normalizePlatform` (257-259) to:
+
+```ts
+        idleWatchlistChannels: normalizeChannelList(ps.idleWatchlistChannels),
+```
+
+Rename the existing `parseCliSettings` body into a new exported function and add a thin wrapper. Replace the signature at line 144 with:
+
+```ts
+export interface CliSettingsParseResult {
+  settings: CliSettings;
+  diagnostics: SettingsMigrationDiagnostic[];
+}
+
+// Runs the shared migration registry first, so deprecated aliases are renamed
+// away before validation and only genuinely unknown keys become errors. The
+// caller's object is never mutated and the config file is never rewritten.
+export function parseCliSettingsWithDiagnostics(raw: unknown): CliSettingsParseResult {
+  if (raw === undefined) return { settings: structuredClone(DEFAULT_CLI_SETTINGS), diagnostics: [] };
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error('Config "settings" must be a JSON object');
+  }
+  const migration = migrateSettings(raw);
+  return { settings: parseMigratedCliSettings(migration.settings), diagnostics: migration.diagnostics };
+}
+
+export function parseCliSettings(raw: unknown): CliSettings {
+  return parseCliSettingsWithDiagnostics(raw).settings;
+}
+
+function parseMigratedCliSettings(value: Record<string, unknown>): CliSettings {
+  const offenders: string[] = [];
+```
+
+Then delete the four now-redundant lines that opened the old function body (the `if (raw === undefined)` guard, the `if (raw === null …)` guard, the `const value = raw as Record<string, unknown>;` line, and the old `const offenders` line) so `parseMigratedCliSettings` continues straight into the existing `for (const key of Object.keys(value))` loop.
+
+- [ ] **Step 4: Surface the diagnostics as config warnings**
+
+In `packages/cli/src/config.ts`:
+
+Add the imports:
+
+```ts
+import { CURRENT_SETTINGS_SCHEMA_VERSION, type SettingsMigrationDiagnostic } from "@lurkloot/shared/settingsSchema";
+import { DEFAULT_CLI_SETTINGS, parseCliSettingsWithDiagnostics, type CliSettings } from "./settings";
+```
+
+(replacing the existing `./settings` import line 6).
+
+In `defaultConfigJsonc`, add the version as the first property of the `settings` block, directly after `"settings": {` (line 44):
+
+```
+    // Schema version of this settings block. Leave it alone unless a release
+    // note tells you otherwise; it lets LurkLoot skip replaying old migrations.
+    "schemaVersion": ${CURRENT_SETTINGS_SCHEMA_VERSION},
+
+```
+
+In `parseConfig`, replace lines 142 and the warning assembly so migration diagnostics join the existing warnings. Replace line 142:
+
+```ts
+  const parsed = parseCliSettingsWithDiagnostics(data.settings);
+  const settings = parsed.settings;
+  warnings.push(...parsed.diagnostics.map(formatMigrationWarning));
+```
+
+and add this helper next to `formatCompatibilityWarning`:
+
+```ts
+// Warnings name the complete deprecated path and its replacement so the user
+// can find and fix the exact line. The CLI config file is intentionally never
+// rewritten, so these repeat on every startup until the file is edited.
+function formatMigrationWarning(diagnostic: SettingsMigrationDiagnostic): string {
+  const verb = diagnostic.code === "moved_property" ? "moved to" : "is deprecated; use";
+  return `settings.${diagnostic.path} ${verb} settings.${diagnostic.replacement}`;
+}
+```
+
+- [ ] **Step 5: Run the CLI suite**
+
+Run: `pnpm --filter @lurkloot/cli test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/settings.ts packages/cli/src/config.ts packages/cli/tests/settings.test.ts packages/cli/tests/config.test.ts
+git commit -m "feat(cli): migrate config settings in memory and warn on deprecations"
+```
+
+---
+
+### Task 6: Document how to add a migration
+
+**Files:**
+- Modify: `docs/architecture.md`
+
+- [ ] **Step 1: Add the section**
+
+`docs/architecture.md` uses `##` for top-level sections. Insert this new section between the existing `## Settings Model` section (line 40) and `## Scheduler Flow` (line 54):
+
+```markdown
+## Settings Migrations
+
+`packages/shared/src/settingsSchema.ts` is the only place legacy settings shapes
+are transformed. Both hosts call `migrateSettings(raw)` on the raw persisted
+payload and pass the result to normalization (`mergeSettings` in the extension,
+`parseCliSettings` in the CLI). Migration and normalization are deliberately
+separate: clamping and defaulting would erase the raw property information the
+deprecation diagnostics depend on.
+
+To add version N+1:
+
+1. Increment `CURRENT_SETTINGS_SCHEMA_VERSION`.
+2. Add exactly one pure `N` → `N+1` entry to `MIGRATIONS`. It receives a deep
+   clone it owns outright, so it may mutate that object freely, but it must not
+   reach outside it or log.
+3. Emit a diagnostic for every deprecated or removed property it recognizes,
+   with the full dotted path and the replacement path when one exists.
+4. When an old and a current representation coexist, the current one wins and
+   the deprecated one still produces a diagnostic.
+5. Add fixtures to `packages/extension/tests/settingsMigrations.test.ts` for
+   version N input, mixed old/current input, and the fully migrated output.
+6. Update `defaultConfigJsonc()` in `packages/cli/src/config.ts` when public
+   property names change.
+
+Extension storage is upgraded automatically: `loadSettings` writes the canonical
+envelope once when `changed` is true, under the settings lock. The CLI's JSONC
+file is never rewritten, so its warnings repeat on every startup until the user
+edits it.
+
+Released migrations are never edited except to fix a data-loss defect. A later
+semantic change gets a new version and a new migration.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/architecture.md
+git commit -m "docs: explain how to add a settings schema migration"
+```
+
+---
+
+### Task 7: Full verification
+
+- [ ] **Step 1: Confirm no legacy names survive outside the registry and tests**
+
+Run: `grep -rn "watchQueue\|verboseLogging" packages/*/src packages/*/entrypoints`
+Expected: matches only in `packages/shared/src/settingsSchema.ts`.
+
+- [ ] **Step 2: Run the full verification**
+
+Run: `pnpm verify`
+Expected: PASS — script tests, workspace typechecks, both test suites, the Astro site build, and both browser builds.
+
+- [ ] **Step 3: Commit any fixes and open the PR**
+
+The PR body must link and close issue #179, show a before/after migration example, and call out explicitly that CLI config files are intentionally read-only.

--- a/docs/superpowers/specs/2026-07-20-settings-schema-migrations-design.md
+++ b/docs/superpowers/specs/2026-07-20-settings-schema-migrations-design.md
@@ -1,0 +1,211 @@
+# Versioned Settings Migration Design
+
+## Context
+
+LurkLoot currently normalizes persisted settings through `mergeSettings` and
+`mergeEngineSettings`. Historical property names are handled as inline
+fallbacks, while each host separately decides whether and how to persist a
+normalized result. PR #177 adds another compatibility bridge for the Watch
+Queue to Idle Watchlist rename.
+
+That approach is safe for an individual rename but does not provide an ordered,
+auditable migration history. A future migration currently requires coordinated
+special cases in shared normalization, extension storage, CLI validation, and
+host-specific warning or persistence code.
+
+This work will be implemented separately from PR #177. The rename PR remains a
+focused compatibility change; the migration PR will convert its aliases into
+the first explicit schema migration.
+
+## Goals
+
+- Give extension and CLI settings one authoritative, versioned migration path.
+- Keep migrations pure, ordered, deterministic, and independently testable.
+- Preserve the same canonical settings semantics across every host.
+- Automatically persist migrated browser-managed extension settings.
+- Never rewrite the user's CLI JSONC file.
+- Warn CLI users about deprecated properties on every startup until they edit
+  their configuration.
+- Refuse unknown future schema versions without overwriting their data.
+- Make adding the next migration a local, documented operation.
+
+## Non-goals
+
+- Rewriting, reformatting, or backing up CLI configuration files.
+- Migrating CLI-only top-level properties such as `transport` or `authDir` in
+  the initial implementation.
+- Changing setting defaults or runtime farming behavior.
+- Providing a standalone migration command.
+- Removing support for unversioned settings.
+
+## Architecture
+
+### Shared migration authority
+
+`@lurkloot/shared` will expose a settings schema module containing:
+
+- `CURRENT_SETTINGS_SCHEMA_VERSION`, an integer incremented for every semantic
+  settings-shape migration.
+- A stored settings document containing `schemaVersion` alongside the persisted
+  settings properties. The reserved metadata property is removed before
+  producing runtime `EngineSettings` or `ExtensionSettings` values.
+- An ordered registry in which migration N accepts the raw payload for version
+  N and returns the raw payload for version N+1.
+- `migrateSettings(raw)`, which detects the source version, applies every
+  required migration, and returns a structured result.
+
+The result will include the migrated raw payload, `fromVersion`, `toVersion`, a
+`changed` flag, and structured diagnostics. Diagnostics identify a stable code,
+the deprecated property path, its replacement when one exists, and a
+human-readable message. Hosts format or route diagnostics; migration functions
+do not log.
+
+Unversioned input is version 0. Version 0 represents every supported historical
+shape that predates the migration framework. The first migration consolidates
+existing legacy behavior, including the Idle Watchlist aliases introduced by
+PR #177. When both deprecated and current properties exist, the current
+property wins and the deprecated property still produces a diagnostic.
+
+Migration and normalization remain separate phases:
+
+1. Read `schemaVersion` from the stored document or classify an unversioned
+   object as version 0.
+2. Apply ordered raw-shape migrations.
+3. Normalize and validate the current payload into canonical runtime settings.
+4. Return canonical storage data and diagnostics to the host.
+
+This separation prevents defaulting or clamping from accidentally hiding the
+raw property information needed to issue accurate deprecation warnings.
+
+### Version safety
+
+Versions must be non-negative integers. A version greater than
+`CURRENT_SETTINGS_SCHEMA_VERSION` produces a typed unsupported-version error.
+Neither host may normalize, save, or otherwise replace settings after this
+error. Missing intermediate migrations are programmer errors covered by tests
+and fail before any write.
+
+Every migration must be pure and must not mutate its input. Running the complete
+pipeline on current canonical storage is a no-op. A migration may be retried
+after an interrupted or failed write without changing the result.
+
+## Host behavior
+
+### Extension
+
+Extension `loadSettings`, `saveSettings`, and reset operations will share one
+serialized settings-storage authority. Loading will read, migrate, normalize,
+and, only when necessary, persist the current envelope while holding that
+authority. Ordinary saves always write a current-version settings document.
+This prevents a
+migration write from overwriting a newer concurrent save.
+
+If migration succeeds in memory but its write-back fails, startup continues
+with the canonical settings and the migration is retried on the next load. If
+the stored schema version is from the future, loading fails explicitly and does
+not write. Reset remains an intentional user action and writes current defaults.
+
+Extension diagnostics are not shown to users in the initial implementation
+because browser storage is upgraded automatically. They remain available for
+tests and diagnostic logging.
+
+### CLI
+
+CLI `loadConfig` will parse JSONC exactly as it does today, pass `settings` to
+the shared migration pipeline, and use the canonical result in memory. It will
+not modify the configuration file.
+
+Every deprecation diagnostic becomes an actionable warning on every startup
+until the source file is edited. Warnings name the complete deprecated path and
+replacement, for example:
+
+`settings.watchQueueFallbackOnly is deprecated; use settings.idleWatchlistFallbackOnly`
+
+Unknown properties that have never been declared migration aliases remain
+validation errors. Deprecated aliases are accepted only through registered
+migrations, eliminating duplicate legacy-key allowlists in CLI parsing.
+
+Because the CLI file is not rewritten, its settings object may remain
+unversioned indefinitely. It will continue to enter at version 0 and receive
+the same deterministic warnings. An optional `settings.schemaVersion` can avoid
+replaying earlier migrations for manually updated configs, and the default
+generated JSONC will include the current version so new files begin in the
+current schema. The metadata property is accepted only at the root of the
+`settings` object and is not part of `CliSettings`.
+
+## Adding a migration
+
+A contributor adding version N+1 must:
+
+1. Increment `CURRENT_SETTINGS_SCHEMA_VERSION`.
+2. Add exactly one pure N-to-N+1 migration to the registry.
+3. Define diagnostics for every deprecated or removed property it recognizes.
+4. Preserve current-property precedence when old and new representations
+   coexist, unless the migration specification explicitly says otherwise.
+5. Add fixtures for version N, mixed old/current input, and the fully migrated
+   output.
+6. Update the generated CLI config template when its public property names
+   change.
+
+Migrations are never edited after release except to fix a data-loss defect.
+Later semantic changes receive a new version and migration.
+
+## Testing
+
+Shared tests will cover:
+
+- every historical-version fixture upgrading to the current canonical shape;
+- sequential application across more than one migration;
+- unversioned input as version 0;
+- current-property precedence over deprecated aliases;
+- stable and deduplicated diagnostics;
+- idempotence and input immutability;
+- current-version no-op behavior;
+- invalid, missing-step, and future-version failures.
+
+Extension tests will cover:
+
+- one-time canonical write-back;
+- no write for current storage;
+- failed write-back returning usable settings and retrying later;
+- concurrent load/save ordering without lost updates;
+- future-version rejection without writes;
+- reset and ordinary saves emitting the current-version settings document.
+
+CLI tests will cover:
+
+- in-memory migration without changing file bytes or timestamps;
+- warnings on every independent load while deprecated properties remain;
+- full deprecated and replacement property paths in warnings;
+- current config loading without migration warnings;
+- deprecated aliases accepted while unrelated unknown keys still fail;
+- future-version rejection.
+
+The implementation must pass `pnpm verify`.
+
+## Delivery boundary
+
+This design will be tracked by a dedicated GitHub issue and implemented from
+`origin/develop` in `refactor/settings-schema-migrations`. PR #177 remains
+unchanged except that the follow-up issue may reference it as the source of the
+Idle Watchlist migration case. The implementation PR will link and close the
+new issue, include migration examples in its summary, and call out that CLI
+files are intentionally read-only.
+
+## Acceptance criteria
+
+- A single shared ordered migration registry is the only place where legacy
+  settings shapes are transformed.
+- Extension and CLI consume the same migration result before host-specific
+  normalization or use.
+- Extension storage is upgraded automatically and safely under serialized
+  writes.
+- CLI JSONC is never rewritten and emits actionable deprecation warnings on
+  every startup while deprecated properties remain.
+- Current names win over legacy aliases without data loss.
+- Unknown future versions fail without persistence.
+- Existing inline Watch Queue/Idle Watchlist and other settings migration
+  fallbacks are represented by the versioned mechanism rather than scattered
+  host-specific checks.
+- Documentation explains how to add a migration.
+- `pnpm verify` passes.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -167,8 +167,13 @@ export function parseConfig(raw: unknown, configPath: string): CliConfig {
 
 // Warnings name the complete deprecated path and its replacement so the user
 // can find and fix the exact line. The CLI config file is intentionally never
-// rewritten, so these repeat on every startup until the file is edited.
+// rewritten, so these repeat on every startup until the file is edited. A future
+// migration that removes a property outright carries no replacement, so fall
+// back to a bare deprecation notice rather than printing "settings.undefined".
 function formatMigrationWarning(diagnostic: SettingsMigrationDiagnostic): string {
+  if (!diagnostic.replacement) {
+    return `settings.${diagnostic.path} is deprecated and ignored`;
+  }
   const verb = diagnostic.code === "moved_property" ? "moved to" : "is deprecated; use";
   return `settings.${diagnostic.path} ${verb} settings.${diagnostic.replacement}`;
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -3,7 +3,8 @@ import { dirname, resolve } from "node:path";
 import { parse as parseJsonc, printParseErrorCode, type ParseError } from "jsonc-parser";
 import { resolveCompatibility } from "@lurkloot/core";
 import type { CompatibilityWarning } from "@lurkloot/shared/compatibility";
-import { DEFAULT_CLI_SETTINGS, parseCliSettings, type CliSettings } from "./settings";
+import { CURRENT_SETTINGS_SCHEMA_VERSION, type SettingsMigrationDiagnostic } from "@lurkloot/shared/settingsSchema";
+import { DEFAULT_CLI_SETTINGS, parseCliSettingsWithDiagnostics, type CliSettings } from "./settings";
 
 export const TRANSPORTS = ["http", "impersonate"] as const;
 export type Transport = (typeof TRANSPORTS)[number];
@@ -42,6 +43,10 @@ export function defaultConfigJsonc(): string {
   "authDir": "auth",
 
   "settings": {
+    // Schema version of this settings block. Leave it alone unless a release
+    // note tells you otherwise; it lets LurkLoot skip replaying old migrations.
+    "schemaVersion": ${CURRENT_SETTINGS_SCHEMA_VERSION},
+
     // Automatically claim completed drops.
     "autoClaim": ${json(defaults.autoClaim)},
 
@@ -139,7 +144,9 @@ export function parseConfig(raw: unknown, configPath: string): CliConfig {
     && Object.hasOwn(rawSettings, "enabledLogLevels")
     ? [ENABLED_LOG_LEVELS_WARNING]
     : [];
-  const settings = parseCliSettings(data.settings);
+  const parsed = parseCliSettingsWithDiagnostics(data.settings);
+  const settings = parsed.settings;
+  warnings.push(...parsed.diagnostics.map(formatMigrationWarning));
   const webWarnings = resolveCompatibility(settings.compatibility, { host: "cli", twitchIdentity: "web" }).warnings;
   const androidWarnings = resolveCompatibility(settings.compatibility, { host: "cli", twitchIdentity: "android" }).warnings;
   warnings.push(...webWarnings.filter((candidate) => androidWarnings.some((warning) =>
@@ -156,6 +163,14 @@ export function parseConfig(raw: unknown, configPath: string): CliConfig {
     configPath,
     warnings,
   };
+}
+
+// Warnings name the complete deprecated path and its replacement so the user
+// can find and fix the exact line. The CLI config file is intentionally never
+// rewritten, so these repeat on every startup until the file is edited.
+function formatMigrationWarning(diagnostic: SettingsMigrationDiagnostic): string {
+  const verb = diagnostic.code === "moved_property" ? "moved to" : "is deprecated; use";
+  return `settings.${diagnostic.path} ${verb} settings.${diagnostic.replacement}`;
 }
 
 function formatCompatibilityWarning(warning: CompatibilityWarning): string {

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -127,6 +127,10 @@ const EXTENSION_ONLY_KEYS = new Set<string>([
 // actually wrote, or the error points at a line their file does not contain. The
 // match is by `replacement`; a nested rename's replacement is a dotted path that
 // never equals a bare top-level key, so this only fires for top-level offenders.
+// A user who writes BOTH the legacy and the current form of such a key sees the
+// "renamed from" framing even though they also wrote the current name directly;
+// that collision is pathological (an extension-only key in two forms in a CLI
+// config) and still names a real offending line, so it is left as-is.
 function describeOffender(key: string, diagnostics: SettingsMigrationDiagnostic[]): string {
   const renamedFrom = diagnostics.find((diagnostic) => diagnostic.replacement === key)?.path;
   const subject = renamedFrom ? `"${renamedFrom}" (renamed to "${key}")` : `"${key}"`;
@@ -140,9 +144,13 @@ export interface CliSettingsParseResult {
   diagnostics: SettingsMigrationDiagnostic[];
 }
 
-// Runs the shared migration registry first, so deprecated aliases are renamed
-// away before validation and only genuinely unknown keys become errors. The
-// caller's object is never mutated and the config file is never rewritten.
+// Parses and validates the `settings` block of a CLI config. Runs the shared
+// migration registry first, so deprecated aliases are renamed away before
+// validation and only genuinely unknown keys become errors; the caller's object
+// is never mutated and the config file is never rewritten. Unknown or
+// extension-only keys (top-level or per-platform) are a hard error listing every
+// offender at once; recognized values are normalized through the shared
+// primitives (range clamps, channel/category/id dedupe, log-level canonicalize).
 export function parseCliSettingsWithDiagnostics(raw: unknown): CliSettingsParseResult {
   if (raw === undefined) return { settings: structuredClone(DEFAULT_CLI_SETTINGS), diagnostics: [] };
   if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
@@ -156,10 +164,9 @@ export function parseCliSettings(raw: unknown): CliSettings {
   return parseCliSettingsWithDiagnostics(raw).settings;
 }
 
-// Parses and validates the `settings` block of a CLI config. Unknown or
-// extension-only keys (top-level or per-platform) are a hard error listing every
-// offender at once; recognized values are normalized through the shared
-// primitives (range clamps, channel/category/id dedupe, log-level canonicalize).
+// Validates and normalizes an already-migrated settings payload. See
+// parseCliSettingsWithDiagnostics for the full contract; `diagnostics` is passed
+// through only so a renamed-away key can be named by its original path in errors.
 function parseMigratedCliSettings(value: Record<string, unknown>, diagnostics: SettingsMigrationDiagnostic[]): CliSettings {
   const offenders: string[] = [];
 

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -122,10 +122,17 @@ const EXTENSION_ONLY_KEYS = new Set<string>([
   "diagnosticLogging",
 ]);
 
-function describeOffender(key: string): string {
+// A migration may rename a legacy key onto one the CLI rejects — `verboseLogging`
+// becomes `diagnosticLogging`, which is extension-only. Name the key the user
+// actually wrote, or the error points at a line their file does not contain. The
+// match is by `replacement`; a nested rename's replacement is a dotted path that
+// never equals a bare top-level key, so this only fires for top-level offenders.
+function describeOffender(key: string, diagnostics: SettingsMigrationDiagnostic[]): string {
+  const renamedFrom = diagnostics.find((diagnostic) => diagnostic.replacement === key)?.path;
+  const subject = renamedFrom ? `"${renamedFrom}" (renamed to "${key}")` : `"${key}"`;
   return EXTENSION_ONLY_KEYS.has(key)
-    ? `"${key}" is an extension-only setting with no effect in the CLI; remove it`
-    : `unknown CLI setting "${key}"`;
+    ? `${subject} is an extension-only setting with no effect in the CLI; remove it`
+    : `unknown CLI setting ${subject}`;
 }
 
 export interface CliSettingsParseResult {
@@ -142,7 +149,7 @@ export function parseCliSettingsWithDiagnostics(raw: unknown): CliSettingsParseR
     throw new Error('Config "settings" must be a JSON object');
   }
   const migration = migrateSettings(raw);
-  return { settings: parseMigratedCliSettings(migration.settings), diagnostics: migration.diagnostics };
+  return { settings: parseMigratedCliSettings(migration.settings, migration.diagnostics), diagnostics: migration.diagnostics };
 }
 
 export function parseCliSettings(raw: unknown): CliSettings {
@@ -153,11 +160,11 @@ export function parseCliSettings(raw: unknown): CliSettings {
 // extension-only keys (top-level or per-platform) are a hard error listing every
 // offender at once; recognized values are normalized through the shared
 // primitives (range clamps, channel/category/id dedupe, log-level canonicalize).
-function parseMigratedCliSettings(value: Record<string, unknown>): CliSettings {
+function parseMigratedCliSettings(value: Record<string, unknown>, diagnostics: SettingsMigrationDiagnostic[]): CliSettings {
   const offenders: string[] = [];
 
   for (const key of Object.keys(value)) {
-    if (!CLI_SETTING_KEYS.has(key)) offenders.push(describeOffender(key));
+    if (!CLI_SETTING_KEYS.has(key)) offenders.push(describeOffender(key, diagnostics));
   }
 
   const platformRaw = value.platform;

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -9,6 +9,7 @@ import {
   normalizeIdList,
   normalizePriorities,
 } from "@lurkloot/shared/settings";
+import { migrateSettings, type SettingsMigrationDiagnostic } from "@lurkloot/shared/settingsSchema";
 import type { CompatibilitySettings, EngineSettings, KickPlatformSettings, Platform, PlatformSettingsByPlatform, PriorityMode, TwitchPlatformSettings } from "@lurkloot/shared/models";
 
 // The CLI's own settings surface — intentionally decoupled from the extension's
@@ -77,7 +78,6 @@ const CLI_SETTING_KEYS = new Set<string>([
   "campaignPriorities",
   "excludedCampaignIds",
   "idleWatchlistFallbackOnly",
-  "watchQueueFallbackOnly",
   "offlineRetryLimit",
   "pollIntervalMinutes",
   "postClaimHandoff",
@@ -95,8 +95,8 @@ const CLI_SETTING_KEYS = new Set<string>([
 ]);
 
 const CLI_PLATFORM_KEYS: Record<Platform, Set<string>> = {
-  twitch: new Set(["enabled", "idleWatchlistChannels", "watchQueueChannels", "excludedChannels", "farmAllCategories", "categories", "autoClaimChannelPoints"]),
-  kick: new Set(["enabled", "idleWatchlistChannels", "watchQueueChannels", "excludedChannels", "farmAllCategories", "categories", "autoClaimChallenges"]),
+  twitch: new Set(["enabled", "idleWatchlistChannels", "excludedChannels", "farmAllCategories", "categories", "autoClaimChannelPoints"]),
+  kick: new Set(["enabled", "idleWatchlistChannels", "excludedChannels", "farmAllCategories", "categories", "autoClaimChallenges"]),
 };
 const CLI_COMPATIBILITY_KEYS: Record<Platform, Set<string>> = {
   twitch: new Set(["profile", "heartbeatTransport", "inventoryQueryVersion"]),
@@ -122,31 +122,38 @@ const EXTENSION_ONLY_KEYS = new Set<string>([
   "diagnosticLogging",
 ]);
 
-// Top-level settings that moved into a per-platform block. Named separately so
-// an existing config that still carries one gets a "move it here" error instead
-// of a misleading "unknown setting".
-const MOVED_SETTING_KEYS: Record<string, string> = {
-  autoClaimChannelPoints: "platform.twitch.autoClaimChannelPoints",
-};
-
 function describeOffender(key: string): string {
-  const movedTo = MOVED_SETTING_KEYS[key];
-  if (movedTo) return `"${key}" moved to "${movedTo}"; move the value there`;
   return EXTENSION_ONLY_KEYS.has(key)
     ? `"${key}" is an extension-only setting with no effect in the CLI; remove it`
     : `unknown CLI setting "${key}"`;
+}
+
+export interface CliSettingsParseResult {
+  settings: CliSettings;
+  diagnostics: SettingsMigrationDiagnostic[];
+}
+
+// Runs the shared migration registry first, so deprecated aliases are renamed
+// away before validation and only genuinely unknown keys become errors. The
+// caller's object is never mutated and the config file is never rewritten.
+export function parseCliSettingsWithDiagnostics(raw: unknown): CliSettingsParseResult {
+  if (raw === undefined) return { settings: structuredClone(DEFAULT_CLI_SETTINGS), diagnostics: [] };
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error('Config "settings" must be a JSON object');
+  }
+  const migration = migrateSettings(raw);
+  return { settings: parseMigratedCliSettings(migration.settings), diagnostics: migration.diagnostics };
+}
+
+export function parseCliSettings(raw: unknown): CliSettings {
+  return parseCliSettingsWithDiagnostics(raw).settings;
 }
 
 // Parses and validates the `settings` block of a CLI config. Unknown or
 // extension-only keys (top-level or per-platform) are a hard error listing every
 // offender at once; recognized values are normalized through the shared
 // primitives (range clamps, channel/category/id dedupe, log-level canonicalize).
-export function parseCliSettings(raw: unknown): CliSettings {
-  if (raw === undefined) return structuredClone(DEFAULT_CLI_SETTINGS);
-  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error('Config "settings" must be a JSON object');
-  }
-  const value = raw as Record<string, unknown>;
+function parseMigratedCliSettings(value: Record<string, unknown>): CliSettings {
   const offenders: string[] = [];
 
   for (const key of Object.keys(value)) {
@@ -207,10 +214,7 @@ export function parseCliSettings(raw: unknown): CliSettings {
       : DEFAULT_CLI_SETTINGS.priorityMode,
     campaignPriorities: normalizePriorities(v.campaignPriorities),
     excludedCampaignIds: normalizeIdList(v.excludedCampaignIds),
-    idleWatchlistFallbackOnly: booleanOr(
-      currentOrLegacy<boolean>(value, "idleWatchlistFallbackOnly", "watchQueueFallbackOnly"),
-      DEFAULT_CLI_SETTINGS.idleWatchlistFallbackOnly,
-    ),
+    idleWatchlistFallbackOnly: booleanOr(v.idleWatchlistFallbackOnly, DEFAULT_CLI_SETTINGS.idleWatchlistFallbackOnly),
     offlineRetryLimit: clampInteger(v.offlineRetryLimit, 1, 10, DEFAULT_CLI_SETTINGS.offlineRetryLimit),
     pollIntervalMinutes: clampNumber(v.pollIntervalMinutes, 1, 60, DEFAULT_CLI_SETTINGS.pollIntervalMinutes),
     postClaimHandoff: booleanOr(v.postClaimHandoff, DEFAULT_CLI_SETTINGS.postClaimHandoff),
@@ -254,9 +258,7 @@ function normalizePlatform(raw: EngineSettings["platform"] | undefined): Platfor
       ps,
       base: {
         enabled: booleanOr(ps.enabled, defaults.enabled),
-        idleWatchlistChannels: normalizeChannelList(
-          currentOrLegacy<string[]>(ps, "idleWatchlistChannels", "watchQueueChannels"),
-        ),
+        idleWatchlistChannels: normalizeChannelList(ps.idleWatchlistChannels),
         excludedChannels: normalizeChannelList(ps.excludedChannels),
         farmAllCategories: booleanOr(ps.farmAllCategories, defaults.farmAllCategories),
         categories: normalizeCategorySelections(ps.categories),
@@ -275,14 +277,6 @@ function normalizePlatform(raw: EngineSettings["platform"] | undefined): Platfor
       autoClaimChallenges: booleanOr(kick.ps.autoClaimChallenges, DEFAULT_CLI_SETTINGS.platform.kick.autoClaimChallenges),
     },
   };
-}
-
-function currentOrLegacy<T>(owner: object | undefined, currentKey: string, legacyKey: string): T | undefined {
-  if (!owner) return undefined;
-  const values = owner as Record<string, unknown>;
-  return Object.prototype.hasOwnProperty.call(values, currentKey)
-    ? values[currentKey] as T | undefined
-    : values[legacyKey] as T | undefined;
 }
 
 // Expands the CLI settings into the EngineSettings contract the shared engine

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -1,11 +1,13 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { parse as parseJsonc } from "jsonc-parser";
 import { defaultConfigJsonc, loadConfig, parseConfig } from "../src/config";
 import { DEFAULT_CLI_SETTINGS } from "../src/settings";
+import { CURRENT_SETTINGS_SCHEMA_VERSION } from "@lurkloot/shared/settingsSchema";
 
 const CONFIG_PATH = "/tmp/lurkloot/config.json";
 const CLI_PACKAGE_DIR = fileURLToPath(new URL("..", import.meta.url));
@@ -123,6 +125,48 @@ describe("parseConfig", () => {
   it("rejects a non-object config", () => {
     expect(() => parseConfig([], CONFIG_PATH)).toThrow(/must be a JSON object/);
     expect(() => parseConfig(null, CONFIG_PATH)).toThrow(/must be a JSON object/);
+  });
+
+  it("warns with the full deprecated and replacement paths", () => {
+    const config = parseConfig({
+      settings: { watchQueueFallbackOnly: false, platform: { kick: { watchQueueChannels: ["a"] } } },
+    }, CONFIG_PATH);
+    expect(config.warnings).toContain("settings.watchQueueFallbackOnly is deprecated; use settings.idleWatchlistFallbackOnly");
+    expect(config.warnings).toContain("settings.platform.kick.watchQueueChannels is deprecated; use settings.platform.kick.idleWatchlistChannels");
+  });
+
+  it("warns about a moved property with its destination path", () => {
+    const config = parseConfig({ settings: { autoClaimChannelPoints: false } }, CONFIG_PATH);
+    expect(config.warnings).toContain("settings.autoClaimChannelPoints moved to settings.platform.twitch.autoClaimChannelPoints");
+  });
+
+  it("repeats the warnings on every independent load", () => {
+    const raw = { settings: { watchQueueFallbackOnly: false } };
+    expect(parseConfig(raw, CONFIG_PATH).warnings).toEqual(parseConfig(raw, CONFIG_PATH).warnings);
+  });
+
+  it("emits no migration warnings for a current config", () => {
+    expect(parseConfig({ settings: { schemaVersion: 1, autoClaim: true } }, CONFIG_PATH).warnings).toEqual([]);
+  });
+
+  it("generates a template that carries the current schema version", () => {
+    expect(defaultConfigJsonc()).toContain(`"schemaVersion": ${CURRENT_SETTINGS_SCHEMA_VERSION}`);
+    expect(parseConfig(parseJsonc(defaultConfigJsonc()), CONFIG_PATH).warnings).toEqual([]);
+  });
+
+  it("never rewrites the config file while migrating", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lurkloot-config-"));
+    const path = join(dir, "config.jsonc");
+    writeFileSync(path, '{ "settings": { "watchQueueFallbackOnly": false } }\n');
+    const before = readFileSync(path, "utf8");
+    const beforeStat = statSync(path).mtimeMs;
+
+    const config = loadConfig(path);
+
+    expect(config.settings.idleWatchlistFallbackOnly).toBe(false);
+    expect(readFileSync(path, "utf8")).toBe(before);
+    expect(statSync(path).mtimeMs).toBe(beforeStat);
+    rmSync(dir, { recursive: true, force: true });
   });
 });
 

--- a/packages/cli/tests/settings.test.ts
+++ b/packages/cli/tests/settings.test.ts
@@ -42,6 +42,14 @@ describe("parseCliSettings", () => {
       .toThrow(/"muteFarmingTabs" is an extension-only setting/);
   });
 
+  it("names the key the user actually wrote when a migration renamed it", () => {
+    // verboseLogging migrates to diagnosticLogging, which the CLI rejects as
+    // extension-only. The error has to name verboseLogging or the user cannot
+    // find the offending line in their config.
+    expect(() => parseCliSettings({ verboseLogging: true }))
+      .toThrow(/"verboseLogging" \(renamed to "diagnosticLogging"\) is an extension-only setting/);
+  });
+
   it("accepts schemaVersion at the root of settings without exposing it", () => {
     const settings = parseCliSettings({ schemaVersion: 1, autoClaim: false });
     expect(settings.autoClaim).toBe(false);

--- a/packages/cli/tests/settings.test.ts
+++ b/packages/cli/tests/settings.test.ts
@@ -1,31 +1,55 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_CLI_SETTINGS, parseCliSettings, toEngineSettings } from "../src/settings";
+import { DEFAULT_CLI_SETTINGS, parseCliSettings, parseCliSettingsWithDiagnostics, toEngineSettings } from "../src/settings";
 
 describe("parseCliSettings", () => {
-  it("accepts legacy Watch Queue keys and normalizes them to Idle Watchlist keys", () => {
-    const settings = parseCliSettings({
+  it("migrates legacy Watch Queue settings and reports them", () => {
+    const { settings, diagnostics } = parseCliSettingsWithDiagnostics({
       watchQueueFallbackOnly: false,
       platform: { twitch: { watchQueueChannels: [" Legacy ", "legacy"] } },
     });
-
     expect(settings.idleWatchlistFallbackOnly).toBe(false);
     expect(settings.platform.twitch.idleWatchlistChannels).toEqual(["legacy"]);
     expect(settings).not.toHaveProperty("watchQueueFallbackOnly");
+    expect(diagnostics.map((d) => d.path)).toEqual(["watchQueueFallbackOnly", "platform.twitch.watchQueueChannels"]);
   });
 
-  it("prefers Idle Watchlist keys over legacy CLI aliases", () => {
+  it("prefers current keys over legacy ones", () => {
     const settings = parseCliSettings({
-      idleWatchlistFallbackOnly: false,
-      watchQueueFallbackOnly: true,
+      idleWatchlistFallbackOnly: true,
+      watchQueueFallbackOnly: false,
       platform: {
         twitch: { idleWatchlistChannels: [], watchQueueChannels: ["legacy"] },
         kick: { idleWatchlistChannels: ["new"], watchQueueChannels: ["legacy"] },
       },
     });
-
-    expect(settings.idleWatchlistFallbackOnly).toBe(false);
+    expect(settings.idleWatchlistFallbackOnly).toBe(true);
     expect(settings.platform.twitch.idleWatchlistChannels).toEqual([]);
     expect(settings.platform.kick.idleWatchlistChannels).toEqual(["new"]);
+  });
+
+  it("accepts a deprecated top-level autoClaimChannelPoints instead of erroring", () => {
+    const { settings, diagnostics } = parseCliSettingsWithDiagnostics({ autoClaimChannelPoints: false });
+    expect(settings.platform.twitch.autoClaimChannelPoints).toBe(false);
+    expect(diagnostics.map((d) => d.path)).toEqual(["autoClaimChannelPoints"]);
+  });
+
+  it("still rejects unknown keys that are not registered aliases", () => {
+    expect(() => parseCliSettings({ nonsense: 1 })).toThrow(/unknown CLI setting "nonsense"/);
+  });
+
+  it("still rejects extension-only keys", () => {
+    expect(() => parseCliSettings({ muteFarmingTabs: true }))
+      .toThrow(/"muteFarmingTabs" is an extension-only setting/);
+  });
+
+  it("accepts schemaVersion at the root of settings without exposing it", () => {
+    const settings = parseCliSettings({ schemaVersion: 1, autoClaim: false });
+    expect(settings.autoClaim).toBe(false);
+    expect(settings).not.toHaveProperty("schemaVersion");
+  });
+
+  it("rejects a future schema version", () => {
+    expect(() => parseCliSettings({ schemaVersion: 999 })).toThrow(/newer than this build supports/);
   });
 
   it("returns defaults for an empty/undefined settings block", () => {
@@ -116,11 +140,6 @@ describe("parseCliSettings", () => {
 
   it("hard-errors on a truly unknown key", () => {
     expect(() => parseCliSettings({ turbo: true })).toThrow(/unknown CLI setting "turbo"/);
-  });
-
-  it("points a moved top-level key at its new per-platform home", () => {
-    expect(() => parseCliSettings({ autoClaimChannelPoints: false }))
-      .toThrow(/"autoClaimChannelPoints" moved to "platform.twitch.autoClaimChannelPoints"/);
   });
 
   it("accepts autoClaimChannelPoints under platform.twitch", () => {

--- a/packages/cli/tests/settings.test.ts
+++ b/packages/cli/tests/settings.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { mergeSettings } from "@lurkloot/shared/settings";
+import { migrateSettings } from "@lurkloot/shared/settingsSchema";
 import { DEFAULT_CLI_SETTINGS, parseCliSettings, parseCliSettingsWithDiagnostics, toEngineSettings } from "../src/settings";
 
 describe("parseCliSettings", () => {
@@ -217,5 +219,29 @@ describe("toEngineSettings", () => {
     expect(engine.deadlineSafetyMarginMinutes).toBe(5);
     expect(engine.platform.kick.enabled).toBe(false);
     expect(engine.compatibility).toEqual(cli.compatibility);
+  });
+
+  // Guards the whole point of the shared registry: both hosts must derive the
+  // same engine-contract values from one legacy document. The extension reaches
+  // them via mergeSettings; the CLI via parseCliSettings + toEngineSettings. If
+  // a future migration diverged the two, this is where it would show up.
+  it("agrees with the extension on the engine contract for a legacy document", () => {
+    const legacy = {
+      watchQueueFallbackOnly: false,
+      autoClaimChannelPoints: false,
+      platform: {
+        twitch: { watchQueueChannels: ["A"] },
+        kick: { watchQueueChannels: ["B"] },
+      },
+    };
+    const cliEngine = toEngineSettings(parseCliSettings(legacy));
+    // The extension migrates then normalizes; replicate that exact pipeline.
+    const extension = mergeSettings(migrateSettings(legacy).settings as never);
+    expect(cliEngine.idleWatchlistFallbackOnly).toBe(extension.idleWatchlistFallbackOnly);
+    expect(cliEngine.idleWatchlistFallbackOnly).toBe(false);
+    expect(cliEngine.platform.twitch.idleWatchlistChannels).toEqual(extension.platform.twitch.idleWatchlistChannels);
+    expect(cliEngine.platform.kick.idleWatchlistChannels).toEqual(extension.platform.kick.idleWatchlistChannels);
+    expect(cliEngine.platform.twitch.autoClaimChannelPoints).toBe(extension.platform.twitch.autoClaimChannelPoints);
+    expect(cliEngine.platform.twitch.autoClaimChannelPoints).toBe(false);
   });
 });

--- a/packages/extension/src/core/storage.ts
+++ b/packages/extension/src/core/storage.ts
@@ -107,11 +107,16 @@ export async function saveTwitchIntegrity(value: TwitchIntegrity): Promise<void>
 }
 
 export async function resetStorage(): Promise<void> {
+  // Both keys are reset in one atomic write, so a reset never lands halfway.
+  // Both locks are held because the write touches both keys; nothing else ever
+  // acquires them in the opposite order, so the nesting cannot deadlock.
   await withSettingsStorageLock(async () => {
-    await browser.storage.local.set({ [SETTINGS_KEY]: withSchemaVersion(DEFAULT_SETTINGS) });
-  });
-  await withStateStorageLock(async () => {
-    await browser.storage.local.set({ [STATE_KEY]: DEFAULT_STATE });
+    await withStateStorageLock(async () => {
+      await browser.storage.local.set({
+        [SETTINGS_KEY]: withSchemaVersion(DEFAULT_SETTINGS),
+        [STATE_KEY]: DEFAULT_STATE,
+      });
+    });
   });
   try {
     await clearActivityEvents();

--- a/packages/extension/src/core/storage.ts
+++ b/packages/extension/src/core/storage.ts
@@ -39,9 +39,17 @@ export async function loadSettings(): Promise<ExtensionSettings> {
   return withSettingsStorageLock(async () => {
     const data = await browser.storage.local.get(SETTINGS_KEY);
     const migration = migrateSettings(data[SETTINGS_KEY]);
+    // migration.diagnostics is deliberately unused: browser storage upgrades
+    // itself, so there is nothing for a user to act on. The CLI surfaces its
+    // diagnostics as startup warnings because its config file is never rewritten.
     const settings = mergeSettings(migration.settings as Partial<ExtensionSettings>);
     if (migration.changed) {
       try {
+        // Persists the normalized settings, not the migrated raw payload, so a
+        // property mergeSettings does not recognize is dropped here. That is
+        // not new: saveSettings has always written the normalized object
+        // wholesale, so an unrecognized property would not have survived the
+        // user's next settings change either.
         await browser.storage.local.set({ [SETTINGS_KEY]: withSchemaVersion(settings) });
       } catch {
         // Startup continues on the canonical in-memory settings. The stored

--- a/packages/extension/src/core/storage.ts
+++ b/packages/extension/src/core/storage.ts
@@ -4,6 +4,7 @@ import type { LegacyEventLogEntry, StoredLegacyEvent } from "@lurkloot/shared/ev
 import type { TwitchIntegrity } from "@lurkloot/core/twitchIntegrity";
 import { DEFAULT_STATE, mergeSchedulerState } from "@lurkloot/core/defaults";
 import { DEFAULT_SETTINGS, mergeSettings } from "@lurkloot/shared/settings";
+import { migrateSettings, withSchemaVersion } from "@lurkloot/shared/settingsSchema";
 import { clearActivityEvents, importLegacyActivityEvents } from "./activityStorage";
 
 export { DEFAULT_STATE };
@@ -29,40 +30,31 @@ function withStateStorageLock<T>(operation: () => Promise<T>): Promise<T> {
   return run;
 }
 
+// Reads, migrates, normalizes and — only when the stored document was not
+// already at the current schema version — persists the canonical envelope, all
+// under the settings lock so a migration write can never overwrite a newer
+// concurrent save. A future schema version throws without writing rather than
+// replacing data this build does not understand.
 export async function loadSettings(): Promise<ExtensionSettings> {
   return withSettingsStorageLock(async () => {
     const data = await browser.storage.local.get(SETTINGS_KEY);
-    const stored = data[SETTINGS_KEY] as Partial<ExtensionSettings> | undefined;
-    const settings = mergeSettings(stored);
-    if (hasLegacyWatchQueueSettings(stored)) {
+    const migration = migrateSettings(data[SETTINGS_KEY]);
+    const settings = mergeSettings(migration.settings as Partial<ExtensionSettings>);
+    if (migration.changed) {
       try {
-        await browser.storage.local.set({ [SETTINGS_KEY]: settings });
+        await browser.storage.local.set({ [SETTINGS_KEY]: withSchemaVersion(settings) });
       } catch {
-        // Loading remains available if the one-time migration write fails. The
-        // legacy aliases stay readable, so a later load can safely retry it.
+        // Startup continues on the canonical in-memory settings. The stored
+        // document is untouched, so the next load retries the same migration.
       }
     }
     return settings;
   });
 }
 
-function hasLegacyWatchQueueSettings(value: unknown): boolean {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const settings = value as Record<string, unknown>;
-  if (Object.prototype.hasOwnProperty.call(settings, "watchQueueFallbackOnly")) return true;
-  if (!settings.platform || typeof settings.platform !== "object" || Array.isArray(settings.platform)) return false;
-  return Object.values(settings.platform as Record<string, unknown>).some((platform) =>
-    Boolean(
-      platform
-      && typeof platform === "object"
-      && !Array.isArray(platform)
-      && Object.prototype.hasOwnProperty.call(platform, "watchQueueChannels"),
-    ));
-}
-
 export async function saveSettings(settings: ExtensionSettings): Promise<void> {
   await withSettingsStorageLock(async () => {
-    await browser.storage.local.set({ [SETTINGS_KEY]: settings });
+    await browser.storage.local.set({ [SETTINGS_KEY]: withSchemaVersion(settings) });
   });
 }
 
@@ -115,11 +107,11 @@ export async function saveTwitchIntegrity(value: TwitchIntegrity): Promise<void>
 }
 
 export async function resetStorage(): Promise<void> {
+  await withSettingsStorageLock(async () => {
+    await browser.storage.local.set({ [SETTINGS_KEY]: withSchemaVersion(DEFAULT_SETTINGS) });
+  });
   await withStateStorageLock(async () => {
-    await browser.storage.local.set({
-      [SETTINGS_KEY]: DEFAULT_SETTINGS,
-      [STATE_KEY]: DEFAULT_STATE,
-    });
+    await browser.storage.local.set({ [STATE_KEY]: DEFAULT_STATE });
   });
   try {
     await clearActivityEvents();

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -34,34 +34,18 @@ describe("engine settings", () => {
 });
 
 describe("settings", () => {
-  it("migrates legacy Watch Queue settings to Idle Watchlist settings", () => {
-    const settings = mergeSettings({
+  it("ignores legacy property names, which the migration registry handles first", () => {
+    const merged = mergeSettings({
       watchQueueFallbackOnly: false,
-      platform: {
-        twitch: { watchQueueChannels: [" LegacyOne ", "legacyone", "Second"] },
-        kick: { watchQueueChannels: ["KickLegacy"] },
-      },
+      verboseLogging: true,
+      autoClaimChannelPoints: false,
+      platform: { ...DEFAULT_SETTINGS.platform, twitch: { ...DEFAULT_SETTINGS.platform.twitch, watchQueueChannels: ["legacy"] } },
     } as never);
-
-    expect(settings.idleWatchlistFallbackOnly).toBe(false);
-    expect(settings.platform.twitch.idleWatchlistChannels).toEqual(["legacyone", "second"]);
-    expect(settings.platform.kick.idleWatchlistChannels).toEqual(["kicklegacy"]);
-    expect(settings).not.toHaveProperty("watchQueueFallbackOnly");
-  });
-
-  it("prefers new Idle Watchlist settings over legacy aliases", () => {
-    const settings = mergeSettings({
-      idleWatchlistFallbackOnly: false,
-      watchQueueFallbackOnly: true,
-      platform: {
-        twitch: { idleWatchlistChannels: [], watchQueueChannels: ["legacy"] },
-        kick: { idleWatchlistChannels: ["new"], watchQueueChannels: ["legacy"] },
-      },
-    } as never);
-
-    expect(settings.idleWatchlistFallbackOnly).toBe(false);
-    expect(settings.platform.twitch.idleWatchlistChannels).toEqual([]);
-    expect(settings.platform.kick.idleWatchlistChannels).toEqual(["new"]);
+    expect(merged.idleWatchlistFallbackOnly).toBe(DEFAULT_SETTINGS.idleWatchlistFallbackOnly);
+    expect(merged.diagnosticLogging).toBe(false);
+    expect(merged.platform.twitch.autoClaimChannelPoints).toBe(true);
+    expect(merged.platform.twitch.idleWatchlistChannels).toEqual([]);
+    expect(merged).not.toHaveProperty("watchQueueFallbackOnly");
   });
 
   it("defaults compatibility selections to automatic detection", () => {
@@ -183,11 +167,6 @@ describe("settings", () => {
     expect("enabledLogLevels" in mergeSettings({ enabledLogLevels: ["debug"] } as never)).toBe(false);
   });
 
-  it("migrates the legacy verboseLogging flag", () => {
-    expect(mergeSettings({ verboseLogging: true } as never).diagnosticLogging).toBe(true);
-    expect(mergeSettings({ verboseLogging: false } as never).diagnosticLogging).toBe(false);
-  });
-
   it("normalizes imported list, priority, mode, and boolean settings", () => {
     const settings = mergeSettings({
       running: "yes",
@@ -297,32 +276,6 @@ describe("settings", () => {
 describe("per-platform claim settings", () => {
   it("defaults autoClaimChannelPoints on for Twitch", () => {
     expect(mergeSettings(undefined).platform.twitch.autoClaimChannelPoints).toBe(true);
-  });
-
-  it("migrates a legacy top-level autoClaimChannelPoints onto platform.twitch", () => {
-    const merged = mergeSettings({ autoClaimChannelPoints: false } as never);
-    expect(merged.platform.twitch.autoClaimChannelPoints).toBe(false);
-  });
-
-  it("prefers an explicit platform.twitch value over the legacy top-level one", () => {
-    const merged = mergeSettings({
-      autoClaimChannelPoints: false,
-      platform: { ...DEFAULT_SETTINGS.platform, twitch: { ...DEFAULT_SETTINGS.platform.twitch, autoClaimChannelPoints: true } },
-    } as never);
-    expect(merged.platform.twitch.autoClaimChannelPoints).toBe(true);
-  });
-
-  it("drops the legacy top-level key from the merged result", () => {
-    // Passing the legacy key is the whole point: merging must consume it into
-    // platform.twitch rather than carrying it through to the merged object.
-    const merged = mergeSettings({ autoClaimChannelPoints: false } as never);
-    expect("autoClaimChannelPoints" in merged).toBe(false);
-    expect(merged.platform.twitch.autoClaimChannelPoints).toBe(false);
-  });
-
-  it("falls back to the default when the legacy top-level value is not a boolean", () => {
-    const merged = mergeSettings({ autoClaimChannelPoints: "yes" } as never);
-    expect(merged.platform.twitch.autoClaimChannelPoints).toBe(true);
   });
 
   it("defaults autoClaimChallenges on for Kick", () => {

--- a/packages/extension/tests/settingsMigrations.test.ts
+++ b/packages/extension/tests/settingsMigrations.test.ts
@@ -99,3 +99,98 @@ describe("settings schema versions", () => {
     }
   });
 });
+
+describe("migration 1: legacy aliases", () => {
+  it("renames the Watch Queue properties", () => {
+    const result = migrateSettings({
+      watchQueueFallbackOnly: false,
+      platform: {
+        twitch: { watchQueueChannels: ["Legacy"] },
+        kick: { watchQueueChannels: ["KickLegacy"] },
+      },
+    });
+    expect(result.settings).toEqual({
+      idleWatchlistFallbackOnly: false,
+      platform: {
+        twitch: { idleWatchlistChannels: ["Legacy"] },
+        kick: { idleWatchlistChannels: ["KickLegacy"] },
+      },
+    });
+    expect(result.settings).not.toHaveProperty("watchQueueFallbackOnly");
+  });
+
+  it("moves a top-level autoClaimChannelPoints onto platform.twitch", () => {
+    const result = migrateSettings({ autoClaimChannelPoints: false });
+    expect(result.settings).toEqual({ platform: { twitch: { autoClaimChannelPoints: false } } });
+    expect(result.diagnostics).toContainEqual({
+      code: "moved_property",
+      path: "autoClaimChannelPoints",
+      replacement: "platform.twitch.autoClaimChannelPoints",
+      message: "autoClaimChannelPoints moved to platform.twitch.autoClaimChannelPoints",
+    });
+  });
+
+  it("renames verboseLogging to diagnosticLogging", () => {
+    expect(migrateSettings({ verboseLogging: true }).settings).toEqual({ diagnosticLogging: true });
+    expect(migrateSettings({ verboseLogging: false }).settings).toEqual({ diagnosticLogging: false });
+  });
+
+  it("keeps a non-boolean legacy value verbatim so normalization decides", () => {
+    // mergeSettings applies booleanOr afterwards; the migration only reshapes.
+    expect(migrateSettings({ autoClaimChannelPoints: "yes" }).settings)
+      .toEqual({ platform: { twitch: { autoClaimChannelPoints: "yes" } } });
+  });
+
+  it("lets the current property win while still reporting the deprecated one", () => {
+    const result = migrateSettings({
+      idleWatchlistFallbackOnly: true,
+      watchQueueFallbackOnly: false,
+      diagnosticLogging: false,
+      verboseLogging: true,
+      autoClaimChannelPoints: false,
+      platform: {
+        twitch: { idleWatchlistChannels: [], watchQueueChannels: ["legacy"], autoClaimChannelPoints: true },
+        kick: { idleWatchlistChannels: ["new"], watchQueueChannels: ["legacy"] },
+      },
+    });
+    expect(result.settings).toEqual({
+      idleWatchlistFallbackOnly: true,
+      diagnosticLogging: false,
+      platform: {
+        twitch: { idleWatchlistChannels: [], autoClaimChannelPoints: true },
+        kick: { idleWatchlistChannels: ["new"] },
+      },
+    });
+    expect(result.diagnostics.map((d) => d.path)).toEqual([
+      "watchQueueFallbackOnly",
+      "verboseLogging",
+      "autoClaimChannelPoints",
+      "platform.twitch.watchQueueChannels",
+      "platform.kick.watchQueueChannels",
+    ]);
+  });
+
+  it("emits a stable, deduplicated diagnostic per deprecated property", () => {
+    const result = migrateSettings({ watchQueueFallbackOnly: false });
+    expect(result.diagnostics).toEqual([{
+      code: "deprecated_property",
+      path: "watchQueueFallbackOnly",
+      replacement: "idleWatchlistFallbackOnly",
+      message: "watchQueueFallbackOnly is deprecated; use idleWatchlistFallbackOnly",
+    }]);
+  });
+
+  it("reports nothing for a payload that only uses current names", () => {
+    const result = migrateSettings({
+      idleWatchlistFallbackOnly: true,
+      platform: { twitch: { idleWatchlistChannels: ["a"] } },
+    });
+    expect(result.diagnostics).toEqual([]);
+    expect(result.changed).toBe(true); // unversioned input still gets stamped
+  });
+
+  it("leaves unrelated and malformed platform blocks alone", () => {
+    expect(migrateSettings({ platform: "nope", other: 1 }).settings).toEqual({ platform: "nope", other: 1 });
+    expect(migrateSettings({ platform: { twitch: null } }).settings).toEqual({ platform: { twitch: null } });
+  });
+});

--- a/packages/extension/tests/settingsMigrations.test.ts
+++ b/packages/extension/tests/settingsMigrations.test.ts
@@ -135,19 +135,19 @@ describe("migration 1: legacy aliases", () => {
     expect(migrateSettings({ verboseLogging: false }).settings).toEqual({ diagnosticLogging: false });
   });
 
-  it("keeps a legacy autoClaimChannelPoints when platform is not an object", () => {
-    // The old mergeEngineSettings read this independently of platform's shape.
-    // Dropping it here would silently re-enable channel-point claiming.
+  it("drops an unhomeable legacy autoClaimChannelPoints when platform is not an object", () => {
+    // The value cannot be rehomed into a corrupt platform block, and leaving it
+    // at the top level would be dead data. Normalization defaults the whole
+    // corrupt block anyway, so this is consistent, not a meaningful loss. The
+    // malformed platform is left verbatim for each host to surface.
     const result = migrateSettings({ autoClaimChannelPoints: false, platform: "nope" });
-    expect(result.settings.autoClaimChannelPoints).toBe(false);
-    expect(result.settings.platform).toBe("nope");
+    expect(result.settings).toEqual({ platform: "nope" });
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("keeps a legacy autoClaimChannelPoints when platform.twitch is not an object", () => {
+  it("drops an unhomeable legacy autoClaimChannelPoints when platform.twitch is not an object", () => {
     const result = migrateSettings({ autoClaimChannelPoints: false, platform: { twitch: null } });
-    expect(result.settings.autoClaimChannelPoints).toBe(false);
-    expect(result.settings.platform).toEqual({ twitch: null });
+    expect(result.settings).toEqual({ platform: { twitch: null } });
     expect(result.diagnostics).toEqual([]);
   });
 

--- a/packages/extension/tests/settingsMigrations.test.ts
+++ b/packages/extension/tests/settingsMigrations.test.ts
@@ -135,15 +135,36 @@ describe("migration 1: legacy aliases", () => {
     expect(migrateSettings({ verboseLogging: false }).settings).toEqual({ diagnosticLogging: false });
   });
 
-  it("keeps a legacy autoClaimChannelPoints when the platform block is malformed", () => {
+  it("keeps a legacy autoClaimChannelPoints when platform is not an object", () => {
     // The old mergeEngineSettings read this independently of platform's shape.
     // Dropping it here would silently re-enable channel-point claiming.
-    for (const platform of ["nope", { twitch: null }]) {
-      const result = migrateSettings({ autoClaimChannelPoints: false, platform });
-      expect(result.settings.autoClaimChannelPoints).toBe(false);
-      expect(result.settings.platform).toEqual(platform);
-      expect(result.diagnostics).toEqual([]);
-    }
+    const result = migrateSettings({ autoClaimChannelPoints: false, platform: "nope" });
+    expect(result.settings.autoClaimChannelPoints).toBe(false);
+    expect(result.settings.platform).toBe("nope");
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps a legacy autoClaimChannelPoints when platform.twitch is not an object", () => {
+    const result = migrateSettings({ autoClaimChannelPoints: false, platform: { twitch: null } });
+    expect(result.settings.autoClaimChannelPoints).toBe(false);
+    expect(result.settings.platform).toEqual({ twitch: null });
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("lets a wrong-typed current value win over a legacy one", () => {
+    // Deliberate: migrations never inspect types, so normalization sees the
+    // wrong-typed current value and applies its default. The pre-registry
+    // inline fallbacks instead fell through to the legacy value here.
+    const logging = migrateSettings({ diagnosticLogging: "yes", verboseLogging: true });
+    expect(logging.settings).toEqual({ diagnosticLogging: "yes" });
+    expect(logging.diagnostics.map((d) => d.path)).toEqual(["verboseLogging"]);
+
+    const points = migrateSettings({
+      autoClaimChannelPoints: false,
+      platform: { twitch: { autoClaimChannelPoints: "yes" } },
+    });
+    expect(points.settings).toEqual({ platform: { twitch: { autoClaimChannelPoints: "yes" } } });
+    expect(points.diagnostics.map((d) => d.path)).toEqual(["autoClaimChannelPoints"]);
   });
 
   it("keeps a non-boolean legacy value verbatim so normalization decides", () => {

--- a/packages/extension/tests/settingsMigrations.test.ts
+++ b/packages/extension/tests/settingsMigrations.test.ts
@@ -135,6 +135,17 @@ describe("migration 1: legacy aliases", () => {
     expect(migrateSettings({ verboseLogging: false }).settings).toEqual({ diagnosticLogging: false });
   });
 
+  it("keeps a legacy autoClaimChannelPoints when the platform block is malformed", () => {
+    // The old mergeEngineSettings read this independently of platform's shape.
+    // Dropping it here would silently re-enable channel-point claiming.
+    for (const platform of ["nope", { twitch: null }]) {
+      const result = migrateSettings({ autoClaimChannelPoints: false, platform });
+      expect(result.settings.autoClaimChannelPoints).toBe(false);
+      expect(result.settings.platform).toEqual(platform);
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+
   it("keeps a non-boolean legacy value verbatim so normalization decides", () => {
     // mergeSettings applies booleanOr afterwards; the migration only reshapes.
     expect(migrateSettings({ autoClaimChannelPoints: "yes" }).settings)

--- a/packages/extension/tests/settingsMigrations.test.ts
+++ b/packages/extension/tests/settingsMigrations.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  CURRENT_SETTINGS_SCHEMA_VERSION,
+  SETTINGS_SCHEMA_VERSION_KEY,
+  UnsupportedSettingsVersionError,
+  migrateSettings,
+  withSchemaVersion,
+} from "@lurkloot/shared/settingsSchema";
+
+describe("settings schema versions", () => {
+  it("treats an unversioned object as version 0", () => {
+    const result = migrateSettings({ autoClaim: false });
+    expect(result.fromVersion).toBe(0);
+    expect(result.toVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    expect(result.changed).toBe(true);
+  });
+
+  it("treats a missing or non-object payload as an empty version 0 document", () => {
+    for (const raw of [undefined, null, "nope", 42, ["a"]]) {
+      const result = migrateSettings(raw);
+      expect(result.settings).toEqual({});
+      expect(result.fromVersion).toBe(0);
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+
+  it("is a no-op for a current-version document", () => {
+    const stored = withSchemaVersion({ autoClaim: false });
+    const result = migrateSettings(stored);
+    expect(result.changed).toBe(false);
+    expect(result.fromVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.settings).toEqual({ autoClaim: false });
+  });
+
+  it("strips the reserved schemaVersion property from the migrated payload", () => {
+    const result = migrateSettings(withSchemaVersion({ autoClaim: true }));
+    expect(result.settings).not.toHaveProperty(SETTINGS_SCHEMA_VERSION_KEY);
+  });
+
+  it("never mutates its input", () => {
+    const stored = { watchQueueFallbackOnly: false, platform: { twitch: { watchQueueChannels: ["A"] } } };
+    const snapshot = structuredClone(stored);
+    migrateSettings(stored);
+    expect(stored).toEqual(snapshot);
+  });
+
+  it("is idempotent when re-run on its own output", () => {
+    const first = migrateSettings({ watchQueueFallbackOnly: false });
+    const second = migrateSettings(withSchemaVersion(first.settings));
+    expect(second.settings).toEqual(first.settings);
+    expect(second.changed).toBe(false);
+  });
+
+  it("rejects a future schema version", () => {
+    const future = CURRENT_SETTINGS_SCHEMA_VERSION + 1;
+    expect(() => migrateSettings({ [SETTINGS_SCHEMA_VERSION_KEY]: future }))
+      .toThrow(UnsupportedSettingsVersionError);
+    try {
+      migrateSettings({ [SETTINGS_SCHEMA_VERSION_KEY]: future });
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnsupportedSettingsVersionError);
+      expect((error as UnsupportedSettingsVersionError).version).toBe(future);
+      expect((error as UnsupportedSettingsVersionError).reason).toBe("future");
+    }
+  });
+
+  it("rejects a malformed schema version", () => {
+    for (const version of [-1, 1.5, Number.NaN, "1", null]) {
+      expect(() => migrateSettings({ [SETTINGS_SCHEMA_VERSION_KEY]: version }))
+        .toThrow(UnsupportedSettingsVersionError);
+    }
+  });
+
+  it("stamps the current version with withSchemaVersion", () => {
+    expect(withSchemaVersion({ autoClaim: true })).toEqual({
+      autoClaim: true,
+      [SETTINGS_SCHEMA_VERSION_KEY]: CURRENT_SETTINGS_SCHEMA_VERSION,
+    });
+  });
+
+  it("upgrades a version 0 document all the way to the current version", () => {
+    // Guards sequential application: whatever CURRENT_SETTINGS_SCHEMA_VERSION
+    // becomes, entering at 0 must land on it. The contiguity of the registry
+    // itself is asserted at module load, so a missing step throws on import
+    // rather than letting a host write a half-migrated document.
+    expect(migrateSettings({}).toVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    expect(migrateSettings({}).fromVersion).toBe(0);
+  });
+
+  it("enters at every intermediate version without skipping steps", () => {
+    // Re-migrating from each supported version must converge on the same
+    // document as migrating the whole way from 0.
+    const target = migrateSettings({ autoClaim: false }).settings;
+    for (let version = 0; version <= CURRENT_SETTINGS_SCHEMA_VERSION; version += 1) {
+      const result = migrateSettings({ ...target, [SETTINGS_SCHEMA_VERSION_KEY]: version });
+      expect(result.settings).toEqual(target);
+      expect(result.toVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    }
+  });
+});

--- a/packages/extension/tests/storageMigration.test.ts
+++ b/packages/extension/tests/storageMigration.test.ts
@@ -99,12 +99,9 @@ describe("legacy activity migration", () => {
     const loading = loadState();
     await vi.waitFor(() => expect(mocks.importLegacyActivityEvents).toHaveBeenCalledOnce());
     const resetting = resetStorage();
+    await Promise.resolve();
 
-    // The settings write takes its own, independent lock, so it is free to
-    // complete right away. Only the scheduler-state write is serialized behind
-    // the in-flight legacy migration below.
-    await vi.waitFor(() => expect(mocks.values.settings).toBeDefined());
-    expect(mocks.values.schedulerState).toEqual(expect.objectContaining({ events: legacyEvents }));
+    expect(mocks.set).not.toHaveBeenCalled();
 
     finishImport();
     await Promise.all([loading, resetting]);

--- a/packages/extension/tests/storageMigration.test.ts
+++ b/packages/extension/tests/storageMigration.test.ts
@@ -99,9 +99,12 @@ describe("legacy activity migration", () => {
     const loading = loadState();
     await vi.waitFor(() => expect(mocks.importLegacyActivityEvents).toHaveBeenCalledOnce());
     const resetting = resetStorage();
-    await Promise.resolve();
 
-    expect(mocks.set).not.toHaveBeenCalled();
+    // The settings write takes its own, independent lock, so it is free to
+    // complete right away. Only the scheduler-state write is serialized behind
+    // the in-flight legacy migration below.
+    await vi.waitFor(() => expect(mocks.values.settings).toBeDefined());
+    expect(mocks.values.schedulerState).toEqual(expect.objectContaining({ events: legacyEvents }));
 
     finishImport();
     await Promise.all([loading, resetting]);

--- a/packages/extension/tests/storageSettingsMigration.test.ts
+++ b/packages/extension/tests/storageSettingsMigration.test.ts
@@ -13,15 +13,23 @@ vi.mock("wxt/browser", () => ({
   },
 }));
 
-import { loadSettings, saveSettings } from "../src/core/storage";
+vi.mock("../src/core/activityStorage", () => ({
+  clearActivityEvents: vi.fn().mockResolvedValue(undefined),
+  importLegacyActivityEvents: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { loadSettings, resetStorage, saveSettings } from "../src/core/storage";
+import { CURRENT_SETTINGS_SCHEMA_VERSION, UnsupportedSettingsVersionError, withSchemaVersion } from "@lurkloot/shared/settingsSchema";
+import { DEFAULT_SETTINGS, mergeSettings } from "@lurkloot/shared/settings";
 
 describe("settings storage migration", () => {
   beforeEach(() => {
     get.mockReset();
     set.mockReset();
+    set.mockResolvedValue(undefined);
   });
 
-  it("writes legacy Watch Queue settings back using only Idle Watchlist keys", async () => {
+  it("writes a legacy document back once, using current keys and the current version", async () => {
     get.mockResolvedValue({
       settings: {
         watchQueueFallbackOnly: false,
@@ -36,40 +44,65 @@ describe("settings storage migration", () => {
 
     expect(settings.idleWatchlistFallbackOnly).toBe(false);
     expect(settings.platform.twitch.idleWatchlistChannels).toEqual(["legacy"]);
-    expect(set).toHaveBeenCalledWith({ settings });
-    expect(set.mock.calls[0]?.[0].settings).not.toHaveProperty("watchQueueFallbackOnly");
-    expect(set.mock.calls[0]?.[0].settings.platform.twitch).not.toHaveProperty("watchQueueChannels");
+    expect(set).toHaveBeenCalledTimes(1);
+    const written = set.mock.calls[0]?.[0].settings;
+    expect(written).toEqual(withSchemaVersion(settings));
+    expect(written.schemaVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+    expect(written).not.toHaveProperty("watchQueueFallbackOnly");
+    expect(written.platform.twitch).not.toHaveProperty("watchQueueChannels");
   });
 
-  it("does not rewrite settings that already use Idle Watchlist keys", async () => {
+  it("stamps an unversioned document that already uses current keys", async () => {
     get.mockResolvedValue({
-      settings: {
-        idleWatchlistFallbackOnly: true,
-        platform: {
-          twitch: { idleWatchlistChannels: ["current"] },
-          kick: { idleWatchlistChannels: [] },
-        },
-      },
+      settings: { idleWatchlistFallbackOnly: true, platform: { twitch: { idleWatchlistChannels: ["current"] } } },
     });
+
+    await loadSettings();
+
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set.mock.calls[0]?.[0].settings.schemaVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+  });
+
+  it("does not write when storage is already at the current version", async () => {
+    get.mockResolvedValue({ settings: withSchemaVersion(DEFAULT_SETTINGS) });
 
     await loadSettings();
 
     expect(set).not.toHaveBeenCalled();
   });
 
-  it("still loads migrated settings when the one-time write-back fails", async () => {
+  it("still returns usable settings when the write-back fails, and retries on the next load", async () => {
     get.mockResolvedValue({
-      settings: {
-        watchQueueFallbackOnly: false,
-        platform: { twitch: { watchQueueChannels: ["Legacy"] } },
-      },
+      settings: { watchQueueFallbackOnly: false, platform: { twitch: { watchQueueChannels: ["Legacy"] } } },
     });
-    set.mockRejectedValue(new Error("storage unavailable"));
+    set.mockRejectedValueOnce(new Error("storage unavailable"));
 
     await expect(loadSettings()).resolves.toMatchObject({
       idleWatchlistFallbackOnly: false,
       platform: { twitch: { idleWatchlistChannels: ["legacy"] } },
     });
+    expect(set).toHaveBeenCalledTimes(1);
+
+    set.mockResolvedValue(undefined);
+    await loadSettings();
+    expect(set).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a future schema version without writing", async () => {
+    get.mockResolvedValue({ settings: { schemaVersion: CURRENT_SETTINGS_SCHEMA_VERSION + 1, autoClaim: false } });
+
+    await expect(loadSettings()).rejects.toThrow(UnsupportedSettingsVersionError);
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("emits the current version on an ordinary save", async () => {
+    await saveSettings(DEFAULT_SETTINGS);
+    expect(set).toHaveBeenCalledWith({ settings: withSchemaVersion(DEFAULT_SETTINGS) });
+  });
+
+  it("emits the current version on reset", async () => {
+    await resetStorage();
+    expect(set.mock.calls[0]?.[0].settings).toEqual(withSchemaVersion(DEFAULT_SETTINGS));
   });
 
   it("serializes a migration write with a concurrent settings save", async () => {
@@ -78,18 +111,14 @@ describe("settings storage migration", () => {
       finishMigration = resolve;
     });
     get.mockResolvedValue({
-      settings: {
-        watchQueueFallbackOnly: false,
-        platform: { twitch: { watchQueueChannels: ["Legacy"] } },
-      },
+      settings: { watchQueueFallbackOnly: false, platform: { twitch: { watchQueueChannels: ["Legacy"] } } },
     });
     set.mockImplementationOnce(() => migrationPending).mockResolvedValue(undefined);
 
     const migration = loadSettings();
     await vi.waitFor(() => expect(set).toHaveBeenCalledTimes(1));
 
-    const current = await import("@lurkloot/shared/settings").then(({ mergeSettings }) =>
-      mergeSettings({ idleWatchlistFallbackOnly: true }));
+    const current = mergeSettings({ idleWatchlistFallbackOnly: true });
     const save = saveSettings(current);
 
     expect(set).toHaveBeenCalledTimes(1);
@@ -97,6 +126,6 @@ describe("settings storage migration", () => {
     await migration;
     await save;
     expect(set).toHaveBeenCalledTimes(2);
-    expect(set.mock.calls[1]?.[0]).toEqual({ settings: current });
+    expect(set.mock.calls[1]?.[0]).toEqual({ settings: withSchemaVersion(current) });
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
     "./categories": "./src/categories.ts",
     "./messages": "./src/messages.ts",
     "./settings": "./src/settings.ts",
+    "./settingsSchema": "./src/settingsSchema.ts",
     "./i18n": "./src/i18n.ts",
     "./logging": "./src/logging.ts",
     "./rewards": "./src/rewards.ts",

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -95,11 +95,11 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
   diagnosticLogging: false,
 };
 
+// Normalizes the universal engine contract. The engine (packages/core) and any
+// non-extension host (CLI) merge through this; host-only fields are not touched.
 // Legacy property names are not read here. Hosts run migrateSettings() from
 // @lurkloot/shared/settingsSchema on the raw payload first; by the time a value
 // reaches normalization it only carries current names.
-// Normalizes the universal engine contract. The engine (packages/core) and any
-// non-extension host (CLI) merge through this; host-only fields are not touched.
 export function mergeEngineSettings(value: Partial<EngineSettings> | undefined): EngineSettings {
   const platform = value?.platform;
   const compatibility = value?.compatibility;

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -95,14 +95,14 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
   diagnosticLogging: false,
 };
 
+// Legacy property names are not read here. Hosts run migrateSettings() from
+// @lurkloot/shared/settingsSchema on the raw payload first; by the time a value
+// reaches normalization it only carries current names.
 // Normalizes the universal engine contract. The engine (packages/core) and any
 // non-extension host (CLI) merge through this; host-only fields are not touched.
 export function mergeEngineSettings(value: Partial<EngineSettings> | undefined): EngineSettings {
   const platform = value?.platform;
   const compatibility = value?.compatibility;
-  // Pre-split configs stored this at the top level. Read it as the fallback for
-  // the Twitch platform block so an existing "off" survives; never written back.
-  const legacyChannelPoints = (value as (Partial<EngineSettings> & { autoClaimChannelPoints?: boolean }) | undefined)?.autoClaimChannelPoints;
   return {
     running: booleanOr(value?.running, DEFAULT_ENGINE_SETTINGS.running),
     autoClaim: booleanOr(value?.autoClaim, DEFAULT_ENGINE_SETTINGS.autoClaim),
@@ -111,32 +111,22 @@ export function mergeEngineSettings(value: Partial<EngineSettings> | undefined):
     notifyRewardEarned: booleanOr(value?.notifyRewardEarned, DEFAULT_ENGINE_SETTINGS.notifyRewardEarned),
     notifyNoDropsLeft: booleanOr(value?.notifyNoDropsLeft, DEFAULT_ENGINE_SETTINGS.notifyNoDropsLeft),
     autoStartDropFarming: booleanOr(value?.autoStartDropFarming, DEFAULT_ENGINE_SETTINGS.autoStartDropFarming),
-    idleWatchlistFallbackOnly: booleanOr(
-      currentOrLegacy<boolean>(value, "idleWatchlistFallbackOnly", "watchQueueFallbackOnly"),
-      DEFAULT_ENGINE_SETTINGS.idleWatchlistFallbackOnly,
-    ),
+    idleWatchlistFallbackOnly: booleanOr(value?.idleWatchlistFallbackOnly, DEFAULT_ENGINE_SETTINGS.idleWatchlistFallbackOnly),
     priorityMode: PRIORITY_MODES.includes(value?.priorityMode as PriorityMode)
       ? (value!.priorityMode as PriorityMode)
       : DEFAULT_ENGINE_SETTINGS.priorityMode,
     platform: {
       twitch: {
         enabled: booleanOr(platform?.twitch?.enabled, DEFAULT_ENGINE_SETTINGS.platform.twitch.enabled),
-        idleWatchlistChannels: normalizeChannelList(
-          currentOrLegacy<string[]>(platform?.twitch, "idleWatchlistChannels", "watchQueueChannels"),
-        ),
+        idleWatchlistChannels: normalizeChannelList(platform?.twitch?.idleWatchlistChannels),
         excludedChannels: normalizeChannelList(platform?.twitch?.excludedChannels),
         farmAllCategories: booleanOr(platform?.twitch?.farmAllCategories, DEFAULT_ENGINE_SETTINGS.platform.twitch.farmAllCategories),
         categories: normalizeCategorySelections(platform?.twitch?.categories),
-        autoClaimChannelPoints: booleanOr(
-          platform?.twitch?.autoClaimChannelPoints,
-          booleanOr(legacyChannelPoints, DEFAULT_ENGINE_SETTINGS.platform.twitch.autoClaimChannelPoints),
-        ),
+        autoClaimChannelPoints: booleanOr(platform?.twitch?.autoClaimChannelPoints, DEFAULT_ENGINE_SETTINGS.platform.twitch.autoClaimChannelPoints),
       },
       kick: {
         enabled: booleanOr(platform?.kick?.enabled, DEFAULT_ENGINE_SETTINGS.platform.kick.enabled),
-        idleWatchlistChannels: normalizeChannelList(
-          currentOrLegacy<string[]>(platform?.kick, "idleWatchlistChannels", "watchQueueChannels"),
-        ),
+        idleWatchlistChannels: normalizeChannelList(platform?.kick?.idleWatchlistChannels),
         excludedChannels: normalizeChannelList(platform?.kick?.excludedChannels),
         farmAllCategories: booleanOr(platform?.kick?.farmAllCategories, DEFAULT_ENGINE_SETTINGS.platform.kick.farmAllCategories),
         categories: normalizeCategorySelections(platform?.kick?.categories),
@@ -172,21 +162,9 @@ export function mergeEngineSettings(value: Partial<EngineSettings> | undefined):
   };
 }
 
-function currentOrLegacy<T>(owner: object | undefined, currentKey: string, legacyKey: string): T | undefined {
-  if (!owner) return undefined;
-  const values = owner as Record<string, unknown>;
-  return Object.prototype.hasOwnProperty.call(values, currentKey)
-    ? values[currentKey] as T | undefined
-    : values[legacyKey] as T | undefined;
-}
-
 // Normalizes the extension's full settings: the engine contract plus the
 // host-only fields the engine never reads.
 export function mergeSettings(value: Partial<ExtensionSettings> | undefined): ExtensionSettings {
-  const legacyVerbose = (value as (Partial<ExtensionSettings> & { verboseLogging?: boolean }) | undefined)?.verboseLogging;
-  const diagnosticLogging = typeof value?.diagnosticLogging === "boolean"
-    ? value.diagnosticLogging
-    : legacyVerbose === true;
   return {
     ...mergeEngineSettings(value),
     muteFarmingTabs: booleanOr(value?.muteFarmingTabs, DEFAULT_SETTINGS.muteFarmingTabs),
@@ -201,7 +179,7 @@ export function mergeSettings(value: Partial<ExtensionSettings> | undefined): Ex
       ? (value!.rateNudgeStatus as RateNudgeStatus)
       : DEFAULT_SETTINGS.rateNudgeStatus,
     showTips: booleanOr(value?.showTips, DEFAULT_SETTINGS.showTips),
-    diagnosticLogging,
+    diagnosticLogging: booleanOr(value?.diagnosticLogging, DEFAULT_SETTINGS.diagnosticLogging),
   };
 }
 

--- a/packages/shared/src/settingsSchema.ts
+++ b/packages/shared/src/settingsSchema.ts
@@ -77,13 +77,20 @@ function migrateToV1(raw: Record<string, unknown>, diagnose: Diagnose): Record<s
   renameProperty(raw, "verboseLogging", "diagnosticLogging", "", diagnose);
 
   if (Object.hasOwn(raw, "autoClaimChannelPoints")) {
-    // Only consume the legacy key once there is somewhere to put it. A
-    // malformed `platform` is left verbatim for validation to report, so
-    // deleting the value here would lose it and the diagnostic would lie.
+    // Move the pre-split top-level toggle under platform.twitch. A genuinely
+    // absent platform block is created here; a malformed one (a non-object, or
+    // platform.twitch not an object) cannot take the value, so it is dropped.
+    // That is consistent, not a loss worth preserving: normalization defaults
+    // the entire corrupt platform block regardless, so keeping this one field
+    // of it would be arbitrary, and a leftover top-level key is dead data the
+    // extension no longer reads and the CLI would reject as unknown. The
+    // malformed platform itself is surfaced by each host — the extension
+    // defaults it, the CLI reports it. Only a manually corrupted document can
+    // reach this; every real prior version wrote platform as an object.
+    const legacy = raw.autoClaimChannelPoints;
+    delete raw.autoClaimChannelPoints;
     const twitch = ensurePlatformBlock(raw, "twitch");
     if (twitch) {
-      const legacy = raw.autoClaimChannelPoints;
-      delete raw.autoClaimChannelPoints;
       diagnose({
         code: "moved_property",
         path: "autoClaimChannelPoints",

--- a/packages/shared/src/settingsSchema.ts
+++ b/packages/shared/src/settingsSchema.ts
@@ -1,0 +1,122 @@
+// The single authority for versioned settings-shape migrations. Both hosts run
+// `migrateSettings` on their raw persisted payload *before* normalization: the
+// raw property information is what makes accurate deprecation diagnostics
+// possible, and defaulting or clamping would erase it.
+//
+// See docs/architecture.md ("Settings Migrations") before adding one.
+
+// Incremented for every semantic settings-shape migration.
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 1;
+
+// Reserved metadata stored alongside the settings properties. It is stripped
+// before any runtime EngineSettings/ExtensionSettings/CliSettings value is
+// produced, so it never appears in those types.
+export const SETTINGS_SCHEMA_VERSION_KEY = "schemaVersion";
+
+export type SettingsMigrationDiagnosticCode = "deprecated_property" | "moved_property";
+
+export interface SettingsMigrationDiagnostic {
+  // Stable across releases; hosts may route on it.
+  code: SettingsMigrationDiagnosticCode;
+  // Dotted path relative to the settings object, e.g. "platform.twitch.watchQueueChannels".
+  path: string;
+  // Dotted replacement path, when the property has one.
+  replacement?: string;
+  // Host-neutral text. Hosts add their own prefix (the CLI prepends "settings.").
+  message: string;
+}
+
+export interface SettingsMigrationResult {
+  // The migrated raw payload, without the reserved version property.
+  settings: Record<string, unknown>;
+  fromVersion: number;
+  toVersion: number;
+  // True when the stored document was not already at the current version, i.e.
+  // when a host should persist the canonical result.
+  changed: boolean;
+  diagnostics: SettingsMigrationDiagnostic[];
+}
+
+export class UnsupportedSettingsVersionError extends Error {
+  readonly version: unknown;
+  readonly supported: number;
+  readonly reason: "future" | "invalid";
+
+  constructor(version: unknown, reason: "future" | "invalid") {
+    super(reason === "future"
+      ? `Settings schema version ${String(version)} is newer than this build supports (${CURRENT_SETTINGS_SCHEMA_VERSION})`
+      : `Settings schema version ${String(version)} is not a non-negative integer`);
+    this.name = "UnsupportedSettingsVersionError";
+    this.version = version;
+    this.supported = CURRENT_SETTINGS_SCHEMA_VERSION;
+    this.reason = reason;
+  }
+}
+
+type Diagnose = (diagnostic: SettingsMigrationDiagnostic) => void;
+
+interface SettingsMigration {
+  // The version this migration produces. MIGRATIONS[i].to === i + 1.
+  to: number;
+  // Receives a deep clone it owns outright, so it may mutate freely.
+  migrate: (raw: Record<string, unknown>, diagnose: Diagnose) => Record<string, unknown>;
+}
+
+// Ordered registry. Entry i upgrades version i to version i + 1. Never edit a
+// released migration except to fix data loss; add a new version instead.
+const MIGRATIONS: SettingsMigration[] = [
+  { to: 1, migrate: (raw) => raw },
+];
+
+if (MIGRATIONS.length !== CURRENT_SETTINGS_SCHEMA_VERSION
+  || MIGRATIONS.some((migration, index) => migration.to !== index + 1)) {
+  throw new Error("Settings migration registry is not a contiguous 1..CURRENT_SETTINGS_SCHEMA_VERSION sequence");
+}
+
+export function withSchemaVersion<T extends object>(settings: T): T & { schemaVersion: number } {
+  return { ...settings, [SETTINGS_SCHEMA_VERSION_KEY]: CURRENT_SETTINGS_SCHEMA_VERSION } as T & { schemaVersion: number };
+}
+
+export function migrateSettings(raw: unknown): SettingsMigrationResult {
+  const source = isPlainObject(raw) ? raw : {};
+  const fromVersion = readVersion(source);
+  const { [SETTINGS_SCHEMA_VERSION_KEY]: _version, ...rest } = source;
+
+  const diagnostics: SettingsMigrationDiagnostic[] = [];
+  const seen = new Set<string>();
+  const diagnose: Diagnose = (diagnostic) => {
+    const key = `${diagnostic.code}:${diagnostic.path}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    diagnostics.push(diagnostic);
+  };
+
+  let settings = structuredClone(rest) as Record<string, unknown>;
+  for (const migration of MIGRATIONS.slice(fromVersion)) {
+    settings = migration.migrate(settings, diagnose);
+  }
+
+  return {
+    settings,
+    fromVersion,
+    toVersion: CURRENT_SETTINGS_SCHEMA_VERSION,
+    changed: fromVersion !== CURRENT_SETTINGS_SCHEMA_VERSION,
+    diagnostics,
+  };
+}
+
+function readVersion(source: Record<string, unknown>): number {
+  if (!Object.hasOwn(source, SETTINGS_SCHEMA_VERSION_KEY)) return 0;
+  const version = source[SETTINGS_SCHEMA_VERSION_KEY];
+  if (typeof version !== "number" || !Number.isInteger(version) || version < 0) {
+    throw new UnsupportedSettingsVersionError(version, "invalid");
+  }
+  if (version > CURRENT_SETTINGS_SCHEMA_VERSION) {
+    throw new UnsupportedSettingsVersionError(version, "future");
+  }
+  return version;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/shared/src/settingsSchema.ts
+++ b/packages/shared/src/settingsSchema.ts
@@ -62,11 +62,82 @@ interface SettingsMigration {
   migrate: (raw: Record<string, unknown>, diagnose: Diagnose) => Record<string, unknown>;
 }
 
+// Migration 1 consolidates every legacy shape that predates the registry: the
+// Idle Watchlist rename (PR #177), the pre-split top-level channel-points
+// toggle, and the verboseLogging rename. Diagnostics are emitted in a fixed
+// order so host warnings are stable across runs.
 // Ordered registry. Entry i upgrades version i to version i + 1. Never edit a
 // released migration except to fix data loss; add a new version instead.
 const MIGRATIONS: SettingsMigration[] = [
-  { to: 1, migrate: (raw) => raw },
+  { to: 1, migrate: migrateToV1 },
 ];
+
+function migrateToV1(raw: Record<string, unknown>, diagnose: Diagnose): Record<string, unknown> {
+  renameProperty(raw, "watchQueueFallbackOnly", "idleWatchlistFallbackOnly", "", diagnose);
+  renameProperty(raw, "verboseLogging", "diagnosticLogging", "", diagnose);
+
+  if (Object.hasOwn(raw, "autoClaimChannelPoints")) {
+    const legacy = raw.autoClaimChannelPoints;
+    delete raw.autoClaimChannelPoints;
+    diagnose({
+      code: "moved_property",
+      path: "autoClaimChannelPoints",
+      replacement: "platform.twitch.autoClaimChannelPoints",
+      message: "autoClaimChannelPoints moved to platform.twitch.autoClaimChannelPoints",
+    });
+    const twitch = ensurePlatformBlock(raw, "twitch");
+    if (twitch && !Object.hasOwn(twitch, "autoClaimChannelPoints")) {
+      twitch.autoClaimChannelPoints = legacy;
+    }
+  }
+
+  for (const platform of ["twitch", "kick"] as const) {
+    const block = platformBlock(raw, platform);
+    if (!block) continue;
+    renameProperty(block, "watchQueueChannels", "idleWatchlistChannels", `platform.${platform}.`, diagnose);
+  }
+
+  return raw;
+}
+
+// Drops the legacy key and reports it. The current key wins when both exist,
+// including when its value is `false` or an empty array.
+function renameProperty(
+  owner: Record<string, unknown>,
+  legacyKey: string,
+  currentKey: string,
+  pathPrefix: string,
+  diagnose: Diagnose,
+): void {
+  if (!Object.hasOwn(owner, legacyKey)) return;
+  const legacy = owner[legacyKey];
+  delete owner[legacyKey];
+  diagnose({
+    code: "deprecated_property",
+    path: `${pathPrefix}${legacyKey}`,
+    replacement: `${pathPrefix}${currentKey}`,
+    message: `${pathPrefix}${legacyKey} is deprecated; use ${pathPrefix}${currentKey}`,
+  });
+  if (!Object.hasOwn(owner, currentKey)) owner[currentKey] = legacy;
+}
+
+function platformBlock(raw: Record<string, unknown>, platform: string): Record<string, unknown> | undefined {
+  const platforms = raw.platform;
+  if (!isPlainObject(platforms)) return undefined;
+  const block = platforms[platform];
+  return isPlainObject(block) ? block : undefined;
+}
+
+// Creates `platform.<name>` only when it is safe to do so; a malformed block is
+// left untouched so validation can report it verbatim.
+function ensurePlatformBlock(raw: Record<string, unknown>, platform: string): Record<string, unknown> | undefined {
+  if (!Object.hasOwn(raw, "platform")) raw.platform = {};
+  const platforms = raw.platform;
+  if (!isPlainObject(platforms)) return undefined;
+  if (!Object.hasOwn(platforms, platform)) platforms[platform] = {};
+  const block = platforms[platform];
+  return isPlainObject(block) ? block : undefined;
+}
 
 if (MIGRATIONS.length !== CURRENT_SETTINGS_SCHEMA_VERSION
   || MIGRATIONS.some((migration, index) => migration.to !== index + 1)) {

--- a/packages/shared/src/settingsSchema.ts
+++ b/packages/shared/src/settingsSchema.ts
@@ -62,16 +62,16 @@ interface SettingsMigration {
   migrate: (raw: Record<string, unknown>, diagnose: Diagnose) => Record<string, unknown>;
 }
 
-// Migration 1 consolidates every legacy shape that predates the registry: the
-// Idle Watchlist rename (PR #177), the pre-split top-level channel-points
-// toggle, and the verboseLogging rename. Diagnostics are emitted in a fixed
-// order so host warnings are stable across runs.
 // Ordered registry. Entry i upgrades version i to version i + 1. Never edit a
 // released migration except to fix data loss; add a new version instead.
 const MIGRATIONS: SettingsMigration[] = [
   { to: 1, migrate: migrateToV1 },
 ];
 
+// Migration 1 consolidates every legacy shape that predates the registry: the
+// Idle Watchlist rename (PR #177), the pre-split top-level channel-points
+// toggle, and the verboseLogging rename. Diagnostics are emitted in a fixed
+// order so host warnings are stable across runs.
 function migrateToV1(raw: Record<string, unknown>, diagnose: Diagnose): Record<string, unknown> {
   renameProperty(raw, "watchQueueFallbackOnly", "idleWatchlistFallbackOnly", "", diagnose);
   renameProperty(raw, "verboseLogging", "diagnosticLogging", "", diagnose);
@@ -103,8 +103,13 @@ function migrateToV1(raw: Record<string, unknown>, diagnose: Diagnose): Record<s
   return raw;
 }
 
-// Drops the legacy key and reports it. The current key wins when both exist,
-// including when its value is `false` or an empty array.
+// Drops the legacy key and reports it. The current key wins whenever it is
+// present, whatever its value — including `false`, `[]`, or a wrong-typed
+// value. Migrations reshape; they never inspect types. Normalization decides
+// what a value means afterwards, so a wrong-typed current value falls to its
+// default rather than resurrecting the deprecated one. That is a deliberate
+// narrow change from the pre-registry inline fallbacks, which fell back to the
+// legacy value when the current one failed a typeof check.
 function renameProperty(
   owner: Record<string, unknown>,
   legacyKey: string,

--- a/packages/shared/src/settingsSchema.ts
+++ b/packages/shared/src/settingsSchema.ts
@@ -77,17 +77,20 @@ function migrateToV1(raw: Record<string, unknown>, diagnose: Diagnose): Record<s
   renameProperty(raw, "verboseLogging", "diagnosticLogging", "", diagnose);
 
   if (Object.hasOwn(raw, "autoClaimChannelPoints")) {
-    const legacy = raw.autoClaimChannelPoints;
-    delete raw.autoClaimChannelPoints;
-    diagnose({
-      code: "moved_property",
-      path: "autoClaimChannelPoints",
-      replacement: "platform.twitch.autoClaimChannelPoints",
-      message: "autoClaimChannelPoints moved to platform.twitch.autoClaimChannelPoints",
-    });
+    // Only consume the legacy key once there is somewhere to put it. A
+    // malformed `platform` is left verbatim for validation to report, so
+    // deleting the value here would lose it and the diagnostic would lie.
     const twitch = ensurePlatformBlock(raw, "twitch");
-    if (twitch && !Object.hasOwn(twitch, "autoClaimChannelPoints")) {
-      twitch.autoClaimChannelPoints = legacy;
+    if (twitch) {
+      const legacy = raw.autoClaimChannelPoints;
+      delete raw.autoClaimChannelPoints;
+      diagnose({
+        code: "moved_property",
+        path: "autoClaimChannelPoints",
+        replacement: "platform.twitch.autoClaimChannelPoints",
+        message: "autoClaimChannelPoints moved to platform.twitch.autoClaimChannelPoints",
+      });
+      if (!Object.hasOwn(twitch, "autoClaimChannelPoints")) twitch.autoClaimChannelPoints = legacy;
     }
   }
 


### PR DESCRIPTION
## Summary

Replaces the scattered inline legacy-settings fallbacks across the extension and CLI with one ordered, versioned migration registry in `@lurkloot/shared`. Both hosts run `migrateSettings(raw)` on the raw persisted payload before their own normalization, so legacy-shape handling lives in exactly one place.

Closes #179.

### How it works

- `packages/shared/src/settingsSchema.ts` owns `CURRENT_SETTINGS_SCHEMA_VERSION`, an ordered migration registry, and `migrateSettings(raw)`. Migration and normalization are separate phases — migrations reshape raw payloads and emit structured diagnostics; they never default, clamp, or validate.
- A stored document carries a reserved `schemaVersion` (unversioned == version 0). `migrateSettings` applies every migration up to the current version and reports `{ settings, fromVersion, toVersion, changed, diagnostics }`. A future version throws `UnsupportedSettingsVersionError` and neither host writes after that error.
- **Migration 1** consolidates every prior inline fallback: `watchQueueFallbackOnly` → `idleWatchlistFallbackOnly`, `platform.<p>.watchQueueChannels` → `idleWatchlistChannels`, `verboseLogging` → `diagnosticLogging`, and top-level `autoClaimChannelPoints` → `platform.twitch.autoClaimChannelPoints`.

### Migration example

Input (legacy stored document):

```json
{ "watchQueueFallbackOnly": false,
  "autoClaimChannelPoints": false,
  "platform": { "twitch": { "watchQueueChannels": ["A"] } } }
```

becomes, after migration:

```json
{ "idleWatchlistFallbackOnly": false,
  "platform": { "twitch": { "idleWatchlistChannels": ["A"], "autoClaimChannelPoints": false } } }
```

with diagnostics for `watchQueueFallbackOnly`, `autoClaimChannelPoints`, and `platform.twitch.watchQueueChannels`.

### Host behavior

- **Extension:** `loadSettings` migrates → normalizes → writes the canonical envelope back **once** when `changed`, all under the settings lock so a migration write never clobbers a concurrent save. Writes stamp `schemaVersion`. `resetStorage` was tightened to one atomic write across both keys.
- **CLI:** migrates the config in memory and **never rewrites the JSONC file**. Every deprecation surfaces as a startup warning naming the full deprecated and replacement paths, repeated on every startup until the user edits the file. The generated config template now carries the current `schemaVersion`. Top-level `autoClaimChannelPoints` changed from a hard error to an accepted deprecation warning.

### Notable review-driven fixes

- A malformed `platform` block can't rehome a legacy top-level `autoClaimChannelPoints`; the value is dropped consistently with the rest of the corrupt block (only reachable via a manually corrupted document) rather than orphaned.
- CLI validation errors name the key the user actually wrote when a migration renamed it onto a rejected one (e.g. `verboseLogging`).
- The "current name wins over a wrong-typed value" precedence is a deliberate, documented narrow change from the old inline fallbacks, pinned by tests.

### Known follow-up (out of scope)

A future `schemaVersion` makes `loadSettings` throw, per the spec's "fail without persistence." Nothing currently catches it, so a downgraded extension against newer stored settings would fail to start rather than degrade gracefully. Refusing beats overwriting; a friendly recovery surface is left as a follow-up.

## Test Plan

- [x] `pnpm verify` (script tests, 7-package typecheck, 104 CLI + 625 extension tests, Astro site build, both browser builds) — green
- [x] New `settingsMigrations.test.ts` covers versions, immutability, idempotence, precedence, malformed input, future/invalid-version rejection
- [x] Extension storage tests cover one-time write-back, no-write-when-current, failed-write retry, concurrent load/save ordering, future-version rejection, reset/save stamping
- [x] CLI tests cover in-memory migration without touching file bytes/mtime, warnings on every load, current-config no-warnings, aliases accepted while unknown keys still fail
- [x] Cross-host test pins that the extension and CLI derive the same engine contract from one legacy document

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioned settings migrations to automatically upgrade older configurations.
  * Legacy setting names and locations are converted to current equivalents, with current values taking precedence when both are present.
  * Added schema versioning to saved extension settings and generated CLI configuration templates.

* **Bug Fixes**
  * Future or invalid settings schema versions are now rejected safely.
  * CLI migration warnings identify deprecated settings and their replacements.
  * Extension settings remain usable if migration persistence fails.

* **Documentation**
  * Documented settings migration behavior, compatibility details, and procedures for introducing future migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->