### PR TITLE
fix(twitch): gate authentication health on current user

### DIFF
--- a/docs/superpowers/plans/2026-07-22-twitch-auth-health-probe.md
+++ b/docs/superpowers/plans/2026-07-22-twitch-auth-health-probe.md
@@ -1,0 +1,323 @@
+# Twitch Authentication Health Probe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Twitch's placeholder authentication health with an explicit authenticated `CurrentUser` probe and safe credential-versus-availability classification.
+
+**Architecture:** The existing extension controller continues to own cookie availability preflight. `TwitchAdapter.checkAuthHealth()` runs the inline `CurrentUser` query through the existing Twitch GQL transport; a small internal typed transport error preserves whether a failure came from request transport, credential rejection, or Twitch service/GQL availability without exposing raw content in health state.
+
+**Tech Stack:** TypeScript 7, pnpm workspaces, Vitest, `@lurkloot/core`, `@lurkloot/shared`.
+
+## Global Constraints
+
+- Implement issue #202 only; scheduler suspension, degraded operational state, and account-operation gating remain in issue #204.
+- Only a successful authenticated GQL response with non-null `currentUser` may produce `healthy`.
+- Missing `auth-token` remains an extension-controller preflight and must avoid adapter invocation.
+- Client-Integrity availability must remain separate and `checkAuthHealth()` must not call `ensureIntegrity`.
+- Health state, events, diagnostics, and logs must not contain tokens, cookies, authenticated response bodies, request URLs, headers, user ids, or raw error messages.
+- Existing Twitch inventory, heartbeat, channel-points, and reward-claim behavior must remain unchanged.
+- Follow red-green-refactor: every production change follows a focused failing test whose expected failure is observed first.
+
+---
+
+### Task 1: Twitch authenticated identity probe and classification
+
+**Files:**
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Consumes: `TwitchGqlTransport`, `TwitchGqlResponse<T>`, and the existing inline `CURRENT_USER_QUERY` in `packages/core/src/platforms/twitch/index.ts`.
+- Produces: `TwitchAdapter.checkAuthHealth(): Promise<PlatformAuthHealth>` returning only normalized shared health fields.
+- Produces internally: `TwitchGqlFailureKind = "network" | "credentials" | "platform"` and `TwitchGqlFailure`, used only to classify probe failures while preserving existing thrown-error behavior for other Twitch operations.
+
+- [ ] **Step 1: Add failing healthy and anonymous-response tests**
+
+Insert at the start of the existing `describe("TwitchAdapter", ...)` block in `packages/extension/tests/adapters.test.ts`:
+
+```ts
+  it("reports healthy only when the authenticated CurrentUser probe returns a user", async () => {
+    const ensureIntegrity = vi.fn(async () => true);
+    const fetcher = jsonFetcher((_url, init) => {
+      expect(operation(init)).toBe("CurrentUser");
+      expect(requestBody(init).query).toContain("currentUser { id }");
+      return { data: { currentUser: { id: "private-user-id" } } };
+    });
+
+    await expect(new TwitchAdapter(fetcher, ensureIntegrity).checkAuthHealth()).resolves.toEqual({
+      status: "healthy",
+      checkedAt: expect.any(String),
+      message: { key: "authHealthy" },
+    });
+    expect(ensureIntegrity).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { data: { currentUser: null } },
+    { data: {} },
+    { data: { user: { id: "public-user-id" } } },
+  ])("rejects a completed response without authenticated identity: %j", async (response) => {
+    const fetcher = jsonFetcher(() => response);
+
+    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+      status: "invalid_credentials",
+      checkedAt: expect.any(String),
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    });
+  });
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- adapters.test.ts`
+
+Expected: FAIL because `checkAuthHealth()` still returns `{ status: "checking" }` and does not send `CurrentUser`.
+
+- [ ] **Step 3: Implement the minimal successful/null identity probe**
+
+Replace the placeholder method in `TwitchAdapter` with:
+
+```ts
+  async checkAuthHealth(): Promise<PlatformAuthHealth> {
+    const checkedAt = new Date().toISOString();
+    const response = await this.gqlTransport<{ currentUser?: { id?: string } | null }>(
+      "CurrentUser",
+      "",
+      {},
+      CURRENT_USER_QUERY,
+      undefined,
+      this.emit,
+    );
+    if (response.data?.currentUser) {
+      return { status: "healthy", checkedAt, message: { key: "authHealthy" } };
+    }
+    return {
+      status: "invalid_credentials",
+      checkedAt,
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    };
+  }
+```
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- adapters.test.ts`
+
+Expected: the new identity tests pass and all existing adapter tests pass.
+
+- [ ] **Step 5: Add failing credential, network, and platform-error classification tests**
+
+Add after the identity tests:
+
+```ts
+  it.each([
+    { error: "Unauthorized", message: "OAuth token is invalid" },
+    { errors: [{ message: "Unauthenticated" }] },
+  ])("classifies explicit Twitch credential rejection as invalid: %j", async (response) => {
+    const fetcher = jsonFetcher(() => response);
+
+    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+      status: "invalid_credentials",
+      checkedAt: expect.any(String),
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    });
+  });
+
+  it("classifies request transport failure as network unavailability", async () => {
+    const fetcher = jsonFetcher(() => {
+      throw new TypeError("Failed to fetch secret-url");
+    });
+
+    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+      status: "unavailable",
+      checkedAt: expect.any(String),
+      reasonCode: "network_unavailable",
+      message: { key: "authNetworkUnavailable" },
+    });
+  });
+
+  it.each([
+    { errors: [{ message: "service unavailable" }] },
+    { error: "Service Unavailable", message: "upstream failed" },
+    null,
+  ])("classifies Twitch response failure as platform unavailability: %j", async (response) => {
+    const fetcher = jsonFetcher(() => response);
+
+    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+      status: "unavailable",
+      checkedAt: expect.any(String),
+      reasonCode: "platform_unavailable",
+      message: { key: "authPlatformUnavailable" },
+    });
+  });
+```
+
+- [ ] **Step 6: Run the focused tests and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- adapters.test.ts`
+
+Expected: FAIL because transport and Twitch errors still reject instead of returning classified health.
+
+- [ ] **Step 7: Add typed internal GQL failures**
+
+Add near `TwitchGqlResponse<T>`:
+
+```ts
+type TwitchGqlFailureKind = "network" | "credentials" | "platform";
+
+class TwitchGqlFailure extends Error {
+  constructor(readonly kind: TwitchGqlFailureKind, message: string) {
+    super(message);
+    this.name = "TwitchGqlFailure";
+  }
+}
+
+function isCredentialRejection(message: string | undefined): boolean {
+  return message != null && /unauthenticated|unauthorized|oauth token (?:is )?invalid|invalid oauth token|token (?:has )?expired/i.test(message);
+}
+```
+
+In `createTwitchGqlTransport`, replace the direct `fetcher.fetchJson` call in `fetchOnce` with:
+
+```ts
+      let raw: unknown;
+      try {
+        raw = await fetcher.fetchJson<unknown>("https://gql.twitch.tv/gql", request, emit);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : `${operationName} request failed`;
+        throw new TwitchGqlFailure("network", message);
+      }
+```
+
+Replace the page-error throw with:
+
+```ts
+      if (pageError) throw new TwitchGqlFailure("network", `${operationName}: ${pageError}`);
+```
+
+Replace every empty-response `throw new Error(...)` inside this transport with `throw new TwitchGqlFailure("platform", ...)` using the same existing message. Replace the final top-level and `errors[]` throws with:
+
+```ts
+    if (response.error || (response.message && response.data === undefined)) {
+      const message = [response.error, response.message].filter(Boolean).join(": ") || `${operationName} failed`;
+      throw new TwitchGqlFailure(isCredentialRejection(message) ? "credentials" : "platform", message);
+    }
+    if (response.errors?.length) {
+      const message = response.errors.map((error) => error.message).filter(Boolean).join("; ") || `${operationName} failed`;
+      throw new TwitchGqlFailure(isCredentialRejection(message) ? "credentials" : "platform", message);
+    }
+```
+
+- [ ] **Step 8: Map typed failures to safe health results**
+
+Wrap the `gqlTransport` call and identity classification in `checkAuthHealth()` with `try/catch` and add:
+
+```ts
+    } catch (error) {
+      if (error instanceof TwitchGqlFailure && error.kind === "credentials") {
+        return {
+          status: "invalid_credentials",
+          checkedAt,
+          reasonCode: "credentials_rejected",
+          message: { key: "authInvalidCredentials" },
+        };
+      }
+      const network = error instanceof TwitchGqlFailure && error.kind === "network";
+      return {
+        status: "unavailable",
+        checkedAt,
+        reasonCode: network ? "network_unavailable" : "platform_unavailable",
+        message: { key: network ? "authNetworkUnavailable" : "authPlatformUnavailable" },
+      };
+    }
+```
+
+Do not emit or copy `error.message` from this catch.
+
+- [ ] **Step 9: Run focused adapter tests and verify GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- adapters.test.ts`
+
+Expected: all adapter tests pass, including every new classification.
+
+- [ ] **Step 10: Commit the probe**
+
+```bash
+git add packages/core/src/platforms/twitch/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "fix(twitch): probe authenticated session health"
+```
+
+### Task 2: Controller recovery regression and complete verification
+
+**Files:**
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: existing `controller.checkAuthHealth(platform)` and `controller.invalidateAuthHealth(platform)` APIs.
+- Verifies: a credential-triggered recheck can replace unhealthy Twitch state with `healthy` without modifying platform settings or invoking the other platform.
+
+- [ ] **Step 1: Add the recovery transition test**
+
+Add after `continues to the authenticated probe when credentials are available`:
+
+```ts
+  it("recovers Twitch authentication health after login without changing enabled settings", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true }, {
+      checkCredentialAvailability: async () => ({ status: "available" }),
+    });
+    vi.mocked(env.twitch.checkAuthHealth)
+      .mockResolvedValueOnce({
+        status: "invalid_credentials",
+        checkedAt: "2026-07-22T12:00:00.000Z",
+        reasonCode: "credentials_rejected",
+        message: { key: "authInvalidCredentials" },
+      })
+      .mockResolvedValueOnce({
+        status: "healthy",
+        checkedAt: "2026-07-22T12:05:00.000Z",
+        message: { key: "authHealthy" },
+      });
+
+    await env.controller.checkAuthHealth("twitch");
+    await env.controller.invalidateAuthHealth("twitch");
+    await env.controller.checkAuthHealth("twitch");
+
+    expect(env.state.authHealth.twitch).toEqual({
+      status: "healthy",
+      checkedAt: "2026-07-22T12:05:00.000Z",
+      message: { key: "authHealthy" },
+    });
+    expect(env.settings.platform.twitch.enabled).toBe(true);
+    expect(env.settings.platform.kick.enabled).toBe(true);
+    expect(env.twitch.checkAuthHealth).toHaveBeenCalledTimes(2);
+    expect(env.kick.checkAuthHealth).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run focused controller tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- backgroundController.test.ts`
+
+Expected: all controller tests pass. This is regression coverage over existing controller behavior; no production change is expected.
+
+- [ ] **Step 3: Run Twitch regression coverage**
+
+Run: `pnpm --filter @lurkloot/extension test -- adapters.test.ts twitchIntegrity.test.ts twitchHeartbeat.test.ts heartbeatTransport.test.ts backgroundController.test.ts`
+
+Expected: all focused Twitch, transport, and recovery tests pass.
+
+- [ ] **Step 4: Run repository verification**
+
+Run: `pnpm verify`
+
+Expected: script tests, all workspace typechecks, extension tests, site build, and Chromium/Firefox extension builds complete with exit code 0.
+
+- [ ] **Step 5: Commit recovery coverage**
+
+```bash
+git add packages/extension/tests/backgroundController.test.ts
+git commit -m "test(twitch): cover authentication recovery"
+```

--- a/docs/superpowers/specs/2026-07-22-twitch-auth-health-probe-design.md
+++ b/docs/superpowers/specs/2026-07-22-twitch-auth-health-probe-design.md
@@ -1,0 +1,67 @@
+# Twitch Authentication Health Probe Design
+
+## Scope
+
+This specification implements issue #202 only. It replaces the Twitch adapter's placeholder authentication-health result with an explicit authenticated identity probe and safe classification. Scheduler-wide suspension, degraded operational state, and account-operation gating remain in issue #204.
+
+## Goals
+
+- Treat the extension-owned `auth-token` cookie check as a preflight, not proof of authentication.
+- Mark Twitch healthy only after a successful authenticated GQL response contains a non-null `currentUser`.
+- Distinguish rejected credentials from network and Twitch availability failures.
+- Keep Twitch Client-Integrity availability independent from authentication health.
+- Preserve existing Twitch inventory, heartbeat, channel-points, and reward-claim behavior.
+
+## Probe Architecture
+
+`TwitchAdapter.checkAuthHealth()` will send the existing inline `CurrentUser` query through the adapter's authenticated Twitch GQL transport. The query requests only `currentUser { id }`; public data and anonymous query success cannot satisfy the probe.
+
+The controller remains responsible for credential availability. When the extension credential provider reports that `auth-token` is missing, the controller returns `missing_credentials` without constructing or invoking the Twitch adapter. When a cookie is present, the adapter probe decides whether Twitch accepts it.
+
+The probe will not call `ensureIntegrity`, request an integrity token, or interpret integrity availability as login health. No credential value or authenticated response content will enter scheduler state, activity events, diagnostics, or logs.
+
+## Classification
+
+Every completed probe result includes an ISO timestamp in `checkedAt` and the safe message key corresponding to its status and reason.
+
+| Observation | Health result |
+| --- | --- |
+| Credential preflight reports no `auth-token` | `missing_credentials` / `credentials_missing` (controller-owned existing behavior) |
+| GQL response has a non-null `currentUser` object | `healthy` |
+| GQL response completes but `currentUser` is null or absent | `invalid_credentials` / `credentials_rejected` |
+| Twitch explicitly rejects authentication | `invalid_credentials` / `credentials_rejected` |
+| Request fails at the network/transport boundary | `unavailable` / `network_unavailable` |
+| Twitch returns a non-authentication service or GQL failure | `unavailable` / `platform_unavailable` |
+
+Classification uses structured response observations at the probe boundary. It does not infer authentication from inventory data, public Twitch fields, diagnostic strings, or Client-Integrity state.
+
+## Recovery
+
+Cookie changes already invalidate platform authentication health and schedule a debounced platform-only recheck. A later successful `CurrentUser` response therefore transitions the stored Twitch health from `missing_credentials`, `invalid_credentials`, or `unavailable` to `healthy` without changing the user's enabled-platform setting. Running or suppressing account automation based on that stored health remains #204.
+
+## Error Handling
+
+The probe catches its own expected request failures and returns the shared safe health contract rather than throwing raw transport or Twitch errors into controller state. Authentication rejection is classified separately from availability. Returned health contains no raw exception message, response body, request URL, headers, token, cookie, or user identifier.
+
+Existing Twitch operations continue to use their current GQL transport behavior. Any helper introduced for probe classification remains focused on the probe and does not refactor inventory, heartbeat, channel-points, or claim execution.
+
+## Testing
+
+Focused deterministic adapter and controller tests will cover:
+
+- a present credential and non-null `currentUser` producing `healthy`;
+- null or absent `currentUser` producing `invalid_credentials`;
+- an explicit Twitch credential rejection producing `invalid_credentials`;
+- network/transport failure producing `unavailable` with `network_unavailable`;
+- non-authentication Twitch failure producing `unavailable` with `platform_unavailable`;
+- a public or anonymous response never producing `healthy`;
+- missing-cookie preflight avoiding adapter invocation;
+- recovery from unhealthy state to `healthy` on a later successful recheck;
+- the probe never requesting Client-Integrity;
+- existing inventory, heartbeat, channel-points, and reward-claim suites remaining green.
+
+Tests use mocked fetchers and fixed expectations; they make no live Twitch requests.
+
+## Delivery Boundary
+
+Issue #202 is complete when Twitch authentication probing and classification replace the adapter placeholder, focused classification and recovery tests pass, and existing Twitch behavior remains covered. It does not alter scheduler execution, platform enabled settings, popup rendering, or Kick authentication.

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -413,13 +413,21 @@ function twitchClientSessionIdValue(): string {
   return twitchClientSessionId;
 }
 
-function twitchGqlErrorEnvelope(summary: string, status: number, body: string, headers: Headers): { __twitchGqlError: string } {
-  return { __twitchGqlError: [
-    `Twitch GQL ${summary}`,
-    `status=${status}`,
-    `authHeader=${headers.has("authorization") ? "yes" : "no"}`,
-    `body=${body.slice(0, 300)}`,
-  ].join("; ") };
+function twitchGqlErrorEnvelope(
+  summary: string,
+  status: number,
+  body: string,
+  headers: Headers,
+): { __twitchGqlError: string; __twitchGqlFailureKind: "network" | "credentials" | "platform" } {
+  return {
+    __twitchGqlError: [
+      `Twitch GQL ${summary}`,
+      `status=${status}`,
+      `authHeader=${headers.has("authorization") ? "yes" : "no"}`,
+      `body=${body.slice(0, 300)}`,
+    ].join("; "),
+    __twitchGqlFailureKind: status === 0 ? "network" : status === 401 ? "credentials" : "platform",
+  };
 }
 
 function isUsableTwitchGql(value: unknown): boolean {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -174,7 +174,7 @@ class TwitchGqlFailure extends Error {
 }
 
 function isCredentialRejection(message: string | undefined): boolean {
-  return message != null && /unauthenticated|unauthorized|oauth token (?:is )?invalid|invalid oauth token|token (?:has )?expired/i.test(message);
+  return message != null && /unauthenticated|unauthorized|(?:the )?oauth token (?:(?:is|was) )?invalid|invalid oauth token|token (?:has )?expired/i.test(message);
 }
 
 interface TwitchDashboardData {
@@ -333,7 +333,7 @@ export function createTwitchGqlTransport(
         throw new TwitchGqlFailure("network", message);
       }
       const pageError = twitchPageFetchError(raw);
-      if (pageError) throw new TwitchGqlFailure("network", `${operationName}: ${pageError}`);
+      if (pageError) throw new TwitchGqlFailure(pageError.kind, `${operationName}: ${pageError.message}`);
       return normalizeTwitchGqlResponse<T>(raw);
     };
     let activeQuery = query;
@@ -993,10 +993,16 @@ function isTwitchGqlResponse<T>(value: TwitchGqlResponse<T> | null): value is Tw
 // response; both PersistedQueryNotFound and integrity rejections arrive this way.
 // The in-page fetcher resolves `{ __twitchGqlError }` instead of rejecting,
 // because executeScript discards rejection messages. Pull the diagnostic out.
-function twitchPageFetchError(value: unknown): string | undefined {
+function twitchPageFetchError(value: unknown): { message: string; kind: TwitchGqlFailureKind } | undefined {
   if (value != null && typeof value === "object" && !Array.isArray(value)) {
-    const error = (value as { __twitchGqlError?: unknown }).__twitchGqlError;
-    if (typeof error === "string") return error;
+    const envelope = value as { __twitchGqlError?: unknown; __twitchGqlFailureKind?: unknown };
+    if (typeof envelope.__twitchGqlError === "string") {
+      const kind = envelope.__twitchGqlFailureKind;
+      return {
+        message: envelope.__twitchGqlError,
+        kind: kind === "credentials" || kind === "platform" ? kind : "network",
+      };
+    }
   }
   return undefined;
 }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -164,6 +164,19 @@ interface TwitchGqlResponse<T> {
   message?: string;
 }
 
+type TwitchGqlFailureKind = "network" | "credentials" | "platform";
+
+class TwitchGqlFailure extends Error {
+  constructor(readonly kind: TwitchGqlFailureKind, message: string) {
+    super(message);
+    this.name = "TwitchGqlFailure";
+  }
+}
+
+function isCredentialRejection(message: string | undefined): boolean {
+  return message != null && /unauthenticated|unauthorized|oauth token (?:is )?invalid|invalid oauth token|token (?:has )?expired/i.test(message);
+}
+
 interface TwitchDashboardData {
   currentUser?: {
     id?: string;
@@ -312,15 +325,21 @@ export function createTwitchGqlTransport(
     } satisfies RequestInit);
     const fetchOnce = async (queryText?: string): Promise<TwitchGqlResponse<T> | null> => {
       const request = buildRequest(queryText);
-      const raw = await fetcher.fetchJson<unknown>("https://gql.twitch.tv/gql", request, emit);
+      let raw: unknown;
+      try {
+        raw = await fetcher.fetchJson<unknown>("https://gql.twitch.tv/gql", request, emit);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : `${operationName} request failed`;
+        throw new TwitchGqlFailure("network", message);
+      }
       const pageError = twitchPageFetchError(raw);
-      if (pageError) throw new Error(`${operationName}: ${pageError}`);
+      if (pageError) throw new TwitchGqlFailure("network", `${operationName}: ${pageError}`);
       return normalizeTwitchGqlResponse<T>(raw);
     };
     let activeQuery = query;
     let response = await fetchOnce(activeQuery);
     if (!isTwitchGqlResponse<T>(response)) {
-      throw new Error(`${operationName} ${query ? "inline query" : "persisted query"} returned an empty Twitch GQL response`);
+      throw new TwitchGqlFailure("platform", `${operationName} ${query ? "inline query" : "persisted query"} returned an empty Twitch GQL response`);
     }
     const fallbackQuery = !query ? TWITCH_INLINE_QUERIES[operationName] : undefined;
     if (fallbackQuery && hasPersistedQueryNotFound(response)) {
@@ -328,21 +347,23 @@ export function createTwitchGqlTransport(
       activeQuery = fallbackQuery;
       response = await fetchOnce(activeQuery);
       if (!isTwitchGqlResponse<T>(response)) {
-        throw new Error(`${operationName} inline query fallback returned an empty Twitch GQL response`);
+        throw new TwitchGqlFailure("platform", `${operationName} inline query fallback returned an empty Twitch GQL response`);
       }
     }
     if (response.errors?.some((error) => isTransientGqlError(error.message))) {
       diagnostic(emit, "debug", `GQL ${operationName} returned a transient error; retrying once`, "twitch");
       response = await fetchOnce(activeQuery);
       if (!isTwitchGqlResponse<T>(response)) {
-        throw new Error(`${operationName} ${activeQuery ? "inline query" : "persisted query"} returned an empty Twitch GQL response`);
+        throw new TwitchGqlFailure("platform", `${operationName} ${activeQuery ? "inline query" : "persisted query"} returned an empty Twitch GQL response`);
       }
     }
     if (response.error || (response.message && response.data === undefined)) {
-      throw new Error([response.error, response.message].filter(Boolean).join(": ") || `${operationName} failed`);
+      const message = [response.error, response.message].filter(Boolean).join(": ") || `${operationName} failed`;
+      throw new TwitchGqlFailure(isCredentialRejection(message) ? "credentials" : "platform", message);
     }
     if (response.errors?.length) {
-      throw new Error(response.errors.map((error) => error.message).filter(Boolean).join("; ") || `${operationName} failed`);
+      const message = response.errors.map((error) => error.message).filter(Boolean).join("; ") || `${operationName} failed`;
+      throw new TwitchGqlFailure(isCredentialRejection(message) ? "credentials" : "platform", message);
     }
     return response;
   };
@@ -353,7 +374,42 @@ export class TwitchAdapter implements PlatformAdapter {
   readonly compatibility?: ResolvedCompatibility["twitch"];
 
   async checkAuthHealth(): Promise<PlatformAuthHealth> {
-    return { status: "checking" };
+    const checkedAt = new Date().toISOString();
+    try {
+      const response = await this.gqlTransport<{ currentUser?: { id?: string } | null }>(
+        "CurrentUser",
+        "",
+        {},
+        CURRENT_USER_QUERY,
+        undefined,
+        this.emit,
+      );
+      if (response.data?.currentUser) {
+        return { status: "healthy", checkedAt, message: { key: "authHealthy" } };
+      }
+      return {
+        status: "invalid_credentials",
+        checkedAt,
+        reasonCode: "credentials_rejected",
+        message: { key: "authInvalidCredentials" },
+      };
+    } catch (error) {
+      if (error instanceof TwitchGqlFailure && error.kind === "credentials") {
+        return {
+          status: "invalid_credentials",
+          checkedAt,
+          reasonCode: "credentials_rejected",
+          message: { key: "authInvalidCredentials" },
+        };
+      }
+      const network = error instanceof TwitchGqlFailure && error.kind === "network";
+      return {
+        status: "unavailable",
+        checkedAt,
+        reasonCode: network ? "network_unavailable" : "platform_unavailable",
+        message: { key: network ? "authNetworkUnavailable" : "authPlatformUnavailable" },
+      };
+    }
   }
 
   private readonly gqlTransport: TwitchGqlTransport;

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
 import { createKickClaimCapability, createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/kick";
-import { KickWafBlockedError } from "@lurkloot/core/tabs";
+import { fetchTwitchInBackgroundWith, KickWafBlockedError } from "@lurkloot/core/tabs";
 import { readFileSync } from "node:fs";
 import { TwitchAdapter } from "@lurkloot/core/twitch";
 import type { EngineEvent } from "@lurkloot/shared/events";
@@ -780,6 +780,7 @@ describe("TwitchAdapter", () => {
   it.each([
     { error: "Unauthorized", message: "OAuth token is invalid" },
     { errors: [{ message: "Unauthenticated" }] },
+    { errors: [{ message: "The OAuth token was invalid" }] },
   ])("classifies explicit Twitch credential rejection as invalid: %j", async (response) => {
     const fetcher = jsonFetcher(() => response);
 
@@ -789,6 +790,34 @@ describe("TwitchAdapter", () => {
       reasonCode: "credentials_rejected",
       message: { key: "authInvalidCredentials" },
     });
+  });
+
+  it.each([
+    [401, "Unauthorized", "invalid_credentials", "credentials_rejected", "authInvalidCredentials"],
+    [503, "Service Unavailable", "unavailable", "platform_unavailable", "authPlatformUnavailable"],
+  ] as const)("classifies background HTTP %i without treating it as a network failure", async (status, statusText, healthStatus, reasonCode, messageKey) => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(status === 401 ? "OAuth token rejected" : "upstream unavailable", { status, statusText }),
+    );
+    const cookieApi = {
+      cookies: {
+        get: vi.fn(async ({ name }: { name: string }) => name === "auth-token" ? { value: "secret" } : null),
+      },
+    };
+    const fetcher: PageFetcher = {
+      fetchJson: (url, init) => fetchTwitchInBackgroundWith(cookieApi, url, init),
+    };
+
+    try {
+      await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+        status: healthStatus,
+        checkedAt: expect.any(String),
+        reasonCode,
+        message: { key: messageKey },
+      });
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 
   it("classifies request transport failure as network unavailability", async () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -746,6 +746,79 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
 });
 
 describe("TwitchAdapter", () => {
+  it("reports healthy only when the authenticated CurrentUser probe returns a user", async () => {
+    const ensureIntegrity = vi.fn(async () => true);
+    const fetcher = jsonFetcher((_url, init) => {
+      expect(operation(init)).toBe("CurrentUser");
+      expect(requestBody(init).query).toContain("currentUser { id }");
+      return { data: { currentUser: { id: "private-user-id" } } };
+    });
+
+    await expect(new TwitchAdapter(fetcher, ensureIntegrity).checkAuthHealth()).resolves.toEqual({
+      status: "healthy",
+      checkedAt: expect.any(String),
+      message: { key: "authHealthy" },
+    });
+    expect(ensureIntegrity).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { data: { currentUser: null } },
+    { data: {} },
+    { data: { user: { id: "public-user-id" } } },
+  ])("rejects a completed response without authenticated identity: %j", async (response) => {
+    const fetcher = jsonFetcher(() => response);
+
+    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+      status: "invalid_credentials",
+      checkedAt: expect.any(String),
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    });
+  });
+
+  it.each([
+    { error: "Unauthorized", message: "OAuth token is invalid" },
+    { errors: [{ message: "Unauthenticated" }] },
+  ])("classifies explicit Twitch credential rejection as invalid: %j", async (response) => {
+    const fetcher = jsonFetcher(() => response);
+
+    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+      status: "invalid_credentials",
+      checkedAt: expect.any(String),
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    });
+  });
+
+  it("classifies request transport failure as network unavailability", async () => {
+    const fetcher = jsonFetcher(() => {
+      throw new TypeError("Failed to fetch secret-url");
+    });
+
+    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+      status: "unavailable",
+      checkedAt: expect.any(String),
+      reasonCode: "network_unavailable",
+      message: { key: "authNetworkUnavailable" },
+    });
+  });
+
+  it.each([
+    { errors: [{ message: "service unavailable" }] },
+    { error: "Service Unavailable", message: "upstream failed" },
+    null,
+  ])("classifies Twitch response failure as platform unavailability: %j", async (response) => {
+    const fetcher = jsonFetcher(() => response);
+
+    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+      status: "unavailable",
+      checkedAt: expect.any(String),
+      reasonCode: "platform_unavailable",
+      message: { key: "authPlatformUnavailable" },
+    });
+  });
+
   it("declares the post-claim handoff capability for Twitch only", () => {
     // Reading a capability must not touch the network.
     const fetcher = jsonFetcher(() => {

--- a/packages/extension/tests/authHealth.test.ts
+++ b/packages/extension/tests/authHealth.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_STATE, mergeSchedulerState, normalizePlatformAuthHealth } from "@lurkloot/core/defaults";
 import type { PlatformAdapter } from "@lurkloot/core/adapter";
-import { TwitchAdapter } from "@lurkloot/core/twitch";
 import { KickAdapter } from "@lurkloot/core/kick";
 import { applyPlatformAuthHealth } from "@lurkloot/core/authHealth";
 
@@ -11,9 +10,8 @@ describe("authentication health normalization", () => {
     expect(await probe()).toEqual({ status: "checking" });
   });
 
-  it("keeps both platform adapters in checking state until their probes are implemented", async () => {
+  it("keeps the Kick adapter in checking state until its probe is implemented", async () => {
     const fetcher = { fetchJson: async () => { throw new Error("not called"); } };
-    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({ status: "checking" });
     await expect(new KickAdapter(fetcher).checkAuthHealth()).resolves.toEqual({ status: "checking" });
   });
   it("defaults both platforms to unchecked checking state", () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -156,6 +156,38 @@ describe("background controller", () => {
     expect(env.state.authHealth.twitch.status).toBe("checking");
   });
 
+  it("recovers Twitch authentication health after login without changing enabled settings", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true }, {
+      checkCredentialAvailability: async () => ({ status: "available" }),
+    });
+    vi.mocked(env.twitch.checkAuthHealth)
+      .mockResolvedValueOnce({
+        status: "invalid_credentials",
+        checkedAt: "2026-07-22T12:00:00.000Z",
+        reasonCode: "credentials_rejected",
+        message: { key: "authInvalidCredentials" },
+      })
+      .mockResolvedValueOnce({
+        status: "healthy",
+        checkedAt: "2026-07-22T12:05:00.000Z",
+        message: { key: "authHealthy" },
+      });
+
+    await env.controller.checkAuthHealth("twitch");
+    await env.controller.invalidateAuthHealth("twitch");
+    await env.controller.checkAuthHealth("twitch");
+
+    expect(env.state.authHealth.twitch).toEqual({
+      status: "healthy",
+      checkedAt: "2026-07-22T12:05:00.000Z",
+      message: { key: "authHealthy" },
+    });
+    expect(env.settings.platform.twitch.enabled).toBe(true);
+    expect(env.settings.platform.kick.enabled).toBe(true);
+    expect(env.twitch.checkAuthHealth).toHaveBeenCalledTimes(2);
+    expect(env.kick.checkAuthHealth).not.toHaveBeenCalled();
+  });
+
   it("invalidates only the requested authentication health and reports the transition once", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: false });
     vi.mocked(env.twitch.checkAuthHealth).mockResolvedValueOnce({ status: "healthy", checkedAt: "2026-07-22T12:00:00.000Z" });


### PR DESCRIPTION
## Summary

- probe Twitch authentication explicitly with the minimal authenticated `CurrentUser` GQL query
- classify missing/rejected credentials separately from network and Twitch availability failures
- preserve safe failure metadata across the extension background transport without exposing credentials or response data
- keep Client-Integrity independent and cover automatic health recovery after login

## Root cause

Twitch authentication health was still a placeholder, while inventory discovery implicitly inferred login from `currentUser`. The background transport also collapsed HTTP and network failures into one diagnostic envelope, preventing reliable classification.

## Impact

Twitch is marked healthy only when Twitch accepts the session and returns a non-null `currentUser`. Expired tokens, network outages, and Twitch service failures now produce distinct shared health states. Scheduler gating remains scoped to #204.

Closes #202.

## Testing

- `pnpm --filter @lurkloot/extension test -- adapters.test.ts tabs.test.ts`
- `pnpm verify`
- independent code review and follow-up review: no remaining critical or important findings