### PR TITLE
feat(locales): add Turkish language support

### DIFF
--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -40,6 +40,7 @@ For every locale below, set its **Summary** + **Description** (from `store-descr
 | hi | `store-screenshots/hi/` | Hindi |
 | pt_BR | `store-screenshots/pt_BR/` | Portuguese (Brazil) |
 | ar | `store-screenshots/ar/` | Arabic |
+| tr | `store-screenshots/tr/` | Turkish |
 
 (English `en` is the default listing in §1.) All short descriptions are within the 132-char limit.
 
@@ -60,8 +61,9 @@ falls back when unhealthy, and confirm reward progress on the platforms' invento
 
 ```bash
 pnpm zip && pnpm zip:firefox     # extension packages
-pnpm screenshot:store            # artifacts/store-screenshots/<locale>/ (all 10)
+pnpm screenshot:store            # artifacts/store-screenshots/<locale>/ (all 11)
 pnpm promo:store                 # artifacts/store-promo/<locale>/
 ```
 
-Pass locale codes to limit, e.g. `pnpm screenshot:store es ar`.
+Pass locale codes to limit, e.g. `pnpm screenshot:store es ar tr`. Turkish promo tiles are under
+`artifacts/store-promo/tr/`.

--- a/docs/store-descriptions.md
+++ b/docs/store-descriptions.md
@@ -29,6 +29,8 @@ Your data stays yours: no passwords, no exported cookies or tokens, and everythi
 
 From the popup you can enable each platform, prioritize the campaigns and games you care about, manage per-platform idle watchlists and excluded channels, and toggle auto-claim and notifications.
 
+Lurkloot can also farm Kick watch time when no drop is active. Add your preferred channels to the idle watchlist and it automatically chooses one that is live. Tabless watching keeps resource use low, while the normal pinned-tab fallback keeps the session resilient.
+
 ---
 
 ## Spanish (es)
@@ -44,6 +46,8 @@ De forma predeterminada usa un modo ligero sin pestañas que envía señales de 
 Tus datos son tuyos: sin contraseñas, sin exportar cookies ni tokens, y todo se queda en tu dispositivo.
 
 Desde el popup puedes activar cada plataforma, priorizar las campañas y los juegos que te interesan, gestionar las listas de visualización inactivas y los canales excluidos de cada plataforma, y activar la reclamación automática y las notificaciones.
+
+Lurkloot también puede farmear tiempo de visualización en Kick cuando no hay ningún drop activo. Añade tus canales favoritos a la lista de visualización inactiva y elegirá automáticamente uno que esté en directo. La visualización sin pestañas reduce el uso de recursos, mientras que la alternativa de pestaña fijada mantiene la sesión estable.
 
 ---
 
@@ -61,6 +65,8 @@ Vos données restent les vôtres : aucun mot de passe, aucun cookie ni token exp
 
 Depuis le popup, vous pouvez activer chaque plateforme, prioriser les campagnes et les jeux qui vous intéressent, gérer les listes de veille inactives et les chaînes exclues par plateforme, et activer la réclamation automatique et les notifications.
 
+Lurkloot peut aussi farmer du temps de visionnage sur Kick lorsqu'aucun drop n'est actif. Ajoutez vos chaînes préférées à la liste de veille inactive : il choisit automatiquement celle qui est en direct. Le visionnage sans onglet limite l'utilisation des ressources, tandis que le repli sur un onglet épinglé préserve la fiabilité de la session.
+
 ---
 
 ## Italian (it)
@@ -76,6 +82,8 @@ Per impostazione predefinita usa una leggera modalità senza schede che invia se
 I tuoi dati restano tuoi: niente password, nessun cookie o token esportato, e tutto rimane sul tuo dispositivo.
 
 Dal popup puoi attivare ogni piattaforma, dare priorità alle campagne e ai giochi che ti interessano, gestire le liste di visione inattive e i canali esclusi per ogni piattaforma, e attivare il riscatto automatico e le notifiche.
+
+Lurkloot può anche farmare il tempo di visione su Kick quando non ci sono drop attivi. Aggiungi i tuoi canali preferiti alla lista di visione inattiva e sceglierà automaticamente quello in diretta. La visione senza schede riduce l'uso delle risorse, mentre il ripiego su una scheda fissata mantiene stabile la sessione.
 
 ---
 
@@ -93,6 +101,8 @@ Lurkloot фармит дропы Twitch и Kick за вас, чтобы вы п�
 
 В попапе можно включать каждую платформу, задавать приоритет кампаниям и играм, управлять списками просмотра в простое и исключёнными каналами для каждой платформы, а также включать автозабор наград и уведомления.
 
+Lurkloot также может фармить время просмотра на Kick, когда активных дропов нет. Добавьте предпочитаемые каналы в список просмотра в простое, и он автоматически выберет тот, который сейчас в эфире. Просмотр без вкладки экономит ресурсы, а переход на закреплённую вкладку при необходимости поддерживает стабильность сессии.
+
 ---
 
 ## German (de)
@@ -108,6 +118,8 @@ Standardmäßig läuft ein ressourcenschonender Modus ohne Tab, der Watch-Signal
 Deine Daten bleiben deine: keine Passwörter, kein Export von Cookies oder Tokens, und alles bleibt auf deinem Gerät.
 
 Über das Popup kannst du jede Plattform aktivieren, die Kampagnen und Spiele priorisieren, die dir wichtig sind, Leerlauf-Watchlists und ausgeschlossene Kanäle pro Plattform verwalten und Auto-Claim sowie Benachrichtigungen umschalten.
+
+Lurkloot kann auch Kick-Watchtime farmen, wenn kein Drop aktiv ist. Füge deine bevorzugten Kanäle zur Leerlauf-Watchlist hinzu; es wählt automatisch einen gerade laufenden Stream. Das Zuschauen ohne Tab spart Ressourcen, während der Rückfall auf einen angepinnten Tab die Sitzung zuverlässig am Laufen hält.
 
 ---
 
@@ -125,6 +137,8 @@ Lurkloot 替你刷 Twitch 和 Kick 掉宝，让你无需亲自盯着直播就能
 
 在弹窗中，你可以启用各个平台，优先安排你关注的活动和游戏，管理每个平台的空闲观看列表和已排除的频道，并开关自动领取与通知。
 
+没有活跃掉宝时，Lurkloot 也能自动累积 Kick 观看时长。把常看的频道加入空闲观看列表，它会自动选择正在直播的频道。无标签页观看可以降低资源占用，必要时回退到固定标签页则能保持会话稳定。
+
 ---
 
 ## Hindi (hi)
@@ -140,6 +154,8 @@ Lurkloot आपके लिए Twitch और Kick के drops फ़ार्�
 आपका डेटा आपका ही रहता है: कोई पासवर्ड नहीं, कोई कुकी या टोकन एक्सपोर्ट नहीं, और सब कुछ आपके डिवाइस पर ही रहता है।
 
 पॉपअप से आप हर प्लेटफ़ॉर्म चालू कर सकते हैं, अपनी पसंद के कैंपेन और गेम को प्राथमिकता दे सकते हैं, हर प्लेटफ़ॉर्म की निष्क्रिय वॉचलिस्ट और बहिष्कृत चैनल प्रबंधित कर सकते हैं, और ऑटो-क्लेम तथा नोटिफ़िकेशन टॉगल कर सकते हैं।
+
+जब कोई सक्रिय drop न हो, तब Lurkloot Kick का watch time भी फ़ार्म कर सकता है। अपने पसंदीदा चैनल निष्क्रिय वॉचलिस्ट में जोड़ें और यह अपने-आप किसी लाइव चैनल को चुन लेगा। बिना-टैब देखने से संसाधनों का उपयोग कम रहता है, जबकि ज़रूरत पड़ने पर पिन किए हुए टैब पर लौटना सत्र को भरोसेमंद बनाए रखता है।
 
 ---
 
@@ -157,6 +173,8 @@ Seus dados continuam seus: sem senhas, sem exportar cookies ou tokens, e tudo fi
 
 Pelo popup você pode ativar cada plataforma, priorizar as campanhas e os jogos que importam para você, gerenciar as listas de visualização ociosas e os canais excluídos de cada plataforma, e alternar o resgate automático e as notificações.
 
+O Lurkloot também pode farmar tempo de exibição na Kick quando não há drops ativos. Adicione seus canais preferidos à lista de visualização ociosa e ele escolhe automaticamente um que esteja ao vivo. A visualização sem abas reduz o uso de recursos, enquanto o retorno a uma aba fixada mantém a sessão confiável.
+
 ---
 
 ## Arabic (ar)
@@ -172,3 +190,23 @@ Pelo popup você pode ativar cada plataforma, priorizar as campanhas e os jogos 
 تبقى بياناتك ملكك: بلا كلمات مرور، وبلا تصدير لملفات تعريف الارتباط أو الرموز، ويبقى كل شيء على جهازك.
 
 من النافذة المنبثقة يمكنك تفعيل كل منصة، وتحديد أولوية الحملات والألعاب التي تهمّك، وإدارة قوائم المشاهدة الخاملة والقنوات المستبعَدة لكل منصة، وتبديل المطالبة التلقائية والإشعارات.
+
+يمكن لـ Lurkloot أيضًا فارم وقت المشاهدة على Kick عند عدم وجود دروب نشط. أضف قنواتك المفضلة إلى قائمة المشاهدة الخاملة وسيختار تلقائيًا قناة تبث مباشرة. تحافظ المشاهدة بلا تبويب على انخفاض استهلاك الموارد، بينما يضمن الرجوع إلى تبويب مثبّت استقرار الجلسة.
+
+---
+
+## Turkish (tr)
+
+**Short:** Twitch ve Kick droplarını ve izlenme süresini tarayıcınızda otomatik kasın. Düşük kaynak modu, otomatik alma ve gizlilik.
+
+**Detailed:**
+
+Lurkloot, Twitch ve Kick droplarını sizin için kasar; böylece yayınları kendiniz izlemek zorunda kalmadan oyun içi ödüller kazanırsınız. Normal, zaten giriş yaptığınız tarayıcı oturumunuz üzerinden çalışır ve parolanızı hiçbir zaman istemez.
+
+Varsayılan olarak video sekmesini açık tutmak yerine arka planda izleme sinyalleri gönderen hafif, sekmesiz modu kullanır; böylece bant genişliğinden ve sistem kaynaklarından tasarruf edersiniz. İstediğiniz drop için doğru kanalı takip eder, kampanyalar bittiğinde otomatik geçiş yapar ve uygun tüm ödülleri alır. İlerleme durursa droplarınızın devam etmesi için sabitlenmiş, sessiz bir sekmeye geri döner.
+
+Verileriniz size ait kalır: parola yok, dışa aktarılan çerez veya oturum anahtarı yok; her şey cihazınızda kalır.
+
+Açılır pencereden her platformu etkinleştirebilir, önemsediğiniz kampanyalara ve oyunlara öncelik verebilir, platforma özel Boşta İzleme Listelerini ve hariç tutulan kanalları yönetebilir, otomatik alma ile bildirimleri açıp kapatabilirsiniz.
+
+Aktif drop olmadığında Lurkloot, Kick izlenme süresini de kasabilir. Tercih ettiğiniz kanalları Boşta İzleme Listesine ekleyin; canlı olanlardan birini otomatik seçer. Sekmesiz izleme kaynak kullanımını düşük tutarken, gerektiğinde sabitlenmiş sekmeye dönmek oturumun güvenilir biçimde sürmesini sağlar.

--- a/docs/superpowers/plans/2026-07-22-turkish-language.md
+++ b/docs/superpowers/plans/2026-07-22-turkish-language.md
@@ -1,0 +1,329 @@
+# Turkish Language and Store-Listing Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Turkish extension localization with complete Chrome Web Store listing assets and describe Kick watch-time farming consistently in every store language.
+
+**Architecture:** Extend the existing explicit `SupportedLocale` registry and statically analyzable catalog loaders with `tr`, while leaving WXT's catalog-discovery hook unchanged. Keep store artwork reproducible by adding Turkish to the current Playwright capture allowlists, then generate gitignored PNG outputs from the real popup. Treat listing prose as documentation and validate locale/catalog/asset invariants with deterministic tests and shell checks.
+
+**Tech Stack:** TypeScript 7, React 19, WXT 0.20, Vitest 4, Playwright 1.61, pnpm 11, ImageMagick, JSON Chrome i18n catalogs.
+
+## Global Constraints
+
+- Work only in `.worktrees/turkish-language` on `feat/turkish-language`, based on `origin/develop`.
+- Use locale code `tr`, native label `Türkçe`, and recognize browser locale `tr-TR`.
+- Turkish must contain every English catalog key and preserve every `$N` placeholder sequence.
+- Store output is five 1280×800 screenshots plus 440×280 and 1400×560 opaque RGB promo tiles.
+- All eleven detailed store descriptions must mention Kick watch-time farming, idle-watchlist automation, and lower-resource tabless watching without promising badges or platform outcomes.
+- Do not add permissions, farming behavior, credentials, email sends, or Chrome Web Store publication.
+- Generated `packages/extension/artifacts/**` files remain gitignored; commit only reproducible sources and documentation.
+
+---
+
+### Task 1: First-class Turkish locale contract
+
+**Files:**
+- Modify: `packages/shared/src/models.ts`
+- Modify: `packages/shared/src/settings.ts`
+- Modify: `packages/shared/src/i18n.ts`
+- Modify: `packages/extension/tests/i18n.test.ts`
+- Modify: `packages/extension/tests/settings.test.ts`
+
+**Interfaces:**
+- Produces: `SupportedLocale` including `"tr"`, `SUPPORTED_LOCALES` including `"tr"`, and `LOCALE_OPTIONS` containing `{ value: "tr", labelKey: "languageTurkish", nativeName: "Türkçe" }`.
+
+- [ ] **Step 1: Add failing locale and settings tests**
+
+Add these assertions to the existing focused tests:
+
+```ts
+// Add LOCALE_OPTIONS to the existing @lurkloot/shared/i18n import.
+import { LOCALE_OPTIONS } from "@lurkloot/shared/i18n";
+
+expect(normalizeBrowserLocale("tr-TR")).toBe("tr");
+expect(effectiveLocale("tr", "en-US")).toBe("tr");
+expect(LOCALE_OPTIONS).toContainEqual({
+  value: "tr",
+  labelKey: "languageTurkish",
+  nativeName: "Türkçe",
+});
+```
+
+In `settings.test.ts`, extend the language normalization case with:
+
+```ts
+expect(mergeSettings({ languageOverride: "tr" }).languageOverride).toBe("tr");
+```
+
+- [ ] **Step 2: Run the focused tests and verify red state**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/i18n.test.ts tests/settings.test.ts`
+
+Expected: TypeScript/Vitest fails because `"tr"` is not assignable to `SupportedLocale` and the option is absent.
+
+- [ ] **Step 3: Extend the explicit locale registries**
+
+Apply these exact additions:
+
+```ts
+// packages/shared/src/models.ts
+export type SupportedLocale = "en" | "es" | "fr" | "it" | "ru" | "de" | "zh_CN" | "hi" | "pt_BR" | "ar" | "tr";
+
+// packages/shared/src/settings.ts
+export const SUPPORTED_LOCALES: SupportedLocale[] = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar", "tr"];
+
+// packages/shared/src/i18n.ts, append to LOCALE_OPTIONS
+{ value: "tr", labelKey: "languageTurkish", nativeName: "Türkçe" },
+
+```
+
+No Turkish-specific branch is needed in `normalizeBrowserLocale`; its base-language logic resolves `tr-TR` once `tr` is supported.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/i18n.test.ts tests/settings.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the locale contract**
+
+```bash
+git add packages/shared/src/models.ts packages/shared/src/settings.ts packages/shared/src/i18n.ts packages/extension/tests/i18n.test.ts packages/extension/tests/settings.test.ts
+git commit -m "feat(locales): register Turkish language support"
+```
+
+### Task 2: Complete Turkish catalog
+
+**Files:**
+- Create: `packages/locales/messages/tr.json`
+- Modify: `packages/locales/src/index.ts`
+- Modify: `packages/locales/messages/en.json`
+- Modify: `packages/locales/messages/es.json`
+- Modify: `packages/locales/messages/fr.json`
+- Modify: `packages/locales/messages/it.json`
+- Modify: `packages/locales/messages/ru.json`
+- Modify: `packages/locales/messages/de.json`
+- Modify: `packages/locales/messages/zh_CN.json`
+- Modify: `packages/locales/messages/hi.json`
+- Modify: `packages/locales/messages/pt_BR.json`
+- Modify: `packages/locales/messages/ar.json`
+- Modify: `packages/extension/tests/i18n.test.ts`
+- Modify: `packages/extension/tests/tips.test.ts`
+
+**Interfaces:**
+- Consumes: `languageTurkish` from Task 1's locale option.
+- Produces: a `MessageCatalog` at `@lurkloot/locales/messages/tr.json` with exactly the English key set and identical placeholder sequences.
+- Produces: `loadCatalog("tr")` through the static loader `tr: () => import("../messages/tr.json")`.
+
+- [ ] **Step 1: Strengthen failing catalog coverage**
+
+Update the locale expectations and translation checks:
+
+```ts
+expect(locales).toContain("tr");
+expect(readCatalog("tr").languageTurkish.message).toBe("Türkçe");
+expect(readCatalog("tr").subscriptionCampaigns.message).toBe("Abonelik kampanyaları");
+```
+
+Add `tr: "Abonelik kampanyaları"` to the existing `translations` record. Add `"tr"` to the fixed locale list in `tips.test.ts`. Do not weaken the existing key-parity, placeholder-parity, or unchanged-English checks.
+
+- [ ] **Step 2: Run tests and verify the missing catalog failure**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/i18n.test.ts tests/tips.test.ts`
+
+Expected: FAIL because `tr.json` and `languageTurkish` messages do not exist.
+
+- [ ] **Step 3: Add the Turkish language name to every catalog**
+
+Insert a `languageTurkish` message beside the other language names in all eleven catalogs. Use the localized name of Turkish in each existing catalog and use this exact Turkish entry:
+
+```json
+"languageTurkish": {
+  "message": "Türkçe"
+}
+```
+
+- [ ] **Step 4: Translate the complete Turkish catalog**
+
+Create `tr.json` in the same key order as `en.json`. Translate every user-visible message into natural Turkish; preserve `Lurkloot`, Twitch, Kick, Drops, URLs, `$1`/`$2` tokens, punctuation semantics, and Chrome message JSON structure. Use gaming terms rather than agricultural language. The store-specific keys must communicate these meanings:
+
+```json
+"extensionStoreName": { "message": "Lurkloot - Twitch ve Kick'te Drop ve İzlenme Süresi Kas" },
+"languageTurkish": { "message": "Türkçe" },
+"screenshotTwitchHeadline": { "message": "Twitch droplarını otomatik kas" },
+"screenshotKickHeadline": { "message": "Kick droplarını ve izlenme süresini kas" },
+"screenshotIdleWatchlistHeadline": { "message": "İzleme listeni sen belirle" },
+"screenshotSettingsHeadline": { "message": "Nasıl kasacağını özelleştir" },
+"screenshotActivityHeadline": { "message": "Her şeyi tek bakışta takip et" },
+"promoTagline": { "message": "Twitch ve Kick droplarını otomatik kas" }
+```
+
+Before committing, compare each final Turkish phrase against its UI context and keep the extension description concise enough for manifest/store use.
+
+Append the statically analyzable loader in `packages/locales/src/index.ts`:
+
+```ts
+tr: () => import("../messages/tr.json"),
+```
+
+- [ ] **Step 5: Validate JSON keys, placeholders, and translation tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/i18n.test.ts tests/tips.test.ts`
+
+Expected: both test files pass; all locale keys and placeholders remain synchronized.
+
+Run: `pnpm --filter @lurkloot/locales typecheck && pnpm --filter @lurkloot/shared typecheck`
+
+Expected: both packages pass typechecking.
+
+- [ ] **Step 6: Commit the catalog**
+
+```bash
+git add packages/locales/messages packages/locales/src/index.ts packages/extension/tests/i18n.test.ts packages/extension/tests/tips.test.ts
+git commit -m "feat(locales): translate Lurkloot into Turkish"
+```
+
+### Task 3: Store capture parity and listing copy
+
+**Files:**
+- Modify: `packages/extension/scripts/capture-store-screenshot.mjs`
+- Modify: `packages/extension/scripts/capture-store-promo.mjs`
+- Modify: `packages/extension/tests/i18n.test.ts`
+- Modify: `docs/store-descriptions.md`
+- Modify: `docs/chrome-web-store-submission.md`
+
+**Interfaces:**
+- Consumes: the Turkish catalog and marketing keys from Task 2.
+- Produces: capture CLIs that accept `tr`, plus complete CWS documentation for eleven locales.
+
+- [ ] **Step 1: Add a failing capture-pipeline invariant test**
+
+In `i18n.test.ts`, read both scripts and assert every catalog locale is represented:
+
+```ts
+const extensionRoot = dirname(import.meta.dirname);
+const captureScripts = [
+  join(extensionRoot, "scripts/capture-store-screenshot.mjs"),
+  join(extensionRoot, "scripts/capture-store-promo.mjs"),
+];
+for (const script of captureScripts) {
+  const source = readFileSync(script, "utf8");
+  for (const locale of localeCodes()) expect(source, `${script}:${locale}`).toContain(`"${locale}"`);
+}
+```
+
+- [ ] **Step 2: Verify the new invariant fails**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/i18n.test.ts`
+
+Expected: FAIL for `tr` in both capture scripts.
+
+- [ ] **Step 3: Add Turkish to both capture allowlists**
+
+Use this exact list in each script:
+
+```js
+const ALL_LOCALES = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar", "tr"];
+```
+
+- [ ] **Step 4: Update all listing descriptions**
+
+Add a `## Turkish (tr)` section with a short description of at most 132 characters and a natural detailed translation. In every language's detailed description, add one paragraph equivalent to:
+
+```text
+Lurkloot can also farm Kick watch time when no drop is active. Add the channels you prefer to the idle watchlist and it automatically chooses one that is live. Tabless watching keeps resource use low, while the normal pinned-tab fallback keeps the session resilient.
+```
+
+Localize the paragraph rather than inserting English. Do not mention or guarantee Kick's level badges. Verify short-description character counts with a small read-only Node command or manual extraction.
+
+- [ ] **Step 5: Update submission documentation**
+
+Add the table row:
+
+```markdown
+| tr | `store-screenshots/tr/` | Turkish |
+```
+
+Change “all 10” to “all 11”, state that Turkish promo tiles use `artifacts/store-promo/tr/`, and include `tr` in the limited-generation example.
+
+- [ ] **Step 6: Run focused tests and documentation checks**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/i18n.test.ts`
+
+Expected: PASS, including both capture-script locale invariants.
+
+Run: `rg -n "watch time|izlenme süresi|store-screenshots/tr|all 11" docs/store-descriptions.md docs/chrome-web-store-submission.md`
+
+Expected: Turkish listing and eleven-locale documentation are present; manually confirm each language contains its localized watch-time paragraph.
+
+- [ ] **Step 7: Commit capture and listing parity**
+
+```bash
+git add packages/extension/scripts/capture-store-screenshot.mjs packages/extension/scripts/capture-store-promo.mjs packages/extension/tests/i18n.test.ts docs/store-descriptions.md docs/chrome-web-store-submission.md
+git commit -m "feat(store): add Turkish listing assets"
+```
+
+### Task 4: Generate, inspect, and package release-ready outputs
+
+**Files:**
+- Generate (gitignored): `packages/extension/artifacts/store-screenshots/tr/*.png`
+- Generate (gitignored): `packages/extension/artifacts/store-promo/tr/*.png`
+- Generate (gitignored): `packages/extension/.output/*chrome*.zip`
+
+**Interfaces:**
+- Consumes: Tasks 1–3.
+- Produces: seven verified Turkish CWS PNGs and a local Chrome pre-release archive suitable for Can's review.
+
+- [ ] **Step 1: Run full repository verification**
+
+Run: `pnpm verify`
+
+Expected: script tests, all workspace typechecks/tests, site build, Chromium build, and Firefox build pass.
+
+- [ ] **Step 2: Generate Turkish screenshots and promo tiles**
+
+Run: `pnpm screenshot:store tr && pnpm promo:store tr`
+
+Expected: five files under `artifacts/store-screenshots/tr/` and two files under `artifacts/store-promo/tr/`, with no raw i18n keys visible.
+
+- [ ] **Step 3: Verify image counts, dimensions, and color model**
+
+Run:
+
+```bash
+find packages/extension/artifacts/store-screenshots/tr -maxdepth 1 -name '*.png' | wc -l
+find packages/extension/artifacts/store-promo/tr -maxdepth 1 -name '*.png' | wc -l
+magick identify -format '%f %wx%h %[channels]\n' packages/extension/artifacts/store-screenshots/tr/*.png packages/extension/artifacts/store-promo/tr/*.png
+```
+
+Expected: counts `5` and `2`; screenshots are `1280x800`; promos are `440x280` and `1400x560`; promo channels contain no alpha.
+
+- [ ] **Step 4: Visually inspect all Turkish artwork**
+
+Open a contact sheet or each PNG and confirm text is Turkish, no text is clipped, the popup is fully rendered, ordering is 01–05, and the promo tiles have no raw keys. If copy clips, shorten the relevant Turkish marketing key, rerun Task 2 tests, rebuild, and recapture.
+
+- [ ] **Step 5: Create the Chrome pre-release archive**
+
+Run: `pnpm zip`
+
+Expected: a versioned Chrome ZIP appears in `packages/extension/.output/` and contains `_locales/tr/messages.json`.
+
+Run:
+
+```bash
+unzip -l packages/extension/.output/*chrome.zip | rg '_locales/tr/messages.json'
+git status --short
+```
+
+Expected: the Turkish catalog is present in the archive; generated artifact directories remain absent from Git status.
+
+- [ ] **Step 6: Final verification commit if visual copy required edits**
+
+If Task 4 required tracked translation or documentation corrections:
+
+```bash
+git add packages/locales/messages/tr.json docs/store-descriptions.md
+git commit -m "fix(locales): refine Turkish store copy"
+```
+
+Otherwise, make no empty commit.

--- a/docs/superpowers/specs/2026-07-22-turkish-language-design.md
+++ b/docs/superpowers/specs/2026-07-22-turkish-language-design.md
@@ -1,0 +1,46 @@
+# Turkish language and store-listing parity design
+
+## Goal
+
+Add Turkish as a first-class Lurkloot locale and give it the same Chrome Web Store support as every existing language. The release-ready output includes the translated extension, five Turkish listing screenshots, two Turkish promotional tiles, and paste-ready Turkish listing copy. Based on the requester's follow-up email, every store-language description will also explain that Lurkloot can farm Kick watch time through its idle watchlist and lower-resource automatic watching, not only earn drops.
+
+## Scope
+
+The feature covers the shared locale contracts, popup language selection, browser-locale normalization, catalog loading, WXT locale packaging, store capture scripts, store documentation, generated Turkish store artwork, and a local pre-release extension artifact for native-speaker testing.
+
+It does not change farming behavior, add permissions, send email, publish to the Chrome Web Store, or promise that watch time will produce a particular Kick badge or reward. Sending the pre-release artifact to the requester remains a separate explicit action.
+
+## Locale integration
+
+`tr` becomes a `SupportedLocale` and appears as `Türkçe` in the language selector. Browser values such as `tr` and `tr-TR` normalize to it, explicit settings persist it, and `@lurkloot/locales` exposes a statically analyzable dynamic import for its catalog. The existing WXT build hook discovers the new catalog and emits `_locales/tr/messages.json` without special-case build logic.
+
+The Turkish catalog will contain every English key. Placeholder sequences such as `$1` will match English exactly. Translations will use natural Turkish gaming vocabulary, retain product and platform brand names, and include localized marketing overlays for screenshots and promo tiles. English fallback behavior remains unchanged.
+
+## Chrome Web Store parity
+
+The screenshot and promo capture scripts will accept `tr` and include it in their default all-locale runs. The implementation will generate:
+
+- five 1280×800 screenshots in `packages/extension/artifacts/store-screenshots/tr/`;
+- one 440×280 and one 1400×560 opaque RGB promotional tile in `packages/extension/artifacts/store-promo/tr/`.
+
+These artifacts follow the repository's existing generated, gitignored workflow. Reproducible source catalogs and capture configuration are committed; the generated PNGs remain available in the feature worktree for inspection and CWS upload.
+
+`docs/store-descriptions.md` will gain a Turkish short and detailed listing. All eleven detailed descriptions will mention Kick watch-time farming in a restrained, factual way: users can maintain a specific idle watchlist, let Lurkloot choose an available channel automatically, and use tabless watching to reduce resource usage. The text will avoid guarantees about Kick levels, badges, or platform outcomes. Short descriptions stay within Chrome's 132-character limit.
+
+`docs/chrome-web-store-submission.md` will list Turkish paths and update locale/asset counts and regeneration examples.
+
+## Testing and validation
+
+Focused tests will verify:
+
+- `tr-TR` browser normalization and Turkish explicit settings;
+- Turkish presence in supported locale options and the catalog loader;
+- key parity and placeholder parity across all catalogs;
+- no unintended English copy in the Turkish catalog, subject to the existing brand/common-term allowlist;
+- Turkish inclusion in both store capture pipelines.
+
+Final verification will run the repository checks and both browser builds. The Turkish store generation commands will then be run, followed by checks for file count, exact dimensions, and opaque RGB promo output. The built Chrome archive will serve as the local pre-release test artifact.
+
+## Error handling and review
+
+Unknown locales continue to fall back to English. Capture scripts continue to reject a request containing no known locale. Missing translations or placeholder drift fail deterministic tests before build. Native-speaker feedback from Can can be applied in a follow-up revision without altering locale architecture or store generation.

--- a/packages/extension/scripts/capture-store-promo.mjs
+++ b/packages/extension/scripts/capture-store-promo.mjs
@@ -24,7 +24,7 @@ const formats = [
 // One tile set per store locale. The ids match the _locales/<id> folders bundled
 // in the build. A subset can be captured by passing locale codes as CLI args,
 // e.g. `node scripts/capture-store-promo.mjs es pt_BR`.
-const ALL_LOCALES = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar"];
+const ALL_LOCALES = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar", "tr"];
 const requested = process.argv.slice(2);
 const locales = requested.length > 0 ? requested.filter((code) => ALL_LOCALES.includes(code)) : ALL_LOCALES;
 if (locales.length === 0) {

--- a/packages/extension/scripts/capture-store-screenshot.mjs
+++ b/packages/extension/scripts/capture-store-screenshot.mjs
@@ -22,7 +22,7 @@ const variants = [
 // One screenshot set per store locale. The ids match the _locales/<id> folders
 // bundled in the build. A subset can be captured by passing locale codes as CLI
 // args, e.g. `node scripts/capture-store-screenshot.mjs es pt_BR`.
-const ALL_LOCALES = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar"];
+const ALL_LOCALES = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar", "tr"];
 const requested = process.argv.slice(2);
 const locales = requested.length > 0 ? requested.filter((code) => ALL_LOCALES.includes(code)) : ALL_LOCALES;
 if (locales.length === 0) {

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -86,6 +86,21 @@ describe("i18n", () => {
     expect(turkish.subscriptionCampaigns?.message).toBe("Abonelik kampanyaları");
   });
 
+  it("captures store artwork for every catalog locale", () => {
+    const extensionRoot = dirname(import.meta.dirname);
+    const captureScripts = [
+      join(extensionRoot, "scripts/capture-store-screenshot.mjs"),
+      join(extensionRoot, "scripts/capture-store-promo.mjs"),
+    ];
+
+    for (const script of captureScripts) {
+      const source = readFileSync(script, "utf8");
+      for (const locale of localeCodes()) {
+        expect(source, `${script}:${locale}`).toContain(`"${locale}"`);
+      }
+    }
+  });
+
   it("defines subscription drop states with matching placeholders in every catalog", () => {
     const englishMessages = {
       subscriptionRequired: "Subscription required",

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createRequire } from "node:module";
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { effectiveLocale, isRtlLocale, normalizeBrowserLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
+import { effectiveLocale, isRtlLocale, LOCALE_OPTIONS, normalizeBrowserLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
 
 // Catalogs live in the single-source @lurkloot/locales package as <locale>.json.
 const messagesDir = dirname(createRequire(import.meta.url).resolve("@lurkloot/locales/messages/en.json"));
@@ -14,14 +14,24 @@ describe("i18n", () => {
     expect(normalizeBrowserLocale("es-MX")).toBe("es");
     expect(normalizeBrowserLocale("zh-TW")).toBe("zh_CN");
     expect(normalizeBrowserLocale("pt-PT")).toBe("pt_BR");
+    expect(normalizeBrowserLocale("tr-TR")).toBe("tr");
     expect(normalizeBrowserLocale("unknown")).toBe("en");
   });
 
   it("resolves explicit overrides and Arabic RTL", () => {
     expect(effectiveLocale("browser", "de-DE")).toBe("de");
     expect(effectiveLocale("ar", "de-DE")).toBe("ar");
+    expect(effectiveLocale("tr", "en-US")).toBe("tr");
     expect(isRtlLocale("ar")).toBe(true);
     expect(isRtlLocale("en")).toBe(false);
+  });
+
+  it("offers Turkish using its native language name", () => {
+    expect(LOCALE_OPTIONS).toContainEqual({
+      value: "tr",
+      labelKey: "languageTurkish",
+      nativeName: "Türkçe",
+    });
   });
 
   it("translates with substitutions and falls back to English", () => {

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -53,6 +53,7 @@ describe("i18n", () => {
     const englishKeys = Object.keys(english).sort();
 
     expect(locales).toContain("ar");
+    expect(locales).toContain("tr");
     for (const locale of locales) {
       const catalog = readCatalog(locale);
       expect(Object.keys(catalog).sort(), locale).toEqual(englishKeys);
@@ -70,12 +71,19 @@ describe("i18n", () => {
       it: "Campagne con abbonamento",
       pt_BR: "Campanhas de assinatura",
       ru: "Кампании за подписку",
+      tr: "Abonelik kampanyaları",
       zh_CN: "订阅活动",
     };
 
     for (const locale of localeCodes()) {
       expect(readCatalog(locale).subscriptionCampaigns?.message, locale).toBe(translations[locale]);
     }
+  });
+
+  it("uses the native Turkish language name", () => {
+    const turkish = readCatalog("tr");
+    expect(turkish.languageTurkish?.message).toBe("Türkçe");
+    expect(turkish.subscriptionCampaigns?.message).toBe("Abonelik kampanyaları");
   });
 
   it("defines subscription drop states with matching placeholders in every catalog", () => {

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -241,6 +241,7 @@ describe("settings", () => {
     expect(mergeSettings({ languageOverride: "zh_CN" }).languageOverride).toBe("zh_CN");
     expect(mergeSettings({ languageOverride: "pt_BR" }).languageOverride).toBe("pt_BR");
     expect(mergeSettings({ languageOverride: "ar" }).languageOverride).toBe("ar");
+    expect(mergeSettings({ languageOverride: "tr" }).languageOverride).toBe("tr");
     expect(mergeSettings({ languageOverride: "pt" } as unknown as Parameters<typeof mergeSettings>[0]).languageOverride)
       .toBe("browser");
   });

--- a/packages/extension/tests/tips.test.ts
+++ b/packages/extension/tests/tips.test.ts
@@ -93,7 +93,7 @@ describe("TipsBanner", () => {
       "tipFeedbackAction",
       "tipExcludedCampaigns",
     ];
-    const locales = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar"];
+    const locales = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar", "tr"];
 
     for (const locale of locales) {
       const catalog = JSON.parse(readFileSync(resolve(import.meta.dirname, `../../locales/messages/${locale}.json`), "utf8"));

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "العربية"
   },
+  "languageTurkish": {
+    "message": "التركية"
+  },
   "settingsLanguageTitle": {
     "message": "اللغة"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "Arabisch"
   },
+  "languageTurkish": {
+    "message": "Türkisch"
+  },
   "settingsLanguageTitle": {
     "message": "Sprache"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "Arabic"
   },
+  "languageTurkish": {
+    "message": "Turkish"
+  },
   "settingsLanguageTitle": {
     "message": "Language"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "Árabe"
   },
+  "languageTurkish": {
+    "message": "Turco"
+  },
   "settingsLanguageTitle": {
     "message": "Idioma"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "Arabe"
   },
+  "languageTurkish": {
+    "message": "Turc"
+  },
   "settingsLanguageTitle": {
     "message": "Langue"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "अरबी"
   },
+  "languageTurkish": {
+    "message": "तुर्की"
+  },
   "settingsLanguageTitle": {
     "message": "भाषा"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "Arabo"
   },
+  "languageTurkish": {
+    "message": "Turco"
+  },
   "settingsLanguageTitle": {
     "message": "Lingua"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "Árabe"
   },
+  "languageTurkish": {
+    "message": "Turco"
+  },
   "settingsLanguageTitle": {
     "message": "Idioma"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "Арабский"
   },
+  "languageTurkish": {
+    "message": "Турецкий"
+  },
   "settingsLanguageTitle": {
     "message": "Язык"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -1,0 +1,966 @@
+{
+  "extensionName": {
+    "message": "Lurkloot"
+  },
+  "extensionStoreName": {
+    "message": "Lurkloot - Twitch ve Kick'te Drop ve İzlenme Süresi Kas"
+  },
+  "extensionDescription": {
+    "message": "Normal tarayıcı oturumunuz, görünür sessiz sekmeler ve isteğe bağlı düşük kaynak modu ile Twitch ve Kick droplarını ve izlenme süresini otomatik kasın."
+  },
+  "promoTagline": {
+    "message": "Twitch ve Kick droplarını otomatik kas"
+  },
+  "languageBrowser": {
+    "message": "Tarayıcı dilini kullan"
+  },
+  "languageEnglish": {
+    "message": "İngilizce"
+  },
+  "languageSpanish": {
+    "message": "İspanyolca"
+  },
+  "languageFrench": {
+    "message": "Fransızca"
+  },
+  "languageItalian": {
+    "message": "İtalyanca"
+  },
+  "languageRussian": {
+    "message": "Rusça"
+  },
+  "languageGerman": {
+    "message": "Almanca"
+  },
+  "languageChinese": {
+    "message": "Çince"
+  },
+  "languageHindi": {
+    "message": "Hintçe"
+  },
+  "languagePortuguese": {
+    "message": "Portekizce"
+  },
+  "languageArabic": {
+    "message": "Arapça"
+  },
+  "languageTurkish": {
+    "message": "Türkçe"
+  },
+  "settingsLanguageTitle": {
+    "message": "Dil"
+  },
+  "settingsLanguageDescription": {
+    "message": "Açılır pencere ve uzantı bildirimleri tarafından kullanılan dili seçin."
+  },
+  "settingsTitle": {
+    "message": "Ayarlar"
+  },
+  "settingsSearchPlaceholder": {
+    "message": "Arama ayarları…"
+  },
+  "settingsSearchNoResults": {
+    "message": "“$1” ile eşleşen ayar yok."
+  },
+  "settingsShowAdvancedTitle": {
+    "message": "Gelişmiş ayarları göster"
+  },
+  "settingsSectionGeneral": {
+    "message": "Genel"
+  },
+  "settingsSectionTwitch": {
+    "message": "Twitch"
+  },
+  "settingsSectionKick": {
+    "message": "Kick"
+  },
+  "activityTitle": {
+    "message": "Etkinlik"
+  },
+  "activeStatus": {
+    "message": "Aktif"
+  },
+  "pausedStatus": {
+    "message": "Duraklatıldı"
+  },
+  "refreshSchedule": {
+    "message": "Programı yenile"
+  },
+  "openActivity": {
+    "message": "Etkinliği aç"
+  },
+  "closeActivity": {
+    "message": "Etkinliği kapat"
+  },
+  "openSettings": {
+    "message": "Ayarları aç"
+  },
+  "closeSettings": {
+    "message": "Ayarları kapat"
+  },
+  "back": {
+    "message": "Geri"
+  },
+  "loading": {
+    "message": "Yükleniyor"
+  },
+  "dropsTab": {
+    "message": "Droplar"
+  },
+  "idleWatchlistTab": {
+    "message": "Boşta İzleme Listesi"
+  },
+  "automationTitle": {
+    "message": "$1 otomasyon"
+  },
+  "automationRunning": {
+    "message": "Çalışıyor"
+  },
+  "automationStarting": {
+    "message": "Başlatılıyor"
+  },
+  "automationStopping": {
+    "message": "Durduruluyor"
+  },
+  "startingAutomation": {
+    "message": "Otomasyon başlatılıyor..."
+  },
+  "pausingAutomation": {
+    "message": "Otomasyon duraklatılıyor..."
+  },
+  "watchingLabel": {
+    "message": "İzleniyor"
+  },
+  "farmingLabel": {
+    "message": "Kasıyor"
+  },
+  "waitingEligibleStream": {
+    "message": "Uygun bir yayın bekleniyor"
+  },
+  "watchingPausedHint": {
+    "message": "İzleme duraklatıldı. Drop kasmaya devam etmek için etkinleştirin."
+  },
+  "hideTipsTitle": {
+    "message": "İpuçlarını gizle"
+  },
+  "hideTipsDescription": {
+    "message": "Ana açılır pencereden faydalı ipuçlarını kaldırın."
+  },
+  "tipCampaignPriority": {
+    "message": "Droplar, Boşta İzleme Listesinden önceliklidir. Kasma sırasını ayarlamak için kampanyaları tutamaçlarından sürükleyin."
+  },
+  "tipMissingCampaigns": {
+    "message": "Bir kampanyayı mı kaçırdınız? Platformunuzun Drop envanterini kontrol edin, ardından Ayarlar'da kampanya filtrelerini inceleyin."
+  },
+  "tipCategorySelection": {
+    "message": "Yalnızca belirli oyunlarda mı kasmak istiyorsunuz? Platform ayarlarında ‘Tüm kategorilerde kas’ seçeneğini kapatıp kategorilerinizi seçin."
+  },
+  "tipIdleWatchlist": {
+    "message": "Droplar birinci öncelikte kalır. Boşta İzleme Listesi, uygun bir ödül mevcut olmadığında seçilen kanalları izler."
+  },
+  "tipTablessMode": {
+    "message": "Sekmesiz mod daha az kaynak kullanır ve gerektiğinde sessiz bir sekmeye geri döner."
+  },
+  "tipCli": {
+    "message": "Uzantı olmadan çalışmayı mı tercih ediyorsunuz? Lurkloot ayrıca Docker tabanlı bir CLI olarak da mevcuttur."
+  },
+  "tipCliAction": {
+    "message": "CLI kılavuzunu okuyun"
+  },
+  "tipFeedback": {
+    "message": "Bir hata mı buldunuz veya bir fikriniz mi var?"
+  },
+  "tipFeedbackAction": {
+    "message": "GitHub sorununu açın"
+  },
+  "tipExcludedCampaigns": {
+    "message": "Bir kampanyayı yanlışlıkla hariç mi tuttunuz? Hariç tutulan kampanyaları Drops ayarlarından geri yükleyin."
+  },
+  "noCampaigns": {
+    "message": "Henüz hiçbir kampanya keşfedilmedi."
+  },
+  "noActivity": {
+    "message": "Henüz kayıtlı bir aktivite yok. Bir kontrolü çalıştırmak için yenile tuşuna basın."
+  },
+  "platformActivity": {
+    "message": "$1 etkinliği"
+  },
+  "lastCheck": {
+    "message": "son kontrol $1"
+  },
+  "noChecksYet": {
+    "message": "henüz kontrol yok"
+  },
+  "debug": {
+    "message": "Hata ayıklama"
+  },
+  "info": {
+    "message": "Bilgi"
+  },
+  "warn": {
+    "message": "Uyarı"
+  },
+  "error": {
+    "message": "Hata"
+  },
+  "notLinked": {
+    "message": "Bağlantılı değil"
+  },
+  "subscriptionCampaigns": {
+    "message": "Abonelik kampanyaları"
+  },
+  "subscriptionRequired": {
+    "message": "Abonelik gerekli"
+  },
+  "subscriptionRewards": {
+    "message": "Abonelik ödülleri"
+  },
+  "qualifyingSubscriptionsRequired": {
+    "message": "$1 uygun abonelik gerekli"
+  },
+  "subscriptionProgressUnknown": {
+    "message": "İlerleme mevcut değil"
+  },
+  "notEarnableByWatching": {
+    "message": "İzlenerek kazanılmıyor"
+  },
+  "subscribedRefresh": {
+    "message": "Abone oldum — durumu yenile"
+  },
+  "waitingForSubscription": {
+    "message": "Uygun bir abonelik bekleniyor"
+  },
+  "actionRequired": {
+    "message": "İşlem gerekli"
+  },
+  "earned": {
+    "message": "Kazanılan"
+  },
+  "linkAccount": {
+    "message": "Hesabınızı bağlayın"
+  },
+  "externalGameAccountRequired": {
+    "message": "Harici oyun hesabı gerekli"
+  },
+  "linkExternalGameAccount": {
+    "message": "Harici oyun hesabını bağlayın"
+  },
+  "viewDropPage": {
+    "message": "Drop sayfasını görüntüle"
+  },
+  "upcoming": {
+    "message": "Yaklaşan"
+  },
+  "expired": {
+    "message": "Günü geçmiş"
+  },
+  "excluded": {
+    "message": "Hariç tutuldu"
+  },
+  "finished": {
+    "message": "Bitti"
+  },
+  "upcomingPill": {
+    "message": "Yaklaşan"
+  },
+  "expiredPill": {
+    "message": "Günü geçmiş"
+  },
+  "finishedPill": {
+    "message": "Bitti"
+  },
+  "complete": {
+    "message": "Tamamlandı"
+  },
+  "nextReward": {
+    "message": "Sonraki: $1"
+  },
+  "startsIn": {
+    "message": "$1'de başlıyor"
+  },
+  "endsIn": {
+    "message": "$1 ile bitiyor"
+  },
+  "left": {
+    "message": "kaldı"
+  },
+  "done": {
+    "message": "Bitti"
+  },
+  "farmed": {
+    "message": "Kasıldı"
+  },
+  "rewards": {
+    "message": "Ödüller"
+  },
+  "inCampaignOrder": {
+    "message": "kampanya sırasına göre"
+  },
+  "allChannels": {
+    "message": "Tüm kanallar"
+  },
+  "channelCount": {
+    "message": "$1 kanal"
+  },
+  "includeInFarming": {
+    "message": "Kasmaya dahil et"
+  },
+  "excludeFromFarming": {
+    "message": "Kasmadan hariç tut"
+  },
+  "noIdleWatchlist": {
+    "message": "Boşta izleme listesi kanalı yapılandırılmadı."
+  },
+  "channelPlaceholder": {
+    "message": "kanal"
+  },
+  "add": {
+    "message": "Ekle"
+  },
+  "addChannel": {
+    "message": "Kanal ekle"
+  },
+  "idleWatchlistChannel": {
+    "message": "İzleme listesinde"
+  },
+  "live": {
+    "message": "canlı"
+  },
+  "settingsGeneralTitle": {
+    "message": "Genel ayarlar"
+  },
+  "settingsGeneralDescription": {
+    "message": "Twitch ve Kick için geçerlidir."
+  },
+  "settingsGroupAppearance": {
+    "message": "Görünüm ve davranış"
+  },
+  "pauseManualTitle": {
+    "message": "Manuel izlerken duraklatın"
+  },
+  "pauseManualDescription": {
+    "message": "Bir yayın açıkken ve kendiniz izlerken kasmayı duraklatın."
+  },
+  "autoStartTitle": {
+    "message": "Başlatıldığında otomatik başlatma"
+  },
+  "autoStartDescription": {
+    "message": "Uzantı yüklenir yüklenmez kasmaya başlayın."
+  },
+  "notificationsTitle": {
+    "message": "Bildirimler"
+  },
+  "notificationsDescription": {
+    "message": "Etkinleştirilen tüm platformlar için geçerlidir."
+  },
+  "settingsGroupNotifications": {
+    "message": "Bildirimler"
+  },
+  "rewardEarnedTitle": {
+    "message": "Kazanılan ödül"
+  },
+  "rewardEarnedDescription": {
+    "message": "Bir drop ödülü alınabilir olduğunda bildirim alın."
+  },
+  "noDropsLeftTitle": {
+    "message": "Drop kalmadı"
+  },
+  "noDropsLeftDescription": {
+    "message": "Tüm aktif kampanyalar tükendiğinde bildirim alın."
+  },
+  "dropsSettingsTitle": {
+    "message": "Droplar"
+  },
+  "dropsSettingsDescription": {
+    "message": "Tüm platformların ortak kampanya kasma davranışı."
+  },
+  "settingsGroupDrops": {
+    "message": "Droplar"
+  },
+  "autoClaimTitle": {
+    "message": "Dropları otomatik al"
+  },
+  "autoClaimDescription": {
+    "message": "Kazanılan drop ödüllerini kullanılabilir olur olmaz otomatik olarak alın."
+  },
+  "campaignPriorityTitle": {
+    "message": "Kampanya önceliği"
+  },
+  "campaignPriorityDescription": {
+    "message": "Kasılacak kampanyaların nasıl seçileceğini belirleyin. Öncelik listesi yalnızca elle sıraladığınız kampanyaları dikkate alır; diğer modlar tüm kampanyalar arasından seçim yapar. Platform ayarlarından her platformda kasılacak kategorileri sınırlandırın."
+  },
+  "priorityListOnly": {
+    "message": "Yalnızca öncelik listesi"
+  },
+  "endingSoonest": {
+    "message": "En kısa sürede bitiyor"
+  },
+  "lowAvailabilityFirst": {
+    "message": "Öncelikle düşük kullanılabilirlik"
+  },
+  "idleWatchlistSettingsTitle": {
+    "message": "Boşta İzleme Listesi"
+  },
+  "idleWatchlistSettingsDescription": {
+    "message": "Uygun droplar mevcut olmadığında kullanılan yedek kanallar."
+  },
+  "idleWatchlistFallbackOnlyTitle": {
+    "message": "Yalnızca uygun droplar mevcut olmadığında"
+  },
+  "idleWatchlistFallbackOnlyDescription": {
+    "message": "Uygun dropları kasmaya öncelik verir."
+  },
+  "platformSettingsTitle": {
+    "message": "Platform ayarları"
+  },
+  "platformSettingsDescription": {
+    "message": "Tek sağlayıcı için otomasyon ve kanallar. Twitch ve Kick arasında geçiş yapın."
+  },
+  "farmingTabsTitle": {
+    "message": "Kasma sekmeleri"
+  },
+  "farmingTabsDescription": {
+    "message": "Video sekmesiyle kasma kontrolleri. Sekmesiz düşük kaynak modu etkinken sekmeye özel kontroller devre dışıdır."
+  },
+  "settingsGroupFarmingTabs": {
+    "message": "Kasma sekmeleri"
+  },
+  "tablessTitle": {
+    "message": "Sekmesiz düşük kaynak modu"
+  },
+  "tablessDescription": {
+    "message": "Video sekmesi yerine hafif izleme sinyalleriyle kasın. Twitch izleme sinyalleri, Kick ise izleyici bağlantısı kullanır. İlerleme durursa otomatik olarak bir sekmeye geri döner."
+  },
+  "autoCloseTabsTitle": {
+    "message": "Kasma sekmelerini otomatik kapat"
+  },
+  "autoCloseTabsDescription": {
+    "message": "Uzantı boştayken sekmeleri otomatik kapatır (kasılacak drop veya izlenecek yayıncı yoksa)."
+  },
+  "muteTabsTitle": {
+    "message": "Kasma sekmelerini sessize al"
+  },
+  "muteTabsDescription": {
+    "message": "Kasma ve Boşta İzleme Listesi sekmelerini sessiz tutun."
+  },
+  "keepVideosUnmutedTitle": {
+    "message": "Kasma videolarının sesini açık tut"
+  },
+  "keepVideosUnmutedDescription": {
+    "message": "Tarayıcı sekmesinin sesi kapalıyken sayfa video oynatıcılarının sesini açık tutar."
+  },
+  "tablessDisabledReason": {
+    "message": "Sekmesiz düşük kaynak modu etkinken devre dışıdır."
+  },
+  "adFocusTitle": {
+    "message": "Reklamlar sırasında sekmeye odaklanın"
+  },
+  "adFocusDescription": {
+    "message": "Arka plan sekmelerinde reklam geri sayımları donabilir. Reklam oynarken geri sayımın ilerlemesi için kasma sekmesine kısa süre odaklanır, ardından önceki sekmenize döner."
+  },
+  "off": {
+    "message": "Kapalı"
+  },
+  "tabOnly": {
+    "message": "Yalnızca sekme"
+  },
+  "tabAndWindow": {
+    "message": "Sekme + pencere"
+  },
+  "advancedTitle": {
+    "message": "Gelişmiş"
+  },
+  "advancedDescription": {
+    "message": "Bunları yalnızca ne yaptığınızı biliyorsanız değiştirin; bunlar düşük seviyeli zamanlayıcıyı ve günlük tutma davranışını kontrol eder."
+  },
+  "settingsGroupAdvanced": {
+    "message": "Gelişmiş"
+  },
+  "schedulerIntervalTitle": {
+    "message": "Zamanlayıcı aralığı"
+  },
+  "schedulerIntervalDescription": {
+    "message": "Kampanya ve yayıncı durumunun ne sıklıkta yenilendiği."
+  },
+  "postClaimHandoffTitle": {
+    "message": "Hızlı ödül aktarımı"
+  },
+  "postClaimHandoffDescription": {
+    "message": "Bir ödülü aldıktan sonra sonraki planlı döngüyü beklemek yerine kampanyadaki bir sonraki ödülü kısa aralıklarla kontrol edin. Yalnızca Twitch."
+  },
+  "postClaimHandoffIntervalTitle": {
+    "message": "Devir kontrol aralığı"
+  },
+  "postClaimHandoffIntervalDescription": {
+    "message": "Sonraki ödül kontrolleri arasında beklenecek süre."
+  },
+  "postClaimHandoffMaxTitle": {
+    "message": "Devir süresi sınırı"
+  },
+  "postClaimHandoffMaxDescription": {
+    "message": "Bu kadar uzun sürenin ardından pes edin ve normal programa dönün."
+  },
+  "secondsSuffix": {
+    "message": "saniye"
+  },
+  "deadlineSafetyMarginTitle": {
+    "message": "Son tarih güvenlik marjı"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "Bir ödül toplamadan önce fazladan dakikalar gerekir."
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "Güvenlik marjını değiştirmek için son tarih filtrelemeyi etkinleştirin."
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "Tamamlanamayan ödülleri atlayın"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "Kalan izlenme süresi, son teslim tarihinden önceki süreyi aştığında ödül toplamayın."
+  },
+  "minutesSuffix": {
+    "message": "dk."
+  },
+  "insufficientTimeRemaining": {
+    "message": "Yetersiz süre kaldı"
+  },
+  "automationSectionTitle": {
+    "message": "Otomasyon"
+  },
+  "farmOnPlatform": {
+    "message": "$1 üzerindeki Boşta İzleme Listesi kanallarını drop olmadığında izle."
+  },
+  "enabled": {
+    "message": "Etkinleştirilmiş"
+  },
+  "idleWatchlistEditHint": {
+    "message": "$1 seçeneğini seçtikten sonra Boştaki İzleme Listesi sekmesinden düzenleyin."
+  },
+  "autoClaimChannelPointsTitle": {
+    "message": "Otomatik talep edilen kanal noktaları"
+  },
+  "autoClaimChannelPointsDescription": {
+    "message": "Bu platformda kasarken kanal puanı bonuslarını alın."
+  },
+  "autoClaimChallengesTitle": {
+    "message": "Günlük zorlukları otomatik olarak talep edin"
+  },
+  "autoClaimChallengesDescription": {
+    "message": "İzlenme süresi hedefine ulaşıldığında Kick'in günlük mücadele ödülünü talep edin."
+  },
+  "settingsGroupExcludedChannels": {
+    "message": "Hariç tutulan kanallar"
+  },
+  "excludedChannelsTitle": {
+    "message": "Hariç tutulan drop kanalları"
+  },
+  "excludedChannelsDescription": {
+    "message": "Kampanya kasma bu yayıncıları atlar."
+  },
+  "excludedChannelsEmpty": {
+    "message": "Hariç tutulan drop kanalı yok."
+  },
+  "settingsGroupCategories": {
+    "message": "Kategoriler"
+  },
+  "farmAllCategoriesTitle": {
+    "message": "Tüm kategorilerde kas"
+  },
+  "farmAllCategoriesDescription": {
+    "message": "Tüm $1 kategorilerindeki dropları kasın. Yalnızca seçilen kategorileri kasmak için kapatın."
+  },
+  "categoriesToFarm": {
+    "message": "Kasılacak kategoriler"
+  },
+  "dragToPrioritize": {
+    "message": "önceliklendirmek için sürükleyin"
+  },
+  "noCategoriesSelected": {
+    "message": "Kategori seçilmedi — $1 üzerinde hiçbir şey kasılmayacak. Aşağıdan kategori ekleyin."
+  },
+  "hasActiveDrops": {
+    "message": "Aktif dropları var"
+  },
+  "searchCategories": {
+    "message": "$1 kategoride ara"
+  },
+  "searching": {
+    "message": "Arama…"
+  },
+  "noCategoriesFound": {
+    "message": "Hiçbir kategori bulunamadı."
+  },
+  "alreadyAdded": {
+    "message": "Zaten eklendi."
+  },
+  "activityLogLevelsTitle": {
+    "message": "Etkinlik günlüğü düzeyleri"
+  },
+  "activityLogLevelsDescription": {
+    "message": "Etkinlik günlüğüne hangi seviyelerin kaydedileceğini seçin. Hatalar her zaman korunur."
+  },
+  "visibleCampaignsTitle": {
+    "message": "Görünür kampanyalar"
+  },
+  "visibleCampaignsDescription": {
+    "message": "Droplar listesinde hangi kampanya durumlarının gösterileceğini seçin. Alınabilir ödülü olan kampanyalar her zaman görünür."
+  },
+  "forgetExcludedTitle": {
+    "message": "Hariç tutulan kampanyaları unutun"
+  },
+  "forgetExcludedDescription": {
+    "message": "Kasmadan hariç tuttuğunuz tüm kampanyaları temizleyin."
+  },
+  "forget": {
+    "message": "Unut"
+  },
+  "unknownGame": {
+    "message": "Bilinmeyen oyun"
+  },
+  "noCategory": {
+    "message": "Kategori yok"
+  },
+  "dropsCampaign": {
+    "message": "Drop kampanyası"
+  },
+  "later": {
+    "message": "Daha sonra"
+  },
+  "ended": {
+    "message": "Sona erdi"
+  },
+  "notificationRewardClaimed": {
+    "message": "Ödül talep edildi"
+  },
+  "notificationRewardEarned": {
+    "message": "Kazanılan ödül"
+  },
+  "notificationNoDropsLeft": {
+    "message": "Drop kalmadı"
+  },
+  "notificationRewardFromCampaign": {
+    "message": "$1, $2'den"
+  },
+  "notificationChallengeClaimed": {
+    "message": "Mücadele ödülü talep edildi"
+  },
+  "notificationChallengeReward": {
+    "message": "$2 mücadelenizden bir $1 kartı kazandınız."
+  },
+  "notificationNoDropsLeftMessage": {
+    "message": "$1 üzerinde kasılabilecek uygun drop yok."
+  },
+  "screenshotTwitchHeadline": {
+    "message": "Twitch droplarını otomatik kas"
+  },
+  "screenshotTwitchSubcopy": {
+    "message": "Lurkloot uygun kampanyaları normal tarayıcı oturumunuzdaki görünür ve sessiz sekmelerle yönetir."
+  },
+  "screenshotKickHeadline": {
+    "message": "Kick droplarını ve izlenme süresini kas"
+  },
+  "screenshotKickSubcopy": {
+    "message": "Kick droplarını ve izlenme süresini düşük kaynak kullanımıyla otomatik kasın."
+  },
+  "screenshotIdleWatchlistHeadline": {
+    "message": "İzleme listeni sen belirle"
+  },
+  "screenshotIdleWatchlistSubcopy": {
+    "message": "Uygun ödül olmadığında Lurkloot seçtiğiniz yedek kanallardan canlı olanı izler."
+  },
+  "screenshotSettingsHeadline": {
+    "message": "Nasıl kasacağını özelleştir"
+  },
+  "screenshotSettingsSubcopy": {
+    "message": "Platform bazında otomasyon, otomatik alma, sessiz sekmeler, oyun öncelikleri ve deneysel düşük kaynak modu."
+  },
+  "screenshotActivityHeadline": {
+    "message": "Her şeyi tek bakışta takip et"
+  },
+  "screenshotActivitySubcopy": {
+    "message": "Şeffaf etkinlik günlüğü her kontrolü, geçişi ve ödül alımını gösterir; hiçbir işlem gözünüzden kaçmaz."
+  },
+  "autoClaimReady": {
+    "message": "Otomatik talep hazır"
+  },
+  "resumingAutomation": {
+    "message": "Otomasyon devam ettiriliyor..."
+  },
+  "attributionLinks": {
+    "message": "İlişkilendirme bağlantıları"
+  },
+  "githubAttribution": {
+    "message": "GitHub'da Lurkloot"
+  },
+  "githubAttributionShort": {
+    "message": "GitHub"
+  },
+  "chromeWebStoreAttribution": {
+    "message": "Chrome Web Mağazası'nda Lurkloot"
+  },
+  "chromeWebStoreAttributionShort": {
+    "message": "Chrome Web Mağazası"
+  },
+  "siteAttribution": {
+    "message": "Lurkloot'un web sitesi"
+  },
+  "siteAttributionShort": {
+    "message": "Web sitesi"
+  },
+  "updateNoticeTitle": {
+    "message": "Lurkloot $1 olarak güncellendi"
+  },
+  "updateNoticeBody": {
+    "message": "Nelerin yeni olduğunu ve nelerin değiştiğini görün."
+  },
+  "updateNoticeAction": {
+    "message": "Değişiklikleri görüntüle"
+  },
+  "updateNoticeDismiss": {
+    "message": "Güncelleme bildirimini reddet"
+  },
+  "rateNudgeTitle": {
+    "message": "Lurkloot'tan hoşlanıyor musunuz?"
+  },
+  "rateNudgeBody": {
+    "message": "Chrome Web Mağazası'nda hızlı bir inceleme çok yardımcı olur."
+  },
+  "rateNudgeAction": {
+    "message": "Değerlendirin"
+  },
+  "rateNudgeDismiss": {
+    "message": "Şimdi değil"
+  },
+  "removeItem": {
+    "message": "$1 öğesini kaldır"
+  },
+  "cliExportTitle": {
+    "message": "Başsız CLI"
+  },
+  "cliExportDescription": {
+    "message": "Bu tarayıcıdaki oturumunuzu kullanarak Lurkloot CLI ile sunucuda veya Docker'da drop kasın."
+  },
+  "cliExportHint": {
+    "message": "CLI'nin \"login --import\" özelliğinin bunları yeniden kullanabilmesi için Twitch ve Kick oturum jetonlarınızı dışa aktarır. Dosyayı gizli tutun; ona sahip olan herkes oturumlarınızı kullanabilir."
+  },
+  "cliExportConfirm": {
+    "message": "Bu, Twitch ve Kick oturum jetonlarınızı bir dosyaya indirir. Bu dosyaya sahip olan herkes bu sitelerde sizin adınıza hareket edebilir. Devam etmek?"
+  },
+  "cliExportCancel": {
+    "message": "İptal"
+  },
+  "cliExportConfirmButton": {
+    "message": "Dışa aktarmayı onayla"
+  },
+  "cliExportButton": {
+    "message": "Kimlik bilgilerini dışa aktar"
+  },
+  "diagnosticLoggingTitle": {
+    "message": "Teşhis günlüklerini dahil et"
+  },
+  "diagnosticLoggingDescription": {
+    "message": "Sorunların teşhis edilmesine yardımcı olabilecek ek teknik ayrıntıları kaydedin. Normal aktivite her zaman korunur."
+  },
+  "activityFarmingStarted": {
+    "message": "$2 üzerinde $1 kasma başlatıldı."
+  },
+  "activityFarmingStopped": {
+    "message": "$2 üzerinde $1 kasma durduruldu: $3."
+  },
+  "activityRewardClaimed": {
+    "message": "$2 kampanyasından $1 alındı."
+  },
+  "activityChallengeClaimed": {
+    "message": "$2 mücadelesinden $1 kartı talep edildi"
+  },
+  "activityPageContextOpened": {
+    "message": "$1 üzerinde bir arka plan içeriği açıldı çünkü $2."
+  },
+  "activityPageContextClosed": {
+    "message": "$2 nedeniyle $1 üzerindeki arka plan bağlamı kapatıldı."
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick arka plan isteğini reddetti"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "önceki arka plan bağlamı kullanılamaz durumdaydı"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "arka plan istekleri düzeldi"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "mevcut bir Kick sekmesi kullanıma sunuldu"
+  },
+  "activityInterruption": {
+    "message": "Kasma kesintiye uğradı: $1."
+  },
+  "activityInterruptionWithDetail": {
+    "message": "Kasma kesintiye uğradı: $1 ($2)."
+  },
+  "activityReasonAutomationDisabled": {
+    "message": "otomasyon devre dışı bırakıldı"
+  },
+  "activityReasonPlatformDisabled": {
+    "message": "platform devre dışı bırakıldı"
+  },
+  "activityReasonPlatformBackoff": {
+    "message": "platform geçici olarak geri çekiliyor"
+  },
+  "activityReasonPlatformError": {
+    "message": "bir platform hatası oluştu"
+  },
+  "activityReasonCampaignIneligible": {
+    "message": "kampanya artık uygun değil"
+  },
+  "activityReasonChannelExcluded": {
+    "message": "kanal hariç tutuldu"
+  },
+  "activityReasonChannelOffline": {
+    "message": "kanal çevrimdışı oldu"
+  },
+  "activityReasonChannelMismatch": {
+    "message": "kanal artık eşleşmiyor"
+  },
+  "activityReasonWatchUnhealthy": {
+    "message": "izleme sağlık kontrolü başarısız oldu"
+  },
+  "activityReasonHigherPriorityReward": {
+    "message": "daha yüksek öncelikli bir ödül devraldı"
+  },
+  "activityReasonHigherPriorityIdleWatchlist": {
+    "message": "daha yüksek öncelikli bir Boşta İzleme Listesi kanalı kullanıma sunuldu"
+  },
+  "activityReasonWatchRequirementCompleted": {
+    "message": "izlenme süresi gereksinimi tamamlandı"
+  },
+  "activityReasonRuntimeRestart": {
+    "message": "uzantı yeniden başlatıldı"
+  },
+  "activityReasonTargetChanged": {
+    "message": "Kasma hedefi değişti"
+  },
+  "activityReasonManualWatch": {
+    "message": "manuel izleme devraldı"
+  },
+  "hideDiagnosticLogs": {
+    "message": "Teşhisleri gizle"
+  },
+  "loadMoreActivity": {
+    "message": "Daha fazlasını yükle"
+  },
+  "clearActivityHistory": {
+    "message": "Geçmişi temizle"
+  },
+  "confirmClearActivityHistory": {
+    "message": "Temizlemeyi onayla"
+  },
+  "clearActivityFailed": {
+    "message": "Etkinlik geçmişi temizlenemedi. Tekrar deneyin."
+  },
+  "showDiagnosticLogs": {
+    "message": "Teşhisi göster"
+  },
+  "settingsGroupCompatibility": {
+    "message": "Uyumluluk"
+  },
+  "compatibilityAutomatic": {
+    "message": "Otomatik"
+  },
+  "compatibilityTwitchProfileTitle": {
+    "message": "Twitch uyumluluk profili"
+  },
+  "compatibilityTwitchProfileDescription": {
+    "message": "Paketlenmiş bir Twitch profili seçin veya Lurkloot'un otomatik olarak seçmesine izin verin."
+  },
+  "compatibilityKickProfileTitle": {
+    "message": "Kick uyumluluk profili"
+  },
+  "compatibilityKickProfileDescription": {
+    "message": "Paketlenmiş bir Kick profili seçin veya Lurkloot'un bunu otomatik olarak seçmesine izin verin."
+  },
+  "compatibilitySectionTitle": {
+    "message": "Uyumluluk"
+  },
+  "compatibilitySectionDescription": {
+    "message": "Lurkloot'un her platformla nasıl konuştuğu. Otomatik, paketlenmiş profili takip eder."
+  },
+  "compatibilityComponentProfile": {
+    "message": "Profil"
+  },
+  "compatibilityComponentHeartbeat": {
+    "message": "Kalp atışı aktarımı"
+  },
+  "compatibilityComponentInventory": {
+    "message": "Envanter sorgusu"
+  },
+  "compatibilityComponentClaim": {
+    "message": "Talep yönetimi"
+  },
+  "compatibilityFromProfile": {
+    "message": "Profilden"
+  },
+  "compatibilityOverridden": {
+    "message": "Geçersiz kılındı"
+  },
+  "compatibilityReplacedBy": {
+    "message": "$1 ile değiştirildi"
+  },
+  "compatibilityTwitchHeartbeatTitle": {
+    "message": "Twitch kalp atışı aktarımı"
+  },
+  "compatibilityTwitchHeartbeatDescription": {
+    "message": "Birlikte verilen Twitch izleme kalp atışını geçersiz kılın."
+  },
+  "compatibilityTwitchInventoryTitle": {
+    "message": "Twitch envanter sorgusu"
+  },
+  "compatibilityTwitchInventoryDescription": {
+    "message": "Paketlenmiş Twitch envanter sorgusunu geçersiz kılın."
+  },
+  "compatibilityKickClaimTitle": {
+    "message": "Hesap bağlantısı işleme"
+  },
+  "compatibilityKickClaimDescription": {
+    "message": "Birlikte verilen Kick hesap bağlantısı işlemeyi geçersiz kılın."
+  },
+  "compatibilityLifecycleRecommended": {
+    "message": "Tavsiye edilen"
+  },
+  "compatibilityLifecycleLegacy": {
+    "message": "Eski"
+  },
+  "compatibilityLifecycleExperimental": {
+    "message": "Deneysel"
+  },
+  "compatibilityOverrideWarning": {
+    "message": "Manuel uyumluluk geçersiz kılmaları etkin. Platformlar değiştiğinde çalışmayı bırakabilirler."
+  },
+  "compatibilityRestoreAutomatic": {
+    "message": "Otomatik uyumluluğu geri yükleyin"
+  },
+  "compatibilityOptionTwitchProfile202607": {
+    "message": "Twitch Temmuz 2026"
+  },
+  "compatibilityOptionTwitchHeartbeatGqlV1": {
+    "message": "GraphQL kalp atışı v1"
+  },
+  "compatibilityOptionTwitchHeartbeatSpadeV1": {
+    "message": "Spade izleme sinyali v1"
+  },
+  "compatibilityOptionTwitchHeartbeatTrowelV1": {
+    "message": "Trowel izleme sinyali v1"
+  },
+  "compatibilityOptionTwitchInventoryV1": {
+    "message": "Envanter sorgusu v1"
+  },
+  "compatibilityOptionKickProfile202607": {
+    "message": "Kick Temmuz 2026"
+  },
+  "compatibilityOptionKickClaimV1": {
+    "message": "Talep işleme v1"
+  },
+  "compatibilityOptionKickClaimV2": {
+    "message": "Talep işleme v2"
+  }
+}
+

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -683,9 +683,6 @@
   "autoClaimReady": {
     "message": "Otomatik alma hazır"
   },
-  "resumingAutomation": {
-    "message": "Otomasyon devam ettiriliyor..."
-  },
   "attributionLinks": {
     "message": "İlişkilendirme bağlantıları"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -681,7 +681,7 @@
     "message": "Şeffaf etkinlik günlüğü her kontrolü, geçişi ve ödül alımını gösterir; hiçbir işlem gözünüzden kaçmaz."
   },
   "autoClaimReady": {
-    "message": "Otomatik talep hazır"
+    "message": "Otomatik alma hazır"
   },
   "resumingAutomation": {
     "message": "Otomasyon devam ettiriliyor..."
@@ -963,4 +963,3 @@
     "message": "Talep işleme v2"
   }
 }
-

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -44,6 +44,9 @@
   "languageArabic": {
     "message": "阿拉伯语"
   },
+  "languageTurkish": {
+    "message": "土耳其语"
+  },
   "settingsLanguageTitle": {
     "message": "语言"
   },

--- a/packages/locales/src/index.ts
+++ b/packages/locales/src/index.ts
@@ -15,6 +15,7 @@ const loaders: Record<SupportedLocale, () => Promise<{ default: MessageCatalog }
   hi: () => import("../messages/hi.json"),
   pt_BR: () => import("../messages/pt_BR.json"),
   ar: () => import("../messages/ar.json"),
+  tr: () => import("../messages/tr.json"),
 };
 
 export async function loadCatalog(locale: SupportedLocale): Promise<MessageCatalog | undefined> {

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -19,6 +19,7 @@ export const LOCALE_OPTIONS: Array<{ value: LanguageOverride; labelKey: string; 
   { value: "hi", labelKey: "languageHindi", nativeName: "हिन्दी" },
   { value: "pt_BR", labelKey: "languagePortuguese", nativeName: "Português (Brasil)" },
   { value: "ar", labelKey: "languageArabic", nativeName: "العربية" },
+  { value: "tr", labelKey: "languageTurkish", nativeName: "Türkçe" },
 ];
 
 export function normalizeBrowserLocale(value: string | undefined): SupportedLocale {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -198,7 +198,7 @@ export interface PlaybackTelemetry {
 // browser throttles in background tabs/windows) keeps progressing.
 export type AdFocusMode = "none" | "tab" | "window";
 
-export type SupportedLocale = "en" | "es" | "fr" | "it" | "ru" | "de" | "zh_CN" | "hi" | "pt_BR" | "ar";
+export type SupportedLocale = "en" | "es" | "fr" | "it" | "ru" | "de" | "zh_CN" | "hi" | "pt_BR" | "ar" | "tr";
 
 export type LanguageOverride = "browser" | SupportedLocale;
 

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -4,7 +4,7 @@ const AD_FOCUS_MODES: AdFocusMode[] = ["none", "tab", "window"];
 const PRIORITY_MODES: PriorityMode[] = ["ending_soonest", "lowest_availability", "priority_list_only"];
 const CAMPAIGN_FILTER_KEYS: CampaignFilterKey[] = ["notLinked", "subscription", "upcoming", "expired", "excluded", "finished"];
 const RATE_NUDGE_STATUSES: RateNudgeStatus[] = ["pending", "rated", "dismissed"];
-export const SUPPORTED_LOCALES: SupportedLocale[] = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar"];
+export const SUPPORTED_LOCALES: SupportedLocale[] = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar", "tr"];
 const LANGUAGE_OVERRIDES: LanguageOverride[] = ["browser", ...SUPPORTED_LOCALES];
 
 export type SettingsPatch = Partial<Omit<ExtensionSettings, "platform" | "compatibility" | "campaignVisibility">> & {


### PR DESCRIPTION
## Summary

- add Turkish as a first-class extension locale, including browser detection, language selection, catalog loading, and complete translated UI/notification copy
- add Turkish to the Chrome Web Store screenshot and promo capture pipelines, with five screenshots and two promo tiles generated and visually checked
- add Turkish CWS listing copy and document the eleventh localized listing
- update every store-language description to cover Kick watch-time farming, idle-watchlist automation, and low-resource tabless watching

Closes #197.

## Testing

- `pnpm verify`
- generated Turkish assets with `pnpm screenshot:store tr` and `pnpm promo:store tr`
- verified 5 screenshots at 1280×800 and 2 opaque RGB promo tiles at 440×280 / 1400×560
- visually reviewed the generated Turkish contact sheet for clipping, untranslated keys, and rendering issues
- built `packages/extension/.output/lurklootextension-1.8.1-chrome.zip` and verified it contains `_locales/tr/messages.json`

## Reviewer note

The initial Turkish catalog is AI-assisted, then manually corrected for gaming terminology and high-visibility copy. The requester has volunteered to test the pre-release and provide native-speaker refinements. Generated store PNGs are intentionally gitignored and remain reproducible through the documented capture commands.