### PR TITLE
fix(settings): apply changes without pausing automation

### DIFF
--- a/docs/superpowers/plans/2026-07-21-settings-without-pausing.md
+++ b/docs/superpowers/plans/2026-07-21-settings-without-pausing.md
@@ -269,7 +269,7 @@ Change campaign visibility to:
 />
 ```
 
-Retain the existing global tick options for priority mode, excluded-campaign reset, tabless mode, skip-unfinishable rewards, and deadline margin. Retain `platformPatch()` for category and excluded-channel targeting.
+Retain the existing global tick options for priority mode, excluded-campaign reset, tabless mode, skip-unfinishable rewards, and deadline margin. Add the same global tick option to Idle Watchlist fallback policy because it changes scheduler selection for both platforms. Retain `platformPatch()` for category and excluded-channel targeting.
 
 - [ ] **Step 4: Make drag priority changes request global reconciliation**
 

--- a/docs/superpowers/plans/2026-07-21-settings-without-pausing.md
+++ b/docs/superpowers/plans/2026-07-21-settings-without-pausing.md
@@ -58,6 +58,8 @@ it("keeps active farming untouched when saving a non-scheduling setting", async 
 });
 ```
 
+Add a handoff regression beside the post-claim handoff tests. Start a handoff, wait until its manual timer is parked, save a non-scheduling setting, and assert the timer remains parked before flushing the loop to its deadline. This proves an ordinary save does not abort the active handoff while the existing `setRunning(false)` test continues to prove explicit shutdown does.
+
 - [ ] **Step 2: Run the focused test and confirm the old lifecycle still exists**
 
 Run:
@@ -293,6 +295,10 @@ pnpm --filter @lurkloot/extension test -- settingsView.test.tsx dropsView.test.t
 ```
 
 Expected: all selected files pass.
+
+- [ ] **Step 5a: Cover rapid serialized reconciliation**
+
+Add a controller test that blocks the first targeted Twitch discovery, sends a second scheduling save while the first reconciliation is active, then releases the first call. Assert both setting patches are present, Twitch discovery ran twice, and an active-discovery counter never exceeded one. Run `backgroundController.test.ts` and expect it to pass.
 
 - [ ] **Step 6: Commit refresh classification**
 

--- a/docs/superpowers/plans/2026-07-21-settings-without-pausing.md
+++ b/docs/superpowers/plans/2026-07-21-settings-without-pausing.md
@@ -1,0 +1,343 @@
+# Settings Without Pausing Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make opening, editing, and closing Settings leave active farming untouched while reconciling scheduling changes promptly at global or platform scope.
+
+**Architecture:** Delete the Settings-specific pause connection across popup, extension shell, shared messages, and controller. Keep the existing serialized `saveSettings` path, and annotate scheduling controls with the existing `tickAfterSave` and `tickAfterSavePlatforms` options so the controller stays browser-free and schema-agnostic.
+
+**Tech Stack:** TypeScript 7, React 19, WXT WebExtension APIs, Vitest, pnpm monorepo.
+
+## Global Constraints
+
+- Work only in `.worktrees/settings-without-pausing` on `fix/settings-without-pausing`.
+- Keep `@lurkloot/core` free of WXT and browser globals.
+- Do not change the settings schema, storage format, scheduler algorithm, CLI behavior, or Settings layout.
+- Global scheduling changes refresh all enabled platforms; platform-specific scheduling changes refresh only that platform.
+- Explicit automation/provider disabling must continue to stop work immediately.
+- Use two-space indentation, double quotes, semicolons, explicit imports, and `type` imports for types.
+
+---
+
+### Task 1: Remove the controller pause lifecycle
+
+**Files:**
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+- Modify: `packages/core/src/background/controller.ts`
+
+**Interfaces:**
+- Consumes: existing `tick(platforms?: Platform[])`, `runWatchHeartbeat()`, and `handleMessage(message)` controller operations.
+- Produces: a controller with no `settingsPauseCount`, `beginSettingsSession()`, `endSettingsSession()`, or `tick(..., { forcePaused: true })` API.
+
+- [ ] **Step 1: Replace pause-specific controller tests with the retained automation guarantees**
+
+Delete the tests named `temporarily pauses active sessions while a settings session is open without persisting running=false`, `does not run tickAfterSave automation while settings are temporarily paused`, and `aborts running handoffs when a settings session begins`.
+
+Add this regression beside the existing `saveSettings` tests to prove an ordinary save cannot stop an active session:
+
+```ts
+it("keeps active farming untouched when saving a non-scheduling setting", async () => {
+  const env = harness({ ...DEFAULT_SETTINGS, running: true });
+  env.state.sessions.twitch = {
+    platform: "twitch",
+    status: "watching",
+    channel: channel("twitch"),
+    tabId: 10,
+    tabManagedByExtension: true,
+    offlineChecks: 0,
+  };
+
+  const snapshot = asSnapshot(await env.controller.handleMessage({
+    type: "saveSettings",
+    settingsPatch: { notifyRewardEarned: false },
+  }));
+
+  expect(env.twitch.stopWatchTab).not.toHaveBeenCalled();
+  expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+  expect(snapshot.state.sessions.twitch.status).toBe("watching");
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm the old lifecycle still exists**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+```
+
+Expected: the new regression passes, while TypeScript/source inspection still shows `settingsPauseCount`, `beginSettingsSession`, and `endSettingsSession`; this establishes behavior before deleting the obsolete API.
+
+- [ ] **Step 3: Delete controller pause state and branches**
+
+In `packages/core/src/background/controller.ts`:
+
+- delete `let settingsPauseCount = 0;`;
+- change `tick(platforms?: Platform[], options?: { forcePaused?: boolean })` to `tick(platforms?: Platform[])`;
+- replace the forced settings selection with `const settings = await deps.loadSettings();`;
+- delete the `if (settingsPauseCount > 0) return;` guard from `runWatchHeartbeat()`;
+- delete `beginSettingsSession()` and `endSettingsSession()`;
+- simplify the `saveSettings` condition to:
+
+```ts
+if (message.tickAfterSave && settings.running && hasEnabledPlatform(settings)) {
+  await tickAndHandOff(message.tickAfterSavePlatforms);
+}
+```
+
+- remove `beginSettingsSession` and `endSettingsSession` from the returned controller object.
+
+- [ ] **Step 4: Run controller tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+pnpm --filter @lurkloot/core typecheck
+```
+
+Expected: the controller tests pass and core typecheck reports no errors.
+
+- [ ] **Step 5: Commit the controller change**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "fix(core): remove settings pause lifecycle"
+```
+
+---
+
+### Task 2: Remove the extension and popup session connection
+
+**Files:**
+- Create: `packages/extension/tests/popupSettingsLifecycle.test.tsx`
+- Modify: `packages/shared/src/messages.ts`
+- Modify: `packages/extension/entrypoints/background.ts`
+- Modify: `packages/extension/entrypoints/popup/app.tsx`
+- Modify: `packages/popup-ui/src/types.ts`
+- Modify: `packages/popup-ui/src/Popup.tsx`
+
+**Interfaces:**
+- Consumes: `PopupAdapter.send`, `PopupAdapter.getStorage`, and the existing Settings/Back buttons.
+- Produces: a popup adapter without `connectSettingsSession`, and UI navigation with no pause/resume side channel or close-time resume polling.
+
+- [ ] **Step 1: Add a popup lifecycle regression test**
+
+Create `packages/extension/tests/popupSettingsLifecycle.test.tsx` using the same `linkedom`, `createRoot`, and global stubs as `settingsCredentialExport.test.tsx`. Start from `createDemoPopupAdapter()`, override `send` with a spy that delegates to the demo adapter, render the popup in preview mode, click Back and Open settings, and assert navigation sends no runtime message:
+
+```ts
+it("opens and closes settings without runtime lifecycle messages", async () => {
+  const demo = createDemoPopupAdapter();
+  const send = vi.fn(demo.send);
+  const adapter: PopupAdapter = {
+    ...demo,
+    send,
+    getMessage: (key) => ({ openSettings: "Open settings", back: "Back" })[key] ?? demo.getMessage(key),
+  };
+
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} initialState={{ preview: true, variant: screenshotVariant("settings") }} />);
+    await Promise.resolve();
+  });
+  send.mockClear();
+
+  act(() => byLabel(container, "Back").click());
+  act(() => byLabel(container, "Open settings").click());
+
+  expect(send).not.toHaveBeenCalled();
+});
+```
+
+Include local `byLabel`, DOM setup, animation-frame stubs, unmount cleanup, and `vi.unstubAllGlobals()` so the file runs independently.
+
+- [ ] **Step 2: Run the lifecycle test**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- popupSettingsLifecycle.test.tsx
+```
+
+Expected: PASS for preview navigation. The production-only port remains detectable by the subsequent type/source removals.
+
+- [ ] **Step 3: Delete the Settings port contract and extension wiring**
+
+- Delete `SETTINGS_SESSION_PORT` from `packages/shared/src/messages.ts`.
+- Remove its import and the `browser.runtime.onConnect` Settings listener from `packages/extension/entrypoints/background.ts`.
+- Remove its import and `connectSettingsSession` implementation from `packages/extension/entrypoints/popup/app.tsx`.
+- Remove `connectSettingsSession?(): () => void;` from `PopupAdapter` in `packages/popup-ui/src/types.ts`.
+
+- [ ] **Step 4: Delete popup resume state and effects**
+
+In `packages/popup-ui/src/Popup.tsx`, delete:
+
+- `resumingAutomation` state;
+- `wasSettingsOpen` and `resumeRefreshRun` refs;
+- `hasTemporaryDisabledSession()`;
+- the effect that calls `adapter.connectSettingsSession()`;
+- the effect that polls after Settings closes;
+- the unmount effect that increments `resumeRefreshRun`.
+
+Pass only the real session message to the hero:
+
+```tsx
+<AutomationHero
+  platformLabel={PLATFORMS[platform].label}
+  enabled={enabled}
+  pending={automationPending}
+  farmingTitle={activeCampaign?.title}
+  farmingChannel={farmingChannel}
+  onFarmingTitleClick={onFarmingTitleClick}
+  statusMessage={session.message}
+  onChange={setAutomation}
+/>
+```
+
+Remove the `resumingAutomation` header branch so the normal active/paused title is always derived from persisted settings.
+
+- [ ] **Step 5: Prove the removed symbols are gone and run focused checks**
+
+Run:
+
+```bash
+rg "SETTINGS_SESSION_PORT|connectSettingsSession|settingsPauseCount|beginSettingsSession|endSettingsSession|resumingAutomation|hasTemporaryDisabledSession" packages
+pnpm --filter @lurkloot/extension test -- popupSettingsLifecycle.test.tsx backgroundController.test.ts
+pnpm typecheck
+```
+
+Expected: `rg` exits 1 with no matches; focused tests and workspace typecheck pass.
+
+- [ ] **Step 6: Commit the extension lifecycle removal**
+
+```bash
+git add packages/shared/src/messages.ts packages/extension/entrypoints/background.ts packages/extension/entrypoints/popup/app.tsx packages/popup-ui/src/types.ts packages/popup-ui/src/Popup.tsx packages/extension/tests/popupSettingsLifecycle.test.tsx
+git commit -m "fix(popup): keep automation running in settings"
+```
+
+---
+
+### Task 3: Classify global and platform scheduling controls
+
+**Files:**
+- Modify: `packages/extension/tests/settingsView.test.tsx`
+- Modify: `packages/popup-ui/src/settingsRegistry.tsx`
+- Modify: `packages/popup-ui/src/Popup.tsx`
+
+**Interfaces:**
+- Consumes: `SettingsView`'s `onSettingsChange(patch, options?)` callback and `updateSettings(patch, options?)`.
+- Produces: global scheduling calls with `{ tickAfterSave: true }` and platform scheduling calls with `{ tickAfterSave: true, tickAfterSavePlatforms: [platform] }`.
+
+- [ ] **Step 1: Add failing assertions for missing global refresh classifications**
+
+Extend `settingsView.test.tsx` with focused interactions asserting:
+
+```ts
+expect(onSettingsChange).toHaveBeenCalledWith(
+  { campaignVisibility: expect.any(Object) },
+  { tickAfterSave: true },
+);
+```
+
+Keep the existing deadline assertion. Add an assertion that a save-only control such as `notifyRewardEarned` calls `onSettingsChange({ notifyRewardEarned: false })` with no second argument. Existing platform category/excluded-channel tests should continue expecting:
+
+```ts
+{ tickAfterSave: true, tickAfterSavePlatforms: ["twitch"] }
+```
+
+- [ ] **Step 2: Run settings tests and verify the campaign-visibility test fails**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- settingsView.test.tsx
+```
+
+Expected: FAIL because campaign visibility currently omits `{ tickAfterSave: true }`.
+
+- [ ] **Step 3: Add global refresh intent in the settings registry**
+
+Change campaign visibility to:
+
+```tsx
+<CampaignFilterSettingRow
+  value={settings.campaignVisibility}
+  onChange={(campaignVisibility) => void onSettingsChange(
+    { campaignVisibility },
+    { tickAfterSave: true },
+  )}
+/>
+```
+
+Retain the existing global tick options for priority mode, excluded-campaign reset, tabless mode, skip-unfinishable rewards, and deadline margin. Retain `platformPatch()` for category and excluded-channel targeting.
+
+- [ ] **Step 4: Make drag priority changes request global reconciliation**
+
+In `packages/popup-ui/src/Popup.tsx`, change the Drops panel callback to:
+
+```tsx
+onReorder={(ordered) => updateSettings(
+  { campaignPriorities: prioritiesFromOrder(ordered) },
+  { tickAfterSave: true },
+)}
+```
+
+Retain global reconciliation for excluded campaigns and targeted reconciliation for idle-watchlist ordering.
+
+- [ ] **Step 5: Run focused settings and popup tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- settingsView.test.tsx dropsView.test.tsx popupSettingsLifecycle.test.tsx
+```
+
+Expected: all selected files pass.
+
+- [ ] **Step 6: Commit refresh classification**
+
+```bash
+git add packages/popup-ui/src/settingsRegistry.tsx packages/popup-ui/src/Popup.tsx packages/extension/tests/settingsView.test.tsx
+git commit -m "fix(settings): reconcile scheduling changes by scope"
+```
+
+---
+
+### Task 4: Verify the complete change
+
+**Files:**
+- Modify only if verification exposes an issue in files already listed above.
+
+**Interfaces:**
+- Consumes: all behavior produced by Tasks 1-3.
+- Produces: evidence that issue #192 acceptance criteria pass across tests, typechecks, site build, and browser builds.
+
+- [ ] **Step 1: Run the full extension suite**
+
+```bash
+pnpm test
+```
+
+Expected: all extension, CLI, and site tests pass with zero failures.
+
+- [ ] **Step 2: Run repository verification**
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, workspace typechecks, extension tests, Astro site build, Chromium build, and Firefox build all pass.
+
+- [ ] **Step 3: Inspect the final diff and repository state**
+
+```bash
+git diff --check origin/develop...HEAD
+git status --short --branch
+git log --oneline origin/develop..HEAD
+```
+
+Expected: no whitespace errors, no uncommitted files, and only the design, plan, lifecycle-removal, refresh-classification, and any focused repair commits appear.
+
+- [ ] **Step 4: Commit any verification-only repair**
+
+If Step 1 or Step 2 required a focused repair, stage only the repaired files and commit with a specific Conventional Commit subject, then rerun both verification commands. If no repair was required, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-21-settings-without-pausing-design.md
+++ b/docs/superpowers/specs/2026-07-21-settings-without-pausing-design.md
@@ -60,7 +60,7 @@ No paused fallback state is introduced when saving or reconciliation fails. The 
 
 ## Testing
 
-Controller tests will replace the temporary-settings-pause expectations with coverage that opening Settings has no controller lifecycle at all. Existing save tests will continue to prove patch merging, alarm recreation, global ticks, targeted ticks, and paused-automation behavior. Handoff coverage will confirm that Settings no longer owns an abort path, while explicit automation shutdown retains it.
+Controller tests will replace the temporary-settings-pause expectations with coverage that opening Settings has no controller lifecycle at all. Existing save tests will continue to prove patch merging, alarm recreation, global ticks, targeted ticks, and paused-automation behavior. Handoff coverage will confirm that an ordinary settings save preserves an active handoff, while explicit automation shutdown still aborts it. A gated rapid-edit regression will prove that every patch is preserved and reconciliation calls remain serialized.
 
 Popup and settings tests will verify:
 
@@ -68,7 +68,7 @@ Popup and settings tests will verify:
 - global scheduling controls request a global post-save tick;
 - platform controls request a post-save tick scoped to their platform;
 - save-only controls do not request reconciliation;
-- serialized rapid changes preserve all patches.
+- serialized rapid changes preserve all patches without overlapping reconciliation.
 
 Focused tests will run during development. Final verification is `pnpm verify` from the isolated worktree.
 

--- a/docs/superpowers/specs/2026-07-21-settings-without-pausing-design.md
+++ b/docs/superpowers/specs/2026-07-21-settings-without-pausing-design.md
@@ -38,7 +38,7 @@ The popup will remove its close-time resume polling, `resumingAutomation` state,
 Global scheduling changes request an immediate reconciliation of all enabled platforms:
 
 - campaign priority mode and priority ordering;
-- campaign visibility and excluded-campaign changes;
+- campaign visibility, excluded-campaign changes, and Idle Watchlist fallback policy;
 - tabless mode;
 - skip-unfinishable-rewards and deadline safety margin.
 

--- a/docs/superpowers/specs/2026-07-21-settings-without-pausing-design.md
+++ b/docs/superpowers/specs/2026-07-21-settings-without-pausing-design.md
@@ -1,0 +1,77 @@
+# Apply Settings Without Pausing Automation
+
+## Context
+
+Opening the popup Settings view currently opens a dedicated runtime port. The background controller treats that connection as a temporary global pause: it aborts post-claim handoffs, runs the scheduler with `running: false`, stops managed farming and page-context tabs, and suppresses tabless heartbeats. Disconnecting the port triggers another global scheduler cycle to rebuild automation. The popup then polls until the temporary disabled session state disappears.
+
+Settings already save automatically. Visiting the view should not alter automation state; only a setting whose value changes should cause work, and that work should be scoped to the affected platforms where possible.
+
+## Goals
+
+- Opening and closing Settings leaves active Twitch and Kick farming untouched.
+- Auto-saved changes remain serialized and cannot overwrite newer changes.
+- Scheduling changes reconcile promptly: global changes refresh all enabled platforms, while platform-specific changes refresh only that platform.
+- Explicitly disabling automation or a provider continues to stop it immediately.
+- Rapid edits do not start overlapping scheduler state mutations.
+
+## Non-goals
+
+- Debouncing or batching setting changes beyond the existing serialized save queue.
+- Moving refresh classification into the browser-free controller.
+- Changing the settings schema, storage format, scheduler algorithm, or CLI behavior.
+- Redesigning the Settings UI.
+
+## Design
+
+### Remove the settings-session lifecycle
+
+The popup will no longer connect a Settings-specific runtime port. The extension background will no longer listen for that port, and the shared port constant and popup adapter hook will be removed.
+
+The controller will remove `settingsPauseCount`, `beginSettingsSession`, `endSettingsSession`, and forced-paused scheduler ticks. Normal scheduler ticks and tabless heartbeats will consult only persisted automation settings. Post-claim handoffs will no longer abort merely because Settings opened.
+
+The popup will remove its close-time resume polling, `resumingAutomation` state, and the temporary-disabled-session detection used only by that workaround. Opening or closing Settings becomes a UI-only state transition.
+
+### Apply setting changes by impact
+
+`saveSettings` retains its existing optional reconciliation request. Refresh intent remains explicit at the UI control that owns the change, keeping the generic controller independent of extension-only settings.
+
+Global scheduling changes request an immediate reconciliation of all enabled platforms:
+
+- campaign priority mode and priority ordering;
+- campaign visibility and excluded-campaign changes;
+- tabless mode;
+- skip-unfinishable-rewards and deadline safety margin.
+
+Platform scheduling changes request an immediate reconciliation only for the affected platform:
+
+- farm-all-categories and category allowlists;
+- excluded channels;
+- idle-watchlist ordering.
+
+Other settings save without a scheduler tick. This includes appearance, startup preference, notifications, auto-claim policy, playback policy, scheduler interval, handoff tuning, diagnostics, and compatibility selection. The scheduler interval still recreates its alarm during the save, as it does today. Runtime consumers read the remaining policies at their existing boundaries.
+
+Automation toggles remain separate from ordinary settings saves. `setAutomation` continues to persist the platform state and run the scheduler immediately, so disabling a provider stops it without waiting for an alarm.
+
+### Serialization and errors
+
+The popup's `settingsSaveQueue` continues to serialize optimistic setting patches and background requests. A failed request does not poison later saves because each queued operation recovers the preceding rejection before starting. The controller's settings lock serializes load-modify-save operations, and its state lock serializes scheduler mutations, so rapid changes cannot lose updates or overlap state reconciliation.
+
+No paused fallback state is introduced when saving or reconciliation fails. The individual request rejects under the existing behavior, while later queued edits remain able to proceed.
+
+## Testing
+
+Controller tests will replace the temporary-settings-pause expectations with coverage that opening Settings has no controller lifecycle at all. Existing save tests will continue to prove patch merging, alarm recreation, global ticks, targeted ticks, and paused-automation behavior. Handoff coverage will confirm that Settings no longer owns an abort path, while explicit automation shutdown retains it.
+
+Popup and settings tests will verify:
+
+- opening and closing Settings does not create a background pause/resume connection or close-time polling cycle;
+- global scheduling controls request a global post-save tick;
+- platform controls request a post-save tick scoped to their platform;
+- save-only controls do not request reconciliation;
+- serialized rapid changes preserve all patches.
+
+Focused tests will run during development. Final verification is `pnpm verify` from the isolated worktree.
+
+## Acceptance mapping
+
+Removing the port and controller pause lifecycle ensures Settings cannot produce `Automation disabled`, stop tabs, or require a resume cycle. Explicit reconciliation flags make scheduling changes prompt and scoped. Existing save and state locks preserve ordering, and `setAutomation` retains immediate shutdown behavior.

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -237,7 +237,6 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     kick: new Set<string>(),
   };
   let settingsMutation: Promise<unknown> = Promise.resolve();
-  let settingsPauseCount = 0;
 
   // The last token handed to setTwitchIntegrity; used to skip re-persisting on
   // every page GQL call (the page sends integrity on most requests).
@@ -404,13 +403,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     });
   }
 
-  async function tick(platforms?: Platform[], options?: { forcePaused?: boolean }): Promise<ClaimedRewards> {
+  async function tick(platforms?: Platform[]): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
     await withStateLock(() => withEventCollector(async (emit, events) => {
-      const storedSettings = await deps.loadSettings();
-      const settings: S = options?.forcePaused || settingsPauseCount > 0
-        ? { ...storedSettings, running: false }
-        : storedSettings;
+      const settings = await deps.loadSettings();
       const state = await deps.loadState();
       const nextWaitingClaimRewardIds: Record<Platform, Set<string>> = {
         twitch: new Set(waitingClaimRewardIds.twitch),
@@ -573,7 +569,6 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // watcher and records its health on the session, falling back to a real tab
   // (by re-running the scheduler) when a heartbeat keeps failing.
   async function runWatchHeartbeat(): Promise<void> {
-    if (settingsPauseCount > 0) return;
     const settings = await deps.loadSettings();
     if (!settings.running) return;
     const fallbackPlatforms = await withStateLock<Platform[]>(() => withEventCollector(async (emit, events) => {
@@ -797,19 +792,6 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       });
       await persistAndReport(nextState, events);
     }));
-  }
-
-  async function beginSettingsSession(): Promise<void> {
-    abortClaimHandoffs();
-    settingsPauseCount += 1;
-    if (settingsPauseCount === 1) await tick(undefined, { forcePaused: true });
-  }
-
-  async function endSettingsSession(): Promise<void> {
-    settingsPauseCount = Math.max(0, settingsPauseCount - 1);
-    if (settingsPauseCount > 0) return;
-    const settings = await deps.loadSettings();
-    if (settings.running && hasEnabledPlatform(settings)) await tick();
   }
 
   async function recordPlaybackTelemetry(
@@ -1072,7 +1054,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
     if (message.type === "saveSettings") {
       const settings = await updateStoredSettings(message.settingsPatch);
-      if (message.tickAfterSave && settingsPauseCount === 0 && settings.running && hasEnabledPlatform(settings)) {
+      if (message.tickAfterSave && settings.running && hasEnabledPlatform(settings)) {
         await tickAndHandOff(message.tickAfterSavePlatforms);
       }
       return snapshot();
@@ -1183,8 +1165,6 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     handleStartup,
     handleTabRemoved,
     handleMessage,
-    beginSettingsSession,
-    endSettingsSession,
     captureTwitchIntegrity,
     tick,
     tickAndHandOff,

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -1,6 +1,6 @@
 import { browser } from "wxt/browser";
 import { loadSettings, loadState, loadTwitchIntegrity, saveSettings, saveState, saveTwitchIntegrity } from "../src/core/storage";
-import { SETTINGS_SESSION_PORT, type CliCredentialBlob, type RuntimeMessage } from "@lurkloot/shared/messages";
+import type { CliCredentialBlob, RuntimeMessage } from "@lurkloot/shared/messages";
 import {
   applyAdFocus,
   ensureTwitchIntegrity,
@@ -227,11 +227,4 @@ export default defineBackground(() => {
     return true;
   });
 
-  browser.runtime.onConnect.addListener((port) => {
-    if (port.name !== SETTINGS_SESSION_PORT) return;
-    void controller.beginSettingsSession();
-    port.onDisconnect.addListener(() => {
-      void controller.endSettingsSession();
-    });
-  });
 });

--- a/packages/extension/entrypoints/popup/app.tsx
+++ b/packages/extension/entrypoints/popup/app.tsx
@@ -10,7 +10,6 @@ import {
   type PopupAdapter,
   type ScreenshotVariant,
 } from "@lurkloot/popup-ui";
-import { SETTINGS_SESSION_PORT } from "@lurkloot/shared/messages";
 import { SUPPORTED_LOCALES } from "@lurkloot/shared/settings";
 import type { SupportedLocale } from "@lurkloot/shared/models";
 import { COMPATIBILITY_REGISTRY, resolveCompatibility } from "@lurkloot/core";
@@ -40,10 +39,6 @@ export function createExtensionPopupAdapter(): PopupAdapter {
     send: (message) => browser.runtime.sendMessage(message),
     getStorage: (keys) => browser.storage.local.get(keys),
     setStorage: (values) => browser.storage.local.set(values),
-    connectSettingsSession: () => {
-      const port = browser.runtime.connect({ name: SETTINGS_SESSION_PORT });
-      return () => port.disconnect();
-    },
     getMessage: (key, substitutions) => browser.i18n.getMessage(key as never, substitutions),
     getUiLanguage: () => browser.i18n.getUILanguage(),
     openLink: (url) => openHttpsLink(url, (safeUrl) => void browser.tabs.create({ url: safeUrl })),

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -923,7 +923,7 @@ describe("background controller", () => {
     expect(snapshot.settings.platform.twitch.idleWatchlistChannels).toEqual(["fallback"]);
   });
 
-  it("temporarily pauses active sessions while a settings session is open without persisting running=false", async () => {
+  it("keeps active farming untouched when saving a non-scheduling setting", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true });
     env.state.sessions.twitch = {
       platform: "twitch",
@@ -934,36 +934,14 @@ describe("background controller", () => {
       offlineChecks: 0,
     };
 
-    await env.controller.beginSettingsSession();
-
-    expect(env.settings.running).toBe(true);
-    expect(env.twitch.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ status: "watching" }));
-    expect(env.state.sessions.twitch.status).toBe("paused");
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-
-    await env.controller.endSettingsSession();
-
-    expect(env.settings.running).toBe(true);
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalled();
-  });
-
-  it("does not run tickAfterSave automation while settings are temporarily paused", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
-
-    await env.controller.beginSettingsSession();
-    vi.mocked(env.twitch.discoverCampaigns).mockClear();
-    vi.mocked(env.kick.discoverCampaigns).mockClear();
-
     const snapshot = asSnapshot(await env.controller.handleMessage({
       type: "saveSettings",
-      settingsPatch: { priorityMode: "priority_list_only" },
-      tickAfterSave: true,
+      settingsPatch: { notifyRewardEarned: false },
     }));
 
-    expect(snapshot.settings.running).toBe(true);
-    expect(snapshot.settings.priorityMode).toBe("priority_list_only");
+    expect(env.twitch.stopWatchTab).not.toHaveBeenCalled();
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+    expect(snapshot.state.sessions.twitch.status).toBe("watching");
   });
 
   it("runs an immediate scheduler tick when requested from the popup", async () => {
@@ -2219,19 +2197,6 @@ describe("background controller", () => {
       await handoff;
 
       expect(env.timer.wait.mock.calls.length).toBeLessThanOrEqual(3);
-    });
-
-    it("aborts running handoffs when a settings session begins", async () => {
-      const env = handoffEnv();
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
-
-      const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
-      await drainMicrotasks();
-      await env.controller.beginSettingsSession();
-      await env.timer.flush();
-      await handoff;
-
-      expect(env.timer.parked).toBe(0);
     });
 
     it("aborts running handoffs when farming is switched off", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -859,6 +859,59 @@ describe("background controller", () => {
     expect(env.settings.platform.kick.enabled).toBe(false);
   });
 
+  it("preserves rapid scheduling patches without overlapping reconciliation", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      notifyRewardEarned: true,
+      notifyNoDropsLeft: true,
+    });
+    let activeDiscoveries = 0;
+    let maxActiveDiscoveries = 0;
+    let discoveryCalls = 0;
+    let markFirstStarted!: () => void;
+    let releaseFirst!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    vi.mocked(env.twitch.discoverCampaigns).mockImplementation(async () => {
+      discoveryCalls += 1;
+      activeDiscoveries += 1;
+      maxActiveDiscoveries = Math.max(maxActiveDiscoveries, activeDiscoveries);
+      if (discoveryCalls === 1) {
+        markFirstStarted();
+        await firstGate;
+      }
+      activeDiscoveries -= 1;
+      return [];
+    });
+
+    const first = env.controller.handleMessage({
+      type: "saveSettings",
+      settingsPatch: { notifyRewardEarned: false },
+      tickAfterSave: true,
+      tickAfterSavePlatforms: ["twitch"],
+    });
+    await firstStarted;
+    const second = env.controller.handleMessage({
+      type: "saveSettings",
+      settingsPatch: { notifyNoDropsLeft: false },
+      tickAfterSave: true,
+      tickAfterSavePlatforms: ["twitch"],
+    });
+    await drainMicrotasks();
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(env.settings.notifyRewardEarned).toBe(false);
+    expect(env.settings.notifyNoDropsLeft).toBe(false);
+    expect(env.twitch.discoverCampaigns).toHaveBeenCalledTimes(2);
+    expect(maxActiveDiscoveries).toBe(1);
+  });
+
   it("runs a scheduler tick after saving settings when requested and automation is active", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true });
     const nextSettings = {
@@ -2197,6 +2250,25 @@ describe("background controller", () => {
       await handoff;
 
       expect(env.timer.wait.mock.calls.length).toBeLessThanOrEqual(3);
+    });
+
+    it("keeps an active handoff running during an ordinary settings save", async () => {
+      const env = handoffEnv({ postClaimHandoffIntervalSeconds: 5, postClaimHandoffMaxSeconds: 15 });
+      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+
+      const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
+      await drainMicrotasks();
+      expect(env.timer.parked).toBe(1);
+
+      await env.controller.handleMessage({
+        type: "saveSettings",
+        settingsPatch: { notifyRewardEarned: false },
+      });
+
+      expect(env.timer.parked).toBe(1);
+      for (let index = 0; index < 4; index += 1) await env.timer.flush();
+      await handoff;
+      expect(env.twitch.discoverCampaigns).toHaveBeenCalled();
     });
 
     it("aborts running handoffs when farming is switched off", async () => {

--- a/packages/extension/tests/popupSettingsLifecycle.test.tsx
+++ b/packages/extension/tests/popupSettingsLifecycle.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
+
+let root: Root | undefined;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+function byLabel(container: Element, label: string): HTMLButtonElement {
+  const button = container.querySelector(`button[aria-label="${label}"]`);
+  if (!button) throw new Error(`Missing button label: ${label}`);
+  return button as HTMLButtonElement;
+}
+
+describe("popup settings lifecycle", () => {
+  it("opens and closes settings without a background lifecycle connection", async () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => window.setTimeout(() => callback(Date.now()), 0));
+    vi.stubGlobal("cancelAnimationFrame", (handle: number) => window.clearTimeout(handle));
+    vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr" }));
+
+    const demo = createDemoPopupAdapter();
+    const connectSettingsSession = vi.fn(() => vi.fn());
+    const adapter: PopupAdapter & { connectSettingsSession: () => () => void } = {
+      ...demo,
+      connectSettingsSession,
+      getMessage: (key) => ({
+        openSettings: "Open settings",
+        back: "Back",
+      })[key] ?? demo.getMessage(key),
+    };
+    const container = document.getElementById("app")!;
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Popup adapter={adapter} />);
+      await Promise.resolve();
+    });
+
+    act(() => byLabel(container, "Open settings").click());
+    expect(connectSettingsSession).not.toHaveBeenCalled();
+
+    act(() => byLabel(container, "Back").click());
+    expect(connectSettingsSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/tests/settingsView.test.tsx
+++ b/packages/extension/tests/settingsView.test.tsx
@@ -154,4 +154,49 @@ describe("deadline feasibility setting", () => {
     expect(input.value).toBe("17");
     expect(input.disabled).toBe(true);
   });
+
+  it("reconciles all platforms after campaign visibility changes", () => {
+    const { container, onSettingsChange } = mountSettings();
+    const toggle = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("notLinked"));
+
+    act(() => toggle?.click());
+
+    expect(onSettingsChange).toHaveBeenCalledWith(
+      { campaignVisibility: { ...DEFAULT_SETTINGS.campaignVisibility, notLinked: false } },
+      { tickAfterSave: true },
+    );
+  });
+
+  it("reconciles all platforms after changing Idle Watchlist fallback policy", () => {
+    const { container, onSettingsChange } = mountSettings();
+    const toggle = container.querySelector('[role="switch"][aria-label="Only when no drops are active"]') as HTMLButtonElement;
+
+    act(() => toggle.click());
+
+    expect(onSettingsChange).toHaveBeenCalledWith(
+      { idleWatchlistFallbackOnly: false },
+      { tickAfterSave: true },
+    );
+  });
+
+  it("targets category changes to their platform", () => {
+    const { container, onSettingsChange } = mountSettings();
+    const toggle = container.querySelector('[role="switch"][aria-label="Farm all categories"]') as HTMLButtonElement;
+
+    act(() => toggle.click());
+
+    expect(onSettingsChange).toHaveBeenCalledWith(
+      { platform: { twitch: { farmAllCategories: false } } },
+      { tickAfterSave: true, tickAfterSavePlatforms: ["twitch"] },
+    );
+  });
+
+  it("saves notification preferences without a scheduler tick", () => {
+    const { container, onSettingsChange } = mountSettings();
+    const toggle = container.querySelector('[role="switch"][aria-label="Reward earned"]') as HTMLButtonElement;
+
+    act(() => toggle.click());
+
+    expect(onSettingsChange).toHaveBeenCalledWith({ notifyRewardEarned: false });
+  });
 });

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "الاستلام التلقائي جاهز"
   },
-  "resumingAutomation": {
-    "message": "جارٍ استئناف التشغيل التلقائي..."
-  },
   "attributionLinks": {
     "message": "روابط النسبة"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "Auto-Beanspruchen bereit"
   },
-  "resumingAutomation": {
-    "message": "Automatisierung wird fortgesetzt..."
-  },
   "attributionLinks": {
     "message": "Attributionslinks"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "Auto-claim ready"
   },
-  "resumingAutomation": {
-    "message": "Resuming automation..."
-  },
   "attributionLinks": {
     "message": "Attribution links"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "Auto-reclamo listo"
   },
-  "resumingAutomation": {
-    "message": "Reanudando automatización..."
-  },
   "attributionLinks": {
     "message": "Enlaces de atribución"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "Réclamation auto prête"
   },
-  "resumingAutomation": {
-    "message": "Reprise de l’automatisation..."
-  },
   "attributionLinks": {
     "message": "Liens d’attribution"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "ऑटो-क्लेम तैयार"
   },
-  "resumingAutomation": {
-    "message": "ऑटोमेशन फिर शुरू हो रहा है..."
-  },
   "attributionLinks": {
     "message": "श्रेय लिंक"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "Auto-riscatto pronto"
   },
-  "resumingAutomation": {
-    "message": "Ripresa dell’automazione..."
-  },
   "attributionLinks": {
     "message": "Link di attribuzione"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "Auto-resgate pronto"
   },
-  "resumingAutomation": {
-    "message": "Retomando automação..."
-  },
   "attributionLinks": {
     "message": "Links de atribuição"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "Автополучение готово"
   },
-  "resumingAutomation": {
-    "message": "Возобновление автоматизации..."
-  },
   "attributionLinks": {
     "message": "Ссылки на автора"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -642,9 +642,6 @@
   "autoClaimReady": {
     "message": "自动领取就绪"
   },
-  "resumingAutomation": {
-    "message": "正在恢复自动化..."
-  },
   "attributionLinks": {
     "message": "署名链接"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -587,7 +587,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                         focus={campaignFocus}
                         refreshing={refreshing}
                         onRefreshCampaign={() => refreshNow()}
-                        onReorder={(ordered) => updateSettings({ campaignPriorities: prioritiesFromOrder(ordered) })}
+                        onReorder={(ordered) => updateSettings({ campaignPriorities: prioritiesFromOrder(ordered) }, { tickAfterSave: true })}
                         onToggleExclude={(id) => {
                           const next = new Set(settings.excludedCampaignIds);
                           if (next.has(id)) next.delete(id);

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -86,7 +86,6 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const [clearingActivity, setClearingActivity] = useState(false);
   const [clearActivityFailed, setClearActivityFailed] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
-  const [resumingAutomation, setResumingAutomation] = useState(false);
   const [pendingChangelogVersion, setPendingChangelogVersion] = useState<string>();
   const [pendingAutomation, setPendingAutomation] = useState<Partial<Record<Platform, boolean>>>({});
   // Request to jump to a campaign in the drops list (expand + scroll). The seq
@@ -99,8 +98,6 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const diagnosticMutationSequenceRef = useRef(createActivityMutationSequence());
   const activityClearInFlightRef = useRef(false);
   const [activityRequestGeneration, setActivityRequestGeneration] = useState(0);
-  const wasSettingsOpen = useRef(settingsOpen);
-  const resumeRefreshRun = useRef(0);
   const languageOverride = initialState?.locale ?? snapshot?.settings.languageOverride ?? DEFAULT_SETTINGS.languageOverride;
   const locale = effectiveLocale(languageOverride, adapter.getUiLanguage());
   const dir = isRtlLocale(locale) ? "rtl" : "ltr";
@@ -157,15 +154,6 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
     const settings = settingsRef.current ?? mergeSettings(nextSnapshot.settings);
     settingsRef.current = settings;
     return { ...nextSnapshot, settings };
-  }
-
-  function hasTemporaryDisabledSession(nextSnapshot: RuntimeSnapshot, currentSettings: ExtensionSettings): boolean {
-    return (["twitch", "kick"] as Platform[]).some((resumePlatform) => (
-      currentSettings.running
-      && currentSettings.platform[resumePlatform].enabled
-      && nextSnapshot.state.sessions[resumePlatform].status === "paused"
-      && nextSnapshot.state.sessions[resumePlatform].message === "Automation disabled"
-    ));
   }
 
   useEffect(() => {
@@ -330,44 +318,6 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
     setPendingChangelogVersion(undefined);
     void adapter.dismissPendingChangelogVersion?.();
   }
-
-  useEffect(() => {
-    if (preview || !settingsOpen || !adapter.connectSettingsSession) return;
-    return adapter.connectSettingsSession();
-  }, [adapter, preview, settingsOpen]);
-
-  useEffect(() => {
-    if (!wasSettingsOpen.current || settingsOpen) {
-      wasSettingsOpen.current = settingsOpen;
-      return;
-    }
-
-    wasSettingsOpen.current = settingsOpen;
-    const currentSettings = settingsRef.current;
-    const shouldResume = Boolean(currentSettings?.running && Object.values(currentSettings.platform).some((platformSettings) => platformSettings.enabled));
-    if (!shouldResume) return;
-
-    const run = resumeRefreshRun.current + 1;
-    resumeRefreshRun.current = run;
-    setResumingAutomation(true);
-
-    void settingsSaveQueue.current.catch(() => undefined).then(async () => {
-      for (let attempt = 0; attempt < 12 && resumeRefreshRun.current === run; attempt += 1) {
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        const nextSnapshot = await adapter.send<RuntimeSnapshot>({ type: "getSnapshot" });
-        const nextSettings = settingsRef.current ?? mergeSettings(nextSnapshot.settings);
-        setSnapshot(snapshotPreservingLocalSettings(nextSnapshot));
-        if (!hasTemporaryDisabledSession(nextSnapshot, nextSettings)) break;
-      }
-      if (resumeRefreshRun.current === run) setResumingAutomation(false);
-    });
-  }, [adapter, settingsOpen]);
-
-  useEffect(() => {
-    return () => {
-      resumeRefreshRun.current += 1;
-    };
-  }, []);
 
   // Keep the snapshot (and its Activity log) live while the popup is open, so
   // background scheduler ticks are reflected without needing a manual refresh.
@@ -537,7 +487,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
               <div className="font-display truncate text-[15px] font-bold tracking-normal text-zinc-900 dark:text-zinc-50">Lurkloot</div>
               <div className="flex items-center gap-1 text-[10px] font-medium text-zinc-400 dark:text-zinc-500">
                 <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: enabled ? "var(--accent)" : "#a1a1aa" }} />
-                {settingsOpen ? t("settingsTitle") : activityOpen ? t("activityTitle") : resumingAutomation ? t("resumingAutomation") : `${enabled ? t("activeStatus") : t("pausedStatus")} · ${PLATFORMS[platform].label}`}
+                {settingsOpen ? t("settingsTitle") : activityOpen ? t("activityTitle") : `${enabled ? t("activeStatus") : t("pausedStatus")} · ${PLATFORMS[platform].label}`}
               </div>
             </div>
           </div>
@@ -618,7 +568,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                     />
                   ) : null}
                 </AnimatePresence>
-                <AutomationHero platformLabel={PLATFORMS[platform].label} enabled={enabled} pending={automationPending} farmingTitle={activeCampaign?.title} farmingChannel={farmingChannel} onFarmingTitleClick={onFarmingTitleClick} statusMessage={resumingAutomation ? t("resumingAutomation") : session.message} onChange={setAutomation} />
+                <AutomationHero platformLabel={PLATFORMS[platform].label} enabled={enabled} pending={automationPending} farmingTitle={activeCampaign?.title} farmingChannel={farmingChannel} onFarmingTitleClick={onFarmingTitleClick} statusMessage={session.message} onChange={setAutomation} />
                 {settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} /> : null}
                 <SubTabs
                   tabs={[

--- a/packages/popup-ui/src/demo.ts
+++ b/packages/popup-ui/src/demo.ts
@@ -80,7 +80,6 @@ export function createDemoPopupAdapter(options?: {
     setStorage: async (values: Record<string, unknown>) => {
       Object.assign(store, values);
     },
-    connectSettingsSession: () => () => undefined,
     getMessage: () => "",
     getUiLanguage: () => options?.locale ?? "en",
     openLink: (url) => openHttpsLink(url, (safeUrl) => window.open(safeUrl, "_blank", "noopener,noreferrer")),

--- a/packages/popup-ui/src/settingsRegistry.tsx
+++ b/packages/popup-ui/src/settingsRegistry.tsx
@@ -173,13 +173,13 @@ export function buildSettingsRegistry(ctx: SettingsRegistryContext): SettingsSec
             id: "general.drops.idleWatchlistFallbackOnly",
             titleKey: "idleWatchlistFallbackOnlyTitle",
             descriptionKey: "idleWatchlistFallbackOnlyDescription",
-            render: () => <SettingRow title={t("idleWatchlistFallbackOnlyTitle")} description={t("idleWatchlistFallbackOnlyDescription")} checked={settings.idleWatchlistFallbackOnly} onChange={setFlag("idleWatchlistFallbackOnly")} />,
+            render: () => <SettingRow title={t("idleWatchlistFallbackOnlyTitle")} description={t("idleWatchlistFallbackOnlyDescription")} checked={settings.idleWatchlistFallbackOnly} onChange={(value) => void onSettingsChange({ idleWatchlistFallbackOnly: value }, { tickAfterSave: true })} />,
           },
           {
             id: "general.drops.campaignVisibility",
             titleKey: "visibleCampaignsTitle",
             descriptionKey: "visibleCampaignsDescription",
-            render: () => <CampaignFilterSettingRow value={settings.campaignVisibility} onChange={(campaignVisibility) => void onSettingsChange({ campaignVisibility })} />,
+            render: () => <CampaignFilterSettingRow value={settings.campaignVisibility} onChange={(campaignVisibility) => void onSettingsChange({ campaignVisibility }, { tickAfterSave: true })} />,
           },
           {
             id: "general.drops.forgetExcluded",

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -115,7 +115,6 @@ export interface PopupAdapter {
   send<T>(message: RuntimeMessage): Promise<T>;
   getStorage(keys?: string | string[]): Promise<Record<string, unknown>>;
   setStorage(values: Record<string, unknown>): Promise<void>;
-  connectSettingsSession?(): () => void;
   getMessage(key: string, substitutions?: string | string[]): string;
   getUiLanguage(): string;
   openLink(url: string): void;

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -2,8 +2,6 @@ import type { ActivityHistoryRecord, EventCategory } from "./events";
 import type { CategorySelection, EngineSettings, ExtensionSettings, Platform, PlaybackTelemetry, SchedulerState } from "./models";
 import type { SettingsPatch } from "./settings";
 
-export const SETTINGS_SESSION_PORT = "lurkloot.settings-session";
-
 export type CoreRuntimeMessage =
   | { type: "getSnapshot" }
   | { type: "getPlaybackControl"; platform: Platform }


### PR DESCRIPTION
## Summary

- remove the Settings-specific runtime connection that forced the controller through a globally disabled scheduler cycle
- keep active Twitch and Kick farming, tabless heartbeats, and post-claim handoffs running while Settings is open
- reconcile global scheduling changes across enabled platforms and platform-specific changes only on their affected platform
- preserve serialized auto-saves and immediate automation/provider shutdown behavior
- remove the obsolete resume polling UI and localized copy

## Root cause

Opening Settings connected a dedicated runtime port. The background treated that port as a temporary pause by running the scheduler with `running: false`, which stopped managed tabs and sessions. Closing Settings then required a second global tick and popup polling to rebuild automation.

## Testing

- `pnpm verify`
- 17 Chrome Web Store script tests
- 70 release script tests
- workspace typechecks
- 104 CLI tests
- 634 extension tests
- Astro site build and tests
- Chromium MV3 production build
- Firefox MV2 production build

Closes #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings changes now apply without interrupting active automation.
  * Scheduler refresh now happens immediately after relevant saves—globally for global scheduling changes, or only for the affected platform.
  * Campaign priority reordering now refreshes automation immediately.
  * Added “Auto-claim ready” status messaging across supported languages.

* **Bug Fixes**
  * Non-scheduling setting saves no longer disrupt active sessions/watch behavior.
  * Removed outdated “resuming automation” status override behavior.

* **Tests**
  * Expanded controller and popup coverage for rapid saves, scheduler scope, handoff behavior, and settings open/close lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->