### PR TITLE
feat(core): model platform authentication health

### DIFF
--- a/docs/superpowers/plans/2026-07-22-platform-auth-health-contracts.md
+++ b/docs/superpowers/plans/2026-07-22-platform-auth-health-contracts.md
@@ -1,0 +1,413 @@
+# Platform Authentication Health Contracts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #200 by adding safe, browser-neutral per-platform authentication health state, adapter boundaries, normalization, and durable transition events.
+
+**Architecture:** Shared models define an allowlisted authentication-health document stored inside `SchedulerState`. Core defaults normalize persisted data by reconstruction, while a focused pure transition helper updates state and creates a safe activity event. Platform adapters temporarily return `checking`; later issues replace those stubs with real extension-owned probes.
+
+**Tech Stack:** TypeScript 7, pnpm workspaces, Vitest, `@lurkloot/shared`, `@lurkloot/core`, WXT extension tests.
+
+## Global Constraints
+
+- This plan implements issue #200 only; browser cookie observation, real Twitch/Kick probes, scheduler gating, and popup rendering remain in #201–#205.
+- `@lurkloot/core` must remain browser-free and must not import WXT or browser globals.
+- State and events must never contain tokens, cookie values, passwords, authorization headers, authenticated response bodies, complete request URLs, or arbitrary raw errors.
+- Persisted health is normalized by allowlist reconstruction, never by spreading untrusted health records.
+- Both platforms default to `{ status: "checking" }` with no timestamp.
+- Follow red-green-refactor: every production change follows a focused failing test whose expected failure is observed first.
+
+---
+
+### Task 1: Shared authentication-health and activity-event contracts
+
+**Files:**
+- Modify: `packages/shared/src/models.ts`
+- Modify: `packages/shared/src/events.ts`
+- Test: `packages/extension/tests/eventContract.test.ts`
+
+**Interfaces:**
+- Produces: `PlatformAuthStatus`, `PlatformAuthReasonCode`, `PlatformAuthMessageKey`, `PlatformAuthMessage`, and `PlatformAuthHealth` from `@lurkloot/shared/models`.
+- Produces: `auth_health_changed` as a discriminated `ActivityEvent` variant with `{ from, to, reason? }`.
+
+- [ ] **Step 1: Write the failing contract test**
+
+Add this test to `eventContract.test.ts` before changing production types:
+
+```ts
+import type { PlatformAuthHealth } from "@lurkloot/shared/models";
+
+it("types safe authentication health and durable transitions", () => {
+  const health: PlatformAuthHealth = {
+    status: "blocked",
+    checkedAt: "2026-07-22T12:00:00.000Z",
+    reasonCode: "security_policy_blocked",
+    message: { key: "authSecurityPolicyBlocked", values: { reference: "safe-ref" } },
+  };
+  const event: EngineEvent = {
+    category: "activity",
+    code: "auth_health_changed",
+    level: "error",
+    platform: "kick",
+    data: { from: "checking", to: health.status, reason: health.reasonCode },
+  };
+
+  expectTypeOf(health).toMatchTypeOf<PlatformAuthHealth>();
+  expectTypeOf(event).toMatchTypeOf<EngineEvent>();
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- eventContract.test.ts`
+
+Expected: TypeScript transform fails because `PlatformAuthHealth` and the `auth_health_changed` event variant do not exist.
+
+- [ ] **Step 3: Add the shared model types**
+
+Add the exact types approved in the design to `models.ts`, immediately after `Platform`:
+
+```ts
+export type PlatformAuthStatus = "checking" | "healthy" | "missing_credentials" | "invalid_credentials" | "blocked" | "unavailable";
+export type PlatformAuthReasonCode = "credentials_missing" | "credentials_rejected" | "security_policy_blocked" | "credential_lookup_failed" | "platform_unavailable" | "network_unavailable";
+export type PlatformAuthMessageKey = "authChecking" | "authHealthy" | "authMissingCredentials" | "authInvalidCredentials" | "authSecurityPolicyBlocked" | "authCredentialLookupFailed" | "authPlatformUnavailable" | "authNetworkUnavailable";
+
+export interface PlatformAuthMessage {
+  key: PlatformAuthMessageKey;
+  values?: Partial<Record<"reference", string | number>>;
+}
+
+export interface PlatformAuthHealth {
+  status: PlatformAuthStatus;
+  checkedAt?: string;
+  reasonCode?: PlatformAuthReasonCode;
+  message?: PlatformAuthMessage;
+}
+```
+
+Add `authHealth: Record<Platform, PlatformAuthHealth>` to `SchedulerState`.
+
+- [ ] **Step 4: Add the durable event variant**
+
+Import `PlatformAuthReasonCode` and `PlatformAuthStatus` in `events.ts`, then add:
+
+```ts
+| {
+    category: "activity";
+    code: "auth_health_changed";
+    level: "info" | "warn" | "error";
+    platform: Platform;
+    message?: never;
+    data: { from: PlatformAuthStatus; to: PlatformAuthStatus; reason?: PlatformAuthReasonCode };
+  }
+```
+
+- [ ] **Step 5: Run the focused test and typecheck**
+
+Run: `pnpm --filter @lurkloot/extension test -- eventContract.test.ts && pnpm --filter @lurkloot/shared typecheck`
+
+Expected: the contract test passes; shared typecheck may identify `SchedulerState` constructors that Task 2 must update, but no errors may remain inside shared sources.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/models.ts packages/shared/src/events.ts packages/extension/tests/eventContract.test.ts
+git commit -m "feat(shared): model platform auth health"
+```
+
+### Task 2: Safe defaults and persisted-state normalization
+
+**Files:**
+- Create: `packages/extension/tests/authHealth.test.ts`
+- Modify: `packages/core/src/core/defaults.ts`
+
+**Interfaces:**
+- Consumes: `PlatformAuthHealth`, `PlatformAuthStatus`, `PlatformAuthReasonCode`, and `SchedulerState.authHealth` from Task 1.
+- Produces: `normalizePlatformAuthHealth(value: unknown): PlatformAuthHealth` exported from `@lurkloot/core/defaults`.
+- Produces: `DEFAULT_STATE.authHealth` and canonical `mergeSchedulerState(...).authHealth`.
+
+- [ ] **Step 1: Write failing default and migration tests**
+
+Create `authHealth.test.ts` with fixed fixtures asserting:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { DEFAULT_STATE, mergeSchedulerState, normalizePlatformAuthHealth } from "@lurkloot/core/defaults";
+
+describe("authentication health normalization", () => {
+  it("defaults both platforms to unchecked checking state", () => {
+    expect(DEFAULT_STATE.authHealth).toEqual({
+      twitch: { status: "checking" },
+      kick: { status: "checking" },
+    });
+    expect(mergeSchedulerState(undefined).authHealth).toEqual(DEFAULT_STATE.authHealth);
+  });
+
+  it("adds defaults to legacy state without losing operational data", () => {
+    const merged = mergeSchedulerState({ lastTickAt: "2026-07-22T12:00:00.000Z" });
+    expect(merged.lastTickAt).toBe("2026-07-22T12:00:00.000Z");
+    expect(merged.authHealth).toEqual(DEFAULT_STATE.authHealth);
+  });
+});
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- authHealth.test.ts`
+
+Expected: FAIL because the default slice and normalizer do not exist.
+
+- [ ] **Step 3: Implement default state and a minimal normalizer**
+
+Add `authHealth` to `DEFAULT_STATE`. Export `normalizePlatformAuthHealth(value: unknown)` and initially accept known statuses while returning `{ status: "checking" }` for non-records and unknown statuses. Update `mergeSchedulerState` to normalize `stored?.authHealth?.twitch` and `.kick` independently rather than spreading them.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- authHealth.test.ts`
+
+Expected: the two migration tests pass.
+
+- [ ] **Step 5: Add failing allowlist and security cases**
+
+Add table-driven tests for every valid status/reason pair and tests that assert:
+
+```ts
+expect(normalizePlatformAuthHealth({
+  status: "blocked",
+  checkedAt: "2026-07-22T12:00:00.000Z",
+  reasonCode: "security_policy_blocked",
+  message: { key: "authSecurityPolicyBlocked", values: { reference: "ref-123", token: "secret" } },
+  token: "secret",
+  cookie: "secret",
+  headers: { authorization: "Bearer secret" },
+  response: { account: "private" },
+  url: "https://kick.com/?token=secret",
+})).toEqual({
+  status: "blocked",
+  checkedAt: "2026-07-22T12:00:00.000Z",
+  reasonCode: "security_policy_blocked",
+  message: { key: "authSecurityPolicyBlocked", values: { reference: "ref-123" } },
+});
+```
+
+Also cover invalid reason/status combinations, non-round-tripping timestamps, unknown message keys, incompatible message keys, nested/array/non-finite values, overlong references, and arbitrary extra fields.
+
+- [ ] **Step 6: Run and verify RED**
+
+Run the same focused test. Expected: FAIL because optional fields are not yet validated and allowlisted.
+
+- [ ] **Step 7: Complete normalization**
+
+Implement constant sets/maps for known statuses, allowed reasons per status, and compatible message keys. Reconstruct a new object field-by-field. Accept `checkedAt` only when `new Date(value).toISOString() === value`; accept `reference` only when it is a finite number or a non-empty string no longer than 128 characters. Omit invalid optional fields and never copy unknown keys.
+
+- [ ] **Step 8: Run focused tests and extension typecheck**
+
+Run: `pnpm --filter @lurkloot/extension test -- authHealth.test.ts storageMigration.test.ts && pnpm --filter @lurkloot/extension typecheck`
+
+Expected: focused tests pass. Fix only mechanical `SchedulerState` fixture omissions by basing fixtures on `DEFAULT_STATE`; do not weaken `authHealth` to optional.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core/src/core/defaults.ts packages/extension/tests/authHealth.test.ts packages/extension/tests
+git commit -m "feat(core): normalize platform auth health"
+```
+
+### Task 3: Browser-neutral adapter probe boundary
+
+**Files:**
+- Modify: `packages/core/src/platforms/adapter.ts`
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Modify: `packages/core/src/platforms/kick/index.ts`
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+- Modify: `packages/extension/tests/scheduler.test.ts`
+- Test: `packages/extension/tests/authHealth.test.ts`
+
+**Interfaces:**
+- Consumes: `PlatformAuthHealth` from Task 1.
+- Produces: required `PlatformAdapter.checkAuthHealth(): Promise<PlatformAuthHealth>`.
+- Temporary implementation: both production adapters return `{ status: "checking" }` until #202/#203.
+
+- [ ] **Step 1: Write the failing adapter-contract test**
+
+Add a type/runtime fixture to `authHealth.test.ts`:
+
+```ts
+import type { PlatformAdapter } from "@lurkloot/core/adapter";
+
+it("requires adapters to expose a browser-neutral auth probe", async () => {
+  const probe: PlatformAdapter["checkAuthHealth"] = async () => ({ status: "checking" });
+  expect(await probe()).toEqual({ status: "checking" });
+});
+```
+
+Also instantiate Twitch and Kick adapters using the existing constructors in `adapters.test.ts` and assert `checkAuthHealth()` returns `checking`.
+
+- [ ] **Step 2: Run and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- authHealth.test.ts adapters.test.ts`
+
+Expected: type failure because `checkAuthHealth` does not exist.
+
+- [ ] **Step 3: Add the required adapter method and stubs**
+
+Import `PlatformAuthHealth` into `adapter.ts` and add:
+
+```ts
+checkAuthHealth(): Promise<PlatformAuthHealth>;
+```
+
+Implement this method in `TwitchAdapter` and `KickAdapter`:
+
+```ts
+async checkAuthHealth(): Promise<PlatformAuthHealth> {
+  return { status: "checking" };
+}
+```
+
+- [ ] **Step 4: Update typed adapter fixtures mechanically**
+
+Run: `pnpm typecheck`
+
+Add `checkAuthHealth: vi.fn(async () => ({ status: "checking" as const }))` to the `adapter(...)` factories in `backgroundController.test.ts` and `scheduler.test.ts`. Re-run typecheck and update any additional explicitly typed adapter literal with the same stub. Do not change `packages/cli/src/transport/common.ts`, which only transports already-constructed Twitch/Kick adapters, and do not make the production interface optional.
+
+- [ ] **Step 5: Verify focused and workspace checks**
+
+Run: `pnpm --filter @lurkloot/extension test -- authHealth.test.ts adapters.test.ts && pnpm typecheck`
+
+Expected: PASS with no browser imports added to core.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/platforms/adapter.ts packages/core/src/platforms/twitch/index.ts packages/core/src/platforms/kick/index.ts packages/extension/tests/adapters.test.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/scheduler.test.ts
+git commit -m "feat(core): add authentication probe boundary"
+```
+
+### Task 4: Pure auth-health state transitions and durable events
+
+**Files:**
+- Create: `packages/core/src/core/authHealth.ts`
+- Modify: `packages/core/package.json`
+- Test: `packages/extension/tests/authHealth.test.ts`
+
+**Interfaces:**
+- Consumes: normalized health contract and `SchedulerState.authHealth`.
+- Produces: `applyPlatformAuthHealth(state, platform, candidate): { state: SchedulerState; event?: ActivityEvent }`.
+- Semantic equality compares status, reason, and safe message metadata, but ignores `checkedAt`.
+
+- [ ] **Step 1: Write failing transition tests**
+
+Add tests asserting:
+
+```ts
+const changed = applyPlatformAuthHealth(DEFAULT_STATE, "kick", {
+  status: "blocked",
+  checkedAt: "2026-07-22T12:00:00.000Z",
+  reasonCode: "security_policy_blocked",
+  message: { key: "authSecurityPolicyBlocked", values: { reference: "ref-123" } },
+});
+
+expect(changed.state.authHealth.kick).toEqual(expect.objectContaining({ status: "blocked" }));
+expect(changed.event).toEqual({
+  category: "activity",
+  code: "auth_health_changed",
+  level: "error",
+  platform: "kick",
+  data: { from: "checking", to: "blocked", reason: "security_policy_blocked" },
+});
+expect(JSON.stringify(changed.event)).not.toContain("ref-123");
+```
+
+Add cases for all event levels, reason-only/message-key changes, malformed candidates being normalized, and timestamp-only refresh returning `event: undefined` while storing the newer timestamp.
+
+- [ ] **Step 2: Run and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- authHealth.test.ts`
+
+Expected: FAIL because `applyPlatformAuthHealth` does not exist.
+
+- [ ] **Step 3: Implement the pure transition helper**
+
+Create `authHealth.ts`. Normalize the candidate, compare a stable semantic tuple built from status/reason/message key/reference, update only the selected platform slice, and create the activity event without message metadata. Map levels as approved: `info` for `checking`/`healthy`, `warn` for missing/invalid/unavailable, and `error` for blocked.
+
+Add `"./authHealth": "./src/core/authHealth.ts"` to the core export map so tests and later scheduler integration import the helper through an explicit package boundary.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- authHealth.test.ts eventContract.test.ts`
+
+Expected: all transition and contract cases pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/core/authHealth.ts packages/core/package.json packages/extension/tests/authHealth.test.ts
+git commit -m "feat(core): record auth health transitions"
+```
+
+### Task 5: Controller persistence boundary and final verification
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/extension/tests/coreBoundary.test.ts`
+
+**Interfaces:**
+- Consumes: `applyPlatformAuthHealth` and adapter `checkAuthHealth()`.
+- Produces: `controller.checkAuthHealth(platform: Platform): Promise<void>`, a platform-only operation that persists normalized health and reports its durable transition event.
+- Does not call this operation from scheduler ticks yet; #201/#204 wire triggers and gating.
+
+- [ ] **Step 1: Write failing controller persistence tests**
+
+Extend the background-controller harness so each adapter's probe is a mock. Add cases that call `controller.checkAuthHealth("kick")` and assert:
+
+- only Kick's adapter probe runs;
+- normalized state is saved under `authHealth.kick`;
+- a semantic transition is reported exactly once through `reportEvents`;
+- a second result differing only in `checkedAt` is saved without another activity event;
+- a hostile adapter result containing extra secret-bearing fields is stripped before state persistence and never appears in serialized events.
+
+- [ ] **Step 2: Run and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- backgroundController.test.ts -t "auth health"`
+
+Expected: FAIL because the controller method does not exist.
+
+- [ ] **Step 3: Implement the controller operation**
+
+Inside `createBackgroundController`, implement the operation under `withStateLock` and `withEventCollector`: load settings/state, construct adapters, await only `adapters[platform].checkAuthHealth()`, apply the pure transition helper, emit its optional event, then call the existing `persistAndReport`. Return `checkAuthHealth` from the public controller object. Do not invoke it automatically from `tick`, startup, or messages in this issue.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- authHealth.test.ts backgroundController.test.ts eventContract.test.ts storageMigration.test.ts coreBoundary.test.ts`
+
+Expected: all focused tests pass, including core boundary enforcement.
+
+- [ ] **Step 5: Run full repository verification**
+
+Run: `pnpm verify`
+
+Expected: script tests, all workspace typechecks, extension tests, site build, and Chromium/Firefox extension builds pass. Record exact test counts and any pre-existing non-failing warnings.
+
+- [ ] **Step 6: Security diff audit**
+
+Run:
+
+```bash
+git diff origin/develop...HEAD --check
+git diff origin/develop...HEAD | rg -n "auth-token|session_token|authorization|cookie|response body|browser\.|wxt/"
+```
+
+Expected: only documentation/test fixture references explain prohibited data; no credential value flow or browser dependency exists in core production code.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(core): persist auth health checks"
+```
+
+- [ ] **Step 8: Review issue #200 acceptance criteria**
+
+Confirm each #200 criterion is backed by a test or type boundary, summarize commits and verification, and stop before beginning #201.

--- a/docs/superpowers/specs/2026-07-22-platform-auth-health-contracts-design.md
+++ b/docs/superpowers/specs/2026-07-22-platform-auth-health-contracts-design.md
@@ -1,0 +1,157 @@
+# Platform Authentication Health Contracts Design
+
+## Scope
+
+This specification implements issue #200, the browser-neutral foundation for the extension authentication-health epic in #199. It defines safe shared state, normalization, adapter and controller boundaries, and durable transition events. It does not read browser cookies, probe Twitch or Kick, gate scheduler work, or render popup status; those behaviors remain in issues #201 through #205.
+
+## Goals
+
+- Represent Twitch and Kick authentication health explicitly without exposing credentials or authenticated response content.
+- Give adapters and the controller a host-neutral contract that does not import WXT or browser globals into `@lurkloot/core`.
+- Preserve safe authentication health in scheduler state and normalize older or malformed persisted documents.
+- Distinguish missing credentials, rejected credentials, security-policy blocking, credential lookup failures, platform outages, and network failures.
+- Produce durable, non-diagnostic activity events for meaningful authentication transitions.
+
+## Shared Contract
+
+`@lurkloot/shared/models` will define:
+
+```ts
+export type PlatformAuthStatus =
+  | "checking"
+  | "healthy"
+  | "missing_credentials"
+  | "invalid_credentials"
+  | "blocked"
+  | "unavailable";
+
+export type PlatformAuthReasonCode =
+  | "credentials_missing"
+  | "credentials_rejected"
+  | "security_policy_blocked"
+  | "credential_lookup_failed"
+  | "platform_unavailable"
+  | "network_unavailable";
+
+export type PlatformAuthMessageKey =
+  | "authChecking"
+  | "authHealthy"
+  | "authMissingCredentials"
+  | "authInvalidCredentials"
+  | "authSecurityPolicyBlocked"
+  | "authCredentialLookupFailed"
+  | "authPlatformUnavailable"
+  | "authNetworkUnavailable";
+
+export interface PlatformAuthMessage {
+  key: PlatformAuthMessageKey;
+  values?: Partial<Record<"reference", string | number>>;
+}
+
+export interface PlatformAuthHealth {
+  status: PlatformAuthStatus;
+  checkedAt?: string;
+  reasonCode?: PlatformAuthReasonCode;
+  message?: PlatformAuthMessage;
+}
+```
+
+`SchedulerState` will gain `authHealth: Record<Platform, PlatformAuthHealth>`. Both platforms default to `{ status: "checking" }`, regardless of whether the platform is enabled. This means “not checked” without asserting that a disabled platform is healthy or unhealthy. The optional `checkedAt` timestamp appears only after an actual health result.
+
+The reason/status combinations are constrained as follows:
+
+| Status | Permitted reason codes |
+| --- | --- |
+| `checking` | none |
+| `healthy` | none |
+| `missing_credentials` | `credentials_missing` |
+| `invalid_credentials` | `credentials_rejected` |
+| `blocked` | `security_policy_blocked` |
+| `unavailable` | `credential_lookup_failed`, `platform_unavailable`, `network_unavailable` |
+
+Messages are presentation metadata, not arbitrary error text. A message key must be one of the enumerated keys and must correspond to the status/reason pair. The only initial interpolation field is `reference`, reserved for a platform-supplied safe troubleshooting identifier such as Kick's security-policy reference. Message values are limited to finite numbers and bounded strings; objects, arrays, and arbitrary field names are rejected.
+
+## Normalization and Persistence
+
+`@lurkloot/core/defaults` will own a pure `normalizePlatformAuthHealth` function and use it from `mergeSchedulerState`. This keeps normalization browser-free and shared by extension and CLI storage hosts.
+
+Normalization constructs a fresh allowlisted object instead of spreading persisted input. It accepts only:
+
+- a known status;
+- a valid status/reason combination;
+- a real ISO-8601 timestamp that round-trips through `Date`;
+- a known message key compatible with the normalized health result;
+- allowlisted primitive message values within explicit size limits.
+
+Unknown statuses or structurally invalid records fall back to `{ status: "checking" }`. Invalid optional fields are omitted without discarding an otherwise valid status. Extra fields—including token, cookie, headers, response, URL, and arbitrary diagnostic properties—are never copied. Existing installations with no `authHealth` slice receive the two default `checking` records on load. Saving the normalized state persists this canonical shape through the existing storage path; no separate schema version is needed for scheduler state.
+
+## Adapter and Controller Boundaries
+
+`PlatformAdapter` will add:
+
+```ts
+checkAuthHealth(): Promise<PlatformAuthHealth>;
+```
+
+The method accepts no credentials. Each host retains credential access inside its adapter construction boundary; the shared result contains only normalized safe metadata. Twitch and Kick implementations are deliberately deferred to #202 and #203. Until those issues land, existing adapters return `checking`, preserving behavior while making the contract compile across all hosts and tests.
+
+The controller will expose a focused state-transition helper that:
+
+1. normalizes the adapter result;
+2. compares semantic fields (`status`, `reasonCode`, and safe message metadata) with the previous health record;
+3. saves the updated scheduler state, including a newer `checkedAt` when supplied; and
+4. emits a durable activity event only when semantic health changes.
+
+Timestamp-only refreshes update state but do not create activity noise. The helper is independent of scheduler gating; #204 will decide when probes run and when account-dependent automation is suspended.
+
+## Durable Activity Events
+
+`@lurkloot/shared/events` will add:
+
+```ts
+type AuthHealthChangedData = {
+  from: PlatformAuthStatus;
+  to: PlatformAuthStatus;
+  reason?: PlatformAuthReasonCode;
+};
+
+type AuthHealthChangedEvent = {
+  category: "activity";
+  code: "auth_health_changed";
+  level: "info" | "warn" | "error";
+  platform: Platform;
+  message?: never;
+  data: AuthHealthChangedData;
+};
+```
+
+The level is `info` for transitions to `checking` or `healthy`, `warn` for missing/invalid credentials or temporary unavailability, and `error` for security-policy blocking. The event excludes message interpolation values, troubleshooting references, raw error text, response data, and timestamps. Existing activity persistence records it even when diagnostic logging is disabled.
+
+## Security Invariants
+
+- No token, cookie value, password, authorization header, authenticated response body, or complete request URL may enter `SchedulerState`, runtime snapshots, activity events, diagnostics, or logs through this contract.
+- Normalization is an allowlist reconstruction, not a blacklist or object spread.
+- Adapter inputs do not carry credentials through core APIs.
+- Troubleshooting references are bounded, plain scalar values and are omitted from durable activity events.
+- `@lurkloot/core` remains free of WXT imports and browser globals.
+
+## Testing
+
+Focused deterministic tests will cover:
+
+- defaults for new and existing scheduler documents;
+- valid health records round-tripping through `mergeSchedulerState`;
+- fallback for unknown statuses and malformed records;
+- removal of invalid reason/status combinations, timestamps, message keys, message values, and extra fields;
+- representative secret-bearing fields being absent from normalized/serialized state;
+- the adapter method's browser-neutral return contract;
+- one durable transition event for status or reason changes;
+- no event for timestamp-only refreshes;
+- event levels and the absence of message values, references, and diagnostic content;
+- continued enforcement of the existing core browser-boundary test.
+
+Tests use fixed timestamps and in-memory mocked storage/adapters. They make no live Twitch, Kick, cookie, or browser calls.
+
+## Delivery Boundary
+
+Issue #200 is complete when the shared contracts, safe state normalization/defaults, adapter/controller transition boundary, activity event, and focused tests are merged. The platform-specific implementations may still report `checking`; operational probing and recovery begin in #201–#204, and user-facing rendering begins in #205.

--- a/packages/cli/src/events.ts
+++ b/packages/cli/src/events.ts
@@ -72,6 +72,8 @@ export function formatCliEvent(event: EngineEvent): string {
       return `Opened background context on ${event.data.host}: ${formatPageContextOpenReason(event.data.reason)}`;
     case "page_context_closed":
       return `Closed background context on ${event.data.host}: ${formatPageContextCloseReason(event.data.reason)}`;
+    case "auth_health_changed":
+      return `${event.platform} authentication changed from ${event.data.from} to ${event.data.to}`;
     default: {
       const exhaustive: never = event;
       return exhaustive;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "./twitchIntegrity": "./src/core/twitchIntegrity.ts",
     "./tabs": "./src/core/tabs.ts",
     "./defaults": "./src/core/defaults.ts",
+    "./authHealth": "./src/core/authHealth.ts",
     "./adapter": "./src/platforms/adapter.ts",
     "./twitch": "./src/platforms/twitch/index.ts",
     "./twitch/parser": "./src/platforms/twitch/parser.ts",

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -10,6 +10,7 @@ import { integrityFromHeaders } from "../core/twitchIntegrity";
 import type { IntegrityHeader, TwitchIntegrity } from "../core/twitchIntegrity";
 import type { PlatformAdapter } from "../platforms/adapter";
 import type { TablessWatchController, WatchContext } from "../core/tablessWatch";
+import { applyPlatformAuthHealth } from "../core/authHealth";
 
 export const ALARM_NAME = "lurkloot.tick";
 // A separate, fixed 1-minute alarm drives tabless watch heartbeats independently
@@ -469,6 +470,16 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       }
     }));
     return claimedRewards;
+  }
+
+  async function checkAuthHealth(platform: Platform): Promise<void> {
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+      const adapter = deps.createAdapters(emit, settings).adapters[platform];
+      const transition = applyPlatformAuthHealth(state, platform, await adapter.checkAuthHealth());
+      if (transition.event) emit(transition.event);
+      await persistAndReport(transition.state, events);
+    }));
   }
 
   async function handleTabRemoved(tabId: number): Promise<void> {
@@ -1221,6 +1232,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     handleTabRemoved,
     handleMessage,
     captureTwitchIntegrity,
+    checkAuthHealth,
     tick,
     tickAndHandOff,
     runWatchHeartbeat,

--- a/packages/core/src/core/authHealth.ts
+++ b/packages/core/src/core/authHealth.ts
@@ -1,0 +1,52 @@
+import type { ActivityEvent } from "@lurkloot/shared/events";
+import type { Platform, PlatformAuthHealth, PlatformAuthStatus, SchedulerState } from "@lurkloot/shared/models";
+import { normalizePlatformAuthHealth } from "./defaults";
+
+export interface PlatformAuthHealthTransition {
+  state: SchedulerState;
+  event?: ActivityEvent;
+}
+
+function semanticHealth(health: PlatformAuthHealth): string {
+  return JSON.stringify({
+    status: health.status,
+    reasonCode: health.reasonCode,
+    message: health.message,
+  });
+}
+
+function transitionLevel(status: PlatformAuthStatus): ActivityEvent["level"] {
+  if (status === "blocked") return "error";
+  if (status === "checking" || status === "healthy") return "info";
+  return "warn";
+}
+
+export function applyPlatformAuthHealth(
+  state: SchedulerState,
+  platform: Platform,
+  candidate: unknown,
+): PlatformAuthHealthTransition {
+  const previous = state.authHealth[platform];
+  const health = normalizePlatformAuthHealth(candidate);
+  const nextState: SchedulerState = {
+    ...state,
+    authHealth: { ...state.authHealth, [platform]: health },
+  };
+
+  if (semanticHealth(previous) === semanticHealth(health)) return { state: nextState };
+
+  return {
+    state: nextState,
+    event: {
+      category: "activity",
+      code: "auth_health_changed",
+      level: transitionLevel(health.status),
+      platform,
+      data: {
+        from: previous.status,
+        to: health.status,
+        ...(health.reasonCode ? { reason: health.reasonCode } : {}),
+      },
+    },
+  };
+}

--- a/packages/core/src/core/defaults.ts
+++ b/packages/core/src/core/defaults.ts
@@ -53,8 +53,10 @@ export function normalizePlatformAuthHealth(value: unknown): PlatformAuthHealth 
 
   const normalizedStatus = status as PlatformAuthStatus;
   const health: PlatformAuthHealth = { status: normalizedStatus };
-  const checkedAt = normalizedIsoTimestamp(value.checkedAt);
-  if (checkedAt) health.checkedAt = checkedAt;
+  if (normalizedStatus !== "checking") {
+    const checkedAt = normalizedIsoTimestamp(value.checkedAt);
+    if (checkedAt) health.checkedAt = checkedAt;
+  }
 
   const reasonCode = typeof value.reasonCode === "string"
     && AUTH_REASONS[normalizedStatus].includes(value.reasonCode as PlatformAuthReasonCode)

--- a/packages/core/src/core/defaults.ts
+++ b/packages/core/src/core/defaults.ts
@@ -1,4 +1,82 @@
-import type { Platform, SchedulerState } from "@lurkloot/shared/models";
+import type { Platform, PlatformAuthHealth, PlatformAuthMessageKey, PlatformAuthReasonCode, PlatformAuthStatus, SchedulerState } from "@lurkloot/shared/models";
+
+const AUTH_STATUSES = new Set<PlatformAuthStatus>([
+  "checking",
+  "healthy",
+  "missing_credentials",
+  "invalid_credentials",
+  "blocked",
+  "unavailable",
+]);
+
+const AUTH_REASONS: Record<PlatformAuthStatus, readonly PlatformAuthReasonCode[]> = {
+  checking: [],
+  healthy: [],
+  missing_credentials: ["credentials_missing"],
+  invalid_credentials: ["credentials_rejected"],
+  blocked: ["security_policy_blocked"],
+  unavailable: ["credential_lookup_failed", "platform_unavailable", "network_unavailable"],
+};
+
+const AUTH_MESSAGE_KEYS: Record<PlatformAuthStatus | PlatformAuthReasonCode, PlatformAuthMessageKey> = {
+  checking: "authChecking",
+  healthy: "authHealthy",
+  missing_credentials: "authMissingCredentials",
+  invalid_credentials: "authInvalidCredentials",
+  blocked: "authSecurityPolicyBlocked",
+  unavailable: "authPlatformUnavailable",
+  credentials_missing: "authMissingCredentials",
+  credentials_rejected: "authInvalidCredentials",
+  security_policy_blocked: "authSecurityPolicyBlocked",
+  credential_lookup_failed: "authCredentialLookupFailed",
+  platform_unavailable: "authPlatformUnavailable",
+  network_unavailable: "authNetworkUnavailable",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizedIsoTimestamp(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  try {
+    return new Date(value).toISOString() === value ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizePlatformAuthHealth(value: unknown): PlatformAuthHealth {
+  if (!isRecord(value)) return { status: "checking" };
+  const status = value.status;
+  if (typeof status !== "string" || !AUTH_STATUSES.has(status as PlatformAuthStatus)) return { status: "checking" };
+
+  const normalizedStatus = status as PlatformAuthStatus;
+  const health: PlatformAuthHealth = { status: normalizedStatus };
+  const checkedAt = normalizedIsoTimestamp(value.checkedAt);
+  if (checkedAt) health.checkedAt = checkedAt;
+
+  const reasonCode = typeof value.reasonCode === "string"
+    && AUTH_REASONS[normalizedStatus].includes(value.reasonCode as PlatformAuthReasonCode)
+    ? value.reasonCode as PlatformAuthReasonCode
+    : undefined;
+  if (reasonCode) health.reasonCode = reasonCode;
+
+  if (isRecord(value.message)) {
+    const expectedKey = AUTH_MESSAGE_KEYS[reasonCode ?? normalizedStatus];
+    if (value.message.key === expectedKey) {
+      health.message = { key: expectedKey };
+      if (isRecord(value.message.values)) {
+        const reference = value.message.values.reference;
+        const safeReference = (typeof reference === "string" && reference.length > 0 && reference.length <= 128)
+          || (typeof reference === "number" && Number.isFinite(reference));
+        if (safeReference) health.message.values = { reference: reference as string | number };
+      }
+    }
+  }
+
+  return health;
+}
 
 // Pure default scheduler state, shared by the extension's browser.storage layer
 // and any other runtime (e.g. a headless CLI's file-backed storage). Kept
@@ -14,6 +92,10 @@ export const DEFAULT_STATE: SchedulerState = {
   sessions: {
     twitch: emptySession("twitch"),
     kick: emptySession("kick"),
+  },
+  authHealth: {
+    twitch: { status: "checking" },
+    kick: { status: "checking" },
   },
   managedWatchTabs: {},
   managedPageContextTabs: {},
@@ -33,6 +115,10 @@ export function mergeSchedulerState(stored: Partial<SchedulerState> | undefined)
     ...DEFAULT_STATE,
     ...operationalState,
     sessions: { ...DEFAULT_STATE.sessions, ...stored?.sessions },
+    authHealth: {
+      twitch: normalizePlatformAuthHealth(stored?.authHealth?.twitch),
+      kick: normalizePlatformAuthHealth(stored?.authHealth?.kick),
+    },
     managedWatchTabs: { ...DEFAULT_STATE.managedWatchTabs, ...stored?.managedWatchTabs },
     managedPageContextTabs: { ...DEFAULT_STATE.managedPageContextTabs, ...stored?.managedPageContextTabs },
     manualWatch: { ...stored?.manualWatch },

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -6,6 +6,7 @@ import type {
   DropReward,
   ManagedWatchTab,
   Platform,
+  PlatformAuthHealth,
   WatchSession,
 } from "@lurkloot/shared/models";
 import type { EventEmitter } from "@lurkloot/shared/events";
@@ -43,6 +44,7 @@ export interface ClaimedChallenge {
 export interface PlatformAdapter {
   platform: Platform;
   readonly compatibility?: ResolvedCompatibility[Platform];
+  checkAuthHealth(): Promise<PlatformAuthHealth>;
   discoverCampaigns(): Promise<DropCampaign[]>;
   readProgress(campaigns: DropCampaign[], session?: WatchSession): Promise<DropCampaign[]>;
   listCandidateChannels(campaign: DropCampaign): Promise<ChannelCandidate[]>;

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -1,4 +1,4 @@
-import type { CategorySelection, ChannelCandidate, ChannelCheck, DropCampaign, DropReward, WatchSession } from "@lurkloot/shared/models";
+import type { CategorySelection, ChannelCandidate, ChannelCheck, DropCampaign, DropReward, PlatformAuthHealth, WatchSession } from "@lurkloot/shared/models";
 import type { EventEmitter } from "@lurkloot/shared/events";
 import type { TablessWatchController } from "../../core/tablessWatch";
 import { KickWafBlockedError } from "../../core/tabs";
@@ -163,6 +163,10 @@ export class KickAdapter implements PlatformAdapter {
   platform = "kick" as const;
   readonly compatibility?: ResolvedCompatibility["kick"];
   private readonly claimCapability: KickClaimCapability;
+
+  async checkAuthHealth(): Promise<PlatformAuthHealth> {
+    return { status: "checking" };
+  }
 
   constructor(
     private readonly fetcher: PageFetcher,

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -1,4 +1,4 @@
-import type { CategorySelection, ChannelCandidate, ChannelCheck, DropCampaign, DropReward, WatchSession } from "@lurkloot/shared/models";
+import type { CategorySelection, ChannelCandidate, ChannelCheck, DropCampaign, DropReward, PlatformAuthHealth, WatchSession } from "@lurkloot/shared/models";
 import type { EventEmitter } from "@lurkloot/shared/events";
 import type { LogLevel } from "@lurkloot/shared/logging";
 import { PendingWatcherDiagnostics, type HeartbeatResult, type TablessWatchController, type WatchContext } from "../../core/tablessWatch";
@@ -351,6 +351,10 @@ export function createTwitchGqlTransport(
 export class TwitchAdapter implements PlatformAdapter {
   platform = "twitch" as const;
   readonly compatibility?: ResolvedCompatibility["twitch"];
+
+  async checkAuthHealth(): Promise<PlatformAuthHealth> {
+    return { status: "checking" };
+  }
 
   private readonly gqlTransport: TwitchGqlTransport;
   private readonly inventoryCapability: TwitchInventoryCapability;

--- a/packages/extension/tests/activityView.test.ts
+++ b/packages/extension/tests/activityView.test.ts
@@ -79,6 +79,22 @@ describe("activity view model", () => {
     }, t)).toBe("activityPageContextClosed:kick.com|activityPageContextCloseReasonBackgroundRecovered:");
   });
 
+  it("formats complete authentication health transitions", () => {
+    const t = vi.fn((key: string, substitutions?: string | string[]) =>
+      `${key}:${Array.isArray(substitutions) ? substitutions.join("|") : substitutions ?? ""}`);
+
+    expect(formatActivityEvent({
+      id: "auth-transition",
+      at,
+      category: "activity",
+      code: "auth_health_changed",
+      level: "warn",
+      platform: "kick",
+      data: { from: "checking", to: "missing_credentials", reason: "credentials_missing" },
+    }, t)).toBe("activityAuthHealthChanged:kick|checking|missing_credentials");
+    expect(t).toHaveBeenCalledWith("activityAuthHealthChanged", ["kick", "checking", "missing_credentials"]);
+  });
+
   it("formats every farming stop reason through its locale key", () => {
     const t = vi.fn((key: string) => key);
     const reasons: FarmingStopReason[] = [

--- a/packages/extension/tests/authHealth.test.ts
+++ b/packages/extension/tests/authHealth.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_STATE, mergeSchedulerState, normalizePlatformAuthHealth } from "@lurkloot/core/defaults";
+
+describe("authentication health normalization", () => {
+  it("defaults both platforms to unchecked checking state", () => {
+    expect(DEFAULT_STATE.authHealth).toEqual({
+      twitch: { status: "checking" },
+      kick: { status: "checking" },
+    });
+    expect(mergeSchedulerState(undefined).authHealth).toEqual(DEFAULT_STATE.authHealth);
+  });
+
+  it("adds defaults to legacy state without losing operational data", () => {
+    const merged = mergeSchedulerState({ lastTickAt: "2026-07-22T12:00:00.000Z" });
+    expect(merged.lastTickAt).toBe("2026-07-22T12:00:00.000Z");
+    expect(merged.authHealth).toEqual(DEFAULT_STATE.authHealth);
+  });
+
+  it("exposes a normalizer for host-neutral persisted values", () => {
+    expect(normalizePlatformAuthHealth({ status: "healthy" })).toEqual({ status: "healthy" });
+  });
+
+  it.each([
+    ["missing_credentials", "credentials_missing", "authMissingCredentials"],
+    ["invalid_credentials", "credentials_rejected", "authInvalidCredentials"],
+    ["blocked", "security_policy_blocked", "authSecurityPolicyBlocked"],
+    ["unavailable", "credential_lookup_failed", "authCredentialLookupFailed"],
+    ["unavailable", "platform_unavailable", "authPlatformUnavailable"],
+    ["unavailable", "network_unavailable", "authNetworkUnavailable"],
+  ] as const)("round-trips %s with its safe reason", (status, reasonCode, key) => {
+    expect(normalizePlatformAuthHealth({
+      status,
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode,
+      message: { key },
+    })).toEqual({
+      status,
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode,
+      message: { key },
+    });
+  });
+
+  it("reconstructs safe state without copying secrets or arbitrary metadata", () => {
+    const normalized = normalizePlatformAuthHealth({
+      status: "blocked",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode: "security_policy_blocked",
+      message: {
+        key: "authSecurityPolicyBlocked",
+        values: { reference: "ref-123", token: "secret" },
+        response: "private",
+      },
+      token: "secret",
+      cookie: "secret",
+      headers: { authorization: "Bearer secret" },
+      response: { account: "private" },
+      url: "https://kick.com/?token=secret",
+    });
+
+    expect(normalized).toEqual({
+      status: "blocked",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode: "security_policy_blocked",
+      message: { key: "authSecurityPolicyBlocked", values: { reference: "ref-123" } },
+    });
+    expect(JSON.stringify(normalized)).not.toContain("secret");
+  });
+
+  it.each([
+    undefined,
+    null,
+    "healthy",
+    { status: "unknown", token: "secret" },
+  ])("falls back malformed records to checking", (value) => {
+    expect(normalizePlatformAuthHealth(value)).toEqual({ status: "checking" });
+  });
+
+  it("omits invalid optional metadata while retaining a valid status", () => {
+    expect(normalizePlatformAuthHealth({
+      status: "healthy",
+      checkedAt: "not-a-date",
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials", values: { reference: { nested: true } } },
+    })).toEqual({ status: "healthy" });
+
+    expect(normalizePlatformAuthHealth({
+      status: "blocked",
+      reasonCode: "security_policy_blocked",
+      message: { key: "unknown", values: { reference: "x" } },
+    })).toEqual({ status: "blocked", reasonCode: "security_policy_blocked" });
+  });
+
+  it("bounds safe troubleshooting references", () => {
+    const base = {
+      status: "blocked",
+      reasonCode: "security_policy_blocked",
+      message: { key: "authSecurityPolicyBlocked" },
+    } as const;
+
+    expect(normalizePlatformAuthHealth({ ...base, message: { ...base.message, values: { reference: Number.NaN } } }))
+      .toEqual({ ...base, message: base.message });
+    expect(normalizePlatformAuthHealth({ ...base, message: { ...base.message, values: { reference: "x".repeat(129) } } }))
+      .toEqual({ ...base, message: base.message });
+  });
+});

--- a/packages/extension/tests/authHealth.test.ts
+++ b/packages/extension/tests/authHealth.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_STATE, mergeSchedulerState, normalizePlatformAuthHealth } from "@lurkloot/core/defaults";
+import type { PlatformAdapter } from "@lurkloot/core/adapter";
+import { TwitchAdapter } from "@lurkloot/core/twitch";
+import { KickAdapter } from "@lurkloot/core/kick";
 
 describe("authentication health normalization", () => {
+  it("requires adapters to expose a browser-neutral auth probe", async () => {
+    const probe: PlatformAdapter["checkAuthHealth"] = async () => ({ status: "checking" });
+    expect(await probe()).toEqual({ status: "checking" });
+  });
+
+  it("keeps both platform adapters in checking state until their probes are implemented", async () => {
+    const fetcher = { fetchJson: async () => { throw new Error("not called"); } };
+    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({ status: "checking" });
+    await expect(new KickAdapter(fetcher).checkAuthHealth()).resolves.toEqual({ status: "checking" });
+  });
   it("defaults both platforms to unchecked checking state", () => {
     expect(DEFAULT_STATE.authHealth).toEqual({
       twitch: { status: "checking" },

--- a/packages/extension/tests/authHealth.test.ts
+++ b/packages/extension/tests/authHealth.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_STATE, mergeSchedulerState, normalizePlatformAuthHealth } from 
 import type { PlatformAdapter } from "@lurkloot/core/adapter";
 import { TwitchAdapter } from "@lurkloot/core/twitch";
 import { KickAdapter } from "@lurkloot/core/kick";
+import { applyPlatformAuthHealth } from "@lurkloot/core/authHealth";
 
 describe("authentication health normalization", () => {
   it("requires adapters to expose a browser-neutral auth probe", async () => {
@@ -115,5 +116,71 @@ describe("authentication health normalization", () => {
       .toEqual({ ...base, message: base.message });
     expect(normalizePlatformAuthHealth({ ...base, message: { ...base.message, values: { reference: "x".repeat(129) } } }))
       .toEqual({ ...base, message: base.message });
+  });
+
+  it("updates health and emits a reference-free durable transition", () => {
+    const changed = applyPlatformAuthHealth(DEFAULT_STATE, "kick", {
+      status: "blocked",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode: "security_policy_blocked",
+      message: { key: "authSecurityPolicyBlocked", values: { reference: "ref-123" } },
+    });
+
+    expect(changed.state.authHealth.kick).toEqual({
+      status: "blocked",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode: "security_policy_blocked",
+      message: { key: "authSecurityPolicyBlocked", values: { reference: "ref-123" } },
+    });
+    expect(changed.event).toEqual({
+      category: "activity",
+      code: "auth_health_changed",
+      level: "error",
+      platform: "kick",
+      data: { from: "checking", to: "blocked", reason: "security_policy_blocked" },
+    });
+    expect(JSON.stringify(changed.event)).not.toContain("ref-123");
+  });
+
+  it.each([
+    ["healthy", "info"],
+    ["checking", "info"],
+    ["missing_credentials", "warn"],
+    ["invalid_credentials", "warn"],
+    ["unavailable", "warn"],
+    ["blocked", "error"],
+  ] as const)("uses the safe activity level for %s", (status, level) => {
+    const changed = applyPlatformAuthHealth({
+      ...DEFAULT_STATE,
+      authHealth: { ...DEFAULT_STATE.authHealth, twitch: { status: status === "healthy" ? "checking" : "healthy" } },
+    }, "twitch", { status });
+    expect(changed.event?.level).toBe(level);
+  });
+
+  it("stores timestamp-only refreshes without emitting activity", () => {
+    const state = {
+      ...DEFAULT_STATE,
+      authHealth: {
+        ...DEFAULT_STATE.authHealth,
+        kick: { status: "healthy" as const, checkedAt: "2026-07-22T12:00:00.000Z" },
+      },
+    };
+
+    const refreshed = applyPlatformAuthHealth(state, "kick", {
+      status: "healthy",
+      checkedAt: "2026-07-22T12:05:00.000Z",
+    });
+    expect(refreshed.state.authHealth.kick.checkedAt).toBe("2026-07-22T12:05:00.000Z");
+    expect(refreshed.event).toBeUndefined();
+  });
+
+  it("normalizes hostile transition candidates before storing them", () => {
+    const changed = applyPlatformAuthHealth(DEFAULT_STATE, "twitch", {
+      status: "healthy",
+      token: "secret",
+      headers: { authorization: "secret" },
+    } as never);
+    expect(changed.state.authHealth.twitch).toEqual({ status: "healthy" });
+    expect(JSON.stringify(changed)).not.toContain("secret");
   });
 });

--- a/packages/extension/tests/authHealth.test.ts
+++ b/packages/extension/tests/authHealth.test.ts
@@ -34,6 +34,13 @@ describe("authentication health normalization", () => {
     expect(normalizePlatformAuthHealth({ status: "healthy" })).toEqual({ status: "healthy" });
   });
 
+  it("drops timestamps from in-progress checking results", () => {
+    expect(normalizePlatformAuthHealth({
+      status: "checking",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+    })).toEqual({ status: "checking" });
+  });
+
   it.each([
     ["missing_credentials", "credentials_missing", "authMissingCredentials"],
     ["invalid_credentials", "credentials_rejected", "authInvalidCredentials"],

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -113,6 +113,61 @@ function harness(
 }
 
 describe("background controller", () => {
+  it("checks and persists authentication health for only the requested platform", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    vi.mocked(env.kick.checkAuthHealth).mockResolvedValueOnce({
+      status: "blocked",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode: "security_policy_blocked",
+      message: { key: "authSecurityPolicyBlocked", values: { reference: "safe-ref" } },
+    });
+
+    await env.controller.checkAuthHealth("kick");
+
+    expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce();
+    expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
+    expect(env.state.authHealth.kick).toEqual(expect.objectContaining({
+      status: "blocked",
+      reasonCode: "security_policy_blocked",
+    }));
+    expect(env.reportEvents).toHaveBeenCalledWith([{
+      category: "activity",
+      code: "auth_health_changed",
+      level: "error",
+      platform: "kick",
+      data: { from: "checking", to: "blocked", reason: "security_policy_blocked" },
+    }]);
+  });
+
+  it("stores timestamp-only auth refreshes without repeating activity", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    vi.mocked(env.kick.checkAuthHealth)
+      .mockResolvedValueOnce({ status: "healthy", checkedAt: "2026-07-22T12:00:00.000Z" })
+      .mockResolvedValueOnce({ status: "healthy", checkedAt: "2026-07-22T12:05:00.000Z" });
+
+    await env.controller.checkAuthHealth("kick");
+    env.reportEvents.mockClear();
+    await env.controller.checkAuthHealth("kick");
+
+    expect(env.state.authHealth.kick.checkedAt).toBe("2026-07-22T12:05:00.000Z");
+    expect(env.reportEvents).not.toHaveBeenCalled();
+  });
+
+  it("strips hostile adapter fields before auth state and events are persisted", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    vi.mocked(env.twitch.checkAuthHealth).mockResolvedValueOnce({
+      status: "healthy",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      token: "do-not-store",
+      headers: { authorization: "Bearer do-not-store" },
+    } as never);
+
+    await env.controller.checkAuthHealth("twitch");
+
+    expect(JSON.stringify(env.state.authHealth.twitch)).not.toContain("do-not-store");
+    expect(JSON.stringify(env.reportEvents.mock.calls)).not.toContain("do-not-store");
+  });
+
   it("reports the effective compatibility profile and capability once per enabled platform", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true });
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -41,6 +41,7 @@ function asSnapshot(value: unknown): RuntimeSnapshot {
 function adapter(platform: Platform): PlatformAdapter {
   return {
     platform,
+    checkAuthHealth: vi.fn(async () => ({ status: "checking" as const })),
     discoverCampaigns: vi.fn(async () => [campaign(platform)]),
     readProgress: vi.fn(async (campaigns) => campaigns),
     listCandidateChannels: vi.fn(async () => [channel(platform)]),

--- a/packages/extension/tests/eventContract.test.ts
+++ b/packages/extension/tests/eventContract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { EngineEvent, StoredEngineEvent } from "@lurkloot/shared/events";
+import type { PlatformAuthHealth } from "@lurkloot/shared/models";
 
 describe("engine event contract", () => {
   it("discriminates activity payloads by code", () => {
@@ -22,5 +23,24 @@ describe("engine event contract", () => {
 
   it("adds persistence metadata only to stored events", () => {
     expectTypeOf<StoredEngineEvent>().toMatchTypeOf<EngineEvent & { id: string; at: string }>();
+  });
+
+  it("types safe authentication health and durable transitions", () => {
+    const health: PlatformAuthHealth = {
+      status: "blocked",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode: "security_policy_blocked",
+      message: { key: "authSecurityPolicyBlocked", values: { reference: "safe-ref" } },
+    };
+    const event: EngineEvent = {
+      category: "activity",
+      code: "auth_health_changed",
+      level: "error",
+      platform: "kick",
+      data: { from: "checking", to: health.status, reason: health.reasonCode },
+    };
+
+    expectTypeOf(health).toMatchTypeOf<PlatformAuthHealth>();
+    expectTypeOf(event).toMatchTypeOf<EngineEvent>();
   });
 });

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -5,6 +5,7 @@ import { NO_CATEGORY_ID } from "@lurkloot/shared/categories";
 import { chooseCampaignDecision, runSchedulerTick, sortCampaigns } from "@lurkloot/core/scheduler";
 import type { PlatformAdapter } from "@lurkloot/core/adapter";
 import { forgetManagedPageContextTabs } from "@lurkloot/core/tabs";
+import { DEFAULT_STATE } from "@lurkloot/core/defaults";
 
 const reward = (status: DropReward["status"] = "in_progress"): DropReward => ({
   id: `reward-${status}`,
@@ -629,6 +630,7 @@ describe("scheduler campaign selection", () => {
 
 describe("scheduler tick", () => {
   const baseState: SchedulerState = {
+    authHealth: DEFAULT_STATE.authHealth,
     sessions: {
       twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
       kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -725,6 +727,7 @@ describe("scheduler tick", () => {
     const result = await runSchedulerTick(
       {
         ...baseState,
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           ...baseState.sessions,
           twitch: {
@@ -761,6 +764,7 @@ describe("scheduler tick", () => {
     const result = await runSchedulerTick(
       {
         ...baseState,
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           ...baseState.sessions,
           twitch: {
@@ -791,6 +795,7 @@ describe("scheduler tick", () => {
     const result = await runSchedulerTick(
       {
         ...baseState,
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           ...baseState.sessions,
           twitch: {
@@ -826,6 +831,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: first, offlineChecks: 2, tabId: 7 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -854,6 +860,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: channel("old"), offlineChecks: 0, tabId: 7, tabManagedByExtension: true },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -884,6 +891,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -923,6 +931,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: old, offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -944,6 +953,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: toonyx, offlineChecks: 0, tabId: 7 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -965,6 +975,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -999,6 +1010,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1039,6 +1051,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1079,6 +1092,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1128,6 +1142,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1171,6 +1186,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1223,6 +1239,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1256,6 +1273,7 @@ describe("scheduler tick", () => {
 
     await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1287,6 +1305,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1320,6 +1339,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1353,6 +1373,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1430,6 +1451,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1482,6 +1504,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1510,6 +1533,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1535,6 +1559,7 @@ describe("scheduler tick", () => {
     const waitingClaimRewardIds = { twitch: new Set<string>(), kick: new Set<string>() };
     const options = { waitingClaimRewardIds };
     const initialState: SchedulerState = {
+      authHealth: DEFAULT_STATE.authHealth,
       sessions: {
         twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
         kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1567,6 +1592,7 @@ describe("scheduler tick", () => {
     const waitingClaimRewardIds = { twitch: new Set<string>(), kick: new Set<string>() };
     const options = { waitingClaimRewardIds };
     const initialState: SchedulerState = {
+      authHealth: DEFAULT_STATE.authHealth,
       sessions: {
         twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
         kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1597,6 +1623,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1617,6 +1644,7 @@ describe("scheduler tick", () => {
 
     await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1636,6 +1664,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1658,6 +1687,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1680,6 +1710,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1703,6 +1734,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1735,6 +1767,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1760,6 +1793,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: channel("current"), offlineChecks: 0, tabId: 42, tabManagedByExtension: true },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1785,6 +1819,7 @@ describe("scheduler tick", () => {
   it("passes the existing managed tab into repeated ticks instead of creating an untracked tab", async () => {
     const twitch = adapter("twitch", [campaign("drops")], [channel("allowed")]);
     const initialState = {
+      authHealth: DEFAULT_STATE.authHealth,
       sessions: {
         twitch: { platform: "twitch" as const, status: "idle" as const, offlineChecks: 0 },
         kick: { platform: "kick" as const, status: "idle" as const, offlineChecks: 0 },
@@ -1812,6 +1847,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: channel("old"), offlineChecks: 0, tabId: 7, tabManagedByExtension: true },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1847,6 +1883,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: channel("old"), offlineChecks: 0, tabId: 7, tabManagedByExtension: true },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1868,6 +1905,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1894,6 +1932,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1922,6 +1961,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1953,6 +1993,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1980,6 +2021,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -2010,6 +2052,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2032,6 +2075,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2054,6 +2098,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2078,6 +2123,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2098,6 +2144,7 @@ describe("scheduler tick", () => {
 
     await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2119,6 +2166,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2145,6 +2193,7 @@ describe("scheduler tabless mode", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2168,6 +2217,7 @@ describe("scheduler tabless mode", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -2200,6 +2250,7 @@ describe("scheduler tabless mode", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -2230,6 +2281,7 @@ describe("scheduler tabless mode", () => {
 
     const result = await runSchedulerTick(
       {
+        authHealth: DEFAULT_STATE.authHealth,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -52,6 +52,7 @@ function settings(patch: SettingsPatch = {}): ExtensionSettings {
 function adapter(platform: Platform, campaigns: DropCampaign[], candidates: ChannelCandidate[]): PlatformAdapter {
   return {
     platform,
+    checkAuthHealth: vi.fn(async () => ({ status: "checking" as const })),
     discoverCampaigns: vi.fn(async () => campaigns),
     readProgress: vi.fn(async (value) => value),
     listCandidateChannels: vi.fn(async () => candidates),

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "تم استلام بطاقة $1 من تحدي $2"
   },
+  "activityAuthHealthChanged": { "message": "تغيّرت مصادقة $1 من $2 إلى $3." },
   "activityPageContextOpened": { "message": "تم فتح سياق في الخلفية على $1 لأن $2." },
   "activityPageContextClosed": { "message": "تم إغلاق سياق الخلفية على $1 لأن $2." },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick رفض الطلب دون علامة تبويب" },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "$1-Karte aus der $2-Challenge erhalten"
   },
+  "activityAuthHealthChanged": { "message": "Die Authentifizierung von $1 wechselte von $2 zu $3." },
   "activityPageContextOpened": { "message": "Ein Hintergrundkontext auf $1 wurde geöffnet, weil $2." },
   "activityPageContextClosed": { "message": "Der Hintergrundkontext auf $1 wurde geschlossen, weil $2." },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick die Anfrage ohne Tab abgelehnt hat" },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "Claimed a $1 card from the $2 challenge"
   },
+  "activityAuthHealthChanged": { "message": "$1 authentication changed from $2 to $3." },
   "activityPageContextOpened": { "message": "Opened a background context on $1 because $2." },
   "activityPageContextClosed": { "message": "Closed the background context on $1 because $2." },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick rejected the tabless request" },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "Reclamó una carta $1 del desafío $2"
   },
+  "activityAuthHealthChanged": { "message": "La autenticación de $1 cambió de $2 a $3." },
   "activityPageContextOpened": { "message": "Se abrió un contexto en segundo plano en $1 porque $2." },
   "activityPageContextClosed": { "message": "Se cerró el contexto en segundo plano en $1 porque $2." },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick rechazó la solicitud sin pestaña" },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "Carte $1 réclamée depuis le défi $2"
   },
+  "activityAuthHealthChanged": { "message": "L’authentification de $1 est passée de $2 à $3." },
   "activityPageContextOpened": { "message": "Un contexte en arrière-plan a été ouvert sur $1 car $2." },
   "activityPageContextClosed": { "message": "Le contexte en arrière-plan sur $1 a été fermé car $2." },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick a refusé la requête sans onglet" },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "$2 चैलेंज से $1 कार्ड प्राप्त किया"
   },
+  "activityAuthHealthChanged": { "message": "$1 प्रमाणीकरण $2 से $3 में बदल गया।" },
   "activityPageContextOpened": { "message": "$1 पर बैकग्राउंड कॉन्टेक्स्ट खोला गया क्योंकि $2।" },
   "activityPageContextClosed": { "message": "$1 का बैकग्राउंड कॉन्टेक्स्ट बंद किया गया क्योंकि $2।" },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick ने बिना टैब वाला अनुरोध अस्वीकार किया" },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "Riscattata una carta $1 dalla sfida $2"
   },
+  "activityAuthHealthChanged": { "message": "L’autenticazione di $1 è passata da $2 a $3." },
   "activityPageContextOpened": { "message": "È stato aperto un contesto in background su $1 perché $2." },
   "activityPageContextClosed": { "message": "Il contesto in background su $1 è stato chiuso perché $2." },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick ha rifiutato la richiesta senza scheda" },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "Carta $1 resgatada do desafio $2"
   },
+  "activityAuthHealthChanged": { "message": "A autenticação da $1 mudou de $2 para $3." },
   "activityPageContextOpened": { "message": "Um contexto em segundo plano foi aberto em $1 porque $2." },
   "activityPageContextClosed": { "message": "O contexto em segundo plano em $1 foi fechado porque $2." },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "a Kick rejeitou a solicitação sem aba" },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "Получена карта $1 за испытание $2"
   },
+  "activityAuthHealthChanged": { "message": "Состояние аутентификации $1 изменилось с $2 на $3." },
   "activityPageContextOpened": { "message": "Фоновый контекст на $1 открыт, потому что $2." },
   "activityPageContextClosed": { "message": "Фоновый контекст на $1 закрыт, потому что $2." },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick отклонил запрос без вкладки" },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -779,6 +779,7 @@
   "activityChallengeClaimed": {
     "message": "$2 mücadelesinden $1 kartı talep edildi"
   },
+  "activityAuthHealthChanged": { "message": "$1 kimlik doğrulaması $2 durumundan $3 durumuna geçti." },
   "activityPageContextOpened": {
     "message": "$1 üzerinde bir arka plan içeriği açıldı çünkü $2."
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -733,6 +733,7 @@
   "activityChallengeClaimed": {
     "message": "已领取 $2 挑战的 $1 卡片"
   },
+  "activityAuthHealthChanged": { "message": "$1 的身份验证状态从 $2 变为 $3。" },
   "activityPageContextOpened": { "message": "已在 $1 打开后台上下文，因为$2。" },
   "activityPageContextClosed": { "message": "已关闭 $1 的后台上下文，因为$2。" },
   "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick 拒绝了无标签页请求" },

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -175,6 +175,8 @@ function formatCurrentActivity(event: StoredEngineEvent & { category: "activity"
       return t("activityPageContextOpened", [event.data.host, formatPageContextOpenReason(event.data.reason, t)]);
     case "page_context_closed":
       return t("activityPageContextClosed", [event.data.host, formatPageContextCloseReason(event.data.reason, t)]);
+    case "auth_health_changed":
+      return t("activityInterruption", event.data.to);
     default: {
       const exhaustive: never = event;
       return exhaustive;

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -176,7 +176,7 @@ function formatCurrentActivity(event: StoredEngineEvent & { category: "activity"
     case "page_context_closed":
       return t("activityPageContextClosed", [event.data.host, formatPageContextCloseReason(event.data.reason, t)]);
     case "auth_health_changed":
-      return t("activityInterruption", event.data.to);
+      return t("activityAuthHealthChanged", [event.platform, event.data.from, event.data.to]);
     default: {
       const exhaustive: never = event;
       return exhaustive;

--- a/packages/popup-ui/src/demo.ts
+++ b/packages/popup-ui/src/demo.ts
@@ -204,6 +204,10 @@ function demoSnapshot(): RuntimeSnapshot {
   return {
     settings,
     state: {
+      authHealth: {
+        twitch: { status: "healthy", checkedAt: new Date().toISOString() },
+        kick: { status: "healthy", checkedAt: new Date().toISOString() },
+      },
       sessions: {
         twitch: {
           platform: "twitch",

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -1,5 +1,5 @@
 import type { LogLevel } from "./logging";
-import type { Platform } from "./models";
+import type { Platform, PlatformAuthReasonCode, PlatformAuthStatus } from "./models";
 
 export type FarmingStopReason =
   | "automation_disabled"
@@ -43,7 +43,8 @@ export type ActivityEvent =
   | { category: "activity"; code: "interruption"; level: "warn" | "error"; platform?: Platform; message?: never; data: { reason: FarmingStopReason; detail?: string } }
   | { category: "activity"; code: "challenge_claimed"; level: "info"; platform: Platform; message?: never; data: { challengeId: string; rarity: string; recurrence: string } }
   | { category: "activity"; code: "page_context_opened"; level: "info"; platform: Platform; message?: never; data: { host: string; reason: PageContextOpenReason } }
-  | { category: "activity"; code: "page_context_closed"; level: "info"; platform: Platform; message?: never; data: { host: string; reason: PageContextCloseReason } };
+  | { category: "activity"; code: "page_context_closed"; level: "info"; platform: Platform; message?: never; data: { host: string; reason: PageContextCloseReason } }
+  | { category: "activity"; code: "auth_health_changed"; level: "info" | "warn" | "error"; platform: Platform; message?: never; data: { from: PlatformAuthStatus; to: PlatformAuthStatus; reason?: PlatformAuthReasonCode } };
 
 export type DiagnosticEvent = {
   category: "diagnostic";

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1,5 +1,23 @@
 export type Platform = "twitch" | "kick";
 
+export type PlatformAuthStatus = "checking" | "healthy" | "missing_credentials" | "invalid_credentials" | "blocked" | "unavailable";
+
+export type PlatformAuthReasonCode = "credentials_missing" | "credentials_rejected" | "security_policy_blocked" | "credential_lookup_failed" | "platform_unavailable" | "network_unavailable";
+
+export type PlatformAuthMessageKey = "authChecking" | "authHealthy" | "authMissingCredentials" | "authInvalidCredentials" | "authSecurityPolicyBlocked" | "authCredentialLookupFailed" | "authPlatformUnavailable" | "authNetworkUnavailable";
+
+export interface PlatformAuthMessage {
+  key: PlatformAuthMessageKey;
+  values?: Partial<Record<"reference", string | number>>;
+}
+
+export interface PlatformAuthHealth {
+  status: PlatformAuthStatus;
+  checkedAt?: string;
+  reasonCode?: PlatformAuthReasonCode;
+  message?: PlatformAuthMessage;
+}
+
 export type CampaignStatus = "active" | "upcoming" | "expired" | "completed";
 
 export type RewardStatus = "locked" | "in_progress" | "claimable" | "claimed";
@@ -310,6 +328,7 @@ export interface ExtensionSettings extends EngineSettings {
 
 export interface SchedulerState {
   sessions: Record<Platform, WatchSession>;
+  authHealth: Record<Platform, PlatformAuthHealth>;
   managedWatchTabs?: Partial<Record<Platform, ManagedWatchTab>>;
   managedPageContextTabs?: Partial<Record<Platform, ManagedPageContextTab>>;
   manualWatch?: Partial<Record<Platform, ManualWatchState>>;


### PR DESCRIPTION
## Summary

- add safe shared authentication-health statuses, reason codes, message metadata, and per-platform scheduler state
- normalize persisted health through an allowlist and migrate existing state to an explicit `checking` default
- add browser-neutral adapter probes, pure state transitions, durable activity events, and a platform-only controller persistence boundary
- keep real cookie observation, Twitch/Kick probes, scheduler gating, and popup UX scoped to follow-up issues #201–#205

## Impact

This establishes the browser-free foundation needed to distinguish missing credentials, rejected sessions, security-policy blocks, and transient failures without storing or emitting secrets. Existing Twitch and Kick adapters remain in `checking` until their dedicated probe issues are implemented.

Closes #200
Part of #199

## Testing

- `pnpm verify`
- `pnpm test`
- focused authentication health, controller, event contract, storage migration, and core-boundary tests

`pnpm verify` passed with 685 extension tests, 105 CLI tests, all workspace typechecks, site checks, and Chromium/Firefox production builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-platform authentication health tracking for Twitch and Kick.
  * Added authentication health checks with safe status, reason, and troubleshooting details.
  * Added activity updates when authentication status meaningfully changes.
  * Added authentication health information to scheduler state and activity displays.

* **Bug Fixes**
  * Prevented credentials, headers, and untrusted metadata from being persisted or reported.
  * Preserved authentication health data when loading existing scheduler state.

* **Tests**
  * Added coverage for normalization, persistence, event behavior, defaults, and security boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->