### PR TITLE
feat(extension): observe platform session credentials

### DIFF
--- a/docs/superpowers/plans/2026-07-22-platform-session-credential-observation.md
+++ b/docs/superpowers/plans/2026-07-22-platform-session-credential-observation.md
@@ -1,0 +1,516 @@
+# Platform Session Credential Observation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add credential-safe Twitch/Kick cookie preflights and a filtered, debounced cookie observer that invalidates platform authentication health and triggers a platform-only scheduler cycle.
+
+**Architecture:** The browser-free controller receives an optional value-only credential-availability callback and owns safe health transitions. Extension modules perform cookie lookup and cookie-change filtering without returning values, while `background.ts` wires those modules to the controller. Cookie presence advances to the adapter probe but never marks authentication healthy.
+
+**Tech Stack:** TypeScript 7, WXT WebExtension APIs, Vitest 4, pnpm workspace scripts.
+
+## Global Constraints
+
+- Work only in `.worktrees/observe-platform-session-credentials` on `feat/observe-platform-session-credentials`.
+- Twitch requires `auth-token`; `unique_id` is supporting metadata and must not prove login.
+- Kick requires `session_token`.
+- Cookie lookup failures must map to `unavailable` / `credential_lookup_failed`, not missing credentials.
+- Cookie values must never enter core state, snapshots, activity history, diagnostics, logs, errors, hashes, or callback arguments.
+- Cookie presence is only a preflight; only #202/#203 may mark an authenticated platform `healthy`.
+- Cookie changes invalidate health immediately and debounce a platform-only `tickAndHandOff([platform])` call.
+- `@lurkloot/core` must not import WXT or browser globals, and no new extension permission is needed.
+
+---
+
+## File Map
+
+- Modify `packages/core/src/background/controller.ts`: define the browser-neutral availability contract, preflight adapter health checks, and expose safe cached-health invalidation.
+- Modify `packages/extension/tests/backgroundController.test.ts`: verify preflight mapping, adapter short-circuiting, state isolation, transition safety, and omitted-dependency compatibility.
+- Create `packages/extension/src/core/credentialAvailability.ts`: read only the required browser cookie and return a value-free availability result.
+- Create `packages/extension/tests/credentialAvailability.test.ts`: cover presence, absence, empty values, lookup failure, and secret non-disclosure.
+- Create `packages/extension/src/core/credentialObserver.ts`: filter credential-cookie events, invalidate immediately, debounce per platform, and dispose cleanly.
+- Create `packages/extension/tests/credentialObserver.test.ts`: cover login/logout/replacement metadata, filtering, coalescing, platform independence, rejection containment, and disposal.
+- Modify `packages/extension/entrypoints/background.ts`: inject the provider, register the observer, and dispose it with the WXT background lifecycle.
+- Modify `packages/extension/tests/coreBoundary.test.ts`: retain the explicit browser-free core import guard for the new contract.
+
+---
+
+### Task 1: Controller Credential Preflight and Invalidation
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Produces: `export type CredentialAvailability = { status: "available" } | { status: "missing" } | { status: "unavailable" }`.
+- Produces: optional `BackgroundControllerDeps.checkCredentialAvailability(platform: Platform): Promise<CredentialAvailability>`.
+- Produces: `controller.invalidateAuthHealth(platform: Platform): Promise<void>`.
+- Changes: `controller.checkAuthHealth(platform)` short-circuits the adapter for `missing` and `unavailable`.
+
+- [ ] **Step 1: Add failing controller preflight tests**
+
+Extend the test harness override type and dependency construction:
+
+```ts
+import type { CredentialAvailability } from "@lurkloot/core/controller";
+
+// In harness overrides:
+checkCredentialAvailability?: (platform: Platform) => Promise<CredentialAvailability>;
+
+// In deps, only when supplied:
+...(overrides.checkCredentialAvailability
+  ? { checkCredentialAvailability: vi.fn(overrides.checkCredentialAvailability) }
+  : {}),
+```
+
+Add focused tests asserting:
+
+```ts
+it("reports missing credentials without calling the platform probe", async () => {
+  const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+    checkCredentialAvailability: async () => ({ status: "missing" }),
+  });
+
+  await env.controller.checkAuthHealth("twitch");
+
+  expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
+  expect(env.state.authHealth.twitch).toEqual(expect.objectContaining({
+    status: "missing_credentials",
+    reasonCode: "credentials_missing",
+  }));
+});
+
+it("reports credential lookup failure without calling the platform probe", async () => {
+  const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+    checkCredentialAvailability: async () => ({ status: "unavailable" }),
+  });
+
+  await env.controller.checkAuthHealth("kick");
+
+  expect(env.kick.checkAuthHealth).not.toHaveBeenCalled();
+  expect(env.state.authHealth.kick).toEqual(expect.objectContaining({
+    status: "unavailable",
+    reasonCode: "credential_lookup_failed",
+  }));
+});
+
+it("continues to the authenticated probe when credentials are available", async () => {
+  const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+    checkCredentialAvailability: async () => ({ status: "available" }),
+  });
+  vi.mocked(env.twitch.checkAuthHealth).mockResolvedValueOnce({ status: "checking" });
+
+  await env.controller.checkAuthHealth("twitch");
+
+  expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+  expect(env.state.authHealth.twitch.status).toBe("checking");
+});
+```
+
+Also preserve the existing test as coverage that omitting the dependency calls the adapter directly.
+
+- [ ] **Step 2: Add failing invalidation tests**
+
+Add tests that seed both platforms with non-checking health, call `invalidateAuthHealth("twitch")`, and assert Twitch becomes exactly `{ status: "checking" }`, Kick and unrelated state remain unchanged, a safe transition is reported once, and a second invalidation creates no repeated event.
+
+```ts
+await env.controller.invalidateAuthHealth("twitch");
+expect(env.state.authHealth.twitch).toEqual({ status: "checking" });
+expect(env.state.authHealth.kick).toEqual(previousKickHealth);
+expect(JSON.stringify(env.reportEvents.mock.calls)).not.toContain("secret");
+```
+
+- [ ] **Step 3: Run the focused tests and verify the new API is missing**
+
+Run: `pnpm --filter @lurkloot/extension test -- backgroundController.test.ts`
+
+Expected: FAIL because `CredentialAvailability`, `checkCredentialAvailability`, and `invalidateAuthHealth` do not exist.
+
+- [ ] **Step 4: Implement the minimal controller contract**
+
+Add near `BackgroundControllerDeps`:
+
+```ts
+export type CredentialAvailability =
+  | { status: "available" }
+  | { status: "missing" }
+  | { status: "unavailable" };
+```
+
+Add the optional dependency:
+
+```ts
+checkCredentialAvailability?(platform: Platform): Promise<CredentialAvailability>;
+```
+
+Refactor `checkAuthHealth` to choose a safe health result before the existing transition call:
+
+```ts
+const availability = await deps.checkCredentialAvailability?.(platform);
+const health = availability?.status === "missing"
+  ? {
+      status: "missing_credentials" as const,
+      checkedAt: new Date().toISOString(),
+      reasonCode: "credentials_missing" as const,
+      message: { key: "authMissingCredentials" as const },
+    }
+  : availability?.status === "unavailable"
+    ? {
+        status: "unavailable" as const,
+        checkedAt: new Date().toISOString(),
+        reasonCode: "credential_lookup_failed" as const,
+        message: { key: "authCredentialLookupFailed" as const },
+      }
+    : await adapter.checkAuthHealth();
+const transition = applyPlatformAuthHealth(state, platform, health);
+```
+
+Add an invalidation method under the state lock:
+
+```ts
+async function invalidateAuthHealth(platform: Platform): Promise<void> {
+  await withStateLock(() => withEventCollector(async (emit, events) => {
+    const state = await deps.loadState();
+    const transition = applyPlatformAuthHealth(state, platform, { status: "checking" });
+    if (transition.event) emit(transition.event);
+    await persistAndReport(transition.state, events);
+  }));
+}
+```
+
+Return `invalidateAuthHealth` from the controller.
+
+- [ ] **Step 5: Run controller tests and typechecking**
+
+Run: `pnpm --filter @lurkloot/extension test -- backgroundController.test.ts && pnpm --filter @lurkloot/core typecheck`
+
+Expected: all focused tests pass and core typechecking exits 0.
+
+- [ ] **Step 6: Commit the controller boundary**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(core): preflight platform credential availability"
+```
+
+---
+
+### Task 2: Extension Credential Availability Provider
+
+**Files:**
+- Create: `packages/extension/src/core/credentialAvailability.ts`
+- Create: `packages/extension/tests/credentialAvailability.test.ts`
+
+**Interfaces:**
+- Consumes: `CredentialAvailability` from `@lurkloot/core/controller`.
+- Produces: `createCredentialAvailabilityProvider(cookieApi): (platform: Platform) => Promise<CredentialAvailability>`.
+- Cookie API input: `{ get(details: { url: string; name: string }): Promise<{ value?: string } | null> }`.
+
+- [ ] **Step 1: Write failing provider tests**
+
+Create table-driven Vitest coverage with a mocked `get` function:
+
+```ts
+it.each([
+  ["twitch", "https://www.twitch.tv", "auth-token"],
+  ["kick", "https://kick.com", "session_token"],
+] as const)("reports %s credentials without returning their value", async (platform, url, name) => {
+  const get = vi.fn(async () => ({ value: "credential-secret" }));
+  const check = createCredentialAvailabilityProvider({ get });
+
+  const result = await check(platform);
+
+  expect(get).toHaveBeenCalledWith({ url, name });
+  expect(result).toEqual({ status: "available" });
+  expect(JSON.stringify(result)).not.toContain("credential-secret");
+});
+```
+
+Add cases for `null`, `{ value: "" }`, and rejected lookup. Assert Twitch makes only the `auth-token` lookup and never requests `unique_id`. Assert serialized results and rejection handling do not contain a sentinel secret.
+
+- [ ] **Step 2: Run provider tests and verify the module is missing**
+
+Run: `pnpm --filter @lurkloot/extension test -- credentialAvailability.test.ts`
+
+Expected: FAIL because `credentialAvailability.ts` does not exist.
+
+- [ ] **Step 3: Implement the provider**
+
+Create the focused module:
+
+```ts
+import type { CredentialAvailability } from "@lurkloot/core/controller";
+import type { Platform } from "@lurkloot/shared/models";
+
+export interface CredentialCookieApi {
+  get(details: { url: string; name: string }): Promise<{ value?: string } | null>;
+}
+
+const REQUIRED_COOKIE: Record<Platform, { url: string; name: string }> = {
+  twitch: { url: "https://www.twitch.tv", name: "auth-token" },
+  kick: { url: "https://kick.com", name: "session_token" },
+};
+
+export function createCredentialAvailabilityProvider(api: CredentialCookieApi) {
+  return async (platform: Platform): Promise<CredentialAvailability> => {
+    try {
+      const cookie = await api.get(REQUIRED_COOKIE[platform]);
+      return cookie?.value ? { status: "available" } : { status: "missing" };
+    } catch {
+      return { status: "unavailable" };
+    }
+  };
+}
+```
+
+- [ ] **Step 4: Run provider tests and extension typechecking**
+
+Run: `pnpm --filter @lurkloot/extension test -- credentialAvailability.test.ts && pnpm --filter @lurkloot/extension typecheck`
+
+Expected: provider tests pass and extension typechecking exits 0.
+
+- [ ] **Step 5: Commit the extension provider**
+
+```bash
+git add packages/extension/src/core/credentialAvailability.ts packages/extension/tests/credentialAvailability.test.ts
+git commit -m "feat(extension): detect required session credentials"
+```
+
+---
+
+### Task 3: Filtered Per-Platform Cookie Observer
+
+**Files:**
+- Create: `packages/extension/src/core/credentialObserver.ts`
+- Create: `packages/extension/tests/credentialObserver.test.ts`
+
+**Interfaces:**
+- Produces: `createCredentialObserver(deps): () => void`.
+- Consumes callbacks: `invalidate(platform): Promise<void>` and `recheck(platform): Promise<void>`.
+- Uses only cookie `name` and `domain`; it must never inspect `value`.
+
+- [ ] **Step 1: Write failing filtering and event tests**
+
+Build a fake event with captured listener and tests for added (login), removed (logout), and changed/replaced credential events. Use these representative inputs:
+
+```ts
+listener({ cookie: { name: "auth-token", domain: ".twitch.tv", value: "secret" }, removed: false });
+listener({ cookie: { name: "session_token", domain: "kick.com", value: "replacement" }, removed: true });
+```
+
+Assert the invalidation callback receives only `"twitch"` or `"kick"`, never the event or its value. Add negative cases for `unique_id`, unrelated names, `auth-token` on `example.com`, and `session_token` on `notkick.com`.
+
+- [ ] **Step 2: Write failing debounce, rejection, and disposal tests**
+
+Use `vi.useFakeTimers()` and assert:
+
+```ts
+listener(twitchChange);
+listener(twitchChange);
+listener(twitchChange);
+expect(invalidate).toHaveBeenCalledTimes(3);
+await vi.advanceTimersByTimeAsync(249);
+expect(recheck).not.toHaveBeenCalled();
+await vi.advanceTimersByTimeAsync(1);
+expect(recheck).toHaveBeenCalledOnce();
+expect(recheck).toHaveBeenCalledWith("twitch");
+```
+
+Trigger Twitch and Kick within the same window and assert one scoped recheck for each. Mock rejected invalidate/recheck promises and confirm no unhandled rejection escapes. Call the disposer, assert `removeListener` receives the registered listener, advance timers, and assert no pending recheck runs.
+
+- [ ] **Step 3: Run observer tests and verify the module is missing**
+
+Run: `pnpm --filter @lurkloot/extension test -- credentialObserver.test.ts`
+
+Expected: FAIL because `credentialObserver.ts` does not exist.
+
+- [ ] **Step 4: Implement exact cookie classification**
+
+Create types that intentionally omit cookie values from the coordinator's needs:
+
+```ts
+import type { Platform } from "@lurkloot/shared/models";
+
+interface ObservedCookie { name: string; domain: string }
+interface CookieChangeInfo { cookie: ObservedCookie; removed: boolean }
+interface CookieChangeEvent {
+  addListener(listener: (change: CookieChangeInfo) => void): void;
+  removeListener(listener: (change: CookieChangeInfo) => void): void;
+}
+
+function normalizedDomain(domain: string): string {
+  return domain.replace(/^\./, "").toLowerCase();
+}
+
+function isDomainOrSubdomain(domain: string, root: string): boolean {
+  return domain === root || domain.endsWith(`.${root}`);
+}
+
+export function credentialPlatform(change: CookieChangeInfo): Platform | undefined {
+  const domain = normalizedDomain(change.cookie.domain);
+  if (change.cookie.name === "auth-token" && isDomainOrSubdomain(domain, "twitch.tv")) return "twitch";
+  if (change.cookie.name === "session_token" && isDomainOrSubdomain(domain, "kick.com")) return "kick";
+  return undefined;
+}
+```
+
+- [ ] **Step 5: Implement per-platform debounce and disposal**
+
+Use a default `250` ms delay, one timer per platform, immediate best-effort invalidation, and best-effort recheck:
+
+```ts
+const timers = new Map<Platform, ReturnType<typeof setTimeout>>();
+const listener = (change: CookieChangeInfo) => {
+  const platform = credentialPlatform(change);
+  if (!platform) return;
+  void deps.invalidate(platform).catch(() => undefined);
+  const current = timers.get(platform);
+  if (current) deps.clearTimeout(current);
+  timers.set(platform, deps.setTimeout(() => {
+    timers.delete(platform);
+    void deps.recheck(platform).catch(() => undefined);
+  }, deps.debounceMs ?? 250));
+};
+```
+
+Return a disposer that removes `listener`, clears every timer, and clears the map. Inject `setTimeout` and `clearTimeout` with defaults so tests remain deterministic.
+
+- [ ] **Step 6: Run observer tests and extension typechecking**
+
+Run: `pnpm --filter @lurkloot/extension test -- credentialObserver.test.ts && pnpm --filter @lurkloot/extension typecheck`
+
+Expected: observer tests pass and extension typechecking exits 0.
+
+- [ ] **Step 7: Commit the observer**
+
+```bash
+git add packages/extension/src/core/credentialObserver.ts packages/extension/tests/credentialObserver.test.ts
+git commit -m "feat(extension): observe session credential changes"
+```
+
+---
+
+### Task 4: Background Wiring and Boundary Regression
+
+**Files:**
+- Modify: `packages/extension/entrypoints/background.ts`
+- Modify: `packages/extension/tests/coreBoundary.test.ts`
+
+**Interfaces:**
+- Consumes: `createCredentialAvailabilityProvider(browser.cookies)`.
+- Consumes: `createCredentialObserver({ onChanged, invalidate, recheck })`.
+- Consumes: `controller.invalidateAuthHealth(platform)` and `controller.tickAndHandOff([platform])`.
+
+- [ ] **Step 1: Strengthen the core-boundary test before wiring**
+
+Extend `coreBoundary.test.ts` so its scan continues to reject imports of `wxt`, `wxt/browser`, `browser`, or extension modules from all `packages/core/src/**/*.ts` files. Add an assertion that `controller.ts` contains the value-only `CredentialAvailability` vocabulary but none of `auth-token`, `session_token`, or `browser.cookies`.
+
+- [ ] **Step 2: Run the boundary test**
+
+Run: `pnpm --filter @lurkloot/extension test -- coreBoundary.test.ts`
+
+Expected: PASS before wiring; this locks the architectural boundary.
+
+- [ ] **Step 3: Inject the credential provider into the controller**
+
+Add imports to `background.ts`:
+
+```ts
+import { createCredentialAvailabilityProvider } from "../src/core/credentialAvailability";
+import { createCredentialObserver } from "../src/core/credentialObserver";
+```
+
+Create the provider once before controller construction:
+
+```ts
+const checkCredentialAvailability = createCredentialAvailabilityProvider(browser.cookies);
+```
+
+Pass it into `createBackgroundController` as `checkCredentialAvailability`.
+
+- [ ] **Step 4: Register and dispose the cookie observer**
+
+Accept the WXT background context and wire only safe platform callbacks:
+
+```ts
+export default defineBackground((ctx) => {
+  const disposeCredentialObserver = createCredentialObserver({
+    onChanged: browser.cookies.onChanged,
+    invalidate: (platform) => controller.invalidateAuthHealth(platform),
+    recheck: (platform) => controller.tickAndHandOff([platform]),
+  });
+  ctx.onInvalidated(disposeCredentialObserver);
+
+  // Existing listeners remain unchanged below.
+});
+```
+
+If WXT's generated type requires an adapter for `browser.cookies.onChanged`, pass `{ addListener, removeListener }` closures rather than widening the observer's value-free event interface.
+
+- [ ] **Step 5: Run focused tests, typechecks, and secret scans**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts credentialAvailability.test.ts credentialObserver.test.ts coreBoundary.test.ts
+pnpm typecheck
+git diff origin/develop...HEAD | rg -n "cookie\.value|authToken|sessionToken|authorization|Bearer"
+```
+
+Expected: focused tests and all workspace typechecks pass. Secret scan output is limited to the existing confirm-gated export and the provider's local truthiness check; no new state, event, diagnostic, log, or callback payload contains a credential.
+
+- [ ] **Step 6: Commit background integration**
+
+```bash
+git add packages/extension/entrypoints/background.ts packages/extension/tests/coreBoundary.test.ts
+git commit -m "feat(extension): recheck auth after credential changes"
+```
+
+---
+
+### Task 5: Full Verification and Acceptance Audit
+
+**Files:**
+- Review: all files changed since `origin/develop`
+
+**Interfaces:**
+- Verifies all earlier tasks as one extension-to-core flow.
+
+- [ ] **Step 1: Run formatting and patch-integrity checks**
+
+Run: `git diff --check && git status --short`
+
+Expected: no whitespace errors; only intentional branch changes are present.
+
+- [ ] **Step 2: Run the repository verification suite**
+
+Run: `pnpm verify`
+
+Expected: script tests, all workspace typechecks, Vitest suites, Astro build, and Chromium/Firefox extension builds pass.
+
+- [ ] **Step 3: Audit every issue #201 acceptance criterion**
+
+Run:
+
+```bash
+git diff --stat origin/develop...HEAD
+git log --oneline origin/develop..HEAD
+rg -n "auth-token|session_token|unique_id|credential_lookup_failed|invalidateAuthHealth|tickAndHandOff" packages/core packages/extension
+```
+
+Confirm explicitly:
+
+- required-cookie absence short-circuits authenticated probes as `missing_credentials`;
+- lookup rejection is `credential_lookup_failed`;
+- provider/observer interfaces expose no values;
+- relevant events invalidate and debounce only their platform;
+- unrelated events do nothing;
+- repeated events coalesce;
+- tests cover login, logout, replacement, lookup failure, filtering, and debounce.
+
+- [ ] **Step 4: Commit any verification-only correction**
+
+If verification required a correction, stage only those corrected files and commit with a focused Conventional Commit subject. If no correction was needed, do not create an empty commit.
+
+- [ ] **Step 5: Prepare completion handoff**
+
+Report the implementation commits, files changed, exact verification commands and results, and any intentional deferrals to #202–#205. Do not push or open a pull request unless the user separately requests publication.

--- a/docs/superpowers/specs/2026-07-22-platform-session-credential-observation-design.md
+++ b/docs/superpowers/specs/2026-07-22-platform-session-credential-observation-design.md
@@ -1,0 +1,135 @@
+# Platform Session Credential Observation Design
+
+## Scope
+
+This specification implements issue #201, the extension-owned browser credential-observation layer for the authentication-health epic in #199. It builds on the safe shared health contracts from #200 and prepares the inputs and recovery trigger needed by the Twitch probe (#202), Kick probe (#203), and scheduler gating (#204).
+
+This issue does not decide whether a present credential is valid, mark a session healthy, interpret authenticated platform responses, or suspend account automation. Credential presence is only a preflight. The later platform probes establish authenticated health, and #204 makes scheduler work depend on that health.
+
+## Goals
+
+- Detect whether Twitch's required `auth-token` and Kick's required `session_token` cookie are available without exposing either value outside the extension boundary.
+- Treat `unique_id` as optional Twitch metadata, never as proof of login.
+- Distinguish a missing required cookie from a browser cookie lookup failure.
+- Invalidate only the affected platform's cached authentication health when a relevant cookie changes.
+- Coalesce repeated changes and trigger one platform-only scheduler cycle so later authentication probes and gating can recover automatically.
+- Ignore unrelated cookie changes and preserve `@lurkloot/core` as browser-free.
+
+## Credential Availability Contract
+
+The browser-neutral controller dependency will accept a platform and return a value-only result with no credential material:
+
+```ts
+type CredentialAvailability =
+  | { status: "available" }
+  | { status: "missing" }
+  | { status: "unavailable" };
+
+checkCredentialAvailability?(platform: Platform): Promise<CredentialAvailability>;
+```
+
+The contract deliberately uses `unavailable` for lookup failure and contains no error object or arbitrary text. The controller maps these results to the shared authentication-health vocabulary:
+
+| Availability | Controller behavior |
+| --- | --- |
+| `available` | Continue to `adapter.checkAuthHealth()`; presence alone never yields `healthy`. |
+| `missing` | Persist `missing_credentials` with `credentials_missing`; do not call the adapter probe. |
+| `unavailable` | Persist `unavailable` with `credential_lookup_failed`; do not call the adapter probe. |
+
+Hosts that omit the dependency preserve the current behavior and call the adapter directly. This keeps the CLI independent of browser cookie observation and avoids forcing browser concepts into core.
+
+The controller applies availability and adapter results through the existing normalization and transition path, so timestamps and durable activity events retain the safe behavior established by #200.
+
+## Extension Credential Provider
+
+`packages/extension/src/core/credentialAvailability.ts` will own the browser implementation behind a small injectable cookie-reader interface. Production wiring passes `browser.cookies.get`; tests pass a deterministic fake.
+
+The provider performs exactly one required lookup per platform:
+
+- Twitch: `https://www.twitch.tv`, cookie name `auth-token`.
+- Kick: `https://kick.com`, cookie name `session_token`.
+
+A returned cookie with a non-empty value is `available`. A missing cookie or empty value is `missing`. A rejected lookup is `unavailable`. The provider never returns, stores, logs, hashes, serializes, or attaches the value to an error. It does not read Twitch `unique_id`, because that cookie cannot establish credential availability.
+
+The existing confirm-gated CLI export remains separate. It may continue reading the credential values for its explicitly authorized export operation; the health provider cannot call or reuse the export blob builder.
+
+## Cached-Health Invalidation
+
+The controller will expose `invalidateAuthHealth(platform)`. Under the existing state-mutation lock, it loads current state and replaces only the selected platform's health with `{ status: "checking" }`. Other scheduler state and the other platform's health remain unchanged.
+
+Invalidation is a cache-state change, not a platform-health conclusion. It emits the normal safe authentication transition only when the semantic state changes. Repeated invalidations while already `checking` remain quiet. The method performs no platform request and does not start scheduler work itself.
+
+## Cookie Change Observation
+
+`packages/extension/src/core/credentialObserver.ts` will contain a testable observer coordinator. It receives:
+
+- a cookie-change event source;
+- `invalidateAuthHealth(platform)`;
+- `recheckPlatform(platform)`;
+- injectable timeout functions and debounce duration.
+
+The observer recognizes only these exact pairs:
+
+| Platform | Cookie | Accepted domains |
+| --- | --- | --- |
+| Twitch | `auth-token` | `twitch.tv` and subdomains represented with or without the cookie API's leading dot |
+| Kick | `session_token` | `kick.com` and subdomains represented with or without the leading dot |
+
+Cookie name alone is insufficient: a same-named cookie on an unrelated domain is ignored. Twitch `unique_id`, unrelated Twitch/Kick cookies, and all other domains are ignored.
+
+For each relevant added, removed, or replaced cookie event, the observer immediately invalidates that platform's cached health. It then resets a short per-platform debounce timer. When the timer expires, it calls `controller.tickAndHandOff([platform])`. The scheduler call is platform-scoped and intentionally follows the normal scheduler path: #202/#203 will supply the authenticated probes and #204 will perform health checking and gating within that cycle.
+
+Timers are independent per platform. A burst of Twitch changes becomes one Twitch cycle; a simultaneous Kick burst becomes one separate Kick cycle. A failure from invalidation or the eventual scheduler cycle is contained by the existing controller reporting path and must not create an unhandled rejection in the browser event listener.
+
+The observer returns a disposer that removes its cookie listener and clears pending timers. `background.ts` creates it once for the service-worker lifetime and registers disposal with the WXT background invalidation lifecycle when available.
+
+## Data Flow
+
+```text
+browser.cookies.onChanged
+  -> exact credential cookie/domain filter
+  -> controller.invalidateAuthHealth(platform)
+  -> reset that platform's debounce timer
+  -> controller.tickAndHandOff([platform])
+       -> later #204 invokes controller.checkAuthHealth(platform)
+            -> extension credential availability preflight
+                 missing / lookup failed -> safe terminal health
+                 available -> later #202 or #203 authenticated probe
+```
+
+The cookie value is inspected only inside the provider to decide whether it is empty. Cookie-change handling uses only event metadata required for filtering and never reads or forwards `cookie.value`.
+
+## Error Handling and Security
+
+- Cookie lookup rejection maps to `credential_lookup_failed`, not `credentials_missing`.
+- No raw lookup error is persisted or reported, because browser error text could contain unexpected details.
+- Observer callbacks attach rejection handlers so browser event dispatch cannot produce unhandled promise rejections.
+- No credential value enters adapter arguments, controller state, snapshots, activity events, diagnostics, or logs.
+- The existing `cookies` permission and Twitch/Kick host permissions are sufficient; this issue adds no permissions.
+- The core package receives only the browser-neutral availability enum and imports no WXT or browser globals.
+
+## Testing
+
+Focused deterministic tests will cover:
+
+1. Twitch `auth-token` and Kick `session_token` presence returning `available` without exposing values.
+2. Missing and empty required cookies returning `missing`.
+3. Cookie lookup rejection returning `unavailable` and mapping to `credential_lookup_failed`.
+4. Twitch `unique_id` alone not satisfying the required-credential check.
+5. The controller skipping adapter probes for missing credentials and lookup failures, while continuing to the probe for available credentials.
+6. Login, logout, and token replacement events invalidating the correct platform.
+7. Exact domain/name filtering, including leading-dot domains and unrelated same-name cookies.
+8. Repeated changes coalescing into one platform-only scheduler cycle.
+9. Independent Twitch and Kick debounce timers.
+10. Disposal removing listeners and cancelling pending work.
+11. Serialized state, events, diagnostics, and callback arguments containing no credential values.
+
+The implementation will run focused Vitest suites during development, followed by the repository's full `pnpm verify` before completion.
+
+## Out of Scope
+
+- Twitch authenticated GQL classification (#202).
+- Kick account probing and security-policy response classification (#203).
+- Scheduler blocking, degraded operational state, and automatic resume rules (#204).
+- Popup authentication-health presentation (#205).
+- CLI authentication-health behavior (#206).

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -21,6 +21,10 @@ export const WATCH_ALARM_NAME = "lurkloot.watch";
 // the ids (not just the platforms) so it can tell a genuine successor from the
 // reward that was just claimed.
 export type ClaimedRewards = Partial<Record<Platform, string[]>>;
+export type CredentialAvailability =
+  | { status: "available" }
+  | { status: "missing" }
+  | { status: "unavailable" };
 // Reasons a refreshed platform has nothing left to farm. Reaching one of these
 // means further refreshes would return the same answer, so the post-claim
 // handoff stops instead of spending the rest of its budget.
@@ -105,6 +109,7 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
     compatibility: ResolvedCompatibility;
     warnings: CompatibilityResolution["warnings"];
   };
+  checkCredentialAvailability?(platform: Platform): Promise<CredentialAvailability>;
   createNotification?(notification: { title: string; message: string }): Promise<void>;
   translate?(key: string, substitutions?: string | string[]): string | Promise<string>;
   closeManagedTabs?(tabs: ManagedWatchTab[]): Promise<void>;
@@ -475,8 +480,32 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function checkAuthHealth(platform: Platform): Promise<void> {
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
-      const adapter = deps.createAdapters(emit, settings).adapters[platform];
-      const transition = applyPlatformAuthHealth(state, platform, await adapter.checkAuthHealth());
+      const availability = await deps.checkCredentialAvailability?.(platform);
+      const health = availability?.status === "missing"
+        ? {
+            status: "missing_credentials" as const,
+            checkedAt: new Date().toISOString(),
+            reasonCode: "credentials_missing" as const,
+            message: { key: "authMissingCredentials" as const },
+          }
+        : availability?.status === "unavailable"
+          ? {
+              status: "unavailable" as const,
+              checkedAt: new Date().toISOString(),
+              reasonCode: "credential_lookup_failed" as const,
+              message: { key: "authCredentialLookupFailed" as const },
+            }
+          : await deps.createAdapters(emit, settings).adapters[platform].checkAuthHealth();
+      const transition = applyPlatformAuthHealth(state, platform, health);
+      if (transition.event) emit(transition.event);
+      await persistAndReport(transition.state, events);
+    }));
+  }
+
+  async function invalidateAuthHealth(platform: Platform): Promise<void> {
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      const state = await deps.loadState();
+      const transition = applyPlatformAuthHealth(state, platform, { status: "checking" });
       if (transition.event) emit(transition.event);
       await persistAndReport(transition.state, events);
     }));
@@ -1233,6 +1262,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     handleMessage,
     captureTwitchIntegrity,
     checkAuthHealth,
+    invalidateAuthHealth,
     tick,
     tickAndHandOff,
     runWatchHeartbeat,

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -31,6 +31,8 @@ import {
   createRuntimeMessageDispatcher,
 } from "../src/core/activityMessages";
 import { twitchHeartbeatFetchText, twitchHeartbeatPost } from "../src/core/twitchHeartbeatTransport";
+import { createCredentialAvailabilityProvider } from "../src/core/credentialAvailability";
+import { createCredentialObserver } from "../src/core/credentialObserver";
 
 const localeCatalogs = new Map<string, MessageCatalog | undefined>();
 const getMessage = browser.i18n.getMessage as (key: string, substitutions?: string | string[]) => string;
@@ -44,6 +46,9 @@ const reportEvents = createActivityEventReporter({
 });
 const kickClaimState = new KickClaimState();
 const KICK_PAGE_CONTEXT_URL = "https://kick.com/drops/inventory";
+const checkCredentialAvailability = createCredentialAvailabilityProvider({
+  get: (details) => browser.cookies.get(details),
+});
 
 async function catalog(locale: string): Promise<MessageCatalog | undefined> {
   if (localeCatalogs.has(locale)) return localeCatalogs.get(locale);
@@ -71,6 +76,7 @@ const controller = createBackgroundController<ExtensionSettings>({
   loadState,
   saveState,
   reportEvents,
+  checkCredentialAvailability,
   createAlarm: (name, options) => browser.alarms.create(name, options),
   closeManagedTabs: async (tabs) => {
     await Promise.all(tabs.map(async ({ tabId, channelUrl }) => {
@@ -201,6 +207,15 @@ const dispatchRuntimeMessage = createRuntimeMessageDispatcher({
 });
 
 export default defineBackground(() => {
+  createCredentialObserver({
+    onChanged: {
+      addListener: (listener) => browser.cookies.onChanged.addListener(listener),
+      removeListener: (listener) => browser.cookies.onChanged.removeListener(listener),
+    },
+    invalidate: (platform) => controller.invalidateAuthHealth(platform),
+    recheck: (platform) => controller.tickAndHandOff([platform]),
+  });
+
   browser.runtime.onInstalled.addListener(async (details) => {
     await controller.ensureAlarm();
     // Stamp the install date once so the popup can time the rate/review nudge.

--- a/packages/extension/src/core/credentialAvailability.ts
+++ b/packages/extension/src/core/credentialAvailability.ts
@@ -1,0 +1,22 @@
+import type { CredentialAvailability } from "@lurkloot/core/controller";
+import type { Platform } from "@lurkloot/shared/models";
+
+export interface CredentialCookieApi {
+  get(details: { url: string; name: string }): Promise<{ value?: string } | null>;
+}
+
+const REQUIRED_COOKIE: Record<Platform, { url: string; name: string }> = {
+  twitch: { url: "https://www.twitch.tv", name: "auth-token" },
+  kick: { url: "https://kick.com", name: "session_token" },
+};
+
+export function createCredentialAvailabilityProvider(api: CredentialCookieApi) {
+  return async (platform: Platform): Promise<CredentialAvailability> => {
+    try {
+      const cookie = await api.get(REQUIRED_COOKIE[platform]);
+      return cookie?.value ? { status: "available" } : { status: "missing" };
+    } catch {
+      return { status: "unavailable" };
+    }
+  };
+}

--- a/packages/extension/src/core/credentialObserver.ts
+++ b/packages/extension/src/core/credentialObserver.ts
@@ -13,13 +13,15 @@ export interface CredentialCookieChangeEvent {
   removeListener(listener: (change: CredentialCookieChange) => void): void;
 }
 
+type TimerHandle = number | ReturnType<typeof setTimeout>;
+
 export interface CredentialObserverDeps {
   onChanged: CredentialCookieChangeEvent;
   invalidate(platform: Platform): Promise<void>;
   recheck(platform: Platform): Promise<void>;
   debounceMs?: number;
-  setTimer?: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>;
-  clearTimer?: (timer: ReturnType<typeof setTimeout>) => void;
+  setTimer?: (callback: () => void, delay: number) => TimerHandle;
+  clearTimer?: (timer: TimerHandle) => void;
 }
 
 function normalizedDomain(domain: string): string {
@@ -40,7 +42,7 @@ export function credentialPlatform(change: CredentialCookieChange): Platform | u
 export function createCredentialObserver(deps: CredentialObserverDeps): () => void {
   const setTimer = deps.setTimer ?? setTimeout;
   const clearTimer = deps.clearTimer ?? clearTimeout;
-  const timers = new Map<Platform, ReturnType<typeof setTimeout>>();
+  const timers = new Map<Platform, TimerHandle>();
 
   const listener = (change: CredentialCookieChange) => {
     const platform = credentialPlatform(change);
@@ -48,7 +50,7 @@ export function createCredentialObserver(deps: CredentialObserverDeps): () => vo
 
     void deps.invalidate(platform).catch(() => undefined);
     const current = timers.get(platform);
-    if (current) clearTimer(current);
+    if (current !== undefined) clearTimer(current);
     timers.set(platform, setTimer(() => {
       timers.delete(platform);
       void deps.recheck(platform).catch(() => undefined);

--- a/packages/extension/src/core/credentialObserver.ts
+++ b/packages/extension/src/core/credentialObserver.ts
@@ -1,0 +1,65 @@
+import type { Platform } from "@lurkloot/shared/models";
+
+export interface CredentialCookieChange {
+  cookie: {
+    name: string;
+    domain: string;
+  };
+  removed: boolean;
+}
+
+export interface CredentialCookieChangeEvent {
+  addListener(listener: (change: CredentialCookieChange) => void): void;
+  removeListener(listener: (change: CredentialCookieChange) => void): void;
+}
+
+export interface CredentialObserverDeps {
+  onChanged: CredentialCookieChangeEvent;
+  invalidate(platform: Platform): Promise<void>;
+  recheck(platform: Platform): Promise<void>;
+  debounceMs?: number;
+  setTimer?: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (timer: ReturnType<typeof setTimeout>) => void;
+}
+
+function normalizedDomain(domain: string): string {
+  return domain.replace(/^\./, "").toLowerCase();
+}
+
+function isDomainOrSubdomain(domain: string, root: string): boolean {
+  return domain === root || domain.endsWith(`.${root}`);
+}
+
+export function credentialPlatform(change: CredentialCookieChange): Platform | undefined {
+  const domain = normalizedDomain(change.cookie.domain);
+  if (change.cookie.name === "auth-token" && isDomainOrSubdomain(domain, "twitch.tv")) return "twitch";
+  if (change.cookie.name === "session_token" && isDomainOrSubdomain(domain, "kick.com")) return "kick";
+  return undefined;
+}
+
+export function createCredentialObserver(deps: CredentialObserverDeps): () => void {
+  const setTimer = deps.setTimer ?? setTimeout;
+  const clearTimer = deps.clearTimer ?? clearTimeout;
+  const timers = new Map<Platform, ReturnType<typeof setTimeout>>();
+
+  const listener = (change: CredentialCookieChange) => {
+    const platform = credentialPlatform(change);
+    if (!platform) return;
+
+    void deps.invalidate(platform).catch(() => undefined);
+    const current = timers.get(platform);
+    if (current) clearTimer(current);
+    timers.set(platform, setTimer(() => {
+      timers.delete(platform);
+      void deps.recheck(platform).catch(() => undefined);
+    }, deps.debounceMs ?? 250));
+  };
+
+  deps.onChanged.addListener(listener);
+
+  return () => {
+    deps.onChanged.removeListener(listener);
+    for (const timer of timers.values()) clearTimer(timer);
+    timers.clear();
+  };
+}

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ALARM_NAME, createBackgroundController } from "@lurkloot/core/controller";
+import { ALARM_NAME, createBackgroundController, type CredentialAvailability } from "@lurkloot/core/controller";
 import { resolveCompatibility } from "@lurkloot/core";
 import type { ChannelCandidate, DropCampaign, DropReward, ExtensionSettings, Platform, SchedulerState } from "@lurkloot/shared/models";
 import type { DiagnosticEvent, EngineEvent, EventEmitter } from "@lurkloot/shared/events";
@@ -59,6 +59,7 @@ function harness(
     reportEvents?: (events: readonly EngineEvent[]) => Promise<void>;
     stopPageContextTabs?: StopPageContextTabs;
     wait?: (ms: number, signal: AbortSignal) => Promise<void>;
+    checkCredentialAvailability?: (platform: Platform) => Promise<CredentialAvailability>;
   } = {},
 ) {
   let currentSettings = settings;
@@ -95,6 +96,9 @@ function harness(
     reportEvents: vi.fn(overrides.reportEvents ?? reportEvents),
     stopPageContextTabs: vi.fn(overrides.stopPageContextTabs ?? forgetManagedPageContextTabs),
     wait: overrides.wait,
+    ...(overrides.checkCredentialAvailability
+      ? { checkCredentialAvailability: vi.fn(overrides.checkCredentialAvailability) }
+      : {}),
   };
 
   return {
@@ -113,6 +117,75 @@ function harness(
 }
 
 describe("background controller", () => {
+  it("reports missing credentials without calling the platform probe", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+      checkCredentialAvailability: async () => ({ status: "missing" }),
+    });
+
+    await env.controller.checkAuthHealth("twitch");
+
+    expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
+    expect(env.state.authHealth.twitch).toEqual(expect.objectContaining({
+      status: "missing_credentials",
+      reasonCode: "credentials_missing",
+    }));
+  });
+
+  it("reports credential lookup failure without calling the platform probe", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+      checkCredentialAvailability: async () => ({ status: "unavailable" }),
+    });
+
+    await env.controller.checkAuthHealth("kick");
+
+    expect(env.kick.checkAuthHealth).not.toHaveBeenCalled();
+    expect(env.state.authHealth.kick).toEqual(expect.objectContaining({
+      status: "unavailable",
+      reasonCode: "credential_lookup_failed",
+    }));
+  });
+
+  it("continues to the authenticated probe when credentials are available", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+      checkCredentialAvailability: async () => ({ status: "available" }),
+    });
+
+    await env.controller.checkAuthHealth("twitch");
+
+    expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+    expect(env.state.authHealth.twitch.status).toBe("checking");
+  });
+
+  it("invalidates only the requested authentication health and reports the transition once", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    vi.mocked(env.twitch.checkAuthHealth).mockResolvedValueOnce({ status: "healthy", checkedAt: "2026-07-22T12:00:00.000Z" });
+    vi.mocked(env.kick.checkAuthHealth).mockResolvedValueOnce({
+      status: "missing_credentials",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode: "credentials_missing",
+    });
+    await env.controller.checkAuthHealth("twitch");
+    await env.controller.checkAuthHealth("kick");
+    const previousKickHealth = env.state.authHealth.kick;
+    env.reportEvents.mockClear();
+
+    await env.controller.invalidateAuthHealth("twitch");
+
+    expect(env.state.authHealth.twitch).toEqual({ status: "checking" });
+    expect(env.state.authHealth.kick).toEqual(previousKickHealth);
+    expect(env.reportEvents).toHaveBeenCalledWith([{
+      category: "activity",
+      code: "auth_health_changed",
+      level: "info",
+      platform: "twitch",
+      data: { from: "healthy", to: "checking" },
+    }]);
+
+    env.reportEvents.mockClear();
+    await env.controller.invalidateAuthHealth("twitch");
+    expect(env.reportEvents).not.toHaveBeenCalled();
+  });
+
   it("checks and persists authentication health for only the requested platform", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: false });
     vi.mocked(env.kick.checkAuthHealth).mockResolvedValueOnce({

--- a/packages/extension/tests/coreBoundary.test.ts
+++ b/packages/extension/tests/coreBoundary.test.ts
@@ -22,6 +22,8 @@ function tsFiles(dir: string): string[] {
 const FORBIDDEN = /\b(?:import|require)\b[^\n]*["'](wxt(?:\/[^"']*)?|webextension-polyfill)["']/;
 const HISTORY_API = /\b(?:ActivityPage|getActivity|clearActivity|activityStorage)\b/;
 const FULL_RUNTIME_MESSAGE = /\bRuntimeMessage\b/;
+const BROWSER_COOKIE_API = /\b(?:browser|chrome)\.cookies\b/;
+const EXTENSION_IMPORT = /\b(?:import|require)\b[^\n]*["'][^"']*packages\/extension|\b(?:import|require)\b[^\n]*["'][^"']*extension\/src/;
 
 describe("@lurkloot/core browser-free boundary", () => {
   it("never imports wxt or a webextension polyfill", () => {
@@ -37,5 +39,20 @@ describe("@lurkloot/core browser-free boundary", () => {
   it("accepts only the core runtime message contract", () => {
     const offenders = tsFiles(coreSrc).filter((file) => FULL_RUNTIME_MESSAGE.test(readFileSync(file, "utf8")));
     expect(offenders, `core must not accept the extension-wide RuntimeMessage union; offending files:\n${offenders.join("\n")}`).toEqual([]);
+  });
+
+  it("keeps browser cookie access and extension modules outside core", () => {
+    const offenders = tsFiles(coreSrc).filter((file) => {
+      const source = readFileSync(file, "utf8");
+      const code = source.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
+      return BROWSER_COOKIE_API.test(code) || EXTENSION_IMPORT.test(code);
+    });
+    expect(offenders, `core must not access browser cookies or extension modules; offending files:\n${offenders.join("\n")}`).toEqual([]);
+  });
+
+  it("models credential availability without naming or carrying browser credentials", () => {
+    const controller = readFileSync(join(coreSrc, "background/controller.ts"), "utf8");
+    expect(controller).toContain("CredentialAvailability");
+    expect(controller).not.toMatch(/auth-token|session_token|unique_id|cookie\.value/);
   });
 });

--- a/packages/extension/tests/credentialAvailability.test.ts
+++ b/packages/extension/tests/credentialAvailability.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCredentialAvailabilityProvider } from "../src/core/credentialAvailability";
+
+describe("credential availability", () => {
+  it.each([
+    ["twitch", "https://www.twitch.tv", "auth-token"],
+    ["kick", "https://kick.com", "session_token"],
+  ] as const)("reports %s credentials without returning their value", async (platform, url, name) => {
+    const get = vi.fn(async () => ({ value: "credential-secret" }));
+    const check = createCredentialAvailabilityProvider({ get });
+
+    const result = await check(platform);
+
+    expect(get).toHaveBeenCalledOnce();
+    expect(get).toHaveBeenCalledWith({ url, name });
+    expect(result).toEqual({ status: "available" });
+    expect(JSON.stringify(result)).not.toContain("credential-secret");
+  });
+
+  it.each([null, { value: "" }, {}])("reports a missing required cookie for %j", async (cookie) => {
+    const check = createCredentialAvailabilityProvider({ get: vi.fn(async () => cookie) });
+
+    await expect(check("twitch")).resolves.toEqual({ status: "missing" });
+  });
+
+  it("reports lookup failure without exposing the rejected error", async () => {
+    const check = createCredentialAvailabilityProvider({
+      get: vi.fn(async () => {
+        throw new Error("credential-secret");
+      }),
+    });
+
+    const result = await check("kick");
+
+    expect(result).toEqual({ status: "unavailable" });
+    expect(JSON.stringify(result)).not.toContain("credential-secret");
+  });
+
+  it("does not use Twitch unique_id as proof of login", async () => {
+    const get = vi.fn(async () => null);
+    const check = createCredentialAvailabilityProvider({ get });
+
+    await expect(check("twitch")).resolves.toEqual({ status: "missing" });
+    expect(get).toHaveBeenCalledWith({ url: "https://www.twitch.tv", name: "auth-token" });
+    expect(get).not.toHaveBeenCalledWith(expect.objectContaining({ name: "unique_id" }));
+  });
+});

--- a/packages/extension/tests/credentialObserver.test.ts
+++ b/packages/extension/tests/credentialObserver.test.ts
@@ -97,6 +97,28 @@ describe("credential cookie observer", () => {
     expect(env.recheck).toHaveBeenCalledWith("kick");
   });
 
+  it("clears a valid zero-valued timer handle when coalescing", () => {
+    let listener: ((event: CredentialCookieChange) => void) | undefined;
+    const clearTimer = vi.fn();
+    createCredentialObserver({
+      onChanged: {
+        addListener: (next) => {
+          listener = next;
+        },
+        removeListener: vi.fn(),
+      },
+      invalidate: vi.fn(async () => undefined),
+      recheck: vi.fn(async () => undefined),
+      setTimer: vi.fn(() => 0),
+      clearTimer,
+    });
+
+    listener?.(change("auth-token", "twitch.tv"));
+    listener?.(change("auth-token", "twitch.tv"));
+
+    expect(clearTimer).toHaveBeenCalledWith(0);
+  });
+
   it("contains rejected invalidation and recheck callbacks", async () => {
     const env = harness();
     env.invalidate.mockRejectedValueOnce(new Error("invalidate failed"));

--- a/packages/extension/tests/credentialObserver.test.ts
+++ b/packages/extension/tests/credentialObserver.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCredentialObserver, type CredentialCookieChange } from "../src/core/credentialObserver";
+
+function harness() {
+  let listener: ((change: CredentialCookieChange) => void) | undefined;
+  const onChanged = {
+    addListener: vi.fn((next: (change: CredentialCookieChange) => void) => {
+      listener = next;
+    }),
+    removeListener: vi.fn(),
+  };
+  const invalidate = vi.fn(async () => undefined);
+  const recheck = vi.fn(async () => undefined);
+  const dispose = createCredentialObserver({ onChanged, invalidate, recheck, debounceMs: 250 });
+  return {
+    dispose,
+    invalidate,
+    onChanged,
+    recheck,
+    change(value: CredentialCookieChange) {
+      if (!listener) throw new Error("observer listener was not registered");
+      listener(value);
+    },
+    get listener() {
+      return listener;
+    },
+  };
+}
+
+const change = (name: string, domain: string, removed = false): CredentialCookieChange => ({
+  cookie: { name, domain },
+  removed,
+});
+
+describe("credential cookie observer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ["login", change("auth-token", ".twitch.tv"), "twitch"],
+    ["logout", change("session_token", "kick.com", true), "kick"],
+    ["replacement", change("auth-token", "passport.twitch.tv"), "twitch"],
+  ] as const)("invalidates the affected platform on %s", (_kind, event, platform) => {
+    const env = harness();
+
+    env.change(event);
+
+    expect(env.invalidate).toHaveBeenCalledOnce();
+    expect(env.invalidate).toHaveBeenCalledWith(platform);
+    expect(JSON.stringify(env.invalidate.mock.calls)).not.toContain("secret");
+  });
+
+  it.each([
+    change("unique_id", ".twitch.tv"),
+    change("other", "kick.com"),
+    change("auth-token", "example.com"),
+    change("session_token", "notkick.com"),
+  ])("ignores unrelated cookie change %j", async (event) => {
+    const env = harness();
+
+    env.change(event);
+    await vi.runAllTimersAsync();
+
+    expect(env.invalidate).not.toHaveBeenCalled();
+    expect(env.recheck).not.toHaveBeenCalled();
+  });
+
+  it("coalesces repeated changes into one platform-only recheck", async () => {
+    const env = harness();
+
+    env.change(change("auth-token", ".twitch.tv"));
+    env.change(change("auth-token", ".twitch.tv", true));
+    env.change(change("auth-token", "www.twitch.tv"));
+
+    expect(env.invalidate).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(249);
+    expect(env.recheck).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(env.recheck).toHaveBeenCalledOnce();
+    expect(env.recheck).toHaveBeenCalledWith("twitch");
+  });
+
+  it("debounces Twitch and Kick independently", async () => {
+    const env = harness();
+
+    env.change(change("auth-token", "twitch.tv"));
+    env.change(change("session_token", ".kick.com"));
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(env.recheck).toHaveBeenCalledTimes(2);
+    expect(env.recheck).toHaveBeenCalledWith("twitch");
+    expect(env.recheck).toHaveBeenCalledWith("kick");
+  });
+
+  it("contains rejected invalidation and recheck callbacks", async () => {
+    const env = harness();
+    env.invalidate.mockRejectedValueOnce(new Error("invalidate failed"));
+    env.recheck.mockRejectedValueOnce(new Error("recheck failed"));
+
+    expect(() => env.change(change("session_token", "kick.com"))).not.toThrow();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(env.recheck).toHaveBeenCalledWith("kick");
+  });
+
+  it("removes its listener and cancels pending rechecks on disposal", async () => {
+    const env = harness();
+    env.change(change("auth-token", "twitch.tv"));
+
+    env.dispose();
+    await vi.runAllTimersAsync();
+
+    expect(env.onChanged.removeListener).toHaveBeenCalledWith(env.listener);
+    expect(env.recheck).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add a browser-neutral credential-availability preflight to the background controller
- detect required Twitch and Kick session cookies without exposing credential values
- observe relevant cookie changes, invalidate only the affected platform, and debounce platform-scoped scheduler rechecks
- preserve the browser-free core boundary and cover login, logout, token replacement, filtering, lookup failure, and debounce behavior

## Impact

This provides the extension-owned credential observation layer required by the authentication-health epic. Cookie presence remains a preflight rather than proof of a healthy authenticated session; the platform probes and scheduler gating remain scoped to #202–#204.

## Testing

- `pnpm verify`
  - 721 extension tests passed
  - 105 CLI tests passed
  - workspace typechecks passed
  - script and site checks passed
  - Chromium MV3 build passed
  - Firefox MV2 build passed

Closes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform credential detection for Twitch and Kick without exposing credential values.
  * Authentication health now distinguishes available, missing, and unavailable credentials.
  * Added automatic platform-specific health invalidation and debounced rechecks when login cookies change.
  * Unrelated cookie changes are ignored.

* **Tests**
  * Added coverage for credential detection, cookie observation, debouncing, cleanup, error handling, and browser-free core boundaries.

* **Documentation**
  * Added implementation plans and design specifications for credential observation and authentication health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->