### PR TITLE
feat(settings): add factory reset action

### DIFF
--- a/docs/superpowers/plans/2026-07-22-settings-factory-reset.md
+++ b/docs/superpowers/plans/2026-07-22-settings-factory-reset.md
@@ -1,0 +1,520 @@
+# Settings Factory Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a confirmed Settings action that stops Lurkloot, closes its managed tabs, removes all extension-owned data, restores defaults, and preserves Twitch/Kick login cookies.
+
+**Architecture:** The extension background owns a new `resetExtension` runtime action and coordinates a browser-free controller shutdown with browser-storage deletion. The controller exposes a host-reset lifecycle method that force-cleans managed resources; the popup exposes reset only when its adapter advertises the capability and replaces its snapshot from the background response.
+
+**Tech Stack:** TypeScript, React, WXT browser APIs, Vitest, pnpm workspaces, JSON locale catalogs.
+
+## Global Constraints
+
+- Work only in `.worktrees/settings-factory-reset` on `feat/settings-factory-reset`.
+- Preserve Twitch and Kick cookies; the reset flow must not call `browser.cookies`.
+- Clear all extension-owned `browser.storage.local` values and IndexedDB activity/diagnostic history.
+- Restore `withSchemaVersion(DEFAULT_SETTINGS)` and `DEFAULT_STATE` after the clear.
+- Close extension-managed watch and page-context tabs even when `autoCloseFinishedDrops` is `false`.
+- Keep browser deletion out of `@lurkloot/core`; the CLI must not gain a factory-reset command.
+- Hide reset in demo and store-screenshot modes.
+- Add every new message to every catalog in `packages/locales/messages/*.json`.
+- Follow two-space indentation, double quotes, semicolons, and explicit type imports.
+
+---
+
+### Task 1: Controller Host-Reset Lifecycle
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: existing `BackgroundControllerDeps`, scheduler state, adapter `stopWatchTab`, `stopPageContextTabs`, `closeManagedTabs`, claim-handoff aborts, and managed-page-context registration.
+- Produces: `prepareForHostReset(): Promise<void>` on the object returned by `createBackgroundController()`.
+
+- [ ] **Step 1: Write failing controller tests**
+
+Add focused tests beside the existing `setRunning(false)` coverage. Build active Twitch and Kick watch sessions, a managed page-context tab, a tabless watcher where supported by the harness, and set `autoCloseFinishedDrops: false`. Assert the new lifecycle is unconditional and idempotent:
+
+```ts
+it("prepares a host reset by stopping live work and force-closing managed tabs", async () => {
+  const env = harness({ ...DEFAULT_SETTINGS, running: true, autoCloseFinishedDrops: false });
+  await env.controller.tick();
+  env.state.managedPageContextTabs = {
+    twitch: {
+      platform: "twitch",
+      tabId: 66,
+      originUrl: "https://www.twitch.tv/drops/inventory",
+      origin: "https://www.twitch.tv",
+      ownedByExtension: true,
+    },
+  };
+
+  await env.controller.prepareForHostReset();
+
+  expect(env.twitch.stopWatchTab).toHaveBeenCalledWith(
+    expect.objectContaining({ tabId: 10 }),
+    expect.objectContaining({ closeManagedTabs: true }),
+  );
+  expect(env.kick.stopWatchTab).toHaveBeenCalledWith(
+    expect.objectContaining({ tabId: 20 }),
+    expect.objectContaining({ closeManagedTabs: true }),
+  );
+  expect(env.deps.stopPageContextTabs).toHaveBeenCalledWith(
+    expect.objectContaining({ twitch: expect.objectContaining({ tabId: 66 }) }),
+    expect.objectContaining({ platforms: ["twitch", "kick"] }),
+  );
+});
+
+it("allows host-reset cleanup to be retried", async () => {
+  const env = harness({ ...DEFAULT_SETTINGS, running: true });
+  await env.controller.tick();
+
+  await env.controller.prepareForHostReset();
+  await expect(env.controller.prepareForHostReset()).resolves.toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run the focused tests and confirm the red state**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+```
+
+Expected: FAIL because `prepareForHostReset` does not exist.
+
+- [ ] **Step 3: Implement the lifecycle method**
+
+In `createBackgroundController`, add a method that aborts handoffs, executes under `withStateLock`, loads settings/state, stops each in-memory tabless watcher, force-stops watch sessions using `{ closeManagedTabs: true }`, stops all registered page contexts, unregisters page contexts, clears the watcher map, resets cached integrity, and does not persist replacement settings/state (the extension storage coordinator owns that write). Reuse existing scoped event-collector and best-effort event reporting patterns.
+
+The public shape must be:
+
+```ts
+async function prepareForHostReset(): Promise<void> {
+  abortClaimHandoffs();
+  await withStateLock(() => withEventCollector(async (emit, events) => {
+    const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+    const adapters = createAdapters(settings, emit);
+    for (const platform of PLATFORMS) {
+      const watcher = tablessWatchers.get(platform);
+      if (watcher) await watcher.stop();
+      await adapters[platform].stopWatchTab(state.sessions[platform], { closeManagedTabs: true }, emit);
+    }
+    if (deps.stopPageContextTabs) {
+      await deps.stopPageContextTabs(state.managedPageContextTabs ?? {}, {
+        platforms: PLATFORMS,
+        reason: "automation_disabled",
+        emit,
+      });
+    }
+    tablessWatchers.clear();
+    registerManagedPageContextTabs({});
+    lastIntegrityToken = undefined;
+    setTwitchIntegrity(undefined);
+    await reportBestEffort(events);
+  }));
+}
+```
+
+Adapt calls to the exact existing `TablessWatchController.stop`, adapter `stopWatchTab`, and `setTwitchIntegrity` signatures rather than adding duplicate cleanup APIs. Export `prepareForHostReset` in the returned controller object.
+
+- [ ] **Step 4: Run controller tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+pnpm --filter @lurkloot/core typecheck
+```
+
+Expected: focused tests PASS and core typecheck exits 0.
+
+- [ ] **Step 5: Commit the lifecycle boundary**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(core): add host reset cleanup lifecycle"
+```
+
+### Task 2: Extension Storage and Runtime Coordinator
+
+**Files:**
+- Modify: `packages/shared/src/messages.ts`
+- Modify: `packages/extension/src/core/storage.ts`
+- Modify: `packages/extension/src/core/activityMessages.ts`
+- Modify: `packages/extension/entrypoints/background.ts`
+- Test: `packages/extension/tests/storageMigration.test.ts`
+- Test: `packages/extension/tests/storageSettingsMigration.test.ts`
+- Test: `packages/extension/tests/activityMessages.test.ts`
+
+**Interfaces:**
+- Consumes: `controller.prepareForHostReset(): Promise<void>`, `resetStorage(): Promise<void>`, and `controller.handleMessage({ type: "getSnapshot" })`.
+- Produces: `{ type: "resetExtension" }` in `RuntimeMessage`; `resetExtension(): Promise<RuntimeSnapshot>` dispatcher dependency; a reset response containing canonical defaults.
+
+- [ ] **Step 1: Write failing storage reset tests**
+
+Extend storage mocks with `clear` and make it delete every mocked key. Replace the existing best-effort activity failure expectation with strict, retryable failure behavior:
+
+```ts
+it("clears every local key before restoring canonical defaults", async () => {
+  mocks.values.settings = { running: true };
+  mocks.values.schedulerState = { ...DEFAULT_STATE, lastTickAt: "2026-07-22T12:00:00.000Z" };
+  mocks.values.twitchIntegrity = { integrity: "secret" };
+  mocks.values["popup:selectedPlatform"] = "kick";
+  mocks.values["future:extension-owned-key"] = true;
+
+  await resetStorage();
+
+  expect(mocks.clear).toHaveBeenCalledOnce();
+  expect(Object.keys(mocks.values).sort()).toEqual(["schedulerState", "settings"]);
+  expect(mocks.values.schedulerState).toEqual(DEFAULT_STATE);
+  expect(mocks.values.settings).toEqual(withSchemaVersion(DEFAULT_SETTINGS));
+});
+
+it("reports activity reset failure and succeeds when retried", async () => {
+  mocks.clearActivityEvents
+    .mockRejectedValueOnce(new Error("IDB unavailable"))
+    .mockResolvedValueOnce(undefined);
+
+  await expect(resetStorage()).rejects.toThrow("IDB unavailable");
+  await expect(resetStorage()).resolves.toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run storage tests and confirm failure**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- storageMigration.test.ts storageSettingsMigration.test.ts
+```
+
+Expected: FAIL because storage is not cleared wholesale and activity failures are swallowed.
+
+- [ ] **Step 3: Make resetStorage authoritative and serialized**
+
+Update the WXT storage mock shape in both test files. Change `resetStorage` so it holds both existing locks, calls `browser.storage.local.clear()`, then writes both canonical documents in one `set`. Call `clearActivityEvents()` without swallowing rejection:
+
+```ts
+export async function resetStorage(): Promise<void> {
+  await withSettingsStorageLock(async () => {
+    await withStateStorageLock(async () => {
+      await browser.storage.local.clear();
+      await browser.storage.local.set({
+        [SETTINGS_KEY]: withSchemaVersion(DEFAULT_SETTINGS),
+        [STATE_KEY]: DEFAULT_STATE,
+      });
+    });
+  });
+  await clearActivityEvents();
+}
+```
+
+- [ ] **Step 4: Write failing dispatcher tests**
+
+Extend the dispatcher harness with `resetExtension: vi.fn()` and assert exact routing:
+
+```ts
+it("routes factory reset to the extension coordinator", async () => {
+  const resetExtension = vi.fn(async () => ({ settings: DEFAULT_SETTINGS, state: DEFAULT_STATE }));
+  const dispatch = createRuntimeMessageDispatcher({
+    exportCliCredentials: vi.fn(),
+    resetExtension,
+    handleActivityMessage: vi.fn(),
+    handleCoreMessage: vi.fn(),
+  });
+
+  await dispatch({ type: "resetExtension" });
+
+  expect(resetExtension).toHaveBeenCalledOnce();
+});
+```
+
+- [ ] **Step 5: Add the runtime action and coordinator**
+
+Add `{ type: "resetExtension" }` to `RuntimeMessage`, not `CoreRuntimeMessage`. Extend `RuntimeMessageDispatcherDeps` and route it before activity/core messages:
+
+```ts
+interface RuntimeMessageDispatcherDeps {
+  exportCliCredentials(): Promise<unknown>;
+  resetExtension(): Promise<unknown>;
+  handleActivityMessage(message: RuntimeMessage): Promise<unknown>;
+  handleCoreMessage(message: CoreRuntimeMessage, sender?: RuntimeMessageSender): Promise<unknown>;
+}
+
+if (message.type === "resetExtension") return deps.resetExtension();
+```
+
+In `background.ts`, import `resetStorage` and provide a serialized coordinator:
+
+```ts
+let resetMutation: Promise<RuntimeSnapshot<ExtensionSettings>> | undefined;
+
+function resetExtension(): Promise<RuntimeSnapshot<ExtensionSettings>> {
+  if (resetMutation) return resetMutation;
+  resetMutation = (async () => {
+    await controller.prepareForHostReset();
+    await resetStorage();
+    return controller.handleMessage({ type: "getSnapshot" }) as Promise<RuntimeSnapshot<ExtensionSettings>>;
+  })().finally(() => {
+    resetMutation = undefined;
+  });
+  return resetMutation;
+}
+```
+
+Use a typed helper instead of an unsafe cast if controller inference permits it. Pass `resetExtension` into `createRuntimeMessageDispatcher`. Do not touch `browser.cookies`.
+
+- [ ] **Step 6: Run storage, dispatcher, boundary, and type tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- storageMigration.test.ts storageSettingsMigration.test.ts activityMessages.test.ts coreBoundary.test.ts
+pnpm typecheck
+```
+
+Expected: all selected tests PASS and all workspace typechecks exit 0.
+
+- [ ] **Step 7: Commit background reset coordination**
+
+```bash
+git add packages/shared/src/messages.ts packages/extension/src/core/storage.ts packages/extension/src/core/activityMessages.ts packages/extension/entrypoints/background.ts packages/extension/tests/storageMigration.test.ts packages/extension/tests/storageSettingsMigration.test.ts packages/extension/tests/activityMessages.test.ts
+git commit -m "feat(extension): coordinate factory reset"
+```
+
+### Task 3: Confirmed Settings Action and Localization
+
+**Files:**
+- Modify: `packages/popup-ui/src/types.ts`
+- Modify: `packages/popup-ui/src/settings.tsx`
+- Modify: `packages/popup-ui/src/Popup.tsx`
+- Modify: `packages/extension/entrypoints/popup/app.tsx`
+- Modify: `packages/locales/messages/*.json`
+- Test: `packages/extension/tests/settingsFactoryReset.test.tsx`
+- Test: `packages/extension/tests/settingsView.test.tsx`
+
+**Interfaces:**
+- Consumes: adapter `send<RuntimeSnapshot>({ type: "resetExtension" })` and the snapshot returned by Task 2.
+- Produces: optional `PopupAdapter.resetExtension(): Promise<RuntimeSnapshot>` capability; `SettingsView` props `onReset?: () => Promise<void>` and `resetConfirmationResetKey: number`.
+
+- [ ] **Step 1: Write failing Settings action tests**
+
+Create `settingsFactoryReset.test.tsx` using the existing LinkeDOM/React test setup from `settingsCredentialExport.test.tsx`. Cover hidden capability, arm/cancel, one in-flight request, success, and failure:
+
+```tsx
+it("requires confirmation and blocks duplicate reset requests", async () => {
+  let finish!: () => void;
+  const onReset = vi.fn(() => new Promise<void>((resolve) => { finish = resolve; }));
+  const view = renderSettings({ onReset });
+
+  click(view.getByText("Reset Lurkloot"));
+  expect(onReset).not.toHaveBeenCalled();
+  click(view.getByText("Reset everything"));
+  click(view.getByText("Resetting…"));
+  expect(onReset).toHaveBeenCalledOnce();
+
+  finish();
+  await act(async () => undefined);
+});
+
+it("shows a retryable alert when reset fails", async () => {
+  const onReset = vi.fn()
+    .mockRejectedValueOnce(new Error("reset failed"))
+    .mockResolvedValueOnce(undefined);
+  const view = renderSettings({ onReset });
+
+  click(view.getByText("Reset Lurkloot"));
+  click(view.getByText("Reset everything"));
+  await act(async () => undefined);
+
+  expect(view.getByRole("alert").textContent).toContain("couldn't reset");
+  click(view.getByText("Try reset again"));
+  await act(async () => undefined);
+  expect(onReset).toHaveBeenCalledTimes(2);
+});
+```
+
+Add a popup-level test using a capable adapter. Assert the reset response replaces settings, Settings closes, and a second click while pending sends only one runtime request.
+
+- [ ] **Step 2: Run popup tests and confirm failure**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- settingsFactoryReset.test.tsx settingsView.test.tsx
+```
+
+Expected: FAIL because reset capability and UI do not exist.
+
+- [ ] **Step 3: Add adapter capability and popup state transition**
+
+In `PopupAdapter`, add:
+
+```ts
+resetExtension?(): Promise<RuntimeSnapshot>;
+```
+
+In the live extension adapter, implement it using runtime messaging:
+
+```ts
+resetExtension: () => browser.runtime.sendMessage({ type: "resetExtension" }),
+```
+
+In `Popup`, create the handler only when capability exists:
+
+```ts
+const resetExtension = adapter.resetExtension
+  ? async () => {
+      await settingsSaveQueue.current.catch(() => undefined);
+      const nextSnapshot = await adapter.resetExtension!();
+      settingsRef.current = mergeSettings(nextSnapshot.settings);
+      invalidateActivityRequests("twitch");
+      setActivityStream(createActivityStream());
+      setDiagnosticStream(createActivityStream());
+      setPlatform("twitch");
+      setTab("drops");
+      setPendingChangelogVersion(undefined);
+      setSnapshot(snapshotWithMergedSettings(nextSnapshot));
+      setSettingsOpen(false);
+    }
+  : undefined;
+```
+
+Pass it to `SettingsView`. Do not add it to `createDemoPopupAdapter`.
+
+- [ ] **Step 4: Implement the inline danger area**
+
+Add `resetArmed`, `resetting`, and `resetFailed` state to `SettingsView`, reset them when `resetConfirmationResetKey` changes, and render the action only when `onReset` exists and search is inactive. Follow the credential-export visual pattern, but use red styling only for the final destructive button:
+
+```tsx
+{onReset && !searching ? (
+  <div className="pt-2">
+    <div className="mb-1 flex items-center gap-1.5 px-1">
+      <span className="text-[10px] font-semibold uppercase tracking-wide text-red-500">{t("factoryResetTitle")}</span>
+      <span className="h-px flex-1 bg-red-100 dark:bg-red-950" />
+    </div>
+    {resetArmed ? (
+      <div className="space-y-2 px-1 py-1">
+        <p className="text-xs leading-relaxed text-zinc-600 dark:text-zinc-300">{t("factoryResetConfirm")}</p>
+        {resetFailed ? <p role="alert" className="text-xs text-red-600">{t("factoryResetFailed")}</p> : null}
+        <div className="flex justify-end gap-2">
+          <button type="button" disabled={resetting} onClick={() => setResetArmed(false)}>{t("factoryResetCancel")}</button>
+          <button type="button" disabled={resetting} onClick={() => void confirmReset()}>
+            {t(resetting ? "factoryResetProgress" : resetFailed ? "factoryResetRetry" : "factoryResetConfirmButton")}
+          </button>
+        </div>
+      </div>
+    ) : (
+      <div className="space-y-2 px-1 pb-1">
+        <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("factoryResetHint")}</p>
+        <div className="flex justify-end">
+          <button type="button" onClick={() => setResetArmed(true)}>{t("factoryResetButton")}</button>
+        </div>
+      </div>
+    )}
+  </div>
+) : null}
+```
+
+Apply the repository's complete existing button classes and add a `RotateCcw` icon; the abbreviated markup above defines behavior and copy keys, not permission to omit accessibility or focus styles.
+
+- [ ] **Step 5: Add English copy and propagate all locale keys**
+
+Add these keys to `packages/locales/messages/en.json` with complete descriptions:
+
+```json
+"factoryResetTitle": { "message": "Reset Lurkloot", "description": "Heading for the destructive factory reset action" },
+"factoryResetHint": { "message": "Erase all Lurkloot settings, farming progress, and activity history. Your Twitch and Kick accounts stay signed in.", "description": "Factory reset scope explanation" },
+"factoryResetButton": { "message": "Reset Lurkloot", "description": "Button that opens factory reset confirmation" },
+"factoryResetConfirm": { "message": "This stops farming, closes tabs opened by Lurkloot, and permanently erases all Lurkloot data. Twitch and Kick stay signed in.", "description": "Factory reset confirmation warning" },
+"factoryResetCancel": { "message": "Cancel", "description": "Cancels factory reset confirmation" },
+"factoryResetConfirmButton": { "message": "Reset everything", "description": "Final factory reset confirmation button" },
+"factoryResetProgress": { "message": "Resetting…", "description": "Factory reset in-progress label" },
+"factoryResetFailed": { "message": "Lurkloot couldn't reset completely. Try again.", "description": "Factory reset failure alert" },
+"factoryResetRetry": { "message": "Try reset again", "description": "Retries a failed factory reset" }
+```
+
+Add accurate translations for the same keys to every other JSON catalog, preserving valid JSON and each catalog's ordering convention.
+
+- [ ] **Step 6: Run popup and locale validation tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- settingsFactoryReset.test.tsx settingsView.test.tsx locales.test.ts
+pnpm --filter @lurkloot/popup-ui typecheck
+pnpm --filter @lurkloot/extension typecheck
+```
+
+Expected: all selected tests PASS and both typechecks exit 0.
+
+- [ ] **Step 7: Commit the Settings experience**
+
+```bash
+git add packages/popup-ui/src/types.ts packages/popup-ui/src/settings.tsx packages/popup-ui/src/Popup.tsx packages/extension/entrypoints/popup/app.tsx packages/locales/messages packages/extension/tests/settingsFactoryReset.test.tsx packages/extension/tests/settingsView.test.tsx
+git commit -m "feat(settings): add factory reset action"
+```
+
+### Task 4: Full Verification and Documentation Check
+
+**Files:**
+- Verify: `docs/superpowers/specs/2026-07-22-settings-factory-reset-design.md`
+- Verify: all files changed by Tasks 1–3
+
+**Interfaces:**
+- Consumes: complete reset lifecycle, storage coordinator, runtime route, popup capability, and localized UI.
+- Produces: a verified issue #208 implementation ready for code review.
+
+- [ ] **Step 1: Inspect scope and forbidden cookie access**
+
+Run:
+
+```bash
+git diff origin/develop...HEAD --stat
+git diff origin/develop...HEAD -- packages/extension packages/core packages/popup-ui packages/shared | rg "browser\.cookies|cookies\.remove|cookies\.set" || true
+git diff --check origin/develop...HEAD
+```
+
+Expected: only planned files plus specs/plans are changed; the cookie search prints no reset-path additions; diff check exits 0.
+
+- [ ] **Step 2: Run the complete test suite**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: all CLI, extension, and site tests PASS.
+
+- [ ] **Step 3: Run release-grade verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, all workspace typechecks, extension tests, site build, Chromium build, and Firefox build all exit 0.
+
+- [ ] **Step 4: Review the final diff and commit any verification-only corrections**
+
+Run:
+
+```bash
+git status --short
+git log --oneline origin/develop..HEAD
+git diff origin/develop...HEAD --check
+```
+
+If verification required a correction, commit only that focused correction:
+
+```bash
+git add -u
+git commit -m "fix(settings): harden factory reset"
+```
+
+Expected: clean worktree and a small Conventional Commit history containing the design, controller lifecycle, background coordinator, and Settings UI changes.

--- a/docs/superpowers/specs/2026-07-22-settings-factory-reset-design.md
+++ b/docs/superpowers/specs/2026-07-22-settings-factory-reset-design.md
@@ -1,0 +1,84 @@
+# Settings Factory Reset
+
+## Context
+
+Issue #208 asks for a Settings action that restores the browser extension to its defaults. The extension already has a tested `resetStorage()` helper, but nothing exposes it to the popup. The helper currently rewrites settings and scheduler state and clears activity history; it does not clear auxiliary extension-owned keys such as popup preferences, update notices, or cached Twitch integrity data, and it does not coordinate with live farming work.
+
+A factory reset must leave no Lurkloot-owned state or behavior behind. It must not modify Twitch or Kick cookies because those belong to the user's normal browser sessions rather than to Lurkloot.
+
+## Goals
+
+- Add a destructive action at the bottom of the extension Settings view.
+- Require an explicit inline confirmation before resetting.
+- Stop automation and close every farming or page-context tab managed by Lurkloot.
+- Remove all extension-owned local-storage data and activity history.
+- Restore canonical, schema-versioned default settings and default scheduler state.
+- Update the open popup immediately with the fresh default snapshot.
+- Preserve Twitch and Kick login cookies.
+- Make failures visible and retryable without claiming the reset succeeded.
+
+## Non-goals
+
+- Logging the user out of Twitch or Kick.
+- Clearing site cookies, cache, browsing history, or any other browser-owned data.
+- Adding reset behavior to the CLI.
+- Resetting browser extension permissions or uninstalling the extension.
+- Redesigning the rest of Settings.
+
+## Architecture
+
+The shared runtime-message contract will gain an extension-owned `resetExtension` message. The extension background dispatcher will handle it before delegating ordinary engine messages to the generic controller, following the existing pattern for activity and credential-export messages.
+
+Reset is coordinated in the background in this order:
+
+1. Ask the controller to prepare for a host reset. This aborts in-flight claim handoffs and stops tabless watchers, managed watch tabs, and managed page-context tabs. Reset cleanup always closes extension-managed tabs, independent of the user's `autoCloseFinishedDrops` preference.
+2. Clear all values in `browser.storage.local` while holding the existing settings and state mutation locks, then atomically write schema-versioned `DEFAULT_SETTINGS` and `DEFAULT_STATE`.
+3. Clear the IndexedDB activity repository.
+4. Clear controller-held transient state, including cached Twitch integrity and managed page-context registrations.
+5. Return a freshly loaded `RuntimeSnapshot` to the popup.
+
+Browser-specific deletion remains in `packages/extension`. The browser-free controller exposes only the lifecycle operation needed to stop its in-memory and managed resources; it does not know about browser storage, popup preferences, update notices, or cookies. Reset coordination is serialized so concurrent settings or scheduler writes cannot repopulate stale data after the reset.
+
+If activity-store clearing fails after operational storage has reset, the reset request rejects and the popup shows an error. Retrying is safe and idempotent. The canonical defaults remain written, while a retry can finish removing the remaining activity data.
+
+## Popup behavior
+
+The live extension adds a “Reset Lurkloot” danger area at the bottom of Settings. The site demo and store-screenshot modes omit it because their adapters do not expose reset capability.
+
+The first click arms an inline confirmation that explains what will be removed and explicitly says Twitch and Kick accounts remain signed in. The confirmation offers Cancel and Reset buttons. Confirming disables the controls and shows an in-progress label so duplicate requests cannot start.
+
+On success, the popup replaces its local snapshot and settings reference with the returned defaults, clears popup-only view state that may have survived in React memory, closes Settings, and shows the normal paused/default main view. The background storage clear naturally resets persisted popup preferences such as selected platform, collapsed sections, advanced-settings visibility, update notices, and install/rate-nudge timing.
+
+On failure, the popup keeps Settings open, disarms the confirmation, and presents a localized alert with a retryable reset button. It does not replace the current snapshot or claim that data was cleared.
+
+## Data scope
+
+The reset removes every value owned by the extension in `browser.storage.local`, including:
+
+- settings and settings-schema metadata;
+- scheduler state and farming progress;
+- cached Twitch integrity data;
+- selected platform and Settings presentation preferences;
+- pending changelog/update-notice state;
+- install-date and rate-nudge state stored with settings or scheduler state;
+- any legacy or future extension-owned local-storage keys.
+
+After clearing, only canonical default settings and scheduler state are written back. Activity and diagnostic history in IndexedDB are cleared separately. Twitch and Kick cookies are neither read nor written by this flow.
+
+## Localization and accessibility
+
+Every supported locale receives strings for the danger-area title, explanation, initial action, confirmation copy, cancel action, final confirmation, progress state, and failure alert. The confirmation is inline rather than a browser modal, matching the existing activity-clear and credential-export interaction patterns. Buttons remain keyboard reachable, focus rings use existing primitives/styles, the failure message uses `role="alert"`, and destructive styling is reserved for the final confirmed action.
+
+## Testing
+
+Storage tests will verify that reset clears arbitrary and known auxiliary local keys, clears activity data, and leaves only current-schema default settings plus default scheduler state. They will retain concurrency coverage so an in-flight migration or save cannot overwrite the reset. Failure tests will cover activity-store errors and safe retry behavior.
+
+Background tests will start from active Twitch and Kick sessions with managed watch and page-context tabs, including `autoCloseFinishedDrops: false`. They will prove that reset aborts live work, closes extension-managed tabs, clears transient controller state, invokes storage reset once, and returns the default snapshot. They will also prove that cookies are outside the reset path.
+
+Popup tests will verify the two-click confirmation, cancellation, duplicate-request blocking, progress state, immediate default snapshot on success, Settings closure, and retryable error behavior without optimistic data loss. Adapter capability tests will verify that the destructive action appears only in the live extension and is absent from the demo/site rendering.
+
+Locale-catalog validation will ensure every new message exists in every supported catalog. Focused tests will run during development, followed by `pnpm verify` from the isolated worktree.
+
+## Acceptance mapping
+
+The background-only coordinator ensures live automation is stopped before data disappears. Clearing all extension local storage plus activity IndexedDB satisfies “settings + data,” while rewriting canonical defaults gives the popup and future background wakes a valid initial state. The adapter capability boundary hides the action from non-extension hosts. Inline confirmation and explicit failure handling make the destructive operation deliberate and recoverable, and the cookie exclusion preserves normal platform login sessions.

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -678,6 +678,31 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     claimHandoffs.clear();
   }
 
+  async function prepareForHostReset(): Promise<void> {
+    abortClaimHandoffs();
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+      const adapters = createAdapters(settings, emit);
+      for (const platform of PLATFORMS) {
+        const watcher = tablessWatchers.get(platform);
+        if (watcher) await watcher.stop();
+        await adapters[platform].stopWatchTab?.(state.sessions[platform], { closeManagedTabs: true });
+      }
+      if (deps.stopPageContextTabs) {
+        await deps.stopPageContextTabs(state.managedPageContextTabs ?? {}, {
+          platforms: PLATFORMS,
+          reason: "automation_disabled",
+          emit,
+        });
+      }
+      tablessWatchers.clear();
+      registerManagedPageContextTabs({});
+      lastIntegrityToken = undefined;
+      setTwitchIntegrity(undefined);
+      await reportBestEffort(events);
+    }));
+  }
+
   // Bounded post-claim handoff (see docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md).
   // Re-runs a scoped tick on the configured cadence until the platform lands on
   // a reward other than the ones just claimed, then hands off to the immediate
@@ -1195,6 +1220,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     runWatchHeartbeat,
     runClaimHandoff,
     abortClaimHandoffs,
+    prepareForHostReset,
   };
 }
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -248,22 +248,24 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   void loadStoredTwitchIntegrity();
 
   async function loadStoredTwitchIntegrity(): Promise<void> {
-    try {
-      const integrity = await deps.loadTwitchIntegrity?.();
-      if (integrity && integrity.expiresAt > Date.now()) {
-        lastIntegrityToken = integrity.integrity;
-        setTwitchIntegrity(integrity);
+    await withStateLock(async () => {
+      try {
+        const integrity = await deps.loadTwitchIntegrity?.();
+        if (integrity && integrity.expiresAt > Date.now()) {
+          lastIntegrityToken = integrity.integrity;
+          setTwitchIntegrity(integrity);
+        }
+      } catch (error) {
+        // A missing/corrupt stored token is non-fatal: fresh page traffic will
+        // re-capture one, and claims simply stay best-effort until then.
+        await reportBestEffort([{
+          category: "diagnostic",
+          level: "debug",
+          platform: "twitch",
+          message: `No stored Twitch integrity token to prime (${error instanceof Error ? error.message : String(error)})`,
+        }]);
       }
-    } catch (error) {
-      // A missing/corrupt stored token is non-fatal: fresh page traffic will
-      // re-capture one, and claims simply stay best-effort until then.
-      await reportBestEffort([{
-        category: "diagnostic",
-        level: "debug",
-        platform: "twitch",
-        message: `No stored Twitch integrity token to prime (${error instanceof Error ? error.message : String(error)})`,
-      }]);
-    }
+    });
   }
 
   // Fed by the background's webRequest listener with the outgoing headers of
@@ -678,14 +680,17 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     claimHandoffs.clear();
   }
 
-  async function prepareForHostReset(): Promise<void> {
+  async function prepareForHostReset(resetHostStorage?: () => Promise<void>): Promise<void> {
     abortClaimHandoffs();
-    await withStateLock(() => withEventCollector(async (emit, events) => {
+    await withSettingsLock(() => withStateLock(() => withEventCollector(async (emit, events) => {
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
       const adapters = createAdapters(settings, emit);
+      const managedTabs = Object.values(state.managedWatchTabs ?? {}).filter((tab): tab is ManagedWatchTab => tab?.ownedByExtension === true);
+      if (deps.closeManagedTabs && managedTabs.length > 0) await deps.closeManagedTabs(managedTabs);
       for (const platform of PLATFORMS) {
         const watcher = tablessWatchers.get(platform);
         if (watcher) await watcher.stop();
+        await deps.applyAdFocus?.(platform, state.sessions[platform].tabId, false, emit);
         await adapters[platform].stopWatchTab?.(state.sessions[platform], { closeManagedTabs: true });
       }
       if (deps.stopPageContextTabs) {
@@ -699,8 +704,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       registerManagedPageContextTabs({});
       lastIntegrityToken = undefined;
       setTwitchIntegrity(undefined);
+      await resetHostStorage?.();
       await reportBestEffort(events);
-    }));
+    })));
   }
 
   // Bounded post-claim handoff (see docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md).

--- a/packages/core/src/platforms/kick/claim/v2.ts
+++ b/packages/core/src/platforms/kick/claim/v2.ts
@@ -27,6 +27,10 @@ export class KickClaimState {
       if (key.startsWith(prefix)) this.#suppressions.delete(key);
     }
   }
+
+  clear(): void {
+    this.#suppressions.clear();
+  }
 }
 
 export class KickClaimV2 implements KickClaimCapability {

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -1,6 +1,6 @@
 import { browser } from "wxt/browser";
-import { loadSettings, loadState, loadTwitchIntegrity, saveSettings, saveState, saveTwitchIntegrity } from "../src/core/storage";
-import type { CliCredentialBlob, RuntimeMessage } from "@lurkloot/shared/messages";
+import { loadSettings, loadState, loadTwitchIntegrity, resetStorage, saveSettings, saveState, saveTwitchIntegrity } from "../src/core/storage";
+import type { CliCredentialBlob, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import {
   applyAdFocus,
   ensureTwitchIntegrity,
@@ -175,10 +175,25 @@ async function buildCliCredentialBlob(): Promise<CliCredentialBlob> {
   };
 }
 
+let resetMutation: Promise<RuntimeSnapshot<ExtensionSettings>> | undefined;
+
+function resetExtension(): Promise<RuntimeSnapshot<ExtensionSettings>> {
+  if (resetMutation) return resetMutation;
+  resetMutation = (async () => {
+    await controller.prepareForHostReset();
+    await resetStorage();
+    return await controller.handleMessage({ type: "getSnapshot" }) as RuntimeSnapshot<ExtensionSettings>;
+  })().finally(() => {
+    resetMutation = undefined;
+  });
+  return resetMutation;
+}
+
 // Credential export reads the user's live session cookies, which only the
 // extension can do. Keep it ahead of activity routing and core delegation.
 const dispatchRuntimeMessage = createRuntimeMessageDispatcher({
   exportCliCredentials: buildCliCredentialBlob,
+  resetExtension,
   handleActivityMessage,
   handleCoreMessage: (message, sender) => controller.handleMessage(message, sender),
 });

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -180,8 +180,10 @@ let resetMutation: Promise<RuntimeSnapshot<ExtensionSettings>> | undefined;
 function resetExtension(): Promise<RuntimeSnapshot<ExtensionSettings>> {
   if (resetMutation) return resetMutation;
   resetMutation = (async () => {
-    await controller.prepareForHostReset();
-    await resetStorage();
+    await controller.prepareForHostReset(async () => {
+      kickClaimState.clear();
+      await resetStorage();
+    });
     return await controller.handleMessage({ type: "getSnapshot" }) as RuntimeSnapshot<ExtensionSettings>;
   })().finally(() => {
     resetMutation = undefined;

--- a/packages/extension/entrypoints/popup/app.tsx
+++ b/packages/extension/entrypoints/popup/app.tsx
@@ -56,6 +56,7 @@ export function createExtensionPopupAdapter(): PopupAdapter {
       anchor.click();
       setTimeout(() => URL.revokeObjectURL(url), 0);
     },
+    resetExtension: () => browser.runtime.sendMessage({ type: "resetExtension" }),
     compatibilityRegistry: COMPATIBILITY_REGISTRY,
     resolveCompatibility: (settings) => resolveCompatibility(settings, { host: "extension", twitchIdentity: "web" }),
   };

--- a/packages/extension/src/core/activityMessages.ts
+++ b/packages/extension/src/core/activityMessages.ts
@@ -17,6 +17,7 @@ interface RuntimeMessageSender {
 
 interface RuntimeMessageDispatcherDeps {
   exportCliCredentials(): Promise<unknown>;
+  resetExtension(): Promise<unknown>;
   handleActivityMessage(message: RuntimeMessage): Promise<unknown>;
   handleCoreMessage(message: CoreRuntimeMessage, sender?: RuntimeMessageSender): Promise<unknown>;
 }
@@ -53,6 +54,7 @@ export function createActivityEventReporter(deps: ActivityEventReporterDeps) {
 export function createRuntimeMessageDispatcher(deps: RuntimeMessageDispatcherDeps) {
   return (message: RuntimeMessage, sender?: RuntimeMessageSender): Promise<unknown> => {
     if (message.type === "exportCliCredentials") return deps.exportCliCredentials();
+    if (message.type === "resetExtension") return deps.resetExtension();
     if (message.type === "getActivity" || message.type === "clearActivity") {
       return deps.handleActivityMessage(message);
     }

--- a/packages/extension/src/core/storage.ts
+++ b/packages/extension/src/core/storage.ts
@@ -115,21 +115,14 @@ export async function saveTwitchIntegrity(value: TwitchIntegrity): Promise<void>
 }
 
 export async function resetStorage(): Promise<void> {
-  // Both keys are reset in one atomic write, so a reset never lands halfway.
-  // Both locks are held because the write touches both keys; nothing else ever
-  // acquires them in the opposite order, so the nesting cannot deadlock.
   await withSettingsStorageLock(async () => {
     await withStateStorageLock(async () => {
+      await browser.storage.local.clear();
       await browser.storage.local.set({
         [SETTINGS_KEY]: withSchemaVersion(DEFAULT_SETTINGS),
         [STATE_KEY]: DEFAULT_STATE,
       });
     });
   });
-  try {
-    await clearActivityEvents();
-  } catch {
-    // Resetting operational state still succeeds if activity storage is
-    // unavailable or has already been removed by the browser.
-  }
+  await clearActivityEvents();
 }

--- a/packages/extension/tests/activityMessages.test.ts
+++ b/packages/extension/tests/activityMessages.test.ts
@@ -107,14 +107,17 @@ describe("activity event reporting", () => {
 describe("runtime message dispatch", () => {
   function setup() {
     const exportCliCredentials = vi.fn(async () => "credentials");
+    const resetExtension = vi.fn(async () => "reset");
     const handleActivityMessage = vi.fn(async () => "activity");
     const handleCoreMessage = vi.fn(async () => "core");
     return {
       exportCliCredentials,
+      resetExtension,
       handleActivityMessage,
       handleCoreMessage,
       dispatch: createRuntimeMessageDispatcher({
         exportCliCredentials,
+        resetExtension,
         handleActivityMessage,
         handleCoreMessage,
       }),
@@ -127,6 +130,16 @@ describe("runtime message dispatch", () => {
     await expect(env.dispatch({ type: "exportCliCredentials" })).resolves.toBe("credentials");
 
     expect(env.exportCliCredentials).toHaveBeenCalledOnce();
+    expect(env.handleActivityMessage).not.toHaveBeenCalled();
+    expect(env.handleCoreMessage).not.toHaveBeenCalled();
+  });
+
+  it("routes factory reset to the extension coordinator", async () => {
+    const env = setup();
+
+    await expect(env.dispatch({ type: "resetExtension" })).resolves.toBe("reset");
+
+    expect(env.resetExtension).toHaveBeenCalledOnce();
     expect(env.handleActivityMessage).not.toHaveBeenCalled();
     expect(env.handleCoreMessage).not.toHaveBeenCalled();
   });

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -438,9 +438,14 @@ describe("KickAdapter", () => {
 
     expect(claimPosts).toBe(1);
 
-    await new KickAdapter(fetcher, undefined, undefined, undefined, { claimState: new KickClaimState() }).claimReward(campaign, reward);
+    state.clear();
+    await new KickAdapter(fetcher, undefined, undefined, undefined, { claimState: state }).claimReward(campaign, reward);
 
     expect(claimPosts).toBe(2);
+
+    await new KickAdapter(fetcher, undefined, undefined, undefined, { claimState: new KickClaimState() }).claimReward(campaign, reward);
+
+    expect(claimPosts).toBe(3);
   });
 
   it("keeps Kick claim v1 limited to campaign account-link metadata", () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -801,6 +801,44 @@ describe("background controller", () => {
     expect(snapshot.state.managedPageContextTabs?.twitch).toBeUndefined();
   });
 
+  it("prepares a host reset by force-closing managed tabs", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoCloseFinishedDrops: false });
+    await env.controller.tick();
+    env.state.managedPageContextTabs = {
+      twitch: {
+        platform: "twitch",
+        tabId: 66,
+        originUrl: "https://www.twitch.tv/drops/inventory",
+        origin: "https://www.twitch.tv",
+        ownedByExtension: true,
+      },
+    };
+
+    await env.controller.prepareForHostReset();
+
+    expect(env.twitch.stopWatchTab).toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: 10 }),
+      expect.objectContaining({ closeManagedTabs: true }),
+    );
+    expect(env.kick.stopWatchTab).toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: 20 }),
+      expect.objectContaining({ closeManagedTabs: true }),
+    );
+    expect(env.deps.stopPageContextTabs).toHaveBeenCalledWith(
+      expect.objectContaining({ twitch: expect.objectContaining({ tabId: 66 }) }),
+      expect.objectContaining({ platforms: ["twitch", "kick"], emit: expect.any(Function) }),
+    );
+  });
+
+  it("allows host-reset cleanup to be retried", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    await env.controller.tick();
+
+    await env.controller.prepareForHostReset();
+
+    await expect(env.controller.prepareForHostReset()).resolves.toBeUndefined();
+  });
+
   it("toggles one platform and immediately applies the scheduler when running", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true });
     await env.controller.tick();

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -839,6 +839,48 @@ describe("background controller", () => {
     await expect(env.controller.prepareForHostReset()).resolves.toBeUndefined();
   });
 
+  it("force-closes registry-owned tabs even when no live session references them", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    env.state.managedWatchTabs = {
+      twitch: {
+        platform: "twitch",
+        tabId: 71,
+        channelUrl: "https://www.twitch.tv/stale-channel",
+        ownedByExtension: true,
+      },
+    };
+
+    await env.controller.prepareForHostReset();
+
+    expect(env.deps.closeManagedTabs).toHaveBeenCalledWith([expect.objectContaining({ tabId: 71 })]);
+  });
+
+  it("holds controller mutations until host storage reset finishes", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    let releaseReset!: () => void;
+    const resetBlocked = new Promise<void>((resolve) => {
+      releaseReset = resolve;
+    });
+    const resetStarted = vi.fn();
+    const resetting = env.controller.prepareForHostReset(async () => {
+      resetStarted();
+      await resetBlocked;
+      await env.deps.saveSettings(DEFAULT_SETTINGS);
+      await env.deps.saveState(DEFAULT_STATE);
+    });
+    await vi.waitFor(() => expect(resetStarted).toHaveBeenCalledOnce());
+    vi.mocked(env.twitch.discoverCampaigns).mockClear();
+
+    const ticking = env.controller.tick();
+    await Promise.resolve();
+
+    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    releaseReset();
+    await Promise.all([resetting, ticking]);
+    expect(env.settings).toEqual(DEFAULT_SETTINGS);
+    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+  });
+
   it("toggles one platform and immediately applies the scheduler when running", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true });
     await env.controller.tick();

--- a/packages/extension/tests/settingsFactoryReset.test.tsx
+++ b/packages/extension/tests/settingsFactoryReset.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Popup, createDemoPopupAdapter, screenshotVariant, type PopupAdapter } from "@lurkloot/popup-ui";
+import type { RuntimeSnapshot } from "@lurkloot/shared/messages";
+import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
+
+const labels: Record<string, string> = {
+  openSettings: "Open settings",
+  back: "Back",
+  settingsSearchPlaceholder: "Search settings…",
+  settingsShowAdvancedTitle: "Show advanced settings",
+  factoryResetTitle: "Reset Lurkloot",
+  factoryResetHint: "Erase all Lurkloot data. Your accounts stay signed in.",
+  factoryResetButton: "Reset Lurkloot",
+  factoryResetConfirm: "This permanently erases all Lurkloot data.",
+  factoryResetCancel: "Cancel",
+  factoryResetConfirmButton: "Reset everything",
+  factoryResetProgress: "Resetting…",
+  factoryResetFailed: "Lurkloot couldn't reset completely. Try again.",
+  factoryResetRetry: "Try reset again",
+};
+
+let root: Root | undefined;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+async function mount(resetExtension?: () => Promise<RuntimeSnapshot>) {
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => window.setTimeout(() => callback(Date.now()), 0));
+  vi.stubGlobal("cancelAnimationFrame", (handle: number) => window.clearTimeout(handle));
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr" }));
+  const container = document.getElementById("app")!;
+  const demoAdapter = createDemoPopupAdapter();
+  const adapter: PopupAdapter = {
+    ...demoAdapter,
+    getMessage: (key) => labels[key] ?? demoAdapter.getMessage(key),
+    resetExtension,
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} initialState={{ preview: true, variant: screenshotVariant("settings") }} />);
+    await Promise.resolve();
+  });
+  return { container };
+}
+
+function byText(container: Element, text: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find((item) => item.textContent?.includes(text));
+  if (!button) throw new Error(`Missing button: ${text}`);
+  return button as HTMLButtonElement;
+}
+
+describe("settings factory reset", () => {
+  it("is hidden when the host does not expose reset capability", async () => {
+    const { container } = await mount();
+
+    expect(container.textContent).not.toContain("Reset Lurkloot");
+  });
+
+  it("requires confirmation and blocks duplicate reset requests", async () => {
+    let finish!: (snapshot: RuntimeSnapshot) => void;
+    const resetExtension = vi.fn(() => new Promise<RuntimeSnapshot>((resolve) => { finish = resolve; }));
+    const { container } = await mount(resetExtension);
+
+    act(() => byText(container, "Reset Lurkloot").click());
+    expect(resetExtension).not.toHaveBeenCalled();
+
+    await act(async () => {
+      byText(container, "Reset everything").click();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Resetting…");
+    act(() => byText(container, "Resetting…").click());
+    expect(resetExtension).toHaveBeenCalledOnce();
+
+    await act(async () => finish(await createDemoPopupAdapter().send({ type: "getSnapshot" })));
+    expect(container.querySelector('button[aria-label="Open settings"]')).not.toBeNull();
+  });
+
+  it("shows a retryable alert when reset fails", async () => {
+    const freshSnapshot = await createDemoPopupAdapter().send<RuntimeSnapshot>({ type: "getSnapshot" });
+    const resetExtension = vi.fn()
+      .mockRejectedValueOnce(new Error("reset failed"))
+      .mockResolvedValueOnce({ ...freshSnapshot, settings: DEFAULT_SETTINGS });
+    const { container } = await mount(resetExtension);
+
+    act(() => byText(container, "Reset Lurkloot").click());
+    await act(async () => byText(container, "Reset everything").click());
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("couldn't reset");
+    await act(async () => byText(container, "Try reset again").click());
+    expect(resetExtension).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('button[aria-label="Open settings"]')).not.toBeNull();
+  });
+});

--- a/packages/extension/tests/storageMigration.test.ts
+++ b/packages/extension/tests/storageMigration.test.ts
@@ -7,13 +7,16 @@ const mocks = vi.hoisted(() => {
     values,
     get: vi.fn(async (key: string) => ({ [key]: values[key] })),
     set: vi.fn(async (items: Record<string, unknown>) => Object.assign(values, items)),
+    clear: vi.fn(async () => {
+      for (const key of Object.keys(values)) delete values[key];
+    }),
     clearActivityEvents: vi.fn(),
     importLegacyActivityEvents: vi.fn(),
   };
 });
 
 vi.mock("wxt/browser", () => ({
-  browser: { storage: { local: { get: mocks.get, set: mocks.set } } },
+  browser: { storage: { local: { get: mocks.get, set: mocks.set, clear: mocks.clear } } },
 }));
 
 vi.mock("../src/core/activityStorage", () => ({
@@ -23,6 +26,8 @@ vi.mock("../src/core/activityStorage", () => ({
 }));
 
 import { DEFAULT_STATE, loadState, resetStorage, saveState } from "../src/core/storage";
+import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
+import { withSchemaVersion } from "@lurkloot/shared/settingsSchema";
 
 const legacyEvents: LegacyEventLogEntry[] = [{
   id: "legacy-1",
@@ -37,6 +42,7 @@ describe("legacy activity migration", () => {
     for (const key of Object.keys(mocks.values)) delete mocks.values[key];
     mocks.get.mockClear();
     mocks.set.mockClear();
+    mocks.clear.mockClear();
     mocks.clearActivityEvents.mockReset();
     mocks.importLegacyActivityEvents.mockReset();
     mocks.values.schedulerState = { ...DEFAULT_STATE, events: legacyEvents };
@@ -110,9 +116,27 @@ describe("legacy activity migration", () => {
     expect(mocks.clearActivityEvents).toHaveBeenCalledOnce();
   });
 
-  it("keeps a successful operational reset when activity storage is unavailable", async () => {
-    mocks.clearActivityEvents.mockRejectedValueOnce(new Error("IDB unavailable"));
+  it("clears every local key before restoring canonical defaults", async () => {
+    mocks.values.settings = { running: true };
+    mocks.values.schedulerState = { ...DEFAULT_STATE, lastTickAt: "2026-07-22T12:00:00.000Z" };
+    mocks.values.twitchIntegrity = { integrity: "secret" };
+    mocks.values["popup:selectedPlatform"] = "kick";
+    mocks.values["future:extension-owned-key"] = true;
 
+    await resetStorage();
+
+    expect(mocks.clear).toHaveBeenCalledOnce();
+    expect(Object.keys(mocks.values).sort()).toEqual(["schedulerState", "settings"]);
+    expect(mocks.values.schedulerState).toEqual(DEFAULT_STATE);
+    expect(mocks.values.settings).toEqual(withSchemaVersion(DEFAULT_SETTINGS));
+  });
+
+  it("reports activity reset failure and succeeds when retried", async () => {
+    mocks.clearActivityEvents
+      .mockRejectedValueOnce(new Error("IDB unavailable"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(resetStorage()).rejects.toThrow("IDB unavailable");
     await expect(resetStorage()).resolves.toBeUndefined();
 
     expect(mocks.values.schedulerState).toEqual(DEFAULT_STATE);

--- a/packages/extension/tests/storageSettingsMigration.test.ts
+++ b/packages/extension/tests/storageSettingsMigration.test.ts
@@ -1,14 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { get, set } = vi.hoisted(() => ({
+const { get, set, clear } = vi.hoisted(() => ({
   get: vi.fn(),
   set: vi.fn(),
+  clear: vi.fn(),
 }));
 
 vi.mock("wxt/browser", () => ({
   browser: {
     storage: {
-      local: { get, set },
+      local: { get, set, clear },
     },
   },
 }));
@@ -27,6 +28,8 @@ describe("settings storage migration", () => {
     get.mockReset();
     set.mockReset();
     set.mockResolvedValue(undefined);
+    clear.mockReset();
+    clear.mockResolvedValue(undefined);
   });
 
   it("writes a legacy document back once, using current keys and the current version", async () => {

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "تصدير بيانات الاعتماد"
   },
+  "factoryResetTitle": { "message": "إعادة ضبط Lurkloot" },
+  "factoryResetHint": { "message": "يمسح جميع إعدادات Lurkloot وتقدم التجميع وسجل النشاط. ستبقى مسجّلًا في Twitch وKick." },
+  "factoryResetButton": { "message": "إعادة ضبط Lurkloot" },
+  "factoryResetConfirm": { "message": "يؤدي هذا إلى إيقاف التجميع وإغلاق علامات التبويب التي فتحها Lurkloot ومسح جميع بياناته نهائيًا. ستبقى مسجّلًا في Twitch وKick." },
+  "factoryResetCancel": { "message": "إلغاء" },
+  "factoryResetConfirmButton": { "message": "إعادة ضبط الكل" },
+  "factoryResetProgress": { "message": "جارٍ إعادة الضبط…" },
+  "factoryResetFailed": { "message": "تعذّرت إعادة ضبط Lurkloot بالكامل. حاول مرة أخرى." },
+  "factoryResetRetry": { "message": "حاول إعادة الضبط مجددًا" },
   "diagnosticLoggingTitle": {
     "message": "تضمين سجلات التشخيص"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "Anmeldedaten exportieren"
   },
+  "factoryResetTitle": { "message": "Lurkloot zurücksetzen" },
+  "factoryResetHint": { "message": "Löscht alle Lurkloot-Einstellungen, den Farming-Fortschritt und den Aktivitätsverlauf. Deine Twitch- und Kick-Konten bleiben angemeldet." },
+  "factoryResetButton": { "message": "Lurkloot zurücksetzen" },
+  "factoryResetConfirm": { "message": "Dadurch wird das Farming beendet, von Lurkloot geöffnete Tabs werden geschlossen und alle Lurkloot-Daten dauerhaft gelöscht. Twitch und Kick bleiben angemeldet." },
+  "factoryResetCancel": { "message": "Abbrechen" },
+  "factoryResetConfirmButton": { "message": "Alles zurücksetzen" },
+  "factoryResetProgress": { "message": "Wird zurückgesetzt…" },
+  "factoryResetFailed": { "message": "Lurkloot konnte nicht vollständig zurückgesetzt werden. Versuche es erneut." },
+  "factoryResetRetry": { "message": "Erneut versuchen" },
   "diagnosticLoggingTitle": {
     "message": "Diagnoseprotokolle einschließen"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "Export credentials"
   },
+  "factoryResetTitle": { "message": "Reset Lurkloot" },
+  "factoryResetHint": { "message": "Erase all Lurkloot settings, farming progress, and activity history. Your Twitch and Kick accounts stay signed in." },
+  "factoryResetButton": { "message": "Reset Lurkloot" },
+  "factoryResetConfirm": { "message": "This stops farming, closes tabs opened by Lurkloot, and permanently erases all Lurkloot data. Twitch and Kick stay signed in." },
+  "factoryResetCancel": { "message": "Cancel" },
+  "factoryResetConfirmButton": { "message": "Reset everything" },
+  "factoryResetProgress": { "message": "Resetting…" },
+  "factoryResetFailed": { "message": "Lurkloot couldn't reset completely. Try again." },
+  "factoryResetRetry": { "message": "Try reset again" },
   "diagnosticLoggingTitle": {
     "message": "Include diagnostic logs"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "Exportar credenciales"
   },
+  "factoryResetTitle": { "message": "Restablecer Lurkloot" },
+  "factoryResetHint": { "message": "Borra todos los ajustes, el progreso de farmeo y el historial de actividad de Lurkloot. Tus cuentas de Twitch y Kick seguirán conectadas." },
+  "factoryResetButton": { "message": "Restablecer Lurkloot" },
+  "factoryResetConfirm": { "message": "Esto detiene el farmeo, cierra las pestañas abiertas por Lurkloot y borra permanentemente todos sus datos. Twitch y Kick seguirán conectados." },
+  "factoryResetCancel": { "message": "Cancelar" },
+  "factoryResetConfirmButton": { "message": "Borrar todo" },
+  "factoryResetProgress": { "message": "Restableciendo…" },
+  "factoryResetFailed": { "message": "Lurkloot no se pudo restablecer por completo. Inténtalo de nuevo." },
+  "factoryResetRetry": { "message": "Reintentar" },
   "diagnosticLoggingTitle": {
     "message": "Incluir registros de diagnóstico"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "Exporter les identifiants"
   },
+  "factoryResetTitle": { "message": "Réinitialiser Lurkloot" },
+  "factoryResetHint": { "message": "Efface tous les réglages, la progression de farming et l’historique d’activité de Lurkloot. Vos comptes Twitch et Kick restent connectés." },
+  "factoryResetButton": { "message": "Réinitialiser Lurkloot" },
+  "factoryResetConfirm": { "message": "Cela arrête le farming, ferme les onglets ouverts par Lurkloot et efface définitivement toutes ses données. Twitch et Kick restent connectés." },
+  "factoryResetCancel": { "message": "Annuler" },
+  "factoryResetConfirmButton": { "message": "Tout réinitialiser" },
+  "factoryResetProgress": { "message": "Réinitialisation…" },
+  "factoryResetFailed": { "message": "Lurkloot n’a pas pu être entièrement réinitialisé. Réessayez." },
+  "factoryResetRetry": { "message": "Réessayer" },
   "diagnosticLoggingTitle": {
     "message": "Inclure les journaux de diagnostic"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "क्रेडेंशियल निर्यात करें"
   },
+  "factoryResetTitle": { "message": "Lurkloot रीसेट करें" },
+  "factoryResetHint": { "message": "Lurkloot की सभी सेटिंग, फ़ार्मिंग प्रगति और गतिविधि इतिहास मिटाता है। आपके Twitch और Kick खाते साइन इन रहेंगे।" },
+  "factoryResetButton": { "message": "Lurkloot रीसेट करें" },
+  "factoryResetConfirm": { "message": "यह फ़ार्मिंग रोकता है, Lurkloot द्वारा खोले गए टैब बंद करता है और Lurkloot का सारा डेटा स्थायी रूप से मिटाता है। Twitch और Kick साइन इन रहेंगे।" },
+  "factoryResetCancel": { "message": "रद्द करें" },
+  "factoryResetConfirmButton": { "message": "सब कुछ रीसेट करें" },
+  "factoryResetProgress": { "message": "रीसेट किया जा रहा है…" },
+  "factoryResetFailed": { "message": "Lurkloot पूरी तरह रीसेट नहीं हो सका। फिर से कोशिश करें।" },
+  "factoryResetRetry": { "message": "फिर से रीसेट करें" },
   "diagnosticLoggingTitle": {
     "message": "डायग्नोस्टिक लॉग शामिल करें"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "Esporta credenziali"
   },
+  "factoryResetTitle": { "message": "Reimposta Lurkloot" },
+  "factoryResetHint": { "message": "Cancella tutte le impostazioni, i progressi di farming e la cronologia attività di Lurkloot. Gli account Twitch e Kick rimarranno connessi." },
+  "factoryResetButton": { "message": "Reimposta Lurkloot" },
+  "factoryResetConfirm": { "message": "Interrompe il farming, chiude le schede aperte da Lurkloot e cancella definitivamente tutti i dati di Lurkloot. Twitch e Kick rimarranno connessi." },
+  "factoryResetCancel": { "message": "Annulla" },
+  "factoryResetConfirmButton": { "message": "Reimposta tutto" },
+  "factoryResetProgress": { "message": "Reimpostazione…" },
+  "factoryResetFailed": { "message": "Non è stato possibile reimpostare completamente Lurkloot. Riprova." },
+  "factoryResetRetry": { "message": "Riprova" },
   "diagnosticLoggingTitle": {
     "message": "Includi registri diagnostici"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "Exportar credenciais"
   },
+  "factoryResetTitle": { "message": "Redefinir o Lurkloot" },
+  "factoryResetHint": { "message": "Apaga todas as configurações, o progresso de farming e o histórico de atividades do Lurkloot. Suas contas da Twitch e Kick continuarão conectadas." },
+  "factoryResetButton": { "message": "Redefinir o Lurkloot" },
+  "factoryResetConfirm": { "message": "Isso interrompe o farming, fecha as abas abertas pelo Lurkloot e apaga permanentemente todos os dados. Twitch e Kick continuarão conectados." },
+  "factoryResetCancel": { "message": "Cancelar" },
+  "factoryResetConfirmButton": { "message": "Redefinir tudo" },
+  "factoryResetProgress": { "message": "Redefinindo…" },
+  "factoryResetFailed": { "message": "Não foi possível redefinir o Lurkloot por completo. Tente novamente." },
+  "factoryResetRetry": { "message": "Tentar novamente" },
   "diagnosticLoggingTitle": {
     "message": "Incluir registros de diagnóstico"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "Экспортировать учётные данные"
   },
+  "factoryResetTitle": { "message": "Сбросить Lurkloot" },
+  "factoryResetHint": { "message": "Удаляет все настройки Lurkloot, прогресс фарма и историю действий. Вы останетесь в своих аккаунтах Twitch и Kick." },
+  "factoryResetButton": { "message": "Сбросить Lurkloot" },
+  "factoryResetConfirm": { "message": "Фарм будет остановлен, открытые Lurkloot вкладки закрыты, а все данные Lurkloot удалены навсегда. Вход в Twitch и Kick сохранится." },
+  "factoryResetCancel": { "message": "Отмена" },
+  "factoryResetConfirmButton": { "message": "Сбросить всё" },
+  "factoryResetProgress": { "message": "Сброс…" },
+  "factoryResetFailed": { "message": "Не удалось полностью сбросить Lurkloot. Попробуйте ещё раз." },
+  "factoryResetRetry": { "message": "Повторить сброс" },
   "diagnosticLoggingTitle": {
     "message": "Включить диагностические журналы"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -752,6 +752,15 @@
   "cliExportButton": {
     "message": "Kimlik bilgilerini dışa aktar"
   },
+  "factoryResetTitle": { "message": "Lurkloot'u sıfırla" },
+  "factoryResetHint": { "message": "Tüm Lurkloot ayarlarını, farming ilerlemesini ve etkinlik geçmişini siler. Twitch ve Kick hesaplarındaki oturumlarınız açık kalır." },
+  "factoryResetButton": { "message": "Lurkloot'u sıfırla" },
+  "factoryResetConfirm": { "message": "Bu işlem farming'i durdurur, Lurkloot'un açtığı sekmeleri kapatır ve tüm Lurkloot verilerini kalıcı olarak siler. Twitch ve Kick oturumları açık kalır." },
+  "factoryResetCancel": { "message": "İptal" },
+  "factoryResetConfirmButton": { "message": "Her şeyi sıfırla" },
+  "factoryResetProgress": { "message": "Sıfırlanıyor…" },
+  "factoryResetFailed": { "message": "Lurkloot tamamen sıfırlanamadı. Tekrar deneyin." },
+  "factoryResetRetry": { "message": "Tekrar sıfırla" },
   "diagnosticLoggingTitle": {
     "message": "Teşhis günlüklerini dahil et"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -706,6 +706,15 @@
   "cliExportButton": {
     "message": "导出凭据"
   },
+  "factoryResetTitle": { "message": "重置 Lurkloot" },
+  "factoryResetHint": { "message": "清除所有 Lurkloot 设置、挂机进度和活动记录。你的 Twitch 和 Kick 账号仍会保持登录。" },
+  "factoryResetButton": { "message": "重置 Lurkloot" },
+  "factoryResetConfirm": { "message": "此操作会停止挂机、关闭 Lurkloot 打开的标签页，并永久清除所有 Lurkloot 数据。Twitch 和 Kick 仍会保持登录。" },
+  "factoryResetCancel": { "message": "取消" },
+  "factoryResetConfirmButton": { "message": "全部重置" },
+  "factoryResetProgress": { "message": "正在重置…" },
+  "factoryResetFailed": { "message": "Lurkloot 未能完全重置，请重试。" },
+  "factoryResetRetry": { "message": "重新尝试重置" },
   "diagnosticLoggingTitle": {
     "message": "包含诊断日志"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -93,6 +93,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const [campaignFocus, setCampaignFocus] = useState<{ id: string; seq: number } | null>(null);
   const settingsRef = useRef<ExtensionSettings | null>(null);
   const settingsSaveQueue = useRef<Promise<void>>(Promise.resolve());
+  const snapshotRequestGenerationRef = useRef(0);
   const activityRequestScopeRef = useRef(createActivityRequestScope(platform));
   const activityMutationSequenceRef = useRef(createActivityMutationSequence());
   const diagnosticMutationSequenceRef = useRef(createActivityMutationSequence());
@@ -324,7 +325,9 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   useEffect(() => {
     if (preview) return;
     const interval = setInterval(() => {
+      const generation = snapshotRequestGenerationRef.current;
       void adapter.send<RuntimeSnapshot>({ type: "getSnapshot" }).then((nextSnapshot) => {
+        if (generation !== snapshotRequestGenerationRef.current) return;
         // Keep the locally-held settings rather than the refreshed ones so an
         // in-flight edit is never clobbered mid-typing. The tradeoff: a setting
         // changed by the background (e.g. startup auto-pausing `running`) is not
@@ -417,6 +420,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const resetExtension = adapter.resetExtension
     ? async () => {
         await settingsSaveQueue.current.catch(() => undefined);
+        snapshotRequestGenerationRef.current += 1;
         const nextSnapshot = await adapter.resetExtension!();
         settingsRef.current = mergeSettings(nextSnapshot.settings);
         invalidateActivityRequests("twitch");

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -414,6 +414,23 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
       }
     : undefined;
 
+  const resetExtension = adapter.resetExtension
+    ? async () => {
+        await settingsSaveQueue.current.catch(() => undefined);
+        const nextSnapshot = await adapter.resetExtension!();
+        settingsRef.current = mergeSettings(nextSnapshot.settings);
+        invalidateActivityRequests("twitch");
+        setActivityStream(createActivityStream());
+        setDiagnosticStream(createActivityStream());
+        setShowDiagnostics(false);
+        setPlatform("twitch");
+        setTab("drops");
+        setPendingChangelogVersion(undefined);
+        setSnapshot(snapshotWithMergedSettings(nextSnapshot));
+        setSettingsOpen(false);
+      }
+    : undefined;
+
   if (!snapshot) {
     return (
       <PopupRuntimeContext.Provider value={{ adapter, preview }}>
@@ -528,7 +545,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
           <AnimatePresence mode="wait" initial={false}>
             {settingsOpen ? (
               <motion.div key="settings" initial={{ opacity: 0, x: 14 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 14 }} transition={{ duration: 0.18 }} className="space-y-2.5">
-                <SettingsView suggestions={dropCategorySuggestions} onSearchCategories={searchCategories} settings={settings} onSettingsChange={updateSettings} onExportCredentials={exportCredentials} exportConfirmationResetKey={settingsOpenGeneration} compatibilityRegistry={adapter.compatibilityRegistry} compatibilityResolution={compatibilityResolution} />
+                <SettingsView suggestions={dropCategorySuggestions} onSearchCategories={searchCategories} settings={settings} onSettingsChange={updateSettings} onExportCredentials={exportCredentials} onReset={resetExtension} exportConfirmationResetKey={settingsOpenGeneration} compatibilityRegistry={adapter.compatibilityRegistry} compatibilityResolution={compatibilityResolution} />
               </motion.div>
             ) : activityOpen ? (
               <motion.div key="activity" initial={{ opacity: 0, x: 14 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 14 }} transition={{ duration: 0.18 }}>

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Terminal } from "lucide-react";
+import { RotateCcw, Terminal } from "lucide-react";
 import type { CategorySelection, ExtensionSettings, Platform } from "@lurkloot/shared/models";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
 import { SHOW_ADVANCED_SETTINGS_KEY } from "./constants";
@@ -9,7 +9,7 @@ import { filterSettingsTree } from "./settingsSearch";
 import { usePopupRuntime, useT } from "./context";
 import type { GameItem, PopupCompatibilityRegistry, PopupCompatibilityResolution } from "./types";
 
-export function SettingsView({ suggestions, onSearchCategories, settings, onSettingsChange, onExportCredentials, exportConfirmationResetKey, compatibilityRegistry, compatibilityResolution }: {
+export function SettingsView({ suggestions, onSearchCategories, settings, onSettingsChange, onExportCredentials, onReset, exportConfirmationResetKey, compatibilityRegistry, compatibilityResolution }: {
   suggestions: Record<Platform, GameItem[]>;
   onSearchCategories(platform: Platform, query: string): Promise<CategorySelection[]>;
   settings: ExtensionSettings;
@@ -17,6 +17,7 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
   // Optional: when provided, the settings view shows an "Export credentials"
   // action for the headless CLI. The extension wires it; the demo omits it.
   onExportCredentials?: () => void | Promise<void>;
+  onReset?: () => Promise<void>;
   exportConfirmationResetKey: number;
   compatibilityRegistry?: PopupCompatibilityRegistry;
   compatibilityResolution?: PopupCompatibilityResolution;
@@ -26,7 +27,28 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
   const [query, setQuery] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [exportArmed, setExportArmed] = useState(false);
-  useEffect(() => setExportArmed(false), [exportConfirmationResetKey]);
+  const [resetArmed, setResetArmed] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [resetFailed, setResetFailed] = useState(false);
+  useEffect(() => {
+    setExportArmed(false);
+    setResetArmed(false);
+    setResetFailed(false);
+  }, [exportConfirmationResetKey]);
+
+  async function confirmReset(): Promise<void> {
+    if (!onReset || resetting) return;
+    setResetting(true);
+    setResetFailed(false);
+    try {
+      await onReset();
+    } catch {
+      setResetArmed(true);
+      setResetFailed(true);
+    } finally {
+      setResetting(false);
+    }
+  }
 
   useEffect(() => {
     if (preview) return;
@@ -141,6 +163,59 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
                 >
                   <Terminal size={13} />
                   {t("cliExportButton")}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      {onReset && !searching ? (
+        <div className="pt-2">
+          <div className="mb-1 flex items-center gap-1.5 px-1">
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-red-500 dark:text-red-400">{t("factoryResetTitle")}</span>
+            <span className="h-px flex-1 bg-red-100 dark:bg-red-950" />
+          </div>
+          {resetArmed ? (
+            <div className="space-y-2 px-1 py-1">
+              <p className="text-xs leading-relaxed text-zinc-600 dark:text-zinc-300">{t("factoryResetConfirm")}</p>
+              {resetFailed ? <p role="alert" className="text-xs font-medium text-red-600 dark:text-red-400">{t("factoryResetFailed")}</p> : null}
+              <div className="flex flex-wrap justify-end gap-2">
+                <button
+                  type="button"
+                  disabled={resetting}
+                  className="rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  onClick={() => {
+                    setResetArmed(false);
+                    setResetFailed(false);
+                  }}
+                >
+                  {t("factoryResetCancel")}
+                </button>
+                <button
+                  type="button"
+                  disabled={resetting}
+                  className="rounded-xl bg-red-600 px-3 py-1.5 text-xs font-semibold text-white outline-none transition-colors hover:bg-red-700 focus-visible:ring-2 focus-visible:ring-red-400 disabled:opacity-50 dark:bg-red-700 dark:hover:bg-red-600"
+                  onClick={() => void confirmReset()}
+                >
+                  {t(resetting ? "factoryResetProgress" : resetFailed ? "factoryResetRetry" : "factoryResetConfirmButton")}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2 px-1 pb-1">
+              <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("factoryResetHint")}</p>
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 rounded-xl border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 outline-none transition-colors hover:bg-red-50 focus-visible:ring-2 focus-visible:ring-red-400 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950/40"
+                  onClick={() => {
+                    setResetArmed(true);
+                    setResetFailed(false);
+                  }}
+                >
+                  <RotateCcw size={13} />
+                  {t("factoryResetButton")}
                 </button>
               </div>
             </div>

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -1,4 +1,4 @@
-import type { CliCredentialBlob, RuntimeMessage } from "@lurkloot/shared/messages";
+import type { CliCredentialBlob, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import type { ClaimGuidance, CompatibilitySettings, DropCampaign, Platform, RewardRequirementType, SupportedLocale } from "@lurkloot/shared/models";
 
 export type CompatibilityLifecycle = "recommended" | "legacy" | "experimental";
@@ -126,6 +126,7 @@ export interface PopupAdapter {
   // Optional: download/persist an exported credential blob for the headless CLI.
   // Only the live extension implements it (the demo omits it, hiding the action).
   exportCredentials?(blob: CliCredentialBlob): void;
+  resetExtension?(): Promise<RuntimeSnapshot>;
   compatibilityRegistry?: PopupCompatibilityRegistry;
   resolveCompatibility?(settings: CompatibilitySettings): PopupCompatibilityResolution;
 }

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -22,6 +22,7 @@ export type RuntimeMessage =
   | CoreRuntimeMessage
   | ({ type: "getActivity" } & ActivityQuery)
   | { type: "clearActivity" }
+  | { type: "resetExtension" }
   | { type: "exportCliCredentials" };
 
 // Credential blob the popup exports for the headless CLI's `login --import`. It


### PR DESCRIPTION
## Summary

- add a confirmed factory-reset action at the bottom of extension Settings
- stop farming and force-close Lurkloot-managed watch/page-context tabs before deletion
- clear all extension-owned local and activity data, then restore versioned default settings and scheduler state
- preserve Twitch and Kick login cookies
- localize the reset flow across all supported catalogs

## Implementation details

- keeps the reset runtime action extension-owned so browser storage concerns do not leak into `@lurkloot/core` or the CLI
- serializes settings and scheduler mutations across cleanup and storage deletion to prevent stale alarms or saves from repopulating reset data
- clears transient Twitch integrity, Kick claim suppression, ad-focus state, and ignores stale popup snapshot polls
- exposes the action only through the live extension adapter, keeping the site demo and store screenshots non-destructive

## Testing

- `pnpm verify`
  - CWS and release script tests
  - all workspace typechecks
  - 105 CLI tests
  - 663 extension tests
  - Astro site tests and production build
  - Chromium MV3 production build
  - Firefox MV2 production build

Closes #208
