### PR TITLE
fix(kick): stabilize page-context tab lifecycle

### DIFF
--- a/docs/superpowers/plans/2026-07-21-kick-page-context-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-21-kick-page-context-lifecycle.md
@@ -56,6 +56,7 @@ export type PageContextCloseReason =
   | "platform_disabled"
   | "automation_disabled"
   | "manual_watch"
+  | "runtime_restart"
   | "managed_context_unusable";
 ```
 

--- a/docs/superpowers/plans/2026-07-21-kick-page-context-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-21-kick-page-context-lifecycle.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Keep Kick fully tabless while cookie-authenticated background transport works, stabilize the single managed fallback context when it does not, and report every real managed context open/close in the Activity view with a safe reason.
+**Goal:** Keep Kick fully tabless while cookie-authenticated background transport works, stabilize the single inventory-page fallback context when it does not, report every real managed context open/close with a safe reason, and defer recovery after a user closes a farming tab.
 
 **Architecture:** `createKickFetcher` remains background-first and reports sanitized transport outcomes to an injected browser lifecycle port. The browser-backed page-context registry owns retained metadata, adaptive recovery, real tab mutations, and lifecycle emission; the scheduler persists the registry and closes contexts only for explicit lifecycle reasons. Typed shared activity events and localized popup formatting make actual opens/closes visible independently of diagnostic logging.
 
@@ -16,6 +16,8 @@
 - Only successful browser create/remove operations emit open/close activity events.
 - Activity and diagnostics may contain platform, safe hostname, enumerated action, and enumerated reason only; never paths, query strings, cookies, tokens, headers, payloads, or raw errors.
 - User-owned tabs are never registered or closed as managed contexts.
+- Extension-created Kick page contexts open `https://kick.com/drops/inventory` unpinned, muted, and inactive.
+- Closing a managed farming tab clears stale state but never calls the scheduler from `tabs.onRemoved`.
 - Core remains browser-global-free; live browser APIs stay behind the extension adapter.
 
 ---
@@ -224,13 +226,151 @@ git add packages/core/src/core/scheduler.ts packages/core/src/background/control
 git commit -m "fix(scheduler): retain required Kick page context"
 ```
 
-### Task 5: Integrated verification and publication
+### Task 5: Use the Kick Drops inventory as the managed context
 
 **Files:**
-- Verify only: all files changed by Tasks 1-4
+- Modify: `packages/extension/entrypoints/background.ts`
+- Test: `packages/extension/tests/tabs.test.ts`
+- Test: `packages/extension/tests/compatibility.test.ts`
 
 **Interfaces:**
-- Consumes: Tasks 1-4.
+- Consumes: existing `fetchJsonInPage(originUrl, requestUrl, init, options)` binding.
+- Produces: `KICK_PAGE_CONTEXT_URL = "https://kick.com/drops/inventory"` as the extension-created fallback target while retaining origin identity `https://kick.com`.
+
+- [ ] **Step 1: Write the failing production-wiring test**
+
+In `compatibility.test.ts`, read `entrypoints/background.ts` with its existing `backgroundSource` fixture and assert:
+
+```ts
+expect(backgroundSource).toContain('const KICK_PAGE_CONTEXT_URL = "https://kick.com/drops/inventory";');
+expect(backgroundSource).toContain("fetchJsonInPage<unknown>(KICK_PAGE_CONTEXT_URL, url, init");
+```
+
+- [ ] **Step 2: Run the exact source test and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- compatibility.test.ts -t "uses the Kick Drops inventory for page-context fallback"`
+
+Expected: FAIL because production currently passes the Kick homepage literal.
+
+- [ ] **Step 3: Add the browser-property test**
+
+Update the managed page-context creation test to call `fetchJsonInPageWithBrowser` with `https://kick.com/drops/inventory`. Assert:
+
+```ts
+expect(browser.tabs.create).toHaveBeenCalledWith({
+  url: "https://kick.com/drops/inventory",
+  pinned: false,
+  active: false,
+});
+expect(browser.tabs.update).toHaveBeenCalledWith(14, { muted: true, active: false });
+expect(currentManagedPageContextTabs().kick).toMatchObject({
+  originUrl: "https://kick.com/drops/inventory",
+  origin: "https://kick.com",
+});
+```
+
+- [ ] **Step 4: Add and bind the inventory context constant**
+
+In `packages/extension/entrypoints/background.ts`, define:
+
+```ts
+const KICK_PAGE_CONTEXT_URL = "https://kick.com/drops/inventory";
+```
+
+Pass that constant as `originUrl` to `fetchJsonInPage`. Do not change API request URLs, request authentication, origin matching, or user-tab reuse.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- tabs.test.ts compatibility.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the inventory context URL**
+
+```bash
+git add packages/extension/entrypoints/background.ts packages/extension/tests/tabs.test.ts packages/extension/tests/compatibility.test.ts
+git commit -m "fix(kick): open fallback on drops inventory"
+```
+
+### Task 6: Defer farming-tab recovery after manual closure
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: `handleTabRemoved(tabId)` and the existing controller state lock/event collector.
+- Produces: a tab-free idle `WatchSession`, removal of `managedWatchTabs[platform]`, and no scheduler invocation from the removal callback.
+
+- [ ] **Step 1: Replace the immediate-reopen test with a failing deferred-recovery test**
+
+For a running, enabled Twitch session with `tabManagedByExtension: true`, tab id `10`, channel metadata, and a matching `managedWatchTabs.twitch`, call `handleTabRemoved(10)` and assert:
+
+```ts
+expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+expect(env.twitch.prepareWatchTab).not.toHaveBeenCalled();
+expect(env.state.sessions.twitch).toMatchObject({
+  platform: "twitch",
+  status: "idle",
+  offlineChecks: 0,
+});
+expect(env.state.sessions.twitch.tabId).toBeUndefined();
+expect(env.state.sessions.twitch.channel).toBeUndefined();
+expect(env.state.managedWatchTabs?.twitch).toBeUndefined();
+```
+
+- [ ] **Step 2: Run the exact test and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- backgroundController.test.ts -t "defers recovery when the active managed farming tab is closed"`
+
+Expected: FAIL because `handleTabRemoved` immediately calls `tick()` and leaves stale session/ownership fields until that tick replaces them.
+
+- [ ] **Step 3: Clear the removed farming tab atomically**
+
+Inside the existing state lock, identify every enabled/running platform whose watching session is extension-managed and matches `tabId`. For each match, replace the session with:
+
+```ts
+{
+  platform,
+  status: "idle",
+  offlineChecks: 0,
+}
+```
+
+Delete that platform from a copied `managedWatchTabs` map, persist the updated state, and emit a safe diagnostic stating that the managed farming tab was closed and recovery is deferred to the next scheduler cycle.
+
+- [ ] **Step 4: Remove callback-driven scheduling**
+
+Make `handleTabRemoved` return after its serialized persistence/reporting work. Delete the `shouldRerunScheduler` return value and trailing `if (shouldRerunScheduler) await tick()` path. Preserve manual-watch cleanup in the same atomic state update.
+
+- [ ] **Step 5: Add ordinary-cycle recovery coverage**
+
+After the deferred-closure assertions, clear adapter mocks and call `env.controller.tick()`. Assert discovery and `prepareWatchTab` are called and the session receives the replacement tab. This proves eventual recovery remains available without coupling it to `tabs.onRemoved`.
+
+- [ ] **Step 6: Add separation cases**
+
+Keep or extend tests proving unrelated ids and disabled platforms do not prepare tabs. Add a page-context id distinct from the farming session id and assert its removal does not clear the farming session or `managedWatchTabs` entry.
+
+- [ ] **Step 7: Run focused controller tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- backgroundController.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit deferred recovery**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "fix(core): defer closed farming tab recovery"
+```
+
+### Task 7: Integrated verification and publication
+
+**Files:**
+- Verify only: all files changed by Tasks 1-6
+
+**Interfaces:**
+- Consumes: Tasks 1-6.
 - Produces: verified branch and draft pull request for issue #193.
 
 - [ ] **Step 1: Run all workspace tests**

--- a/docs/superpowers/plans/2026-07-21-kick-page-context-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-21-kick-page-context-lifecycle.md
@@ -1,0 +1,261 @@
+# Kick Page-Context Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Kick fully tabless while cookie-authenticated background transport works, stabilize the single managed fallback context when it does not, and report every real managed context open/close in the Activity view with a safe reason.
+
+**Architecture:** `createKickFetcher` remains background-first and reports sanitized transport outcomes to an injected browser lifecycle port. The browser-backed page-context registry owns retained metadata, adaptive recovery, real tab mutations, and lifecycle emission; the scheduler persists the registry and closes contexts only for explicit lifecycle reasons. Typed shared activity events and localized popup formatting make actual opens/closes visible independently of diagnostic logging.
+
+**Tech Stack:** TypeScript 7, pnpm workspaces, Vitest, WXT browser adapters, React popup UI, JSON locale catalogs.
+
+## Global Constraints
+
+- Background cookie replay is always attempted before any page-context creation.
+- Recovery requires three consecutive successful background requests and ten minutes since the most recent page fallback.
+- A new fallback resets the success count and recovery window.
+- Only successful browser create/remove operations emit open/close activity events.
+- Activity and diagnostics may contain platform, safe hostname, enumerated action, and enumerated reason only; never paths, query strings, cookies, tokens, headers, payloads, or raw errors.
+- User-owned tabs are never registered or closed as managed contexts.
+- Core remains browser-global-free; live browser APIs stay behind the extension adapter.
+
+---
+
+### Task 1: Typed and localized page-context activity
+
+**Files:**
+- Modify: `packages/shared/src/events.ts`
+- Modify: `packages/popup-ui/src/activity.logic.ts`
+- Modify: `packages/locales/messages/*.json`
+- Test: `packages/extension/tests/activityView.test.ts`
+
+**Interfaces:**
+- Produces: `PageContextOpenReason`, `PageContextCloseReason`, and `ActivityEvent` variants `page_context_opened` / `page_context_closed` with `data: { host: string; reason: ... }`.
+- Consumes: existing `StoredEngineEvent`, `TFunction`, and locale catalog conventions.
+
+- [ ] **Step 1: Add failing formatter tests**
+
+Add cases that pass stored Kick `page_context_opened` and `page_context_closed` events to `formatActivityEvent`, asserting localized output such as `Opened a Kick background context on kick.com because Kick rejected the tabless request.` and `Closed the Kick background context on kick.com because tabless requests recovered.`
+
+- [ ] **Step 2: Run the focused tests and confirm the type/formatter failure**
+
+Run: `pnpm --filter @lurkloot/extension test -- activityView.test.ts`
+
+Expected: FAIL because the new event codes and formatter branches do not exist.
+
+- [ ] **Step 3: Add exact shared event contracts**
+
+Add:
+
+```ts
+export type PageContextOpenReason = "background_rejected" | "managed_context_unusable";
+export type PageContextCloseReason =
+  | "background_recovered"
+  | "user_tab_available"
+  | "platform_disabled"
+  | "automation_disabled"
+  | "manual_watch"
+  | "managed_context_unusable";
+```
+
+Extend `ActivityEvent` with structured `page_context_opened` and `page_context_closed` variants. Both use `level: "info"`, a required `platform`, and `{ host, reason }` data.
+
+- [ ] **Step 4: Format and localize the new activity variants**
+
+Add exhaustive reason formatters and event branches in `activity.logic.ts`. Add English source strings and corresponding translated catalog keys in every existing locale file, following the repository's catalog completeness rules.
+
+- [ ] **Step 5: Run the focused tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- activityView.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the activity contract**
+
+```bash
+git add packages/shared/src/events.ts packages/popup-ui/src/activity.logic.ts packages/locales/messages packages/extension/tests/activityView.test.ts
+git commit -m "feat(activity): report page-context tab lifecycle"
+```
+
+### Task 2: Ownership-safe browser lifecycle and diagnostics
+
+**Files:**
+- Modify: `packages/shared/src/models.ts`
+- Modify: `packages/core/src/core/tabs.ts`
+- Modify: `packages/extension/src/core/tabs.ts`
+- Test: `packages/extension/tests/tabs.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 activity event reason types and existing `EventEmitter`.
+- Produces: optional `lastFallbackAt?: string` and `backgroundSuccesses?: number` on `ManagedPageContextTab`; `recordPageContextBackgroundSuccessWithBrowser(...)`; reason-aware `stopManagedPageContextTabsWithBrowser(...)`; `PageFetchOptions.emit` and `PageFetchOptions.openReason`.
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+Cover one real create emitting exactly one `page_context_opened`, retained reuse emitting no second open, user-tab replacement emitting one successful close, a failed remove emitting no false close, stale/manual closure emitting only a forget diagnostic, and all messages containing only safe hostnames.
+
+- [ ] **Step 2: Run the focused lifecycle tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- tabs.test.ts`
+
+Expected: FAIL because page-context operations do not emit typed activity or reasoned diagnostics.
+
+- [ ] **Step 3: Add persisted adaptive metadata**
+
+Extend `ManagedPageContextTab` with optional recovery fields. When a fallback is acquired, store `lastFallbackAt` as ISO time and reset `backgroundSuccesses` to zero. Preserve backwards compatibility when restoring records without either field.
+
+- [ ] **Step 4: Emit real mutation events at the ownership boundary**
+
+Thread `EventEmitter` and enumerated reasons through page acquisition and managed cleanup. Emit `page_context_opened` only after `tabs.create`, mute/update, and readiness succeed. Emit `page_context_closed` only after `tabs.remove` resolves. Add a safe diagnostic for every create, reuse, retain, replace, close, and forget decision.
+
+- [ ] **Step 5: Keep user-owned tabs outside managed cleanup**
+
+Retain the existing `createdByExtension: false` representation for queried user tabs. When one replaces a managed context, remove only the registered managed tab ID; never insert the user tab into `retainedPageContextTabs`.
+
+- [ ] **Step 6: Run focused lifecycle tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- tabs.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit browser lifecycle behavior**
+
+```bash
+git add packages/shared/src/models.ts packages/core/src/core/tabs.ts packages/extension/src/core/tabs.ts packages/extension/tests/tabs.test.ts
+git commit -m "fix(kick): make page-context cleanup ownership-aware"
+```
+
+### Task 3: Adaptive background recovery
+
+**Files:**
+- Modify: `packages/core/src/platforms/kick/index.ts`
+- Modify: `packages/core/src/core/tabs.ts`
+- Modify: `packages/extension/src/core/tabs.ts`
+- Modify: `packages/extension/entrypoints/background.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+- Test: `packages/extension/tests/tabs.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2 `recordPageContextBackgroundSuccessWithBrowser` and fallback metadata.
+- Produces: `createKickFetcher` lifecycle callbacks `onBackgroundSuccess(host, emit)` and `onPageFallback(host, emit)`; extension wrappers bound to the live browser.
+
+- [ ] **Step 1: Add failing transport-policy tests**
+
+Assert background success calls the success hook without page fetch, WAF rejection calls the fallback hook before page fetch, non-WAF background errors retain existing fallback behavior, and hooks receive only `new URL(url).host` plus the operation emitter.
+
+- [ ] **Step 2: Add failing threshold tests with an injected clock**
+
+Register a managed Kick context and assert: one or two successes retain it; three successes before ten minutes retain it; three successes after ten minutes remove it once and emit `background_recovered`; a fallback between successes resets both fields.
+
+- [ ] **Step 3: Run both focused files and confirm failure**
+
+Run: `pnpm --filter @lurkloot/extension test -- adapters.test.ts tabs.test.ts`
+
+Expected: FAIL because transport outcome hooks and recovery reconciliation are absent.
+
+- [ ] **Step 4: Implement sanitized outcome hooks**
+
+Extend `createKickFetcher` dependencies with optional async lifecycle callbacks. Await the success callback after a successful background response; await the fallback callback before executing page fetch. Pass only `safeHost(url)` and `emit`.
+
+- [ ] **Step 5: Implement the recovery state machine**
+
+Use constants `PAGE_CONTEXT_RECOVERY_SUCCESSES = 3` and `PAGE_CONTEXT_RECOVERY_MIN_MS = 10 * 60_000`. Success increments the persisted counter. Close only when both thresholds pass. Fallback stamps the current time and resets the counter. A remove failure forgets stale metadata but does not emit a false close activity.
+
+- [ ] **Step 6: Bind the extension lifecycle port**
+
+Add thin wrappers in `packages/extension/src/core/tabs.ts` and inject them into `createKickFetcher` from `background.ts`, passing the operation's `emit` so events reach the controller collector and durable Activity repository.
+
+- [ ] **Step 7: Run focused tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- adapters.test.ts tabs.test.ts activityView.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit adaptive recovery**
+
+```bash
+git add packages/core/src/platforms/kick/index.ts packages/core/src/core/tabs.ts packages/extension/src/core/tabs.ts packages/extension/entrypoints/background.ts packages/extension/tests/adapters.test.ts packages/extension/tests/tabs.test.ts
+git commit -m "fix(kick): release recovered page contexts"
+```
+
+### Task 4: Scheduler retention and explicit cleanup reasons
+
+**Files:**
+- Modify: `packages/core/src/core/scheduler.ts`
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/extension/entrypoints/background.ts`
+- Test: `packages/extension/tests/scheduler.test.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: reason-aware Task 2 stop port and current managed registry snapshot.
+- Produces: `StopPageContextTabs` options `{ platforms?: Platform[]; reason: PageContextCloseReason; emit?: EventEmitter }` and explicit reason mapping for scheduler/controller cleanup.
+
+- [ ] **Step 1: Add the cycling regression test**
+
+Drive consecutive Kick scheduler ticks with a retained context while normal watching continues. Assert the stop port is not invoked merely because `prepareWatchTab` ran and the same context remains in `state.managedPageContextTabs`.
+
+- [ ] **Step 2: Add explicit cleanup tests**
+
+Assert automation stop uses `automation_disabled`, Kick disable uses `platform_disabled`, manual-watch takeover uses `manual_watch`, and startup/manual-close handling never closes an unowned tab.
+
+- [ ] **Step 3: Run scheduler/controller tests and confirm failure**
+
+Run: `pnpm --filter @lurkloot/extension test -- scheduler.test.ts backgroundController.test.ts`
+
+Expected: FAIL on unconditional teardown and missing reason propagation.
+
+- [ ] **Step 4: Remove ordinary watch-transition teardown**
+
+Delete the unconditional `stopPageContextTabs(currentManagedPageContextTabs(), { platforms: [platform] })` after watch preparation. Continue assigning `currentManagedPageContextTabs()` into next state so metadata changes persist.
+
+- [ ] **Step 5: Propagate explicit cleanup reasons**
+
+Pass the appropriate enumerated close reason and current operation emitter from manual-watch and disabled branches through the injected browser stop port. Preserve the headless default by making pure `forgetManagedPageContextTabs` accept and ignore browser-only emission details.
+
+- [ ] **Step 6: Run scheduler/controller tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- scheduler.test.ts backgroundController.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit scheduler lifecycle behavior**
+
+```bash
+git add packages/core/src/core/scheduler.ts packages/core/src/background/controller.ts packages/extension/entrypoints/background.ts packages/extension/tests/scheduler.test.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "fix(scheduler): retain required Kick page context"
+```
+
+### Task 5: Integrated verification and publication
+
+**Files:**
+- Verify only: all files changed by Tasks 1-4
+
+**Interfaces:**
+- Consumes: Tasks 1-4.
+- Produces: verified branch and draft pull request for issue #193.
+
+- [ ] **Step 1: Run all workspace tests**
+
+Run: `pnpm test`
+
+Expected: all extension, CLI, and site tests pass.
+
+- [ ] **Step 2: Run required release-grade verification**
+
+Run: `pnpm verify`
+
+Expected: script tests, all workspace typechecks, extension and CLI tests, site build, Chromium build, and Firefox build all pass.
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run: `git diff --check && git status --short && git log --oneline origin/develop..HEAD`
+
+Expected: no whitespace errors, only issue #193 files changed, and focused Conventional Commits.
+
+- [ ] **Step 4: Push and open the draft PR**
+
+```bash
+git push -u origin fix/kick-page-context-lifecycle
+gh pr create --draft --base develop --head fix/kick-page-context-lifecycle --title "fix(kick): stabilize page-context tab lifecycle" --body-file /tmp/lurkloot-193-pr.md
+```
+
+The PR body must summarize background-first adaptive behavior, user-visible open/close activity, ownership safety, and verification; include `Closes #193`.

--- a/docs/superpowers/specs/2026-07-21-kick-page-context-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-21-kick-page-context-lifecycle-design.md
@@ -2,9 +2,9 @@
 
 ## Goal
 
-Keep Kick farming fully tabless whenever service-worker requests authenticated by the normal browser session work. When Kick rejects those requests, use at most one muted, inactive, extension-managed `kick.com` page context and retain it only while the fallback remains necessary.
+Keep Kick farming fully tabless whenever service-worker requests authenticated by the normal browser session work. When Kick rejects those requests, use at most one unpinned, muted, inactive, extension-managed `kick.com` page context on the Drops inventory page and retain it only while the fallback remains necessary.
 
-The change fixes the repeated opening and closing reported in issue #193 without making a Kick tab a prerequisite for tabless farming.
+The change fixes the repeated opening and closing reported in issue #193 without making a Kick tab a prerequisite for tabless farming. It also makes deliberate user closure of a pinned farming tab non-confrontational: LurkLoot clears the stale tab handle and waits for the next ordinary scheduler cycle instead of reopening the tab immediately.
 
 ## Current Behavior and Root Cause
 
@@ -12,17 +12,21 @@ Kick requests already try the service worker first. The extension reads the norm
 
 The scheduler currently closes a retained page context after preparing a watch tab. Later discovery or heartbeat requests can still require that page context, so they recreate it. Persisted state, the in-memory registry, and the real browser tab can consequently move out of sync and produce visible cycling.
 
+Separately, the controller treats closure of an extension-managed farming tab as a request for immediate recovery and runs another scheduler tick from the `tabs.onRemoved` callback. That can recreate the pinned channel tab before the user has finished interacting with the browser. The two tab types have different purposes and must not share recovery policy: a WAF context is demand-created by a rejected API request, while a farming tab is selected and prepared by an ordinary scheduler cycle.
+
 ## Selected Approach
 
 Use an adaptive, lifecycle-driven retained context:
 
 1. Every Kick request continues to try cookie-authenticated service-worker transport first.
 2. A successful background request does not create a page context.
-3. A rejected background request reuses a qualifying user-owned Kick tab when available; otherwise it creates or reuses one extension-managed muted, inactive homepage context.
+3. A rejected background request reuses a qualifying user-owned Kick tab when available; otherwise it creates or reuses one extension-managed, unpinned, muted, inactive context at `https://kick.com/drops/inventory`.
 4. Ordinary scheduler/watch-tab transitions do not close a valid retained context.
 5. A retained context is released after the background transport demonstrates sustained recovery: at least three consecutive successful background requests and at least ten minutes since the most recent page fallback.
 6. Another page fallback resets the success count and recovery window, preventing intermittent success from causing close/reopen flapping.
 7. Explicit lifecycle events close the managed context immediately: Kick is disabled, automation stops, manual watching takes over, or a qualifying user-owned Kick tab replaces it.
+8. Closing an extension-managed farming tab clears its tab id, channel, ownership record, and tab-bound playback state without calling the scheduler from the removal callback.
+9. The next normal alarm, startup, settings-triggered tick, or other existing scheduler entry point may select a channel and create a new farming tab. Closing a tab does not silently disable Kick, stop all automation, or add a persisted cooldown.
 
 The recovery threshold is deliberately conservative. It removes an unnecessary context after background transport becomes healthy while favoring one stable tab over disruptive cycling when Kick behaves intermittently.
 
@@ -46,6 +50,8 @@ The registry will expose focused lifecycle operations to:
 
 All registry mutations update the state returned by `currentManagedPageContextTabs`, allowing the controller's normal state save to synchronize browser and persisted state.
 
+The configured context URL is the user-meaningful Kick Drops inventory page rather than the homepage. Context identity remains origin-based (`https://kick.com`) so any qualifying user-owned Kick page can service same-origin execution, while extension-created replacements consistently return to the inventory page. The context is explicitly unpinned, muted, and inactive; those properties distinguish it from a pinned farming tab.
+
 ### User-visible activity events
 
 Opening or closing an extension-managed page-context tab is a user-visible side effect, not merely a debugging detail. Each successful browser create or close operation will therefore emit a typed activity event that is stored and shown in the Activity view regardless of whether diagnostic logging is enabled:
@@ -61,11 +67,19 @@ Only successful, real browser mutations create these activity records. Reusing o
 
 The scheduler stops treating watch-tab preparation as a reason to tear down page contexts. It continues to request immediate cleanup for explicit platform lifecycle changes. This keeps page-context tabs distinct from farming/watch tabs.
 
+### Farming-tab manual closure
+
+The tab-removal handler continues to serialize state changes with ticks and heartbeats. When the removed id belongs to the active extension-managed farming session, it removes the corresponding `managedWatchTabs` entry and changes the session to an idle, tab-free state. It preserves accumulated campaign data and automation settings, and it emits a diagnostic stating that recovery is deferred to the next normal scheduler cycle.
+
+The handler does not invoke `tick()` after releasing the state lock. This prevents the immediate close/reopen loop while retaining eventual recovery through the existing alarm and startup paths. Removal of an unrelated tab remains a no-op. Removal of a page-context tab is not misclassified as farming-tab closure because page contexts are tracked separately in `managedPageContextTabs`.
+
 ### Restart and manual closure
 
 On service-worker wake, persisted managed context metadata is registered before the tick. Reuse validates the real tab with `tabs.get`. A missing, navigated, or otherwise unusable tab is forgotten before exactly one replacement may be created.
 
 Startup while automation is stopped retains the existing stale-state cleanup policy and closes only recorded extension-owned contexts. User-owned tabs are never persisted as managed contexts and are therefore never included in managed cleanup.
+
+Manual closure has type-specific behavior. A missing WAF context is forgotten and recreated only if a later background request is rejected. A missing farming tab is cleared immediately from scheduler state and can be recreated only by a later ordinary scheduler entry point. Neither type is recreated directly from `tabs.onRemoved`.
 
 ## Diagnostics and Privacy
 
@@ -86,6 +100,7 @@ The corresponding user-visible open/close activity events follow the same privac
 - Failure to close a known managed tab is tolerated because the user may already have closed it; the registry still forgets the stale handle.
 - Failure to create or execute in a page context keeps the existing request error behavior and does not leave an invalid registry entry.
 - Concurrent fallback requests for the same origin continue sharing the existing acquisition promise, preventing duplicate creation.
+- Failure to persist farming-tab closure is reported through the controller's existing best-effort event path; the removal handler never starts an overlapping recovery tick to mask stale state.
 
 ## Testing
 
@@ -93,6 +108,7 @@ Deterministic tests will cover:
 
 - background cookie replay succeeds and creates no tab;
 - a rejected request creates one managed context and later operations reuse it;
+- an extension-created Kick context opens `https://kick.com/drops/inventory` with `pinned: false`, `active: false`, and muted playback;
 - scheduler and heartbeat cycles do not close and immediately recreate the context;
 - fewer than three successes or less than ten minutes retains the context;
 - three consecutive successes after the recovery window close the managed context;
@@ -104,6 +120,10 @@ Deterministic tests will cover:
 - every lifecycle action has a safe reason and diagnostics contain hostnames but no sensitive URL or request details.
 - every successful managed page-context creation and closure appears in the Activity view even with diagnostic logging disabled, with the correct localized reason;
 - reuse, retention, failed close attempts, and user-initiated tab closure do not produce false open/close activity events.
+- closing the active extension-managed farming tab clears its session and ownership state without preparing another tab in the same removal operation;
+- a later normal scheduler tick can resume farming and prepare a replacement tab;
+- closing an unrelated, user-owned, or page-context tab does not mutate the farming session;
+- closing a farming tab while Kick is disabled does not schedule or prepare replacement work.
 
 After focused tests, the complete `pnpm verify` command must pass before publication.
 
@@ -112,4 +132,5 @@ After focused tests, the complete `pnpm verify` command must pass before publica
 - Spoofing Kick's page origin or restricted browser headers.
 - Exporting, persisting, or otherwise changing credential handling.
 - Removing the page fallback when Kick demonstrably rejects service-worker access.
+- Adding a persisted farming cooldown or changing the user's enabled/running settings when a farming tab is closed.
 - Changing Twitch page-context behavior except where shared helpers require ownership-safe diagnostics.

--- a/docs/superpowers/specs/2026-07-21-kick-page-context-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-21-kick-page-context-lifecycle-design.md
@@ -46,6 +46,17 @@ The registry will expose focused lifecycle operations to:
 
 All registry mutations update the state returned by `currentManagedPageContextTabs`, allowing the controller's normal state save to synchronize browser and persisted state.
 
+### User-visible activity events
+
+Opening or closing an extension-managed page-context tab is a user-visible side effect, not merely a debugging detail. Each successful browser create or close operation will therefore emit a typed activity event that is stored and shown in the Activity view regardless of whether diagnostic logging is enabled:
+
+- `page_context_opened`, with the platform, safe hostname, and reason the page context became necessary;
+- `page_context_closed`, with the platform, safe hostname, and reason the page context was released.
+
+The reason is structured data rendered through localized messages. Opening reasons include a rejected background request and recovery from a missing or unusable managed context. Closure reasons include stable background recovery, a user-owned tab becoming available, platform disablement, automation stopping, manual-watch takeover, and unusable-context replacement.
+
+Only successful, real browser mutations create these activity records. Reusing or retaining an existing tab does not claim that a tab was opened, and discovering that a user already closed a tab does not claim that LurkLoot closed it. Those non-mutating decisions remain diagnostics.
+
 ### Scheduler ownership
 
 The scheduler stops treating watch-tab preparation as a reason to tear down page contexts. It continues to request immediate cleanup for explicit platform lifecycle changes. This keeps page-context tabs distinct from farming/watch tabs.
@@ -58,7 +69,7 @@ Startup while automation is stopped retains the existing stale-state cleanup pol
 
 ## Diagnostics and Privacy
 
-Each lifecycle decision emits a diagnostic with:
+Each lifecycle decision also emits a diagnostic with:
 
 - platform (`kick`);
 - safe hostname only (`kick.com`, `web.kick.com`, or `websockets.kick.com`);
@@ -66,6 +77,8 @@ Each lifecycle decision emits a diagnostic with:
 - functional reason such as `background rejected`, `recovery threshold pending`, `background transport stable`, `user tab available`, `tab missing`, `platform disabled`, or `automation stopped`.
 
 Diagnostics must not contain URL paths, query strings, cookies, authorization values, request headers, request or response bodies, or raw platform errors that may contain those values.
+
+The corresponding user-visible open/close activity events follow the same privacy rule. Their formatter uses only the platform, safe hostname, and enumerated reason; it never displays raw error text.
 
 ## Error Handling
 
@@ -89,6 +102,8 @@ Deterministic tests will cover:
 - a manually closed or navigated context is forgotten and replaced without duplication;
 - disabling Kick, stopping automation, and manual-watch takeover close only managed contexts;
 - every lifecycle action has a safe reason and diagnostics contain hostnames but no sensitive URL or request details.
+- every successful managed page-context creation and closure appears in the Activity view even with diagnostic logging disabled, with the correct localized reason;
+- reuse, retention, failed close attempts, and user-initiated tab closure do not produce false open/close activity events.
 
 After focused tests, the complete `pnpm verify` command must pass before publication.
 

--- a/docs/superpowers/specs/2026-07-21-kick-page-context-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-21-kick-page-context-lifecycle-design.md
@@ -1,0 +1,100 @@
+# Kick Page-Context Lifecycle Design
+
+## Goal
+
+Keep Kick farming fully tabless whenever service-worker requests authenticated by the normal browser session work. When Kick rejects those requests, use at most one muted, inactive, extension-managed `kick.com` page context and retain it only while the fallback remains necessary.
+
+The change fixes the repeated opening and closing reported in issue #193 without making a Kick tab a prerequisite for tabless farming.
+
+## Current Behavior and Root Cause
+
+Kick requests already try the service worker first. The extension reads the normal `session_token` cookie and replays it as a Bearer token for authenticated Kick hosts. A real Kick page context is used only when the service-worker request is rejected by WAF, CORS, origin policy, or a challenge response.
+
+The scheduler currently closes a retained page context after preparing a watch tab. Later discovery or heartbeat requests can still require that page context, so they recreate it. Persisted state, the in-memory registry, and the real browser tab can consequently move out of sync and produce visible cycling.
+
+## Selected Approach
+
+Use an adaptive, lifecycle-driven retained context:
+
+1. Every Kick request continues to try cookie-authenticated service-worker transport first.
+2. A successful background request does not create a page context.
+3. A rejected background request reuses a qualifying user-owned Kick tab when available; otherwise it creates or reuses one extension-managed muted, inactive homepage context.
+4. Ordinary scheduler/watch-tab transitions do not close a valid retained context.
+5. A retained context is released after the background transport demonstrates sustained recovery: at least three consecutive successful background requests and at least ten minutes since the most recent page fallback.
+6. Another page fallback resets the success count and recovery window, preventing intermittent success from causing close/reopen flapping.
+7. Explicit lifecycle events close the managed context immediately: Kick is disabled, automation stops, manual watching takes over, or a qualifying user-owned Kick tab replaces it.
+
+The recovery threshold is deliberately conservative. It removes an unnecessary context after background transport becomes healthy while favoring one stable tab over disruptive cycling when Kick behaves intermittently.
+
+## Architecture
+
+### Core Kick fetch policy
+
+`createKickFetcher` remains browser-free and keeps its background-first policy. It will report safe transport outcomes through an injected lifecycle callback. The callback receives only the platform, safe hostname, outcome, and functional reason; it never receives request paths, query values, headers, cookies, tokens, or payloads.
+
+### Browser page-context registry
+
+The page-context registry remains the ownership authority for extension-created contexts. Retained Kick context metadata will include the last fallback time and consecutive background-success count. The fields are optional so previously persisted scheduler state remains compatible.
+
+The registry will expose focused lifecycle operations to:
+
+- record that a fallback is required;
+- record a background success and determine whether recovery is stable;
+- validate and reuse a retained browser tab;
+- replace a managed context with a user-owned tab;
+- close only a context whose persisted handle says it is extension-owned.
+
+All registry mutations update the state returned by `currentManagedPageContextTabs`, allowing the controller's normal state save to synchronize browser and persisted state.
+
+### Scheduler ownership
+
+The scheduler stops treating watch-tab preparation as a reason to tear down page contexts. It continues to request immediate cleanup for explicit platform lifecycle changes. This keeps page-context tabs distinct from farming/watch tabs.
+
+### Restart and manual closure
+
+On service-worker wake, persisted managed context metadata is registered before the tick. Reuse validates the real tab with `tabs.get`. A missing, navigated, or otherwise unusable tab is forgotten before exactly one replacement may be created.
+
+Startup while automation is stopped retains the existing stale-state cleanup policy and closes only recorded extension-owned contexts. User-owned tabs are never persisted as managed contexts and are therefore never included in managed cleanup.
+
+## Diagnostics and Privacy
+
+Each lifecycle decision emits a diagnostic with:
+
+- platform (`kick`);
+- safe hostname only (`kick.com`, `web.kick.com`, or `websockets.kick.com`);
+- action (`create`, `reuse`, `retain`, `replace`, `close`, or `forget`);
+- functional reason such as `background rejected`, `recovery threshold pending`, `background transport stable`, `user tab available`, `tab missing`, `platform disabled`, or `automation stopped`.
+
+Diagnostics must not contain URL paths, query strings, cookies, authorization values, request headers, request or response bodies, or raw platform errors that may contain those values.
+
+## Error Handling
+
+- Failure to inspect a persisted context treats it as stale and forgets the handle.
+- Failure to close a known managed tab is tolerated because the user may already have closed it; the registry still forgets the stale handle.
+- Failure to create or execute in a page context keeps the existing request error behavior and does not leave an invalid registry entry.
+- Concurrent fallback requests for the same origin continue sharing the existing acquisition promise, preventing duplicate creation.
+
+## Testing
+
+Deterministic tests will cover:
+
+- background cookie replay succeeds and creates no tab;
+- a rejected request creates one managed context and later operations reuse it;
+- scheduler and heartbeat cycles do not close and immediately recreate the context;
+- fewer than three successes or less than ten minutes retains the context;
+- three consecutive successes after the recovery window close the managed context;
+- a new fallback resets recovery tracking;
+- a user-owned Kick tab replaces the managed context without ever being closed by cleanup;
+- service-worker state restoration reuses a valid context;
+- a manually closed or navigated context is forgotten and replaced without duplication;
+- disabling Kick, stopping automation, and manual-watch takeover close only managed contexts;
+- every lifecycle action has a safe reason and diagnostics contain hostnames but no sensitive URL or request details.
+
+After focused tests, the complete `pnpm verify` command must pass before publication.
+
+## Out of Scope
+
+- Spoofing Kick's page origin or restricted browser headers.
+- Exporting, persisting, or otherwise changing credential handling.
+- Removing the page fallback when Kick demonstrably rejects service-worker access.
+- Changing Twitch page-context behavior except where shared helpers require ownership-safe diagnostics.

--- a/packages/cli/src/events.ts
+++ b/packages/cli/src/events.ts
@@ -43,7 +43,7 @@ function formatPageContextCloseReason(reason: PageContextCloseReason): string {
     case "platform_disabled": return "platform disabled";
     case "automation_disabled": return "automation disabled";
     case "manual_watch": return "manual watch detected";
-    case "runtime_restart": return "browser restarted";
+    case "runtime_restart": return "extension runtime restarted";
     case "managed_context_unusable": return "background context unusable";
     default: {
       const exhaustive: never = reason;

--- a/packages/cli/src/events.ts
+++ b/packages/cli/src/events.ts
@@ -1,4 +1,4 @@
-import type { EngineEvent, FarmingStopReason } from "@lurkloot/shared/events";
+import type { EngineEvent, FarmingStopReason, PageContextCloseReason, PageContextOpenReason } from "@lurkloot/shared/events";
 import type { Logger } from "./logger";
 
 function formatStopReason(reason: FarmingStopReason): string {
@@ -25,6 +25,32 @@ function formatStopReason(reason: FarmingStopReason): string {
   }
 }
 
+function formatPageContextOpenReason(reason: PageContextOpenReason): string {
+  switch (reason) {
+    case "background_rejected": return "background request rejected";
+    case "managed_context_unusable": return "previous background context unusable";
+    default: {
+      const exhaustive: never = reason;
+      return exhaustive;
+    }
+  }
+}
+
+function formatPageContextCloseReason(reason: PageContextCloseReason): string {
+  switch (reason) {
+    case "background_recovered": return "background requests recovered";
+    case "user_tab_available": return "user Kick tab available";
+    case "platform_disabled": return "platform disabled";
+    case "automation_disabled": return "automation disabled";
+    case "manual_watch": return "manual watch detected";
+    case "managed_context_unusable": return "background context unusable";
+    default: {
+      const exhaustive: never = reason;
+      return exhaustive;
+    }
+  }
+}
+
 export function formatCliEvent(event: EngineEvent): string {
   if (event.category === "diagnostic") return event.message;
 
@@ -41,6 +67,10 @@ export function formatCliEvent(event: EngineEvent): string {
     }
     case "challenge_claimed":
       return `Claimed a ${event.data.rarity} ${event.data.recurrence} challenge`;
+    case "page_context_opened":
+      return `Opened background context on ${event.data.host}: ${formatPageContextOpenReason(event.data.reason)}`;
+    case "page_context_closed":
+      return `Closed background context on ${event.data.host}: ${formatPageContextCloseReason(event.data.reason)}`;
     default: {
       const exhaustive: never = event;
       return exhaustive;

--- a/packages/cli/src/events.ts
+++ b/packages/cli/src/events.ts
@@ -43,6 +43,7 @@ function formatPageContextCloseReason(reason: PageContextCloseReason): string {
     case "platform_disabled": return "platform disabled";
     case "automation_disabled": return "automation disabled";
     case "manual_watch": return "manual watch detected";
+    case "runtime_restart": return "browser restarted";
     case "managed_context_unusable": return "background context unusable";
     default: {
       const exhaustive: never = reason;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -141,6 +141,23 @@ describe("CLI engine event reporting", () => {
         .toContain(reason.replaceAll("_", " "));
     }
   });
+
+  it("formats managed page-context lifecycle activity", () => {
+    expect(formatCliEvent({
+      category: "activity",
+      code: "page_context_opened",
+      level: "info",
+      platform: "kick",
+      data: { host: "kick.com", reason: "background_rejected" },
+    })).toBe("Opened background context on kick.com: background request rejected");
+    expect(formatCliEvent({
+      category: "activity",
+      code: "page_context_closed",
+      level: "info",
+      platform: "kick",
+      data: { host: "kick.com", reason: "background_recovered" },
+    })).toBe("Closed background context on kick.com: background requests recovered");
+  });
 });
 
 describe("CLI campaign status reporting", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -157,6 +157,13 @@ describe("CLI engine event reporting", () => {
       platform: "kick",
       data: { host: "kick.com", reason: "background_recovered" },
     })).toBe("Closed background context on kick.com: background requests recovered");
+    expect(formatCliEvent({
+      category: "activity",
+      code: "page_context_closed",
+      level: "info",
+      platform: "kick",
+      data: { host: "kick.com", reason: "runtime_restart" },
+    })).toBe("Closed background context on kick.com: extension runtime restarted");
   });
 });
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -474,11 +474,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function handleTabRemoved(tabId: number): Promise<void> {
     // Serialize the load-modify-persist under the state lock so it cannot race a
     // concurrent tick()/heartbeat (both fire on a ~1-minute cadence while the
-    // user can close a tab at any moment). The trailing tick() is deferred to
-    // outside the lock because it re-acquires the lock itself — mirroring how
-    // runWatchHeartbeat returns its fallback work and ticks afterwards.
-    const shouldRerunScheduler = await withStateLock(() => withEventCollector(async (emit, events) => {
-      const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+    // user can close a tab at any moment). A removal never runs the scheduler
+    // directly: the next ordinary alarm may recover without fighting the user's
+    // close action by immediately recreating the tab.
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      const state = await deps.loadState();
       const manualPlatforms = (["twitch", "kick"] as Platform[]).filter((platform) => state.manualWatch?.[platform]?.tabId === tabId);
       let nextState = state;
       if (manualPlatforms.length > 0) {
@@ -489,26 +489,32 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           manualWatch,
         };
       }
-      let shouldRerun = false;
 
-      for (const platform of settings.running ? ["twitch", "kick"] as Platform[] : []) {
+      const closedManagedPlatforms: Platform[] = [];
+      for (const platform of PLATFORMS) {
         const session = state.sessions[platform];
         if (
-          settings.platform[platform].enabled
-          && session.status === "watching"
+          session.status === "watching"
           && session.tabManagedByExtension
           && session.tabId === tabId
         ) {
-          emit({ category: "diagnostic", platform, level: "info", message: "Managed watch tab was closed; re-running scheduler" });
-          shouldRerun = true;
-          break;
+          closedManagedPlatforms.push(platform);
+          emit({ category: "diagnostic", platform, level: "info", message: "Managed watch tab was closed; recovery deferred to the next scheduler cycle" });
         }
       }
-      if (manualPlatforms.length > 0 || events.length > 0) await persistAndReport(nextState, events);
-      return shouldRerun;
-    }));
 
-    if (shouldRerunScheduler) await tick();
+      if (closedManagedPlatforms.length > 0) {
+        const sessions = { ...nextState.sessions };
+        const managedWatchTabs = { ...nextState.managedWatchTabs };
+        for (const platform of closedManagedPlatforms) {
+          sessions[platform] = { platform, status: "idle", offlineChecks: 0 };
+          delete managedWatchTabs[platform];
+        }
+        nextState = { ...nextState, sessions, managedWatchTabs };
+      }
+
+      if (nextState !== state || events.length > 0) await persistAndReport(nextState, events);
+    }));
   }
 
   function tablessWatchContext(): WatchContext {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -5,7 +5,7 @@ import type { SettingsPatch } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
 import { isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
 import { MANUAL_WATCH_TTL_MS, runSchedulerTick, type StopPageContextTabs } from "../core/scheduler";
-import { setTwitchIntegrity } from "../core/tabs";
+import { currentManagedPageContextTabs, registerManagedPageContextTabs, setTwitchIntegrity } from "../core/tabs";
 import { integrityFromHeaders } from "../core/twitchIntegrity";
 import type { IntegrityHeader, TwitchIntegrity } from "../core/twitchIntegrity";
 import type { PlatformAdapter } from "../platforms/adapter";
@@ -361,8 +361,18 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       return;
     }
 
-    if (deps.closeManagedTabsByUrl) {
+    if (deps.closeManagedTabsByUrl && cleanup.managedUrls.length > 0) {
       await deps.closeManagedTabsByUrl(cleanup.managedUrls);
+    }
+    if (deps.stopPageContextTabs && Object.keys(state.managedPageContextTabs ?? {}).length > 0) {
+      await withEventCollector(async (emit, events) => {
+        await deps.stopPageContextTabs!(state.managedPageContextTabs ?? {}, {
+          platforms: ["twitch", "kick"],
+          reason: "runtime_restart",
+          emit,
+        });
+        await reportBestEffort(events);
+      });
     }
 
     let nextSettings = settings;
@@ -578,6 +588,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     if (!settings.running) return;
     const fallbackPlatforms = await withStateLock<Platform[]>(() => withEventCollector(async (emit, events) => {
       let nextState = await deps.loadState();
+      registerManagedPageContextTabs(nextState.managedPageContextTabs ?? {});
       // After a service-worker restart the in-memory watcher map is empty, so
       // rebuild it from persisted tabless sessions before the size check below.
       // Otherwise the 1-minute watch alarm would do nothing until the next
@@ -639,6 +650,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           emit({ category: "diagnostic", platform, level: "warn", message: "Tabless watch heartbeat keeps failing; falling back to a watch tab" });
         }
       }
+
+      nextState = {
+        ...nextState,
+        managedPageContextTabs: currentManagedPageContextTabs(),
+      };
 
       if (changed) await persistAndReport(nextState, events);
       else await reportBestEffort(events);
@@ -1299,7 +1315,6 @@ function staleStartupCleanup(state: SchedulerState): {
     const managedTab = state.managedWatchTabs?.[platform];
     const managedPageContextTab = state.managedPageContextTabs?.[platform];
     if (managedTab?.channelUrl) managedUrls.add(managedTab.channelUrl);
-    if (managedPageContextTab?.originUrl) managedUrls.add(managedPageContextTab.originUrl);
     if (session.tabManagedByExtension && session.channel?.url) managedUrls.add(session.channel.url);
 
     if (session.status === "watching" || session.tabId != null || managedTab || managedPageContextTab) {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1,5 +1,5 @@
 import type { CategorySearchResult, CoreRuntimeMessage, PlaybackControl, RuntimeSnapshot } from "@lurkloot/shared/messages";
-import type { DropCampaign, DropReward, EngineSettings, Platform, PlaybackTelemetry, SchedulerState, WatchReasonCode, WatchSession } from "@lurkloot/shared/models";
+import type { DropCampaign, DropReward, EngineSettings, ManagedWatchTab, Platform, PlaybackTelemetry, SchedulerState, WatchReasonCode, WatchSession } from "@lurkloot/shared/models";
 import type { ActivityEvent, DiagnosticEvent, EngineEvent, EventEmitter, EventReporter, FarmingStopReason } from "@lurkloot/shared/events";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
@@ -106,7 +106,7 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
   };
   createNotification?(notification: { title: string; message: string }): Promise<void>;
   translate?(key: string, substitutions?: string | string[]): string | Promise<string>;
-  closeManagedTabsByUrl?(urls: string[]): Promise<void>;
+  closeManagedTabs?(tabs: ManagedWatchTab[]): Promise<void>;
   // Tab-mode ad focus. The host (extension) owns the focus policy (adFocusMode),
   // so the engine only reports whether an ad is active for a given watch tab.
   applyAdFocus?(platform: Platform, tabId: number | undefined, adActive: boolean, emit: EventEmitter): Promise<void>;
@@ -363,8 +363,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       return;
     }
 
-    if (deps.closeManagedTabsByUrl && cleanup.managedUrls.length > 0) {
-      await deps.closeManagedTabsByUrl(cleanup.managedUrls);
+    if (deps.closeManagedTabs && cleanup.managedTabs.length > 0) {
+      await deps.closeManagedTabs(cleanup.managedTabs);
     }
     if (!preservePageContexts && deps.stopPageContextTabs && Object.keys(state.managedPageContextTabs ?? {}).length > 0) {
       await withEventCollector(async (emit, events) => {
@@ -1311,19 +1311,18 @@ function isFarmingStopReason(code: WatchReasonCode): code is FarmingStopReason {
 
 function staleStartupCleanup(state: SchedulerState, preservePageContexts = false): {
   hasStaleSession: boolean;
-  managedUrls: string[];
+  managedTabs: ManagedWatchTab[];
   state: SchedulerState;
 } {
   let hasStaleSession = false;
-  const managedUrls = new Set<string>();
+  const managedTabs = new Map<number, ManagedWatchTab>();
   const sessions = { ...state.sessions };
 
   for (const platform of ["twitch", "kick"] as Platform[]) {
     const session = state.sessions[platform];
     const managedTab = state.managedWatchTabs?.[platform];
     const managedPageContextTab = state.managedPageContextTabs?.[platform];
-    if (managedTab?.channelUrl) managedUrls.add(managedTab.channelUrl);
-    if (session.tabManagedByExtension && session.channel?.url) managedUrls.add(session.channel.url);
+    if (managedTab?.ownedByExtension) managedTabs.set(managedTab.tabId, managedTab);
 
     if (session.status === "watching" || session.tabId != null || managedTab || (!preservePageContexts && managedPageContextTab)) {
       hasStaleSession = true;
@@ -1333,7 +1332,7 @@ function staleStartupCleanup(state: SchedulerState, preservePageContexts = false
 
   return {
     hasStaleSession,
-    managedUrls: [...managedUrls],
+    managedTabs: [...managedTabs.values()],
     state: {
       ...state,
       sessions,

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -352,7 +352,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     // A restart kills any in-memory watchers; start clean and let tick() rebuild.
     tablessWatchers.clear();
 
-    const cleanup = staleStartupCleanup(state);
+    const preservePageContexts = settings.running && settings.autoStartDropFarming;
+    registerManagedPageContextTabs(preservePageContexts ? state.managedPageContextTabs ?? {} : {});
+    const cleanup = staleStartupCleanup(state, preservePageContexts);
     if (!cleanup.hasStaleSession) {
       if (settings.autoStartDropFarming && settings.running) await tick();
       if (settings.running && !settings.autoStartDropFarming) {
@@ -364,7 +366,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     if (deps.closeManagedTabsByUrl && cleanup.managedUrls.length > 0) {
       await deps.closeManagedTabsByUrl(cleanup.managedUrls);
     }
-    if (deps.stopPageContextTabs && Object.keys(state.managedPageContextTabs ?? {}).length > 0) {
+    if (!preservePageContexts && deps.stopPageContextTabs && Object.keys(state.managedPageContextTabs ?? {}).length > 0) {
       await withEventCollector(async (emit, events) => {
         await deps.stopPageContextTabs!(state.managedPageContextTabs ?? {}, {
           platforms: ["twitch", "kick"],
@@ -1307,7 +1309,7 @@ function isFarmingStopReason(code: WatchReasonCode): code is FarmingStopReason {
   return Object.prototype.hasOwnProperty.call(FARMING_STOP_REASON_CODES, code);
 }
 
-function staleStartupCleanup(state: SchedulerState): {
+function staleStartupCleanup(state: SchedulerState, preservePageContexts = false): {
   hasStaleSession: boolean;
   managedUrls: string[];
   state: SchedulerState;
@@ -1323,7 +1325,7 @@ function staleStartupCleanup(state: SchedulerState): {
     if (managedTab?.channelUrl) managedUrls.add(managedTab.channelUrl);
     if (session.tabManagedByExtension && session.channel?.url) managedUrls.add(session.channel.url);
 
-    if (session.status === "watching" || session.tabId != null || managedTab || managedPageContextTab) {
+    if (session.status === "watching" || session.tabId != null || managedTab || (!preservePageContexts && managedPageContextTab)) {
       hasStaleSession = true;
       sessions[platform] = pausedStartupSession(session);
     }
@@ -1336,7 +1338,7 @@ function staleStartupCleanup(state: SchedulerState): {
       ...state,
       sessions,
       managedWatchTabs: {},
-      managedPageContextTabs: {},
+      managedPageContextTabs: preservePageContexts ? state.managedPageContextTabs : {},
     },
   };
 }

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -13,7 +13,7 @@ import type {
 import { categoryListIndex } from "@lurkloot/shared/categories";
 import { isSubscriptionReward, isWatchReward, reconcileCampaignAfterClaims, rewardFeasibility } from "@lurkloot/shared/rewards";
 import { autoClaimChallengesFor, autoClaimChannelPointsFor } from "@lurkloot/shared/settings";
-import type { EngineEvent, EventEmitter, FarmingStopReason } from "@lurkloot/shared/events";
+import type { EngineEvent, EventEmitter, FarmingStopReason, PageContextCloseReason } from "@lurkloot/shared/events";
 import { currentManagedPageContextTabs, forgetManagedPageContextTabs, registerManagedPageContextTabs, type SchedulerManagedPageContexts } from "./tabs";
 import type { LogLevel } from "@lurkloot/shared/logging";
 
@@ -363,7 +363,7 @@ export interface SchedulerTickResult {
 // the real tabs.
 export type StopPageContextTabs = (
   contexts: SchedulerManagedPageContexts,
-  options?: { platforms?: Platform[] },
+  options?: { platforms?: Platform[]; reason?: PageContextCloseReason; emit?: EventEmitter },
 ) => Promise<SchedulerManagedPageContexts> | SchedulerManagedPageContexts;
 
 export interface SchedulerTickOptions {
@@ -427,7 +427,7 @@ export async function runSchedulerTick(
           lastHeartbeatOk: undefined,
         };
         nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
-        nextState.managedPageContextTabs = await stopPageContextTabs(nextState.managedPageContextTabs ?? {}, { platforms: [platform] });
+        nextState.managedPageContextTabs = await stopPageContextTabs(nextState.managedPageContextTabs ?? {}, { platforms: [platform], reason: "manual_watch", emit });
         emitDiagnostic(emit, platform, "info", "Manual watch detected; pausing farming for this platform");
         continue;
       }
@@ -454,7 +454,11 @@ export async function runSchedulerTick(
           lastHeartbeatOk: undefined,
         };
         nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
-        nextState.managedPageContextTabs = await stopPageContextTabs(nextState.managedPageContextTabs ?? {}, { platforms: [platform] });
+        nextState.managedPageContextTabs = await stopPageContextTabs(nextState.managedPageContextTabs ?? {}, {
+          platforms: [platform],
+          reason: settings.running ? "platform_disabled" : "automation_disabled",
+          emit,
+        });
         emitDiagnostic(emit, platform, "info", "Automation disabled");
         continue;
       }
@@ -688,7 +692,6 @@ export async function runSchedulerTick(
             nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
           }
         }
-        nextState.managedPageContextTabs = await stopPageContextTabs(currentManagedPageContextTabs(), { platforms: [platform] });
         if (autoClaimChannelPointsFor(settings, platform) && adapter.claimChannelPoints) {
           try {
             const claimed = await adapter.claimChannelPoints(decision.channel);

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -1,5 +1,5 @@
 import type { AdFocusMode, ChannelCandidate, ManagedPageContextTab, ManagedWatchTab, Platform, WatchSession } from "@lurkloot/shared/models";
-import type { EventEmitter } from "@lurkloot/shared/events";
+import type { EventEmitter, PageContextCloseReason, PageContextOpenReason } from "@lurkloot/shared/events";
 import type { LogLevel } from "@lurkloot/shared/logging";
 import type { TwitchIntegrity } from "./twitchIntegrity";
 import type { PreparedWatchTab, WatchTabOptions } from "../platforms/adapter";
@@ -56,6 +56,8 @@ const DEFAULT_WATCH_TAB_OPTIONS: WatchTabOptions = {
   keepVideosUnmuted: true,
 };
 const PLAYBACK_PRIME_RESTORE_DELAY_MS = 1500;
+const PAGE_CONTEXT_RECOVERY_SUCCESSES = 3;
+const PAGE_CONTEXT_RECOVERY_MIN_MS = 10 * 60_000;
 
 export async function openPinnedMutedTabWithBrowser(
   browserApi: BrowserTabApi,
@@ -292,6 +294,8 @@ export interface PageFetchOptions {
     platform: Platform;
     managedContext?: ManagedPageContextTab;
   };
+  emit?: EventEmitter;
+  openReason?: PageContextOpenReason;
 }
 
 export interface CookieApi {
@@ -573,7 +577,7 @@ export async function fetchJsonInPageWithBrowser<T>(
 
     throw new Error("No supported page script execution API is available");
   } finally {
-    await releasePageContextTab(browserApi, origin, pageContext);
+    await releasePageContextTab(browserApi, origin, pageContext, options?.emit);
   }
 }
 
@@ -604,7 +608,7 @@ async function acquirePageContextTab(
   }
 }
 
-async function releasePageContextTab(browserApi: BrowserTabApi, origin: string, pageContext: PageContextTab): Promise<void> {
+async function releasePageContextTab(browserApi: BrowserTabApi, origin: string, pageContext: PageContextTab, emit: EventEmitter = ignoreEvent): Promise<void> {
   const entry = pageContextTabs.get(origin);
   if (!entry) return;
 
@@ -615,6 +619,7 @@ async function releasePageContextTab(browserApi: BrowserTabApi, origin: string, 
   if (!pageContext.createdByExtension || !browserApi.tabs.remove) return;
   if (pageContext.retainedContext) {
     retainedPageContextTabs.set(pageContext.retainedContext.platform, pageContext.retainedContext);
+    diagnostic(emit, "debug", `Retained managed page context on ${new URL(pageContext.retainedContext.origin).host} because it may still be required`, pageContext.retainedContext.platform);
     return;
   }
 
@@ -632,6 +637,7 @@ async function findOrCreatePageContextTab(
   options?: PageFetchOptions,
 ): Promise<PageContextTab> {
   const retain = options?.retainPageContext;
+  let openReason = options?.openReason ?? "background_rejected";
   const retained = retain?.managedContext ?? (retain ? retainedPageContextTabs.get(retain.platform) : undefined);
   const tabs = await browserApi.tabs.query({ url: `${origin}/*` });
   const retainedIds = new Set(
@@ -645,22 +651,52 @@ async function findOrCreatePageContextTab(
       retainedPageContextTabs.delete(retained.platform);
       try {
         await browserApi.tabs.remove?.(retained.tabId);
+        options?.emit?.({
+          category: "activity",
+          code: "page_context_closed",
+          level: "info",
+          platform: retained.platform,
+          data: { host: new URL(retained.origin).host, reason: "user_tab_available" },
+        });
+        diagnostic(options?.emit ?? ignoreEvent, "info", `Closed managed page context on ${new URL(retained.origin).host} because a user tab is available`, retained.platform);
       } catch {
         // The retained page context may already be gone.
+        diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(retained.origin).host} because the tab was already gone`, retained.platform);
       }
     }
+    diagnostic(options?.emit ?? ignoreEvent, "debug", `Reused user page context on ${new URL(origin).host}`, retain?.platform);
     return { tabId, createdByExtension: false };
   }
 
   if (retained?.origin === origin) {
     try {
       const tab = await browserApi.tabs.get(retained.tabId);
-      if (tab?.id) {
+      if (tab?.id && tab.url?.startsWith(origin)) {
         retainedPageContextTabs.set(retained.platform, retained);
+        diagnostic(options?.emit ?? ignoreEvent, "debug", `Reused managed page context on ${new URL(origin).host}`, retained.platform);
         return { tabId: tab.id, createdByExtension: true, retainedContext: retained };
+      }
+      retainedPageContextTabs.delete(retained.platform);
+      openReason = "managed_context_unusable";
+      if (tab?.id) {
+        try {
+          await browserApi.tabs.remove?.(retained.tabId);
+          options?.emit?.({
+            category: "activity",
+            code: "page_context_closed",
+            level: "info",
+            platform: retained.platform,
+            data: { host: new URL(origin).host, reason: "managed_context_unusable" },
+          });
+          diagnostic(options?.emit ?? ignoreEvent, "info", `Closed managed page context on ${new URL(origin).host} because it became unusable`, retained.platform);
+        } catch {
+          diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(origin).host} because it was already gone`, retained.platform);
+        }
       }
     } catch {
       retainedPageContextTabs.delete(retained.platform);
+      openReason = "managed_context_unusable";
+      diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(origin).host} because it is unusable`, retained.platform);
     }
   }
 
@@ -679,6 +715,14 @@ async function findOrCreatePageContextTab(
       ownedByExtension: true,
     };
     retainedPageContextTabs.set(retain.platform, retainedContext);
+    options?.emit?.({
+      category: "activity",
+      code: "page_context_opened",
+      level: "info",
+      platform: retain.platform,
+      data: { host: new URL(origin).host, reason: openReason },
+    });
+    diagnostic(options?.emit ?? ignoreEvent, "info", `Created managed page context on ${new URL(origin).host} because background access was rejected`, retain.platform);
     return { tabId: tab.id, createdByExtension: true, retainedContext };
   }
   return { tabId: tab.id, createdByExtension: true };
@@ -710,6 +754,65 @@ export function currentManagedPageContextTabs(): SchedulerManagedPageContexts {
   return Object.fromEntries(retainedPageContextTabs) as SchedulerManagedPageContexts;
 }
 
+export function recordManagedPageContextFallback(
+  platform: Platform,
+  host: string,
+  emit: EventEmitter = ignoreEvent,
+  now: number = Date.now(),
+): void {
+  const context = retainedPageContextTabs.get(platform);
+  if (!context) return;
+  const updated: ManagedPageContextTab = {
+    ...context,
+    lastFallbackAt: new Date(now).toISOString(),
+    fallbackHost: host,
+    backgroundSuccesses: 0,
+  };
+  retainedPageContextTabs.set(platform, updated);
+  diagnostic(emit, "debug", `Retained managed page context on ${new URL(context.origin).host} because background access is still rejected`, platform);
+}
+
+export async function recordManagedPageContextBackgroundSuccessWithBrowser(
+  browserApi: BrowserTabApi,
+  platform: Platform,
+  host: string,
+  emit: EventEmitter = ignoreEvent,
+  now: number = Date.now(),
+): Promise<void> {
+  const context = retainedPageContextTabs.get(platform);
+  if (!context?.lastFallbackAt || context.fallbackHost !== host) return;
+
+  const updated: ManagedPageContextTab = {
+    ...context,
+    backgroundSuccesses: (context.backgroundSuccesses ?? 0) + 1,
+  };
+  retainedPageContextTabs.set(platform, updated);
+  const fallbackAt = Date.parse(context.lastFallbackAt);
+  const recovered = updated.backgroundSuccesses! >= PAGE_CONTEXT_RECOVERY_SUCCESSES
+    && !Number.isNaN(fallbackAt)
+    && now - fallbackAt >= PAGE_CONTEXT_RECOVERY_MIN_MS
+    && !pageContextTabs.has(context.origin);
+  if (!recovered) {
+    diagnostic(emit, "debug", `Retained managed page context on ${new URL(context.origin).host} while background recovery is being confirmed`, platform);
+    return;
+  }
+
+  retainedPageContextTabs.delete(platform);
+  try {
+    await browserApi.tabs.remove?.(context.tabId);
+    emit({
+      category: "activity",
+      code: "page_context_closed",
+      level: "info",
+      platform,
+      data: { host: new URL(context.origin).host, reason: "background_recovered" },
+    });
+    diagnostic(emit, "info", `Closed managed page context on ${new URL(context.origin).host} because background access recovered`, platform);
+  } catch {
+    diagnostic(emit, "debug", `Forgot managed page context on ${new URL(context.origin).host} because the tab was already gone`, platform);
+  }
+}
+
 // Pure state cleanup: drop the given platforms from the contexts map and the
 // retained-tab registry, returning the next contexts. No browser access, so a
 // headless runtime — and the scheduler's default — can forget page contexts
@@ -717,7 +820,7 @@ export function currentManagedPageContextTabs(): SchedulerManagedPageContexts {
 // on top.
 export function forgetManagedPageContextTabs(
   contexts: SchedulerManagedPageContexts,
-  options: { platforms?: Platform[] } = {},
+  options: { platforms?: Platform[]; reason?: PageContextCloseReason; emit?: EventEmitter } = {},
 ): SchedulerManagedPageContexts {
   const platforms = options.platforms ?? ["twitch", "kick"];
   const next = { ...contexts };
@@ -732,7 +835,7 @@ export function forgetManagedPageContextTabs(
 export async function stopManagedPageContextTabsWithBrowser(
   browserApi: BrowserTabApi,
   contexts: SchedulerManagedPageContexts,
-  options: { platforms?: Platform[] } = {},
+  options: { platforms?: Platform[]; reason?: PageContextCloseReason; emit?: EventEmitter } = {},
 ): Promise<SchedulerManagedPageContexts> {
   const platforms = options.platforms ?? ["twitch", "kick"];
   for (const platform of platforms) {
@@ -740,8 +843,17 @@ export async function stopManagedPageContextTabsWithBrowser(
     if (!context) continue;
     try {
       await browserApi.tabs.remove?.(context.tabId);
+      options.emit?.({
+        category: "activity",
+        code: "page_context_closed",
+        level: "info",
+        platform,
+        data: { host: new URL(context.origin).host, reason: options.reason ?? "automation_disabled" },
+      });
+      diagnostic(options.emit ?? ignoreEvent, "info", `Closed managed page context on ${new URL(context.origin).host} because ${options.reason ?? "automation_disabled"}`, platform);
     } catch {
       // The retained page context may have been closed manually.
+      diagnostic(options.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(context.origin).host} because the tab was already gone`, platform);
     }
   }
   return forgetManagedPageContextTabs(contexts, options);

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -722,7 +722,12 @@ async function findOrCreatePageContextTab(
       platform: retain.platform,
       data: { host: new URL(origin).host, reason: openReason },
     });
-    diagnostic(options?.emit ?? ignoreEvent, "info", `Created managed page context on ${new URL(origin).host} because background access was rejected`, retain.platform);
+    diagnostic(
+      options?.emit ?? ignoreEvent,
+      "info",
+      `Created managed page context on ${new URL(origin).host} because ${openReason === "managed_context_unusable" ? "the previous context was unusable" : "background access was rejected"}`,
+      retain.platform,
+    );
     return { tabId: tab.id, createdByExtension: true, retainedContext };
   }
   return { tabId: tab.id, createdByExtension: true };

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -649,19 +649,24 @@ async function findOrCreatePageContextTab(
   if (tabId != null) {
     if (retained?.origin === origin) {
       retainedPageContextTabs.delete(retained.platform);
-      try {
-        await browserApi.tabs.remove?.(retained.tabId);
-        options?.emit?.({
-          category: "activity",
-          code: "page_context_closed",
-          level: "info",
-          platform: retained.platform,
-          data: { host: new URL(retained.origin).host, reason: "user_tab_available" },
-        });
-        diagnostic(options?.emit ?? ignoreEvent, "info", `Closed managed page context on ${new URL(retained.origin).host} because a user tab is available`, retained.platform);
-      } catch {
-        // The retained page context may already be gone.
-        diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(retained.origin).host} because the tab was already gone`, retained.platform);
+      const remove = browserApi.tabs.remove;
+      if (!remove) {
+        diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(retained.origin).host} because tab removal is unavailable`, retained.platform);
+      } else {
+        try {
+          await remove(retained.tabId);
+          options?.emit?.({
+            category: "activity",
+            code: "page_context_closed",
+            level: "info",
+            platform: retained.platform,
+            data: { host: new URL(retained.origin).host, reason: "user_tab_available" },
+          });
+          diagnostic(options?.emit ?? ignoreEvent, "info", `Closed managed page context on ${new URL(retained.origin).host} because a user tab is available`, retained.platform);
+        } catch {
+          // The retained page context may already be gone.
+          diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(retained.origin).host} because the tab was already gone`, retained.platform);
+        }
       }
     }
     diagnostic(options?.emit ?? ignoreEvent, "debug", `Reused user page context on ${new URL(origin).host}`, retain?.platform);
@@ -679,18 +684,23 @@ async function findOrCreatePageContextTab(
       retainedPageContextTabs.delete(retained.platform);
       openReason = "managed_context_unusable";
       if (tab?.id) {
-        try {
-          await browserApi.tabs.remove?.(retained.tabId);
-          options?.emit?.({
-            category: "activity",
-            code: "page_context_closed",
-            level: "info",
-            platform: retained.platform,
-            data: { host: new URL(origin).host, reason: "managed_context_unusable" },
-          });
-          diagnostic(options?.emit ?? ignoreEvent, "info", `Closed managed page context on ${new URL(origin).host} because it became unusable`, retained.platform);
-        } catch {
-          diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(origin).host} because it was already gone`, retained.platform);
+        const remove = browserApi.tabs.remove;
+        if (!remove) {
+          diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(origin).host} because tab removal is unavailable`, retained.platform);
+        } else {
+          try {
+            await remove(retained.tabId);
+            options?.emit?.({
+              category: "activity",
+              code: "page_context_closed",
+              level: "info",
+              platform: retained.platform,
+              data: { host: new URL(origin).host, reason: "managed_context_unusable" },
+            });
+            diagnostic(options?.emit ?? ignoreEvent, "info", `Closed managed page context on ${new URL(origin).host} because it became unusable`, retained.platform);
+          } catch {
+            diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(origin).host} because it was already gone`, retained.platform);
+          }
         }
       }
     } catch {
@@ -803,8 +813,13 @@ export async function recordManagedPageContextBackgroundSuccessWithBrowser(
   }
 
   retainedPageContextTabs.delete(platform);
+  const remove = browserApi.tabs.remove;
+  if (!remove) {
+    diagnostic(emit, "debug", `Forgot managed page context on ${new URL(context.origin).host} because tab removal is unavailable`, platform);
+    return;
+  }
   try {
-    await browserApi.tabs.remove?.(context.tabId);
+    await remove(context.tabId);
     emit({
       category: "activity",
       code: "page_context_closed",
@@ -846,8 +861,13 @@ export async function stopManagedPageContextTabsWithBrowser(
   for (const platform of platforms) {
     const context = contexts[platform];
     if (!context) continue;
+    const remove = browserApi.tabs.remove;
+    if (!remove) {
+      diagnostic(options.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(context.origin).host} because tab removal is unavailable`, platform);
+      continue;
+    }
     try {
-      await browserApi.tabs.remove?.(context.tabId);
+      await remove(context.tabId);
       options.emit?.({
         category: "activity",
         code: "page_context_closed",

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -82,28 +82,44 @@ interface KickChallengeClaimResponse {
 export function createKickFetcher(deps: {
   background: (url: string, init?: RequestInit) => Promise<unknown>;
   pageFetch: (url: string, init?: RequestInit) => Promise<unknown>;
+  onBackgroundSuccess?: (host: string, emit: EventEmitter) => Promise<void> | void;
+  onPageFallback?: (host: string, emit: EventEmitter) => Promise<void> | void;
 }): PageFetcher {
-  const { background, pageFetch } = deps;
+  const { background, pageFetch, onBackgroundSuccess, onPageFallback } = deps;
   const announced = new Map<string, "background" | "fallback">();
   const report = (emit: EventEmitter, host: string, outcome: "background" | "fallback", detail: string): void => {
     const repeat = announced.get(host) === outcome;
     announced.set(host, outcome);
     diagnostic(emit, repeat ? "debug" : "info", `Kick fetch ${host} ${detail}`, "kick");
   };
+  const notifyLifecycle = async (
+    callback: ((host: string, emit: EventEmitter) => Promise<void> | void) | undefined,
+    host: string,
+    emit: EventEmitter,
+  ): Promise<void> => {
+    try {
+      await callback?.(host, emit);
+    } catch {
+      diagnostic(emit, "debug", `Kick page-context lifecycle update failed for ${host}`, "kick");
+    }
+  };
   return {
     fetchJson: async <T,>(url: string, init?: RequestInit, emit: EventEmitter = ignoreEvent): Promise<T> => {
       const host = safeHost(url);
+      let result: unknown;
       try {
-        const result = await background(url, init);
-        report(emit, host, "background", "→ service worker OK (tabless-capable)");
-        return result as T;
+        result = await background(url, init);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
         report(emit, host, "fallback", error instanceof KickWafBlockedError
-          ? `→ WAF-blocked from service worker, using page tab (${message})`
-          : `→ service worker error, using page tab (${message})`);
-        return await pageFetch(url, init) as T;
+          ? "→ WAF-blocked from service worker, using page tab"
+          : "→ service worker error, using page tab");
+        result = await pageFetch(url, init);
+        await notifyLifecycle(onPageFallback, host, emit);
+        return result as T;
       }
+      report(emit, host, "background", "→ service worker OK (tabless-capable)");
+      await notifyLifecycle(onBackgroundSuccess, host, emit);
+      return result as T;
     },
   };
 }
@@ -112,7 +128,7 @@ function safeHost(url: string): string {
   try {
     return new URL(url).host;
   } catch {
-    return url;
+    return "unknown-host";
   }
 }
 

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -113,8 +113,8 @@ export function createKickFetcher(deps: {
         report(emit, host, "fallback", error instanceof KickWafBlockedError
           ? "→ WAF-blocked from service worker, using page tab"
           : "→ service worker error, using page tab");
-        result = await pageFetch(url, init);
         await notifyLifecycle(onPageFallback, host, emit);
+        result = await pageFetch(url, init);
         return result as T;
       }
       report(emit, host, "background", "→ service worker OK (tabless-capable)");

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -43,6 +43,7 @@ const reportEvents = createActivityEventReporter({
   append: appendActivityEvents,
 });
 const kickClaimState = new KickClaimState();
+const KICK_PAGE_CONTEXT_URL = "https://kick.com/drops/inventory";
 
 async function catalog(locale: string): Promise<MessageCatalog | undefined> {
   if (localeCatalogs.has(locale)) return localeCatalogs.get(locale);
@@ -133,7 +134,7 @@ const controller = createBackgroundController<ExtensionSettings>({
         kick: new KickAdapter(
           createKickFetcher({
             background: (url, init) => fetchKickInBackground<unknown>(url, init),
-            pageFetch: (url, init) => fetchJsonInPage<unknown>("https://kick.com", url, init, {
+            pageFetch: (url, init) => fetchJsonInPage<unknown>(KICK_PAGE_CONTEXT_URL, url, init, {
               retainPageContext: { platform: "kick" },
               emit,
               openReason: "background_rejected",

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -8,6 +8,8 @@ import {
   fetchKickInBackground,
   fetchTwitchInBackground,
   openPinnedMutedTab,
+  recordManagedPageContextBackgroundSuccess,
+  recordManagedPageContextFallback,
   stopManagedPageContextTabs,
   stopWatchTab,
 } from "../src/core/tabs";
@@ -131,7 +133,13 @@ const controller = createBackgroundController<ExtensionSettings>({
         kick: new KickAdapter(
           createKickFetcher({
             background: (url, init) => fetchKickInBackground<unknown>(url, init),
-            pageFetch: (url, init) => fetchJsonInPage<unknown>("https://kick.com", url, init, { retainPageContext: { platform: "kick" } }),
+            pageFetch: (url, init) => fetchJsonInPage<unknown>("https://kick.com", url, init, {
+              retainPageContext: { platform: "kick" },
+              emit,
+              openReason: "background_rejected",
+            }),
+            onBackgroundSuccess: (host, operationEmit) => recordManagedPageContextBackgroundSuccess(host, operationEmit),
+            onPageFallback: (host, operationEmit) => recordManagedPageContextFallback(host, operationEmit),
           }),
           watchTabPort,
           undefined,

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -72,13 +72,15 @@ const controller = createBackgroundController<ExtensionSettings>({
   saveState,
   reportEvents,
   createAlarm: (name, options) => browser.alarms.create(name, options),
-  closeManagedTabsByUrl: async (urls) => {
-    for (const url of urls) {
-      const tabs = await browser.tabs.query({ url });
-      await Promise.all(tabs.map(async (tab) => {
-        if (tab.id != null) await browser.tabs.remove(tab.id);
-      }));
-    }
+  closeManagedTabs: async (tabs) => {
+    await Promise.all(tabs.map(async ({ tabId, channelUrl }) => {
+      try {
+        const tab = await browser.tabs.get(tabId);
+        if (tab.id === tabId && tab.url === channelUrl) await browser.tabs.remove(tabId);
+      } catch {
+        // The recorded tab may already be closed or its id may be stale.
+      }
+    }));
   },
   createNotification: async ({ title, message }) => {
     await browser.notifications.create({

--- a/packages/extension/src/core/tabs.ts
+++ b/packages/extension/src/core/tabs.ts
@@ -1,6 +1,6 @@
 import { browser } from "wxt/browser";
 import type { AdFocusMode, ChannelCandidate, Platform, WatchSession } from "@lurkloot/shared/models";
-import type { EventEmitter } from "@lurkloot/shared/events";
+import type { EventEmitter, PageContextCloseReason } from "@lurkloot/shared/events";
 import {
   applyAdFocusWithBrowser,
   ensureTwitchIntegrityWithBrowser,
@@ -8,6 +8,8 @@ import {
   fetchKickInBackgroundWith,
   fetchTwitchInBackgroundWith,
   openPinnedMutedTabWithBrowser,
+  recordManagedPageContextBackgroundSuccessWithBrowser,
+  recordManagedPageContextFallback as recordManagedPageContextFallbackInRegistry,
   stopManagedPageContextTabsWithBrowser,
   stopWatchTabWithBrowser,
   TWITCH_PAGE_CONTEXT_URL,
@@ -52,9 +54,17 @@ export function fetchJsonInPage<T>(originUrl: string, url: string, init?: Reques
   return fetchJsonInPageWithBrowser<T>(browser as BrowserTabApi, originUrl, url, init, options);
 }
 
+export function recordManagedPageContextBackgroundSuccess(host: string, emit?: EventEmitter): Promise<void> {
+  return recordManagedPageContextBackgroundSuccessWithBrowser(browser as BrowserTabApi, "kick", host, emit);
+}
+
+export function recordManagedPageContextFallback(host: string, emit?: EventEmitter): void {
+  recordManagedPageContextFallbackInRegistry("kick", host, emit);
+}
+
 export function stopManagedPageContextTabs(
   contexts: SchedulerManagedPageContexts,
-  options: { platforms?: Platform[] } = {},
+  options: { platforms?: Platform[]; reason?: PageContextCloseReason; emit?: EventEmitter } = {},
 ): Promise<SchedulerManagedPageContexts> {
   return stopManagedPageContextTabsWithBrowser(browser as BrowserTabApi, contexts, options);
 }

--- a/packages/extension/tests/activityView.test.ts
+++ b/packages/extension/tests/activityView.test.ts
@@ -54,6 +54,31 @@ describe("activity view model", () => {
     expect(t).toHaveBeenCalledWith("activityReasonRuntimeRestart");
   });
 
+  it("formats managed page-context opens and closes with their reasons", () => {
+    const t = vi.fn((key: string, substitutions?: string | string[]) =>
+      `${key}:${Array.isArray(substitutions) ? substitutions.join("|") : substitutions ?? ""}`);
+
+    expect(formatActivityEvent({
+      id: "opened",
+      at,
+      category: "activity",
+      code: "page_context_opened",
+      level: "info",
+      platform: "kick",
+      data: { host: "kick.com", reason: "background_rejected" },
+    }, t)).toBe("activityPageContextOpened:kick.com|activityPageContextOpenReasonBackgroundRejected:");
+
+    expect(formatActivityEvent({
+      id: "closed",
+      at,
+      category: "activity",
+      code: "page_context_closed",
+      level: "info",
+      platform: "kick",
+      data: { host: "kick.com", reason: "background_recovered" },
+    }, t)).toBe("activityPageContextClosed:kick.com|activityPageContextCloseReasonBackgroundRecovered:");
+  });
+
   it("formats every farming stop reason through its locale key", () => {
     const t = vi.fn((key: string) => key);
     const reasons: FarmingStopReason[] = [

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -673,6 +673,22 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
     expect(onPageFallback).toHaveBeenCalledWith("web.kick.com", expect.any(Function));
   });
 
+  it("records fallback before page execution even when the page request fails", async () => {
+    const order: string[] = [];
+    const fetcher = createKickFetcher({
+      background: async () => { throw new KickWafBlockedError("blocked"); },
+      onPageFallback: async () => { order.push("fallback"); },
+      pageFetch: async () => {
+        order.push("page");
+        throw new Error("page unavailable");
+      },
+    });
+
+    await expect(fetcher.fetchJson("https://web.kick.com/api/v1/drops/campaigns"))
+      .rejects.toThrow("page unavailable");
+    expect(order).toEqual(["fallback", "page"]);
+  });
+
   it("keeps fallback diagnostics free of request details and raw errors", async () => {
     const events: EngineEvent[] = [];
     const fetcher = createKickFetcher({

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -645,19 +645,24 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
   it("uses the service-worker result and never touches the page tab when the background fetch succeeds", async () => {
     const background = vi.fn(async () => ({ data: "from-sw" }));
     const pageFetch = vi.fn(async () => ({ data: "from-tab" }));
-    const fetcher = createKickFetcher({ background, pageFetch });
+    const onBackgroundSuccess = vi.fn(async () => undefined);
+    const onPageFallback = vi.fn(async () => undefined);
+    const fetcher = createKickFetcher({ background, pageFetch, onBackgroundSuccess, onPageFallback });
 
     const result = await fetcher.fetchJson("https://web.kick.com/api/v1/drops/campaigns");
 
     expect(result).toEqual({ data: "from-sw" });
     expect(background).toHaveBeenCalledTimes(1);
     expect(pageFetch).not.toHaveBeenCalled();
+    expect(onBackgroundSuccess).toHaveBeenCalledWith("web.kick.com", expect.any(Function));
+    expect(onPageFallback).not.toHaveBeenCalled();
   });
 
   it("falls back to the page tab when the background fetch is WAF-blocked", async () => {
     const background = vi.fn(async () => { throw new KickWafBlockedError("HTTP 403 Forbidden"); });
     const pageFetch = vi.fn(async () => ({ data: "from-tab" }));
-    const fetcher = createKickFetcher({ background, pageFetch });
+    const onPageFallback = vi.fn(async () => undefined);
+    const fetcher = createKickFetcher({ background, pageFetch, onPageFallback });
 
     const result = await fetcher.fetchJson("https://web.kick.com/api/v1/drops/campaigns", { method: "GET" });
 
@@ -665,6 +670,48 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
     expect(background).toHaveBeenCalledTimes(1);
     // The same url + init are forwarded to the fallback unchanged.
     expect(pageFetch).toHaveBeenCalledWith("https://web.kick.com/api/v1/drops/campaigns", { method: "GET" });
+    expect(onPageFallback).toHaveBeenCalledWith("web.kick.com", expect.any(Function));
+  });
+
+  it("keeps fallback diagnostics free of request details and raw errors", async () => {
+    const events: EngineEvent[] = [];
+    const fetcher = createKickFetcher({
+      background: async () => { throw new Error("token=secret-value"); },
+      pageFetch: async () => ({ ok: true }),
+    });
+
+    await fetcher.fetchJson("https://web.kick.com/api/private?token=secret-value", undefined, (event) => events.push(event));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ category: "diagnostic", platform: "kick" });
+    expect(events[0].category === "diagnostic" ? events[0].message : "").toContain("web.kick.com");
+    expect(events[0].category === "diagnostic" ? events[0].message : "").not.toContain("secret-value");
+
+    events.length = 0;
+    await fetcher.fetchJson("not-a-url-secret-value", undefined, (event) => events.push(event));
+    expect(events[0].category === "diagnostic" ? events[0].message : "").toContain("unknown-host");
+    expect(events[0].category === "diagnostic" ? events[0].message : "").not.toContain("secret-value");
+  });
+
+  it("does not turn lifecycle bookkeeping failures into request failures or extra fallbacks", async () => {
+    const pageFetch = vi.fn(async () => ({ data: "from-tab" }));
+    const backgroundFetcher = createKickFetcher({
+      background: async () => ({ data: "from-sw" }),
+      pageFetch,
+      onBackgroundSuccess: async () => { throw new Error("bookkeeping failed"); },
+    });
+
+    await expect(backgroundFetcher.fetchJson("https://web.kick.com/api/v1/drops/campaigns"))
+      .resolves.toEqual({ data: "from-sw" });
+    expect(pageFetch).not.toHaveBeenCalled();
+
+    const fallbackFetcher = createKickFetcher({
+      background: async () => { throw new KickWafBlockedError("blocked"); },
+      pageFetch,
+      onPageFallback: async () => { throw new Error("bookkeeping failed"); },
+    });
+    await expect(fallbackFetcher.fetchJson("https://web.kick.com/api/v1/drops/campaigns"))
+      .resolves.toEqual({ data: "from-tab" });
   });
 
   it("also falls back on a non-WAF background error", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1389,7 +1389,7 @@ describe("background controller", () => {
     )).resolves.toEqual({ managed: true, keepVideosUnmuted: true });
   });
 
-  it("runs an immediate tick when the active managed Twitch tab is closed", async () => {
+  it("defers recovery when the active managed farming tab is closed", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
       running: true,
@@ -1406,11 +1406,66 @@ describe("background controller", () => {
       tabId: 10,
       tabManagedByExtension: true,
     };
+    env.state.managedWatchTabs = {
+      twitch: {
+        platform: "twitch",
+        tabId: 10,
+        channelUrl: "https://www.twitch.tv/twitch-creator",
+        ownedByExtension: true,
+      },
+    };
 
     await env.controller.handleTabRemoved(10);
 
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalled();
-    expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
+    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.prepareWatchTab).not.toHaveBeenCalled();
+    expect(env.state.sessions.twitch).toEqual({
+      platform: "twitch",
+      status: "idle",
+      offlineChecks: 0,
+    });
+    expect(env.state.managedWatchTabs?.twitch).toBeUndefined();
+
+    await env.controller.tick();
+
+    expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.twitch.prepareWatchTab).toHaveBeenCalledOnce();
+    expect(env.state.sessions.twitch.tabId).toBe(10);
+  });
+
+  it("does not confuse a removed page-context tab with the active farming tab", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    env.state.sessions.kick = {
+      platform: "kick",
+      status: "watching",
+      channel: channel("kick"),
+      offlineChecks: 0,
+      tabId: 20,
+      tabManagedByExtension: true,
+    };
+    env.state.managedWatchTabs = {
+      kick: {
+        platform: "kick",
+        tabId: 20,
+        channelUrl: "https://kick.com/kick-creator",
+        ownedByExtension: true,
+      },
+    };
+    env.state.managedPageContextTabs = {
+      kick: {
+        platform: "kick",
+        tabId: 91,
+        originUrl: "https://kick.com/drops/inventory",
+        origin: "https://kick.com",
+        ownedByExtension: true,
+      },
+    };
+
+    await env.controller.handleTabRemoved(91);
+
+    expect(env.state.sessions.kick.tabId).toBe(20);
+    expect(env.state.managedWatchTabs?.kick?.tabId).toBe(20);
+    expect(env.kick.prepareWatchTab).not.toHaveBeenCalled();
   });
 
   it("ignores removed tabs that are not the active managed watch tab", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -704,6 +704,38 @@ describe("background controller", () => {
     });
   });
 
+  it("preserves a retained Kick page context across a running service-worker restart", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      autoStartDropFarming: true,
+      platform: {
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false, idleWatchlistChannels: [] },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
+      },
+    });
+    const context = {
+      platform: "kick" as const,
+      tabId: 91,
+      originUrl: "https://kick.com/drops/inventory",
+      origin: "https://kick.com",
+      ownedByExtension: true as const,
+      lastFallbackAt: "2026-07-22T08:00:00.000Z",
+      fallbackHost: "web.kick.com",
+      backgroundSuccesses: 0,
+    };
+    env.state.managedPageContextTabs = { kick: context };
+
+    await env.controller.handleStartup();
+
+    expect(env.deps.stopPageContextTabs).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kick: expect.objectContaining({ tabId: 91 }) }),
+      expect.objectContaining({ reason: "runtime_restart" }),
+    );
+    expect(env.state.managedPageContextTabs?.kick).toEqual(context);
+    expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+  });
+
   it("does not log startup cleanup when there is no stale farming state", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: false, autoStartDropFarming: true });
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -9,6 +9,8 @@ import { DEFAULT_STATE } from "../src/core/storage";
 import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
 import { KickAdapter, KickClaimState } from "@lurkloot/core/kick";
 import type { TablessWatchController } from "@lurkloot/core/tablessWatch";
+import type { StopPageContextTabs } from "@lurkloot/core/scheduler";
+import { forgetManagedPageContextTabs, recordManagedPageContextFallback, registerManagedPageContextTabs } from "@lurkloot/core/tabs";
 
 const reward = (status: DropReward["status"] = "in_progress"): DropReward => ({
   id: "reward",
@@ -54,6 +56,7 @@ function harness(
   overrides: {
     saveState?: (state: SchedulerState) => Promise<void>;
     reportEvents?: (events: readonly EngineEvent[]) => Promise<void>;
+    stopPageContextTabs?: StopPageContextTabs;
     wait?: (ms: number, signal: AbortSignal) => Promise<void>;
   } = {},
 ) {
@@ -89,6 +92,7 @@ function harness(
       ...resolveCompatibility(nextSettings.compatibility, { host: "extension", twitchIdentity: "web" }),
     })),
     reportEvents: vi.fn(overrides.reportEvents ?? reportEvents),
+    stopPageContextTabs: vi.fn(overrides.stopPageContextTabs ?? forgetManagedPageContextTabs),
     wait: overrides.wait,
   };
 
@@ -687,7 +691,11 @@ describe("background controller", () => {
 
     await env.controller.handleStartup();
 
-    expect(env.deps.closeManagedTabsByUrl).toHaveBeenCalledWith(["https://www.twitch.tv/drops/inventory"]);
+    expect(env.deps.closeManagedTabsByUrl).not.toHaveBeenCalled();
+    expect(env.deps.stopPageContextTabs).toHaveBeenCalledWith(
+      expect.objectContaining({ twitch: expect.objectContaining({ tabId: 66 }) }),
+      expect.objectContaining({ platforms: ["twitch", "kick"], reason: "runtime_restart", emit: expect.any(Function) }),
+    );
     expect(env.state.managedPageContextTabs).toEqual({});
     expect(env.state.sessions.twitch).toMatchObject({
       status: "paused",
@@ -1807,6 +1815,34 @@ describe("background controller", () => {
     expect(watcher.tick).toHaveBeenCalled();
     expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
     expect(env.state.sessions.twitch.heartbeatChecks).toBe(0);
+  });
+
+  it("persists page-context lifecycle metadata changed during a heartbeat", async () => {
+    const watcher = fakeTablessWatcher(async () => {
+      recordManagedPageContextFallback("twitch", "gql.twitch.tv", undefined, Date.parse("2026-07-21T12:00:00.000Z"));
+      return { ok: true, live: true };
+    });
+    const env = tablessEnv();
+    env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
+    await env.controller.tick();
+    const context = {
+      platform: "twitch" as const,
+      tabId: 66,
+      originUrl: "https://www.twitch.tv/drops/inventory",
+      origin: "https://www.twitch.tv",
+      ownedByExtension: true as const,
+    };
+    env.state.managedPageContextTabs = { twitch: context };
+    registerManagedPageContextTabs({ twitch: context });
+
+    await env.controller.runWatchHeartbeat();
+
+    expect(env.state.managedPageContextTabs?.twitch).toMatchObject({
+      tabId: 66,
+      fallbackHost: "gql.twitch.tv",
+      backgroundSuccesses: 0,
+      lastFallbackAt: "2026-07-21T12:00:00.000Z",
+    });
   });
 
   it("publishes persistent watcher diagnostics once through the current operation batch", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -82,7 +82,7 @@ function harness(
     })),
     createAlarm: vi.fn(async () => undefined),
     createNotification: vi.fn(async () => undefined),
-    closeManagedTabsByUrl: vi.fn(async () => undefined),
+    closeManagedTabs: vi.fn(async () => undefined),
     applyAdFocus: vi.fn<(platform: Platform, tabId: number | undefined, adActive: boolean, emit: EventEmitter) => Promise<void>>(async () => undefined),
     // Host-owned tab policy + settings-patch application (see background.ts).
     loadTabPlaybackPolicy: vi.fn(async () => ({ keepVideosUnmuted: currentSettings.keepFarmingVideosUnmuted !== false })),
@@ -601,7 +601,9 @@ describe("background controller", () => {
     await env.controller.handleStartup();
 
     expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
-    expect(env.deps.closeManagedTabsByUrl).toHaveBeenCalledWith(["https://www.twitch.tv/twitch-creator"]);
+    expect(env.deps.closeManagedTabs).toHaveBeenCalledWith([
+      expect.objectContaining({ tabId: 44, channelUrl: "https://www.twitch.tv/twitch-creator", ownedByExtension: true }),
+    ]);
     expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
     expect(env.state.sessions.twitch.status).toBe("watching");
     expect(env.state.sessions.twitch.tabId).toBe(10);
@@ -637,7 +639,9 @@ describe("background controller", () => {
 
     expect(env.settings.running).toBe(false);
     expect(env.deps.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ running: false }));
-    expect(env.deps.closeManagedTabsByUrl).toHaveBeenCalledWith(["https://www.twitch.tv/twitch-creator"]);
+    expect(env.deps.closeManagedTabs).toHaveBeenCalledWith([
+      expect.objectContaining({ tabId: 44, channelUrl: "https://www.twitch.tv/twitch-creator", ownedByExtension: true }),
+    ]);
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
     expect(env.twitch.prepareWatchTab).not.toHaveBeenCalled();
     expect(env.state.managedWatchTabs).toEqual({});
@@ -671,7 +675,9 @@ describe("background controller", () => {
     await env.controller.handleStartup();
 
     expect(env.settings.running).toBe(false);
-    expect(env.deps.closeManagedTabsByUrl).toHaveBeenCalledWith(["https://kick.com/kick-creator"]);
+    expect(env.deps.closeManagedTabs).toHaveBeenCalledWith([
+      expect.objectContaining({ tabId: 55, channelUrl: "https://kick.com/kick-creator", ownedByExtension: true }),
+    ]);
     expect(env.kick.prepareWatchTab).not.toHaveBeenCalled();
     expect(env.state.sessions.kick.status).toBe("paused");
     expect(env.state.sessions.kick.tabId).toBeUndefined();
@@ -691,7 +697,7 @@ describe("background controller", () => {
 
     await env.controller.handleStartup();
 
-    expect(env.deps.closeManagedTabsByUrl).not.toHaveBeenCalled();
+    expect(env.deps.closeManagedTabs).not.toHaveBeenCalled();
     expect(env.deps.stopPageContextTabs).toHaveBeenCalledWith(
       expect.objectContaining({ twitch: expect.objectContaining({ tabId: 66 }) }),
       expect.objectContaining({ platforms: ["twitch", "kick"], reason: "runtime_restart", emit: expect.any(Function) }),
@@ -742,7 +748,7 @@ describe("background controller", () => {
     await env.controller.handleStartup();
 
     expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
-    expect(env.deps.closeManagedTabsByUrl).not.toHaveBeenCalled();
+    expect(env.deps.closeManagedTabs).not.toHaveBeenCalled();
     expect(env.deps.saveState).not.toHaveBeenCalled();
     expect(env.reportEvents.mock.calls.flatMap(([events]) => events).some((event) =>
       event.category === "diagnostic" && event.message.includes("Browser restarted")

--- a/packages/extension/tests/compatibility.test.ts
+++ b/packages/extension/tests/compatibility.test.ts
@@ -26,6 +26,13 @@ describe("compatibility registry", () => {
 });
 
 describe("extension compatibility construction", () => {
+  it("uses the Kick Drops inventory for page-context fallback", () => {
+    const backgroundSource = readFileSync(new URL("../entrypoints/background.ts", import.meta.url), "utf8");
+
+    expect(backgroundSource).toContain('const KICK_PAGE_CONTEXT_URL = "https://kick.com/drops/inventory";');
+    expect(backgroundSource).toContain("fetchJsonInPage<unknown>(KICK_PAGE_CONTEXT_URL, url, init");
+  });
+
   it("injects the resolved web selection into both adapter option boundaries", () => {
     const backgroundSource = readFileSync(new URL("../entrypoints/background.ts", import.meta.url), "utf8");
 

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
 import { NO_CATEGORY_ID } from "@lurkloot/shared/categories";
 import { chooseCampaignDecision, runSchedulerTick, sortCampaigns } from "@lurkloot/core/scheduler";
 import type { PlatformAdapter } from "@lurkloot/core/adapter";
+import { forgetManagedPageContextTabs } from "@lurkloot/core/tabs";
 
 const reward = (status: DropReward["status"] = "in_progress"): DropReward => ({
   id: `reward-${status}`,
@@ -1720,6 +1721,37 @@ describe("scheduler tick", () => {
     });
   });
 
+  it("retains a required Kick page context across ordinary watch preparation", async () => {
+    const kickCandidate = { ...channel("kick-allowed"), platform: "kick" as const, url: "https://kick.com/kick-allowed" };
+    const kick = adapter("kick", [campaign("kick-drops", { platform: "kick" })], [kickCandidate]);
+    const stopPageContextTabs = vi.fn(forgetManagedPageContextTabs);
+    const managedContext = {
+      platform: "kick" as const,
+      tabId: 91,
+      originUrl: "https://kick.com",
+      origin: "https://kick.com",
+      ownedByExtension: true as const,
+    };
+
+    const result = await runSchedulerTick(
+      {
+        sessions: {
+          twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [], kick: [] },
+        managedPageContextTabs: { kick: managedContext },
+      },
+      settings({ platform: { twitch: { enabled: false }, kick: { enabled: true } } }),
+      { twitch: adapter("twitch", [], []), kick },
+      { platforms: ["kick"], stopPageContextTabs },
+    );
+
+    expect(kick.prepareWatchTab).toHaveBeenCalledOnce();
+    expect(stopPageContextTabs).not.toHaveBeenCalled();
+    expect(result.state.managedPageContextTabs?.kick).toEqual(managedContext);
+  });
+
   it("only evaluates requested platforms during a targeted tick", async () => {
     const twitch = adapter("twitch", [campaign("twitch-drops")], [channel("twitch-allowed")]);
     const kickCandidate = { ...channel("kick-allowed"), platform: "kick" as const, url: "https://kick.com/kick-allowed" };
@@ -1776,6 +1808,7 @@ describe("scheduler tick", () => {
 
   it("stops the previous watch tab when automation is disabled", async () => {
     const twitch = adapter("twitch", [], []);
+    const stopPageContextTabs = vi.fn(forgetManagedPageContextTabs);
 
     const result = await runSchedulerTick(
       {
@@ -1796,12 +1829,17 @@ describe("scheduler tick", () => {
       },
       settings({ running: false }),
       { twitch, kick: adapter("kick", [], []) },
+      { stopPageContextTabs },
     );
 
     expect(twitch.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 7, tabManagedByExtension: true }));
     expect(result.state.sessions.twitch.tabId).toBeUndefined();
     expect(result.state.sessions.twitch.channel).toBeUndefined();
     expect(result.state.managedPageContextTabs?.twitch).toBeUndefined();
+    expect(stopPageContextTabs).toHaveBeenCalledWith(
+      expect.objectContaining({ twitch: expect.objectContaining({ tabId: 9 }) }),
+      expect.objectContaining({ platforms: ["twitch"], reason: "automation_disabled", emit: expect.any(Function) }),
+    );
   });
 
   it("stops the previous watch tab when no eligible campaigns or fallback remain", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -113,6 +113,24 @@ describe("tab manager", () => {
     expect(events.some((event) => event.category === "activity" && event.code === "page_context_closed")).toBe(false);
   });
 
+  it("does not report a close activity without a browser removal capability", async () => {
+    const browser = browserMock();
+    browser.tabs.remove = undefined as unknown as typeof browser.tabs.remove;
+    const events: EngineEvent[] = [];
+    registerManagedPageContextTabs({
+      kick: { platform: "kick", tabId: 14, originUrl: "https://kick.com/drops/inventory", origin: "https://kick.com", ownedByExtension: true },
+    });
+
+    await stopManagedPageContextTabsWithBrowser(browser, currentManagedPageContextTabs(), {
+      platforms: ["kick"],
+      reason: "background_recovered",
+      emit: (event) => events.push(event),
+    });
+
+    expect(events.some((event) => event.category === "activity" && event.code === "page_context_closed")).toBe(false);
+    expect(currentManagedPageContextTabs().kick).toBeUndefined();
+  });
+
   it("releases a retained Kick context only after sustained background recovery", async () => {
     const browser = browserMock();
     const events: EngineEvent[] = [];

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -68,11 +68,21 @@ describe("tab manager", () => {
 
     await fetchJsonInPageWithBrowser(
       browser,
-      "https://kick.com",
+      "https://kick.com/drops/inventory",
       "https://web.kick.com/api/v1/drops/progress?secret=value",
       undefined,
       { retainPageContext: { platform: "kick" }, emit, openReason: "background_rejected" },
     );
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: "https://kick.com/drops/inventory",
+      pinned: false,
+      active: false,
+    });
+    expect(browser.tabs.update).toHaveBeenCalledWith(14, { muted: true, active: false });
+    expect(currentManagedPageContextTabs().kick).toMatchObject({
+      originUrl: "https://kick.com/drops/inventory",
+      origin: "https://kick.com",
+    });
     await stopManagedPageContextTabsWithBrowser(browser, currentManagedPageContextTabs(), {
       platforms: ["kick"],
       reason: "background_recovered",

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -562,6 +562,11 @@ describe("tab manager", () => {
       { category: "activity", code: "page_context_closed", level: "info", platform: "kick", data: { host: "kick.com", reason: "managed_context_unusable" } },
       { category: "activity", code: "page_context_opened", level: "info", platform: "kick", data: { host: "kick.com", reason: "managed_context_unusable" } },
     ]);
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      platform: "kick",
+      message: expect.stringContaining("because the previous context was unusable"),
+    }));
   });
 
   it("does not close an existing user tab reused for a page-context fetch", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -11,8 +11,11 @@ import {
   hasValidTwitchIntegrity,
   KickWafBlockedError,
   openPinnedMutedTabWithBrowser,
+  recordManagedPageContextBackgroundSuccessWithBrowser,
+  recordManagedPageContextFallback,
   registerManagedPageContextTabs,
   setTwitchIntegrity,
+  stopManagedPageContextTabsWithBrowser,
   stopWatchTabWithBrowser,
 } from "@lurkloot/core/tabs";
 
@@ -52,6 +55,95 @@ describe("tab manager", () => {
     events.length = 0;
     await stopWatchTabWithBrowser(browser, { platform: "twitch", status: "watching", offlineChecks: 0, tabId: 9, tabManagedByExtension: true }, undefined, emit);
     expect(events.some((event) => event.level === "debug" && event.message.includes("Closed managed watch tab 9"))).toBe(true);
+  });
+
+  it("reports managed page-context creation and closure as activity", async () => {
+    const browser = {
+      ...browserMock(),
+      scripting: { executeScript: vi.fn(async () => [{ result: { ok: true } }]) },
+    };
+    browser.tabs.create.mockResolvedValue({ id: 14 });
+    const events: EngineEvent[] = [];
+    const emit = (event: EngineEvent) => events.push(event);
+
+    await fetchJsonInPageWithBrowser(
+      browser,
+      "https://kick.com",
+      "https://web.kick.com/api/v1/drops/progress?secret=value",
+      undefined,
+      { retainPageContext: { platform: "kick" }, emit, openReason: "background_rejected" },
+    );
+    await stopManagedPageContextTabsWithBrowser(browser, currentManagedPageContextTabs(), {
+      platforms: ["kick"],
+      reason: "background_recovered",
+      emit,
+    });
+
+    expect(events.filter((event) => event.category === "activity")).toEqual([
+      { category: "activity", code: "page_context_opened", level: "info", platform: "kick", data: { host: "kick.com", reason: "background_rejected" } },
+      { category: "activity", code: "page_context_closed", level: "info", platform: "kick", data: { host: "kick.com", reason: "background_recovered" } },
+    ]);
+    expect(events.every((event) => event.category === "activity" || !event.message.includes("secret=value"))).toBe(true);
+  });
+
+  it("does not report a close activity when managed page-context removal fails", async () => {
+    const browser = browserMock();
+    browser.tabs.remove.mockRejectedValue(new Error("already gone"));
+    const events: EngineEvent[] = [];
+    registerManagedPageContextTabs({
+      kick: { platform: "kick", tabId: 14, originUrl: "https://kick.com", origin: "https://kick.com", ownedByExtension: true },
+    });
+
+    await stopManagedPageContextTabsWithBrowser(browser, currentManagedPageContextTabs(), {
+      platforms: ["kick"],
+      reason: "background_recovered",
+      emit: (event) => events.push(event),
+    });
+
+    expect(events.some((event) => event.category === "activity" && event.code === "page_context_closed")).toBe(false);
+  });
+
+  it("releases a retained Kick context only after sustained background recovery", async () => {
+    const browser = browserMock();
+    const events: EngineEvent[] = [];
+    const emit = (event: EngineEvent) => events.push(event);
+    const startedAt = Date.parse("2026-07-21T12:00:00.000Z");
+    registerManagedPageContextTabs({
+      kick: { platform: "kick", tabId: 14, originUrl: "https://kick.com", origin: "https://kick.com", ownedByExtension: true },
+    });
+    recordManagedPageContextFallback("kick", "web.kick.com", emit, startedAt);
+
+    await recordManagedPageContextBackgroundSuccessWithBrowser(browser, "kick", "web.kick.com", emit, startedAt + 11 * 60_000);
+    await recordManagedPageContextBackgroundSuccessWithBrowser(browser, "kick", "web.kick.com", emit, startedAt + 11 * 60_000 + 1);
+    expect(browser.tabs.remove).not.toHaveBeenCalled();
+
+    await recordManagedPageContextBackgroundSuccessWithBrowser(browser, "kick", "web.kick.com", emit, startedAt + 11 * 60_000 + 2);
+
+    expect(browser.tabs.remove).toHaveBeenCalledOnce();
+    expect(currentManagedPageContextTabs().kick).toBeUndefined();
+    expect(events).toContainEqual({
+      category: "activity",
+      code: "page_context_closed",
+      level: "info",
+      platform: "kick",
+      data: { host: "kick.com", reason: "background_recovered" },
+    });
+  });
+
+  it("resets managed context recovery when another page fallback is required", async () => {
+    const browser = browserMock();
+    const startedAt = Date.parse("2026-07-21T12:00:00.000Z");
+    registerManagedPageContextTabs({
+      kick: { platform: "kick", tabId: 14, originUrl: "https://kick.com", origin: "https://kick.com", ownedByExtension: true },
+    });
+    recordManagedPageContextFallback("kick", "web.kick.com", undefined, startedAt);
+    await recordManagedPageContextBackgroundSuccessWithBrowser(browser, "kick", "web.kick.com", undefined, startedAt + 11 * 60_000);
+    await recordManagedPageContextBackgroundSuccessWithBrowser(browser, "kick", "web.kick.com", undefined, startedAt + 11 * 60_000 + 1);
+    recordManagedPageContextFallback("kick", "web.kick.com", undefined, startedAt + 11 * 60_000 + 2);
+    await recordManagedPageContextBackgroundSuccessWithBrowser(browser, "kick", "web.kick.com", undefined, startedAt + 22 * 60_000);
+
+    expect(browser.tabs.remove).not.toHaveBeenCalled();
+    expect(currentManagedPageContextTabs().kick).toMatchObject({ backgroundSuccesses: 1 });
   });
 
   it("keeps tab diagnostics scoped to the supplied emitter", async () => {
@@ -441,6 +533,35 @@ describe("tab manager", () => {
     expect(browser.scripting.executeScript).toHaveBeenCalledWith(expect.objectContaining({
       target: { tabId: 14 },
     }));
+  });
+
+  it("replaces a retained page context that navigated away from its origin", async () => {
+    const browser = {
+      ...browserMock(),
+      scripting: { executeScript: vi.fn(async () => [{ result: { ok: true } }]) },
+    };
+    browser.tabs.get.mockResolvedValue({ id: 14, url: "https://example.com/elsewhere" });
+    browser.tabs.create.mockResolvedValue({ id: 15 });
+    registerManagedPageContextTabs({
+      kick: { platform: "kick", tabId: 14, originUrl: "https://kick.com", origin: "https://kick.com", ownedByExtension: true },
+    });
+    const events: EngineEvent[] = [];
+
+    await fetchJsonInPageWithBrowser(
+      browser,
+      "https://kick.com",
+      "https://web.kick.com/api/v1/drops/progress",
+      undefined,
+      { retainPageContext: { platform: "kick" }, emit: (event) => events.push(event), openReason: "background_rejected" },
+    );
+
+    expect(browser.tabs.remove).toHaveBeenCalledWith(14);
+    expect(browser.tabs.create).toHaveBeenCalledOnce();
+    expect(currentManagedPageContextTabs().kick?.tabId).toBe(15);
+    expect(events.filter((event) => event.category === "activity")).toEqual([
+      { category: "activity", code: "page_context_closed", level: "info", platform: "kick", data: { host: "kick.com", reason: "managed_context_unusable" } },
+      { category: "activity", code: "page_context_opened", level: "info", platform: "kick", data: { host: "kick.com", reason: "managed_context_unusable" } },
+    ]);
   });
 
   it("does not close an existing user tab reused for a page-context fetch", async () => {

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "تم استلام بطاقة $1 من تحدي $2"
   },
+  "activityPageContextOpened": { "message": "تم فتح سياق في الخلفية على $1 لأن $2." },
+  "activityPageContextClosed": { "message": "تم إغلاق سياق الخلفية على $1 لأن $2." },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick رفض الطلب دون علامة تبويب" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "سياق الخلفية السابق لم يكن صالحًا للاستخدام" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "طلبات العمل دون علامة تبويب عادت للعمل" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "أصبحت علامة تبويب Kick موجودة متاحة" },
   "activityInterruption": {
     "message": "توقف الجمع: $1."
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "$1-Karte aus der $2-Challenge erhalten"
   },
+  "activityPageContextOpened": { "message": "Ein Hintergrundkontext auf $1 wurde geöffnet, weil $2." },
+  "activityPageContextClosed": { "message": "Der Hintergrundkontext auf $1 wurde geschlossen, weil $2." },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick die Anfrage ohne Tab abgelehnt hat" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "der vorherige Hintergrundkontext unbrauchbar war" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "Anfragen ohne Tab wieder funktionieren" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "ein vorhandener Kick-Tab verfügbar wurde" },
   "activityInterruption": {
     "message": "Sammeln unterbrochen: $1."
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "Claimed a $1 card from the $2 challenge"
   },
+  "activityPageContextOpened": { "message": "Opened a background context on $1 because $2." },
+  "activityPageContextClosed": { "message": "Closed the background context on $1 because $2." },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick rejected the tabless request" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "the previous background context was unusable" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "tabless requests recovered" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "an existing Kick tab became available" },
   "activityInterruption": {
     "message": "Farming interrupted: $1."
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "Reclamó una carta $1 del desafío $2"
   },
+  "activityPageContextOpened": { "message": "Se abrió un contexto en segundo plano en $1 porque $2." },
+  "activityPageContextClosed": { "message": "Se cerró el contexto en segundo plano en $1 porque $2." },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick rechazó la solicitud sin pestaña" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "el contexto anterior no se podía usar" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "las solicitudes sin pestaña se recuperaron" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "había disponible una pestaña de Kick existente" },
   "activityInterruption": {
     "message": "Obtención interrumpida: $1."
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "Carte $1 réclamée depuis le défi $2"
   },
+  "activityPageContextOpened": { "message": "Un contexte en arrière-plan a été ouvert sur $1 car $2." },
+  "activityPageContextClosed": { "message": "Le contexte en arrière-plan sur $1 a été fermé car $2." },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick a refusé la requête sans onglet" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "le contexte précédent était inutilisable" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "les requêtes sans onglet ont été rétablies" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "un onglet Kick existant est devenu disponible" },
   "activityInterruption": {
     "message": "Collecte interrompue : $1."
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "$2 चैलेंज से $1 कार्ड प्राप्त किया"
   },
+  "activityPageContextOpened": { "message": "$1 पर बैकग्राउंड कॉन्टेक्स्ट खोला गया क्योंकि $2।" },
+  "activityPageContextClosed": { "message": "$1 का बैकग्राउंड कॉन्टेक्स्ट बंद किया गया क्योंकि $2।" },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick ने बिना टैब वाला अनुरोध अस्वीकार किया" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "पिछला बैकग्राउंड कॉन्टेक्स्ट उपयोग योग्य नहीं था" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "बिना टैब वाले अनुरोध फिर से काम करने लगे" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "एक मौजूदा Kick टैब उपलब्ध हो गया" },
   "activityInterruption": {
     "message": "ड्रॉप जुटाना रुका: $1।"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "Riscattata una carta $1 dalla sfida $2"
   },
+  "activityPageContextOpened": { "message": "È stato aperto un contesto in background su $1 perché $2." },
+  "activityPageContextClosed": { "message": "Il contesto in background su $1 è stato chiuso perché $2." },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick ha rifiutato la richiesta senza scheda" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "il contesto precedente non era utilizzabile" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "le richieste senza scheda sono state ripristinate" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "è diventata disponibile una scheda Kick esistente" },
   "activityInterruption": {
     "message": "Raccolta interrotta: $1."
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "Carta $1 resgatada do desafio $2"
   },
+  "activityPageContextOpened": { "message": "Um contexto em segundo plano foi aberto em $1 porque $2." },
+  "activityPageContextClosed": { "message": "O contexto em segundo plano em $1 foi fechado porque $2." },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "a Kick rejeitou a solicitação sem aba" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "o contexto anterior não podia ser usado" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "as solicitações sem aba voltaram a funcionar" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "uma aba existente da Kick ficou disponível" },
   "activityInterruption": {
     "message": "Coleta interrompida: $1."
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "Получена карта $1 за испытание $2"
   },
+  "activityPageContextOpened": { "message": "Фоновый контекст на $1 открыт, потому что $2." },
+  "activityPageContextClosed": { "message": "Фоновый контекст на $1 закрыт, потому что $2." },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick отклонил запрос без вкладки" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "предыдущий фоновый контекст был непригоден" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "запросы без вкладки снова работают" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "стала доступна существующая вкладка Kick" },
   "activityInterruption": {
     "message": "Сбор прерван: $1."
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -724,6 +724,12 @@
   "activityChallengeClaimed": {
     "message": "已领取 $2 挑战的 $1 卡片"
   },
+  "activityPageContextOpened": { "message": "已在 $1 打开后台上下文，因为$2。" },
+  "activityPageContextClosed": { "message": "已关闭 $1 的后台上下文，因为$2。" },
+  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick 拒绝了无标签页请求" },
+  "activityPageContextReasonManagedContextUnusable": { "message": "之前的后台上下文无法使用" },
+  "activityPageContextCloseReasonBackgroundRecovered": { "message": "无标签页请求已恢复" },
+  "activityPageContextCloseReasonUserTabAvailable": { "message": "已有 Kick 标签页可用" },
   "activityInterruption": {
     "message": "领取已中断：$1。"
   },

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -1,5 +1,7 @@
 import type {
   ActivityHistoryRecord,
+  PageContextCloseReason,
+  PageContextOpenReason,
   FarmingStopReason,
   StoredEngineEvent,
 } from "@lurkloot/shared/events";
@@ -122,6 +124,32 @@ function formatStopReason(reason: FarmingStopReason, t: TFunction): string {
   }
 }
 
+function formatPageContextOpenReason(reason: PageContextOpenReason, t: TFunction): string {
+  switch (reason) {
+    case "background_rejected": return t("activityPageContextOpenReasonBackgroundRejected");
+    case "managed_context_unusable": return t("activityPageContextReasonManagedContextUnusable");
+    default: {
+      const exhaustive: never = reason;
+      return exhaustive;
+    }
+  }
+}
+
+function formatPageContextCloseReason(reason: PageContextCloseReason, t: TFunction): string {
+  switch (reason) {
+    case "background_recovered": return t("activityPageContextCloseReasonBackgroundRecovered");
+    case "user_tab_available": return t("activityPageContextCloseReasonUserTabAvailable");
+    case "platform_disabled": return t("activityReasonPlatformDisabled");
+    case "automation_disabled": return t("activityReasonAutomationDisabled");
+    case "manual_watch": return t("activityReasonManualWatch");
+    case "managed_context_unusable": return t("activityPageContextReasonManagedContextUnusable");
+    default: {
+      const exhaustive: never = reason;
+      return exhaustive;
+    }
+  }
+}
+
 function formatCurrentActivity(event: StoredEngineEvent & { category: "activity" }, t: TFunction): string {
   switch (event.code) {
     case "farming_started":
@@ -142,6 +170,10 @@ function formatCurrentActivity(event: StoredEngineEvent & { category: "activity"
     }
     case "challenge_claimed":
       return t("activityChallengeClaimed", [event.data.rarity, event.data.recurrence]);
+    case "page_context_opened":
+      return t("activityPageContextOpened", [event.data.host, formatPageContextOpenReason(event.data.reason, t)]);
+    case "page_context_closed":
+      return t("activityPageContextClosed", [event.data.host, formatPageContextCloseReason(event.data.reason, t)]);
     default: {
       const exhaustive: never = event;
       return exhaustive;

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -142,6 +142,7 @@ function formatPageContextCloseReason(reason: PageContextCloseReason, t: TFuncti
     case "platform_disabled": return t("activityReasonPlatformDisabled");
     case "automation_disabled": return t("activityReasonAutomationDisabled");
     case "manual_watch": return t("activityReasonManualWatch");
+    case "runtime_restart": return t("activityReasonRuntimeRestart");
     case "managed_context_unusable": return t("activityPageContextReasonManagedContextUnusable");
     default: {
       const exhaustive: never = reason;

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -25,12 +25,24 @@ type CampaignRewardData = {
   rewardName: string;
 };
 
+export type PageContextOpenReason = "background_rejected" | "managed_context_unusable";
+
+export type PageContextCloseReason =
+  | "background_recovered"
+  | "user_tab_available"
+  | "platform_disabled"
+  | "automation_disabled"
+  | "manual_watch"
+  | "managed_context_unusable";
+
 export type ActivityEvent =
   | { category: "activity"; code: "farming_started"; level: "info"; platform: Platform; message?: never; data: CampaignRewardData & { channel?: string } }
   | { category: "activity"; code: "farming_stopped"; level: "info" | "warn" | "error"; platform: Platform; message?: never; data: CampaignRewardData & { reason: FarmingStopReason } }
   | { category: "activity"; code: "reward_claimed"; level: "info"; platform: Platform; message?: never; data: CampaignRewardData & { method: "automatic" | "manual" } }
   | { category: "activity"; code: "interruption"; level: "warn" | "error"; platform?: Platform; message?: never; data: { reason: FarmingStopReason; detail?: string } }
-  | { category: "activity"; code: "challenge_claimed"; level: "info"; platform: Platform; message?: never; data: { challengeId: string; rarity: string; recurrence: string } };
+  | { category: "activity"; code: "challenge_claimed"; level: "info"; platform: Platform; message?: never; data: { challengeId: string; rarity: string; recurrence: string } }
+  | { category: "activity"; code: "page_context_opened"; level: "info"; platform: Platform; message?: never; data: { host: string; reason: PageContextOpenReason } }
+  | { category: "activity"; code: "page_context_closed"; level: "info"; platform: Platform; message?: never; data: { host: string; reason: PageContextCloseReason } };
 
 export type DiagnosticEvent = {
   category: "diagnostic";

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -33,6 +33,7 @@ export type PageContextCloseReason =
   | "platform_disabled"
   | "automation_disabled"
   | "manual_watch"
+  | "runtime_restart"
   | "managed_context_unusable";
 
 export type ActivityEvent =

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -160,6 +160,9 @@ export interface ManagedPageContextTab {
   originUrl: string;
   origin: string;
   ownedByExtension: true;
+  lastFallbackAt?: string;
+  fallbackHost?: string;
+  backgroundSuccesses?: number;
 }
 
 export interface ManualWatchState {


### PR DESCRIPTION
## Summary

- keep Kick cookie-authenticated service-worker requests as the primary tabless path
- use at most one unpinned, muted, inactive `https://kick.com/drops/inventory` context when Kick rejects background access
- preserve a required context across ordinary scheduler cycles and MV3 service-worker restarts
- release the fallback context only after three successful background requests and a ten-minute recovery window, or an explicit lifecycle event
- respect manual farming-tab closure by clearing stale ownership state and waiting for the next normal scheduler cycle instead of immediately reopening
- report every real managed page-context open and close in Activity with localized, privacy-safe reasons

## Root cause

The scheduler closed a retained page-context tab immediately after preparing a watch tab, although later Kick discovery, daily-reward, or heartbeat requests could still require it. Routine service-worker startup also treated valid retained contexts as stale. Together these paths caused visible close/reopen cycling.

Separately, closing an extension-managed farming tab triggered a new scheduler tick directly from `tabs.onRemoved`, causing the pinned channel tab to reopen immediately. Fallback bookkeeping also occurred after page execution, so a failed page request could leave recovery metadata incomplete.

## User impact

Kick remains fully tabless whenever background cookie replay works. If Kick rejects it, LurkLoot reuses a user-owned Kick tab or opens the Drops inventory as a stable unpinned support context. User-owned tabs are never registered or closed as managed contexts.

Closing a pinned farming tab now takes effect immediately without LurkLoot fighting the browser action. Farming may resume on the next ordinary alarm or startup cycle while preserving the user's enabled/running settings.

## Testing

- `pnpm verify`
  - 646 extension tests
  - 105 CLI tests
  - script and release tests
  - all workspace typechecks
  - site tests and build
  - Chromium MV3 production build
  - Firefox MV2 production build
- independent code review and focused re-review
- `git diff --check`

Closes #193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new Kick page-context lifecycle activity events (open/close) with human-readable reasons in the Activity view and CLI.
  * Implemented adaptive recovery that retains managed fallback contexts only when warranted, and releases them after sustained background recovery.
* **Bug Fixes**
  * Prevented auto-reopen/recovery loops after manually closing managed farming tabs.
  * Improved handling when retained fallback contexts become unusable; better persistence of lifecycle metadata across restarts.
* **Documentation**
  * Added Kick page-context lifecycle design and implementation plan docs.
* **Localization**
  * Added translated Activity and reason strings for page-context open/close across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->