### PR TITLE
fix(kick): detect authentication and blocked page contexts

### DIFF
--- a/docs/superpowers/plans/2026-07-22-kick-auth-page-context.md
+++ b/docs/superpowers/plans/2026-07-22-kick-auth-page-context.md
@@ -1,0 +1,354 @@
+# Kick Authentication and Page-Context Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Kick authentication health authoritative and preserve safe failure metadata when service-worker or page-context requests are rejected.
+
+**Architecture:** Add a browser-neutral sanitized fetch error in core, use it in both Kick transports, and map it through an identity-requiring `/api/v1/user` probe. Harden Kick page-context reuse with a self-contained injected document validator while preserving existing lifecycle and recovery behavior.
+
+**Tech Stack:** TypeScript 7, pnpm workspaces, Vitest, WXT browser APIs.
+
+## Global Constraints
+
+- Never persist or log tokens, cookies, authorization headers, sensitive request data, or complete authenticated response bodies.
+- `healthy` requires a non-empty Kick account identity (`id`, `username`, or `slug` at the root or under `user`).
+- Public campaign discovery must never determine authentication health.
+- Preserve only bounded HTTP status, normalized reason, and bounded string or finite numeric reference metadata.
+- Do not add browser permissions or attempt to bypass Kick's security policy.
+- Keep `@lurkloot/core` browser-free; browser APIs remain injected through existing ports.
+
+---
+
+### Task 1: Sanitized Fetch Error Contract
+
+**Files:**
+- Create: `packages/core/src/core/fetchError.ts`
+- Modify: `packages/core/package.json`
+- Test: `packages/extension/tests/fetchError.test.ts`
+
+**Interfaces:**
+- Produces: `SafeFetchFailureKind`, `SafeFetchFailure`, `SafeFetchError`, `safeFetchFailure(input)`, and `isSafeFetchError(error)`.
+- `SafeFetchFailure` contains only `kind`, optional `status`, optional `reason`, and optional `reference`.
+- Later tasks import the contract through `@lurkloot/core/fetchError`.
+
+- [ ] **Step 1: Write failing normalization tests**
+
+Create tests that pass a source object containing status, reason, reference, token, cookie, headers, URL, and body. Assert the returned object is exactly:
+
+```ts
+{
+  kind: "security_policy_blocked",
+  status: 403,
+  reason: "Request blocked by security policy.",
+  reference: "9e4db7e3",
+}
+```
+
+Also assert invalid statuses, reasons longer than 256 characters, references longer than 128 characters, non-finite numeric references, and arbitrary fields are omitted. Test that `new SafeFetchError(failure)` serializes no secret input and that `isSafeFetchError` recognizes only the typed error.
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/fetchError.test.ts`
+
+Expected: FAIL because `@lurkloot/core/fetchError` is not exported.
+
+- [ ] **Step 3: Implement the minimal safe error module**
+
+Define:
+
+```ts
+export type SafeFetchFailureKind =
+  | "authentication_rejected"
+  | "security_policy_blocked"
+  | "http_error"
+  | "invalid_response"
+  | "network_error";
+
+export interface SafeFetchFailure {
+  kind: SafeFetchFailureKind;
+  status?: number;
+  reason?: string;
+  reference?: string | number;
+}
+
+export class SafeFetchError extends Error {
+  readonly failure: SafeFetchFailure;
+  constructor(candidate: SafeFetchFailure) {
+    const failure = safeFetchFailure(candidate);
+    super([failure.status ? `HTTP ${failure.status}` : undefined, failure.reason].filter(Boolean).join(" ") || failure.kind);
+    this.name = "SafeFetchError";
+    this.failure = failure;
+  }
+}
+```
+
+Implement `safeFetchFailure` with allowlists and length bounds, then export `./fetchError` from `packages/core/package.json` using the same source/types pattern as the existing `./tabs` export.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/fetchError.test.ts`
+
+Expected: the new test file passes with no failures.
+
+- [ ] **Step 5: Commit the contract**
+
+```bash
+git add packages/core/src/core/fetchError.ts packages/core/package.json packages/extension/tests/fetchError.test.ts
+git commit -m "feat(core): add sanitized fetch failures"
+```
+
+### Task 2: Kick Transport Metadata Preservation
+
+**Files:**
+- Modify: `packages/core/src/core/tabs.ts`
+- Test: `packages/extension/tests/tabs.test.ts`
+
+**Interfaces:**
+- Consumes: `SafeFetchError` and `SafeFetchFailure` from Task 1.
+- Produces: sanitized failures from `fetchKickInBackgroundWith` and `fetchJsonInPageWithBrowser`.
+- Keeps `KickWafBlockedError` as the background-to-page fallback signal, extending it with a sanitized `failure` field.
+
+- [ ] **Step 1: Add failing background transport tests**
+
+Update the exact security-policy test to use:
+
+```ts
+JSON.stringify({
+  error: "Request blocked by security policy.",
+  reference: "9e4db7e3",
+  token: "must-not-survive",
+})
+```
+
+Catch the error and assert its safe failure equals:
+
+```ts
+{
+  kind: "security_policy_blocked",
+  status: 403,
+  reason: "Request blocked by security policy.",
+  reference: "9e4db7e3",
+}
+```
+
+Assert serialized error data excludes `must-not-survive`. Add separate 401 and ordinary 500 cases producing `authentication_rejected` and `http_error`.
+
+- [ ] **Step 2: Run the transport test and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts`
+
+Expected: FAIL because current errors expose only generic messages and no `failure` metadata.
+
+- [ ] **Step 3: Parse and sanitize background failures**
+
+After reading response text, parse only JSON object fields `error`, `message`, and `reference`. Classify security-policy wording before status-based authentication rules. Build `KickWafBlockedError` with the sanitized failure for block/network fallback cases and `SafeFetchError` for final 401/other HTTP failures. Never retain the raw text.
+
+- [ ] **Step 4: Verify background transport GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts`
+
+Expected: all `tabs.test.ts` tests pass.
+
+- [ ] **Step 5: Add failing page transport envelope tests**
+
+Mock `scripting.executeScript` to return an injected error envelope for the exact security-policy response and assert `fetchJsonInPageWithBrowser` rejects with a `SafeFetchError` carrying the same four safe fields. Add an envelope containing secret extra properties and assert they do not survive reconstruction.
+
+- [ ] **Step 6: Run the page transport tests and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts`
+
+Expected: FAIL because the wrapper currently returns the envelope as successful data.
+
+- [ ] **Step 7: Implement the serializable page result envelope**
+
+Make the self-contained `pageFetchJson` return one of:
+
+```ts
+{ ok: true, data: unknown }
+{ ok: false, error: SafeFetchFailure }
+```
+
+Inline the narrow JSON error-field parsing and bounds because injected functions cannot access module helpers. Update both Manifest V3 and legacy script wrappers to unwrap success data or reconstruct `SafeFetchError` from the allowed failure fields.
+
+- [ ] **Step 8: Verify transport tests GREEN and commit**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts`
+
+Expected: all `tabs.test.ts` tests pass.
+
+```bash
+git add packages/core/src/core/tabs.ts packages/extension/tests/tabs.test.ts
+git commit -m "fix(kick): preserve safe fetch failure metadata"
+```
+
+### Task 3: Authoritative Kick Authentication Probe
+
+**Files:**
+- Modify: `packages/core/src/platforms/kick/index.ts`
+- Modify: `packages/extension/tests/authHealth.test.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Consumes: `SafeFetchError` and the existing `PageFetcher`.
+- Produces: `KickAdapter.checkAuthHealth(): Promise<PlatformAuthHealth>` based only on `/api/v1/user` identity/error results.
+
+- [ ] **Step 1: Replace the Kick checking-state test with failing probe tests**
+
+Keep Twitch's existing `checking` expectation. Add table-driven Kick tests for root `{ id: 42 }`, `{ username: "viewer" }`, and nested `{ user: { slug: "viewer" } }`; each must report `healthy`, include a valid `checkedAt`, and call exactly `https://kick.com/api/v1/user`.
+
+Add an identity-free `{ data: [] }` result and assert `invalid_credentials`. Assert a public campaign-shaped response cannot report healthy.
+
+- [ ] **Step 2: Run adapter auth tests and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/authHealth.test.ts tests/adapters.test.ts`
+
+Expected: FAIL because `KickAdapter.checkAuthHealth()` still returns `checking` without fetching.
+
+- [ ] **Step 3: Implement the identity-requiring success path**
+
+Add a small `hasKickIdentity` helper accepting finite/string ids and non-empty username/slug fields at the root or nested `user`. Probe `/api/v1/user`; return `healthy` only when that helper succeeds, otherwise return:
+
+```ts
+{
+  status: "invalid_credentials",
+  checkedAt,
+  reasonCode: "credentials_rejected",
+  message: { key: "authInvalidCredentials" },
+}
+```
+
+- [ ] **Step 4: Run focused auth tests and verify GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/authHealth.test.ts tests/adapters.test.ts`
+
+Expected: identity and identity-free cases pass.
+
+- [ ] **Step 5: Add failing classification tests**
+
+Have the fetcher reject with `SafeFetchError` values for `authentication_rejected`, `security_policy_blocked` with reference `9e4db7e3`, `network_error`, and `http_error`. Assert the corresponding health results are `invalid_credentials`, `blocked`, `unavailable/network_unavailable`, and `unavailable/platform_unavailable`. Assert only the blocked result exposes the safe reference.
+
+- [ ] **Step 6: Run classification tests and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/adapters.test.ts`
+
+Expected: FAIL because the adapter does not yet map typed failures.
+
+- [ ] **Step 7: Implement typed failure-to-health mapping**
+
+Map the safe error kind to the existing shared status, reason code, and localized message keys. Create one timestamp per probe. For unknown errors, return `unavailable/platform_unavailable` without copying the unknown error message.
+
+- [ ] **Step 8: Verify auth tests GREEN and commit**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/authHealth.test.ts tests/adapters.test.ts tests/backgroundController.test.ts`
+
+Expected: all selected tests pass.
+
+```bash
+git add packages/core/src/platforms/kick/index.ts packages/extension/tests/authHealth.test.ts packages/extension/tests/adapters.test.ts
+git commit -m "fix(kick): probe authenticated account identity"
+```
+
+### Task 4: Kick Page-Context Validation and Recovery
+
+**Files:**
+- Modify: `packages/core/src/core/tabs.ts`
+- Test: `packages/extension/tests/tabs.test.ts`
+
+**Interfaces:**
+- Produces: a self-contained injected `validateKickPageContext` result used by `findOrCreatePageContextTab` for `https://kick.com` contexts.
+- Validation proves document usability, not user authentication.
+
+- [ ] **Step 1: Add a failing completed-error-document test**
+
+Configure a queried completed `https://kick.com/` user tab and mock validation to report a JSON content type or body matching `Request blocked by security policy.`. Assert it is not selected as the page context and a replacement managed tab is created.
+
+- [ ] **Step 2: Run the context test and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts`
+
+Expected: FAIL because the completed user tab is currently reused without document validation.
+
+- [ ] **Step 3: Implement bounded Kick document validation**
+
+For `origin === "https://kick.com"`, inject a self-contained validator returning a small object with `usable` and optional sanitized failure. Accept HTML Kick documents; reject JSON/error or security-policy documents. Treat inability to validate as unusable. Apply validation to user tabs, retained managed tabs, and newly created tabs after readiness.
+
+- [ ] **Step 4: Run the context test and verify GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts`
+
+Expected: the blocked completed document is rejected.
+
+- [ ] **Step 5: Add a failing recovery test**
+
+Model the first candidate as a blocked JSON document and the replacement as a completed HTML Kick page. Assert the request executes only in the valid replacement and returns its successful JSON data. Assert managed lifecycle state contains only the recovered context.
+
+- [ ] **Step 6: Run the recovery test and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts`
+
+Expected: FAIL until replacement validation/retry is complete.
+
+- [ ] **Step 7: Complete recovery and cleanup behavior**
+
+Ensure rejected managed tabs are forgotten/removed through existing lifecycle rules, a valid replacement is retained, and a later request can reuse it. Bound creation attempts so persistent blocking returns a sanitized `SafeFetchError` rather than looping.
+
+- [ ] **Step 8: Verify page-context tests GREEN and commit**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts tests/backgroundController.test.ts tests/scheduler.test.ts`
+
+Expected: all selected tests pass.
+
+```bash
+git add packages/core/src/core/tabs.ts packages/extension/tests/tabs.test.ts
+git commit -m "fix(kick): reject blocked page contexts"
+```
+
+### Task 5: Full Verification and Acceptance Audit
+
+**Files:**
+- Modify only files needed to fix verification failures caused by Tasks 1-4.
+
+**Interfaces:**
+- Consumes all prior task outputs.
+- Produces a verified branch satisfying issue #203.
+
+- [ ] **Step 1: Run formatting and type verification**
+
+Run: `pnpm typecheck`
+
+Expected: all workspace typechecks exit 0.
+
+- [ ] **Step 2: Run the complete test suite**
+
+Run: `pnpm test`
+
+Expected: all workspace tests and the Astro site test build exit 0.
+
+- [ ] **Step 3: Run production verification**
+
+Run: `pnpm verify`
+
+Expected: repository checks plus Chromium and Firefox production builds exit 0.
+
+- [ ] **Step 4: Audit security and acceptance criteria**
+
+Run:
+
+```bash
+git diff origin/develop...HEAD -- packages/core packages/extension packages/shared | rg -n "session_token|authorization|cookie|response body|token"
+git diff --check origin/develop...HEAD
+git status --short --branch
+```
+
+Review every match and confirm it is transport logic, a negative security assertion, or existing safe commentary—not persisted/logged credential data. Confirm the branch is clean and each issue acceptance criterion has a corresponding passing test.
+
+- [ ] **Step 5: Commit any verification-only corrections**
+
+If verification required code corrections, first add a regression test that fails for the discovered problem, make it pass, rerun the affected command, then commit only those corrections:
+
+```bash
+git add packages/core/src/core/fetchError.ts packages/core/src/core/tabs.ts packages/core/src/platforms/kick/index.ts packages/core/package.json packages/extension/tests/fetchError.test.ts packages/extension/tests/tabs.test.ts packages/extension/tests/authHealth.test.ts packages/extension/tests/adapters.test.ts
+git commit -m "fix(kick): complete authentication health handling"
+```
+
+If no corrections were needed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-22-kick-auth-page-context-design.md
+++ b/docs/superpowers/specs/2026-07-22-kick-auth-page-context-design.md
@@ -1,0 +1,103 @@
+# Kick Authentication and Page-Context Error Design
+
+## Goal
+
+Implement issue #203 by making Kick authentication health authoritative and by preserving safe diagnostics when Kick or its security policy rejects either the extension service worker or its fallback page context.
+
+Authentication must be based on an authenticated account identity, never on public campaign discovery or the mere presence of a completed `kick.com` document.
+
+## Existing Context
+
+The controller already checks whether the browser has a `session_token` before calling the platform adapter. A missing cookie therefore maps to `missing_credentials` without exposing the cookie value. The shared authentication-health contract already supports `healthy`, `invalid_credentials`, `blocked`, and `unavailable`, including a bounded troubleshooting `reference`.
+
+The remaining gaps are:
+
+- `KickAdapter.checkAuthHealth()` currently returns `checking` without probing Kick.
+- background and page-context fetch failures lose structured HTTP metadata;
+- page-context acquisition accepts any completed document on the correct origin, including a JSON security-policy response;
+- the current background fetch treats every HTTP 403 as a WAF block and discards Kick's safe reference.
+
+## Authentication Probe
+
+`KickAdapter.checkAuthHealth()` will request `GET https://kick.com/api/v1/user` through its injected `PageFetcher`. This is an authenticated account endpoint and is independent of public drops campaign discovery.
+
+A successful response reports `healthy` only when it contains a non-empty identity. Accepted identity evidence is a finite/string `id` or a non-empty `username`/`slug`, either at the response root or in a nested `user` object. A 2xx JSON response without identity is not healthy; it is classified as rejected credentials because it does not prove an authenticated account.
+
+The controller remains responsible for the preflight cookie-presence distinction:
+
+- no `session_token`: `missing_credentials` with `credentials_missing`;
+- cookie present and authenticated identity returned: `healthy`;
+- cookie present but rejected, expired, or response lacks identity: `invalid_credentials` with `credentials_rejected`;
+- security-policy rejection: `blocked` with `security_policy_blocked` and an optional safe reference;
+- network failure or ordinary platform failure: `unavailable` with `network_unavailable` or `platform_unavailable`.
+
+All completed probe results include `checkedAt`.
+
+## Sanitized Fetch Failures
+
+Introduce a shared error representation in the browser-free core fetch layer. It carries only:
+
+- a bounded numeric HTTP status when available;
+- a normalized, bounded reason suitable for classification;
+- a bounded string or finite numeric reference when Kick provides one;
+- a coarse failure kind such as authentication rejection, security-policy block, HTTP failure, invalid response, or network failure.
+
+The error must not carry request headers, cookies, tokens, authorization values, URLs containing query secrets, or complete response bodies. Its human-readable message is generated from the safe fields.
+
+Both `fetchKickInBackgroundWith` and the injected page-fetch path will convert failures to this representation. The injected function cannot throw a custom class across the browser serialization boundary reliably, so it will return a serializable success/error envelope. The extension-side wrapper reconstructs the typed error before returning to the adapter.
+
+The exact response
+
+```json
+{
+  "error": "Request blocked by security policy.",
+  "reference": "9e4db7e3"
+}
+```
+
+is classified as a security-policy block and retains only `9e4db7e3`. HTTP status and status text may be retained as sanitized metadata, but the complete body is discarded.
+
+An HTTP 401 is an authentication rejection. An HTTP 403 is a security-policy block only when the sanitized response reason indicates Kick's security policy or blocking; otherwise it remains an authentication/HTTP rejection as appropriate. Network/CORS rejection from the service worker still triggers the existing page fallback, but if the page path also fails, its final structured failure determines authentication guidance.
+
+## Page-Context Validation
+
+Origin and load completion remain necessary but are no longer sufficient to reuse a Kick page context. Before accepting a completed `kick.com` tab, the browser adapter will execute a bounded validation in that tab which confirms it is an HTML Kick application context rather than a JSON error document or challenge response.
+
+Validation is intentionally independent of login: a legitimate logged-out Kick page is a usable page context, while authentication is decided only by `/api/v1/user`. This preserves the distinction between:
+
+- usable page context plus no credentials: login guidance;
+- unusable/security-policy-blocked browser profile: browser/profile security guidance.
+
+If a retained or user tab fails validation, acquisition forgets or closes managed state using the existing lifecycle rules and opens/retries a replacement context. A later valid document can be accepted, allowing successful recovery without restarting the extension.
+
+## Data Flow
+
+1. The controller checks `session_token` availability.
+2. If present, it calls `KickAdapter.checkAuthHealth()`.
+3. The adapter probes `/api/v1/user` through `createKickFetcher`.
+4. The service-worker request either succeeds, yields a sanitized failure, or triggers page fallback.
+5. Page acquisition validates the Kick document before executing the request.
+6. The injected request returns either JSON data or a sanitized error envelope.
+7. The wrapper reconstructs a typed safe error.
+8. The adapter maps identity or error classification to `PlatformAuthHealth`.
+9. Existing normalization and UI localization render distinct login, invalid-session, blocked-profile, and unavailable guidance.
+
+## Testing
+
+Focused deterministic Vitest coverage will include:
+
+- controller preflight maps a missing `session_token` to `missing_credentials` without calling the adapter;
+- `/api/v1/user` with root or nested valid identity reports `healthy`;
+- 401, expired/rejected token responses, and identity-free 2xx JSON report `invalid_credentials`;
+- the exact security-policy JSON reports `blocked` and preserves `9e4db7e3`;
+- public campaign responses cannot produce `healthy`;
+- background and page fetch paths retain safe status, reason, and reference metadata while excluding secrets and full bodies;
+- a completed JSON error document is rejected as a Kick page context;
+- a blocked context followed by a valid Kick document recovers successfully;
+- existing page-context retention, lifecycle, and fallback tests remain passing.
+
+Repository verification will run focused tests during development, then `pnpm typecheck`, `pnpm test`, and the broader verification appropriate to the changed extension/core boundary.
+
+## Scope Boundaries
+
+This change does not persist or log Kick credentials, export cookies, add browser permissions, alter public campaign parsing, or change Twitch authentication. It does not attempt to bypass Kick's security policy. It only detects the condition, retains safe troubleshooting metadata, and gives the user accurate guidance.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "./tabs": "./src/core/tabs.ts",
     "./defaults": "./src/core/defaults.ts",
     "./authHealth": "./src/core/authHealth.ts",
+    "./fetchError": "./src/core/fetchError.ts",
     "./adapter": "./src/platforms/adapter.ts",
     "./twitch": "./src/platforms/twitch/index.ts",
     "./twitch/parser": "./src/platforms/twitch/parser.ts",

--- a/packages/core/src/core/fetchError.ts
+++ b/packages/core/src/core/fetchError.ts
@@ -1,0 +1,59 @@
+export type SafeFetchFailureKind =
+  | "authentication_rejected"
+  | "security_policy_blocked"
+  | "http_error"
+  | "invalid_response"
+  | "network_error";
+
+export interface SafeFetchFailure {
+  kind: SafeFetchFailureKind;
+  status?: number;
+  reason?: string;
+  reference?: string | number;
+}
+
+const FAILURE_KINDS = new Set<SafeFetchFailureKind>([
+  "authentication_rejected",
+  "security_policy_blocked",
+  "http_error",
+  "invalid_response",
+  "network_error",
+]);
+
+export function safeFetchFailure(candidate: unknown): SafeFetchFailure {
+  const value = candidate && typeof candidate === "object" ? candidate as Record<string, unknown> : {};
+  const kind = FAILURE_KINDS.has(value.kind as SafeFetchFailureKind)
+    ? value.kind as SafeFetchFailureKind
+    : "http_error";
+  const failure: SafeFetchFailure = { kind };
+  if (typeof value.status === "number" && Number.isInteger(value.status) && value.status >= 100 && value.status <= 599) {
+    failure.status = value.status;
+  }
+  if (typeof value.reason === "string" && value.reason.length > 0 && value.reason.length <= 256) {
+    failure.reason = value.reason;
+  }
+  const reference = value.reference;
+  if ((typeof reference === "string" && reference.length > 0 && reference.length <= 128)
+    || (typeof reference === "number" && Number.isFinite(reference))) {
+    failure.reference = reference;
+  }
+  return failure;
+}
+
+export class SafeFetchError extends Error {
+  readonly failure: SafeFetchFailure;
+
+  constructor(candidate: SafeFetchFailure) {
+    const failure = safeFetchFailure(candidate);
+    super([
+      failure.status == null ? undefined : `HTTP ${failure.status}`,
+      failure.reason,
+    ].filter(Boolean).join(" ") || failure.kind);
+    this.name = "SafeFetchError";
+    this.failure = failure;
+  }
+}
+
+export function isSafeFetchError(error: unknown): error is SafeFetchError {
+  return error instanceof SafeFetchError;
+}

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -3,6 +3,7 @@ import type { EventEmitter, PageContextCloseReason, PageContextOpenReason } from
 import type { LogLevel } from "@lurkloot/shared/logging";
 import type { TwitchIntegrity } from "./twitchIntegrity";
 import type { PreparedWatchTab, WatchTabOptions } from "../platforms/adapter";
+import { SafeFetchError, safeFetchFailure, type SafeFetchFailure } from "./fetchError";
 
 const ignoreEvent: EventEmitter = () => {};
 
@@ -491,11 +492,39 @@ const KICK_AUTH_HOSTS = ["web.kick.com", "websockets.kick.com"];
 // Distinguishes "Kick's WAF / origin check rejected the service-worker request"
 // (fall back to the page-context tab) from a genuine error. Thrown by
 // fetchKickInBackground so the adapter wrapper can log and fall back cleanly.
-export class KickWafBlockedError extends Error {
-  constructor(message: string) {
-    super(message);
+export class KickWafBlockedError extends SafeFetchError {
+  constructor(candidate: string | SafeFetchFailure) {
+    super(typeof candidate === "string"
+      ? { kind: "network_error", reason: candidate }
+      : candidate);
     this.name = "KickWafBlockedError";
   }
+}
+
+function safeKickFailure(status: number, text: string): SafeFetchFailure {
+  let body: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) body = parsed as Record<string, unknown>;
+  } catch {
+    // Non-JSON response bodies are never retained.
+  }
+  const reason = typeof body.error === "string"
+    ? body.error
+    : typeof body.message === "string"
+      ? body.message
+      : undefined;
+  const blocked = /security policy|request blocked/i.test(reason ?? "");
+  return safeFetchFailure({
+    kind: blocked
+      ? "security_policy_blocked"
+      : status === 401 || status === 403
+        ? "authentication_rejected"
+        : "http_error",
+    status,
+    reason,
+    reference: body.reference,
+  });
 }
 
 // Spike: attempt a Kick API call straight from the service worker (no tab),
@@ -517,14 +546,18 @@ export async function fetchKickInBackgroundWith<T>(api: CookieApi, url: string, 
   } catch (error) {
     // A network/CORS rejection from the extension origin is exactly the
     // origin-level failure we want to fall back on, not a hard error.
-    throw new KickWafBlockedError(error instanceof Error ? error.message : "network error");
+    throw new KickWafBlockedError({
+      kind: "network_error",
+      reason: error instanceof Error ? error.message : "network error",
+    });
   }
 
   const text = await response.text();
   if (!response.ok) {
-    const blocked = response.status === 403 || /security policy|blocked/i.test(text);
-    const message = `HTTP ${response.status} ${response.statusText}`;
-    throw blocked ? new KickWafBlockedError(message) : new Error(message);
+    const failure = safeKickFailure(response.status, text);
+    throw failure.kind === "security_policy_blocked"
+      ? new KickWafBlockedError(failure)
+      : new SafeFetchError(failure);
   }
 
   const contentType = response.headers.get("content-type") ?? "";
@@ -573,20 +606,28 @@ export async function fetchJsonInPageWithBrowser<T>(
       // means the context tab was closed or navigated away before injection.
       // Surface that clearly instead of dereferencing undefined.
       if (!result) throw new Error(`Page context for ${origin} returned no script result`);
-      return result.result as T;
+      return unwrapPageFetchResult<T>(result.result);
     }
 
     if (runtimeBrowser.tabs.executeScript) {
       const code = `(${pageFetchJson.toString()})(${JSON.stringify(url)}, ${JSON.stringify(init ? JSON.stringify(init) : undefined)})`;
       const results = await runtimeBrowser.tabs.executeScript(pageContext.tabId, { code });
       const result = results?.[0];
-      return result as T;
+      return unwrapPageFetchResult<T>(result);
     }
 
     throw new Error("No supported page script execution API is available");
   } finally {
     await releasePageContextTab(browserApi, origin, pageContext, options?.emit);
   }
+}
+
+function unwrapPageFetchResult<T>(candidate: unknown): T {
+  if (!candidate || typeof candidate !== "object") return candidate as T;
+  const envelope = candidate as Record<string, unknown>;
+  if (envelope.__lurklootPageFetch !== true) return candidate as T;
+  if (envelope.ok === true) return envelope.data as T;
+  throw new SafeFetchError(safeFetchFailure(envelope.error));
 }
 
 async function acquirePageContextTab(
@@ -911,17 +952,56 @@ async function pageFetchJson(targetUrl: string, initJson?: string): Promise<unkn
       ?.slice("session_token=".length);
     if (sessionToken) headers.set("authorization", `Bearer ${decodeURIComponent(sessionToken)}`);
   }
-  const response = await fetch(targetUrl, {
-    ...parsedInit,
-    headers,
-    credentials: parsedInit?.credentials ?? "include",
-  });
-  if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
+  try {
+    const response = await fetch(targetUrl, {
+      ...parsedInit,
+      headers,
+      credentials: parsedInit?.credentials ?? "include",
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      let body: Record<string, unknown> = {};
+      try {
+        const parsed = JSON.parse(text) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) body = parsed as Record<string, unknown>;
+      } catch {
+        // Never retain non-JSON response bodies.
+      }
+      const rawReason = typeof body.error === "string"
+        ? body.error
+        : typeof body.message === "string"
+          ? body.message
+          : undefined;
+      const reason = rawReason && rawReason.length <= 256 ? rawReason : undefined;
+      const rawReference = body.reference;
+      const reference = (typeof rawReference === "string" && rawReference.length > 0 && rawReference.length <= 128)
+        || (typeof rawReference === "number" && Number.isFinite(rawReference))
+        ? rawReference
+        : undefined;
+      const blocked = /security policy|request blocked/i.test(reason ?? "");
+      return {
+        __lurklootPageFetch: true,
+        ok: false,
+        error: {
+          kind: blocked
+            ? "security_policy_blocked"
+            : response.status === 401 || response.status === 403
+              ? "authentication_rejected"
+              : "http_error",
+          status: response.status,
+          ...(reason ? { reason } : {}),
+          ...(reference !== undefined ? { reference } : {}),
+        },
+      };
+    }
+    const contentType = response.headers.get("content-type") ?? "";
+    const data = contentType.includes("application/json") ? JSON.parse(text) : { html: text };
+    return { __lurklootPageFetch: true, ok: true, data };
+  } catch {
+    return {
+      __lurklootPageFetch: true,
+      ok: false,
+      error: { kind: "network_error" },
+    };
   }
-  const contentType = response.headers.get("content-type") ?? "";
-  if (contentType.includes("application/json")) {
-    return await response.json();
-  }
-  return { html: await response.text() };
 }

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -694,7 +694,14 @@ async function findOrCreatePageContextTab(
       .filter((tab): tab is ManagedPageContextTab => tab != null && tab.origin === origin)
       .map((tab) => tab.tabId),
   );
-  const tabId = tabs.find((tab) => tab.id != null && !retainedIds.has(tab.id))?.id;
+  let tabId: number | undefined;
+  for (const tab of tabs) {
+    if (tab.id == null || retainedIds.has(tab.id)) continue;
+    if (await isUsablePageContext(browserApi, tab.id, origin)) {
+      tabId = tab.id;
+      break;
+    }
+  }
   if (tabId != null) {
     if (retained?.origin === origin) {
       retainedPageContextTabs.delete(retained.platform);
@@ -725,7 +732,7 @@ async function findOrCreatePageContextTab(
   if (retained?.origin === origin) {
     try {
       const tab = await browserApi.tabs.get(retained.tabId);
-      if (tab?.id && tab.url?.startsWith(origin)) {
+      if (tab?.id && tab.url?.startsWith(origin) && await isUsablePageContext(browserApi, tab.id, origin)) {
         retainedPageContextTabs.set(retained.platform, retained);
         diagnostic(options?.emit ?? ignoreEvent, "debug", `Reused managed page context on ${new URL(origin).host}`, retained.platform);
         return { tabId: tab.id, createdByExtension: true, retainedContext: retained };
@@ -765,6 +772,17 @@ async function findOrCreatePageContextTab(
   }
   await browserApi.tabs.update(tab.id, { muted: true, active: false });
   await waitForPageContextReady(browserApi, tab.id, origin);
+  if (!await isUsablePageContext(browserApi, tab.id, origin)) {
+    try {
+      await browserApi.tabs.remove?.(tab.id);
+    } catch {
+      // The unusable page may already have been closed.
+    }
+    throw new SafeFetchError({
+      kind: "security_policy_blocked",
+      reason: "Kick page context is blocked or unusable",
+    });
+  }
   if (retain) {
     const retainedContext: ManagedPageContextTab = {
       platform: retain.platform,
@@ -790,6 +808,66 @@ async function findOrCreatePageContextTab(
     return { tabId: tab.id, createdByExtension: true, retainedContext };
   }
   return { tabId: tab.id, createdByExtension: true };
+}
+
+async function isUsablePageContext(browserApi: BrowserTabApi, tabId: number, origin: string): Promise<boolean> {
+  if (origin !== "https://kick.com") return true;
+  try {
+    if (browserApi.scripting?.executeScript) {
+      const [result] = await browserApi.scripting.executeScript({
+        target: { tabId },
+        world: "MAIN",
+        func: validateKickPageContext,
+      });
+      const value = result?.result as { usable?: unknown } | undefined;
+      return value?.usable === true || (value as { ok?: unknown } | undefined)?.ok === true;
+    }
+    if (browserApi.tabs.executeScript) {
+      const results = await browserApi.tabs.executeScript(tabId, { code: `(${validateKickPageContext.toString()})()` });
+      const value = results?.[0] as { usable?: unknown; ok?: unknown } | undefined;
+      return value?.usable === true || value?.ok === true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function validateKickPageContext(): { usable: boolean; failure?: SafeFetchFailure } {
+  const contentType = document.contentType?.toLowerCase() ?? "";
+  const text = document.body?.textContent?.trim().slice(0, 512) ?? "";
+  let body: Record<string, unknown> = {};
+  if (contentType.includes("json") || text.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) body = parsed as Record<string, unknown>;
+    } catch {
+      return { usable: false, failure: { kind: "invalid_response" } };
+    }
+  }
+  const rawReason = typeof body.error === "string"
+    ? body.error
+    : typeof body.message === "string"
+      ? body.message
+      : undefined;
+  const reason = rawReason && rawReason.length <= 256 ? rawReason : undefined;
+  const blocked = /security policy|request blocked/i.test(reason ?? text);
+  if (contentType.includes("json") || blocked) {
+    const rawReference = body.reference;
+    const reference = (typeof rawReference === "string" && rawReference.length > 0 && rawReference.length <= 128)
+      || (typeof rawReference === "number" && Number.isFinite(rawReference))
+      ? rawReference
+      : undefined;
+    return {
+      usable: false,
+      failure: {
+        kind: blocked ? "security_policy_blocked" : "invalid_response",
+        ...(reason ? { reason } : {}),
+        ...(reference !== undefined ? { reference } : {}),
+      },
+    };
+  }
+  return { usable: contentType.includes("html") || document.documentElement?.tagName === "HTML" };
 }
 
 async function waitForPageContextReady(browserApi: BrowserTabApi, tabId: number, origin: string): Promise<void> {

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -10,6 +10,7 @@ import { createKickClaimCapability } from "./claim/factory";
 import type { KickClaimCapability } from "./claim/types";
 import { safeHttpsUrl } from "./claim/types";
 import { KickClaimState } from "./claim/v2";
+import { isSafeFetchError } from "../../core/fetchError";
 
 export { createKickClaimCapability } from "./claim/factory";
 export type { KickClaimCapability, KickClaimOutcome } from "./claim/types";
@@ -58,6 +59,26 @@ interface KickClaimResponse {
 
 interface KickChallengesResponse {
   data?: KickChallenge[];
+}
+
+interface KickIdentityResponse {
+  id?: string | number;
+  username?: string;
+  slug?: string;
+  user?: {
+    id?: string | number;
+    username?: string;
+    slug?: string;
+  };
+}
+
+function hasKickIdentity(response: KickIdentityResponse): boolean {
+  const identity = response.user ?? response;
+  const id = identity.id;
+  return (typeof id === "string" && id.trim().length > 0)
+    || (typeof id === "number" && Number.isFinite(id))
+    || (typeof identity.username === "string" && identity.username.trim().length > 0)
+    || (typeof identity.slug === "string" && identity.slug.trim().length > 0);
 }
 
 interface KickChallenge {
@@ -165,7 +186,54 @@ export class KickAdapter implements PlatformAdapter {
   private readonly claimCapability: KickClaimCapability;
 
   async checkAuthHealth(): Promise<PlatformAuthHealth> {
-    return { status: "checking" };
+    const checkedAt = new Date().toISOString();
+    try {
+      const response = await this.fetcher.fetchJson<KickIdentityResponse>("https://kick.com/api/v1/user", undefined, this.emit);
+      if (hasKickIdentity(response)) return { status: "healthy", checkedAt };
+      return {
+        status: "invalid_credentials",
+        checkedAt,
+        reasonCode: "credentials_rejected",
+        message: { key: "authInvalidCredentials" },
+      };
+    } catch (error) {
+      if (isSafeFetchError(error)) {
+        if (error.failure.kind === "authentication_rejected") {
+          return {
+            status: "invalid_credentials",
+            checkedAt,
+            reasonCode: "credentials_rejected",
+            message: { key: "authInvalidCredentials" },
+          };
+        }
+        if (error.failure.kind === "security_policy_blocked") {
+          const reference = error.failure.reference;
+          return {
+            status: "blocked",
+            checkedAt,
+            reasonCode: "security_policy_blocked",
+            message: {
+              key: "authSecurityPolicyBlocked",
+              ...(reference === undefined ? {} : { values: { reference } }),
+            },
+          };
+        }
+        if (error.failure.kind === "network_error") {
+          return {
+            status: "unavailable",
+            checkedAt,
+            reasonCode: "network_unavailable",
+            message: { key: "authNetworkUnavailable" },
+          };
+        }
+      }
+      return {
+        status: "unavailable",
+        checkedAt,
+        reasonCode: "platform_unavailable",
+        message: { key: "authPlatformUnavailable" },
+      };
+    }
   }
 
   constructor(

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -9,6 +9,7 @@ import type { DropCampaign, DropReward, ExtensionSettings } from "@lurkloot/shar
 import { chooseCampaignDecision } from "@lurkloot/core/scheduler";
 import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
 import { resolveCompatibility } from "@lurkloot/core";
+import { SafeFetchError, type SafeFetchFailureKind } from "@lurkloot/core/fetchError";
 
 function jsonFetcher(handler: (url: string, init?: RequestInit) => unknown): PageFetcher {
   const fetchJson = vi.fn(async (url: string, init?: RequestInit): Promise<unknown> => handler(url, init));
@@ -26,6 +27,41 @@ function requestBody(init?: RequestInit): Record<string, unknown> {
 }
 
 describe("KickAdapter", () => {
+  it.each([
+    ["authentication_rejected", "invalid_credentials", "credentials_rejected", "authInvalidCredentials"],
+    ["security_policy_blocked", "blocked", "security_policy_blocked", "authSecurityPolicyBlocked"],
+    ["network_error", "unavailable", "network_unavailable", "authNetworkUnavailable"],
+    ["http_error", "unavailable", "platform_unavailable", "authPlatformUnavailable"],
+  ] as const)("maps %s account probe failures to %s", async (kind, status, reasonCode, key) => {
+    const fetcher = jsonFetcher(() => {
+      throw new SafeFetchError({
+        kind: kind as SafeFetchFailureKind,
+        status: kind === "network_error" ? undefined : kind === "authentication_rejected" ? 401 : 403,
+        reason: kind === "security_policy_blocked" ? "Request blocked by security policy." : undefined,
+        reference: kind === "security_policy_blocked" ? "9e4db7e3" : undefined,
+      });
+    });
+
+    const health = await new KickAdapter(fetcher).checkAuthHealth();
+
+    expect(health).toMatchObject({ status, reasonCode, message: { key } });
+    expect(health.message?.values?.reference).toBe(kind === "security_policy_blocked" ? "9e4db7e3" : undefined);
+    expect(Date.parse(health.checkedAt ?? "")).not.toBeNaN();
+  });
+
+  it("does not copy unknown account probe errors into health state", async () => {
+    const fetcher = jsonFetcher(() => { throw new Error("token=secret-value"); });
+
+    const health = await new KickAdapter(fetcher).checkAuthHealth();
+
+    expect(health).toMatchObject({
+      status: "unavailable",
+      reasonCode: "platform_unavailable",
+      message: { key: "authPlatformUnavailable" },
+    });
+    expect(JSON.stringify(health)).not.toContain("secret-value");
+  });
+
   it("uses the automatic Kick claim capability selected by compatibility resolution", async () => {
     let claimPosts = 0;
     const fetcher = jsonFetcher((url) => {

--- a/packages/extension/tests/authHealth.test.ts
+++ b/packages/extension/tests/authHealth.test.ts
@@ -10,9 +10,38 @@ describe("authentication health normalization", () => {
     expect(await probe()).toEqual({ status: "checking" });
   });
 
-  it("keeps the Kick adapter in checking state until its probe is implemented", async () => {
-    const fetcher = { fetchJson: async () => { throw new Error("not called"); } };
-    await expect(new KickAdapter(fetcher).checkAuthHealth()).resolves.toEqual({ status: "checking" });
+  it.each([
+    { id: 42 },
+    { username: "viewer" },
+    { user: { slug: "viewer" } },
+  ])("requires authenticated Kick identity for healthy status", async (identity) => {
+    const calls: string[] = [];
+    const fetcher = {
+      fetchJson: async <T,>(url: string): Promise<T> => {
+        calls.push(url);
+        return identity as T;
+      },
+    };
+
+    const health = await new KickAdapter(fetcher).checkAuthHealth();
+
+    expect(health.status).toBe("healthy");
+    expect(Date.parse(health.checkedAt ?? "")).not.toBeNaN();
+    expect(calls).toEqual(["https://kick.com/api/v1/user"]);
+  });
+
+  it.each([
+    {},
+    { data: [] },
+    { data: [{ id: "public-campaign" }] },
+  ])("does not infer Kick authentication from identity-free JSON", async (response) => {
+    const fetcher = { fetchJson: async <T,>(): Promise<T> => response as T };
+
+    await expect(new KickAdapter(fetcher).checkAuthHealth()).resolves.toMatchObject({
+      status: "invalid_credentials",
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+  });
   });
   it("defaults both platforms to unchecked checking state", () => {
     expect(DEFAULT_STATE.authHealth).toEqual({

--- a/packages/extension/tests/fetchError.test.ts
+++ b/packages/extension/tests/fetchError.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { isSafeFetchError, SafeFetchError, safeFetchFailure } from "@lurkloot/core/fetchError";
+
+describe("sanitized fetch failures", () => {
+  it("retains only bounded troubleshooting metadata", () => {
+    const failure = safeFetchFailure({
+      kind: "security_policy_blocked",
+      status: 403,
+      reason: "Request blocked by security policy.",
+      reference: "9e4db7e3",
+      token: "secret-token",
+      cookie: "session_token=secret",
+      headers: { authorization: "Bearer secret" },
+      url: "https://kick.com/?token=secret",
+      body: { account: "private" },
+    });
+
+    expect(failure).toEqual({
+      kind: "security_policy_blocked",
+      status: 403,
+      reason: "Request blocked by security policy.",
+      reference: "9e4db7e3",
+    });
+    expect(JSON.stringify(failure)).not.toContain("secret");
+  });
+
+  it("drops invalid optional metadata", () => {
+    expect(safeFetchFailure({
+      kind: "http_error",
+      status: -1,
+      reason: "x".repeat(257),
+      reference: "x".repeat(129),
+    })).toEqual({ kind: "http_error" });
+    expect(safeFetchFailure({
+      kind: "network_error",
+      status: 1000,
+      reference: Number.NaN,
+    })).toEqual({ kind: "network_error" });
+  });
+
+  it("constructs recognizable errors without copying source secrets", () => {
+    const error = new SafeFetchError({
+      kind: "authentication_rejected",
+      status: 401,
+      reason: "Unauthenticated",
+      token: "secret",
+    } as never);
+
+    expect(isSafeFetchError(error)).toBe(true);
+    expect(isSafeFetchError(new Error("HTTP 401"))).toBe(false);
+    expect(error.message).toBe("HTTP 401 Unauthenticated");
+    expect(JSON.stringify(error)).not.toContain("secret");
+  });
+});

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -18,6 +18,7 @@ import {
   stopManagedPageContextTabsWithBrowser,
   stopWatchTabWithBrowser,
 } from "@lurkloot/core/tabs";
+import { isSafeFetchError } from "@lurkloot/core/fetchError";
 
 const channel: ChannelCandidate = {
   platform: "twitch",
@@ -453,6 +454,41 @@ describe("tab manager", () => {
       args: ["https://web.kick.com/api/v1/drops/progress", null],
     }));
     expect(browser.tabs.remove).not.toHaveBeenCalled();
+  });
+
+  it("reconstructs sanitized page-context failures", async () => {
+    const browser = {
+      ...browserMock(),
+      scripting: {
+        executeScript: vi.fn(async () => [{ result: {
+          __lurklootPageFetch: true,
+          ok: false,
+          error: {
+            kind: "security_policy_blocked",
+            status: 403,
+            reason: "Request blocked by security policy.",
+            reference: "9e4db7e3",
+            token: "must-not-survive",
+          },
+        } }]),
+      },
+    };
+    browser.tabs.query.mockResolvedValue([{ id: 3 }]);
+
+    const error = await fetchJsonInPageWithBrowser(
+      browser,
+      "https://kick.com",
+      "https://kick.com/api/v1/user",
+    ).catch((caught: unknown) => caught);
+
+    expect(isSafeFetchError(error)).toBe(true);
+    expect(error.failure).toEqual({
+      kind: "security_policy_blocked",
+      status: 403,
+      reason: "Request blocked by security policy.",
+      reference: "9e4db7e3",
+    });
+    expect(JSON.stringify(error)).not.toContain("must-not-survive");
   });
 
   it("throws a clear error when page-context execution returns no result", async () => {
@@ -979,12 +1015,43 @@ describe("fetchKickInBackgroundWith", () => {
 
   it("throws KickWafBlockedError on a 403 security-policy block", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response(
-      JSON.stringify({ error: "Request blocked by security policy." }),
+      JSON.stringify({
+        error: "Request blocked by security policy.",
+        reference: "9e4db7e3",
+        token: "must-not-survive",
+      }),
       { status: 403, headers: { "content-type": "application/json" } },
     )));
 
-    await expect(fetchKickInBackgroundWith(cookieApi, "https://web.kick.com/api/v1/drops/progress"))
-      .rejects.toBeInstanceOf(KickWafBlockedError);
+    const error = await fetchKickInBackgroundWith(cookieApi, "https://web.kick.com/api/v1/drops/progress")
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(KickWafBlockedError);
+    expect(error.failure).toEqual({
+      kind: "security_policy_blocked",
+      status: 403,
+      reason: "Request blocked by security policy.",
+      reference: "9e4db7e3",
+    });
+    expect(JSON.stringify(error)).not.toContain("must-not-survive");
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    [401, "Unauthenticated", "authentication_rejected"],
+    [500, "Internal Server Error", "http_error"],
+  ] as const)("classifies HTTP %s as %s", async (status, reason, kind) => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(
+      JSON.stringify({ error: reason, body: "must-not-survive" }),
+      { status, headers: { "content-type": "application/json" } },
+    )));
+
+    const error = await fetchKickInBackgroundWith(cookieApi, "https://web.kick.com/api/v1/drops/progress")
+      .catch((caught: unknown) => caught);
+
+    expect(isSafeFetchError(error)).toBe(true);
+    expect(error.failure).toEqual({ kind, status, reason });
+    expect(JSON.stringify(error)).not.toContain("must-not-survive");
     vi.unstubAllGlobals();
   });
 

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -457,21 +457,22 @@ describe("tab manager", () => {
   });
 
   it("reconstructs sanitized page-context failures", async () => {
+    const executeScript = vi.fn()
+      .mockResolvedValueOnce([{ result: { usable: true } }])
+      .mockResolvedValueOnce([{ result: {
+        __lurklootPageFetch: true,
+        ok: false,
+        error: {
+          kind: "security_policy_blocked",
+          status: 403,
+          reason: "Request blocked by security policy.",
+          reference: "9e4db7e3",
+          token: "must-not-survive",
+        },
+      } }]);
     const browser = {
       ...browserMock(),
-      scripting: {
-        executeScript: vi.fn(async () => [{ result: {
-          __lurklootPageFetch: true,
-          ok: false,
-          error: {
-            kind: "security_policy_blocked",
-            status: 403,
-            reason: "Request blocked by security policy.",
-            reference: "9e4db7e3",
-            token: "must-not-survive",
-          },
-        } }]),
-      },
+      scripting: { executeScript },
     };
     browser.tabs.query.mockResolvedValue([{ id: 3 }]);
 
@@ -491,12 +492,63 @@ describe("tab manager", () => {
     expect(JSON.stringify(error)).not.toContain("must-not-survive");
   });
 
-  it("throws a clear error when page-context execution returns no result", async () => {
+  it("rejects a completed security-policy document and recovers with a valid Kick context", async () => {
+    const executeScript = vi.fn()
+      .mockResolvedValueOnce([{ result: {
+        usable: false,
+        failure: {
+          kind: "security_policy_blocked",
+          status: 403,
+          reason: "Request blocked by security policy.",
+          reference: "9e4db7e3",
+        },
+      } }])
+      .mockResolvedValueOnce([{ result: { usable: true } }])
+      .mockResolvedValueOnce([{ result: {
+        __lurklootPageFetch: true,
+        ok: true,
+        data: { id: 42, username: "viewer" },
+      } }]);
     const browser = {
       ...browserMock(),
-      scripting: {
-        executeScript: vi.fn(async () => []),
-      },
+      scripting: { executeScript },
+    };
+    browser.tabs.query.mockResolvedValue([{
+      id: 3,
+      url: "https://kick.com/",
+      status: "complete",
+    }]);
+    browser.tabs.create.mockResolvedValue({ id: 14 });
+
+    const result = await fetchJsonInPageWithBrowser<{ id: number; username: string }>(
+      browser,
+      "https://kick.com/drops/inventory",
+      "https://kick.com/api/v1/user",
+      undefined,
+      { retainPageContext: { platform: "kick" } },
+    );
+
+    expect(result).toEqual({ id: 42, username: "viewer" });
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: "https://kick.com/drops/inventory",
+      pinned: false,
+      active: false,
+    });
+    expect(executeScript.mock.calls.map(([details]) => details.target)).toEqual([
+      { tabId: 3 },
+      { tabId: 14 },
+      { tabId: 14 },
+    ]);
+    expect(currentManagedPageContextTabs().kick?.tabId).toBe(14);
+  });
+
+  it("throws a clear error when page-context execution returns no result", async () => {
+    const executeScript = vi.fn()
+      .mockResolvedValueOnce([{ result: { usable: true } }])
+      .mockResolvedValueOnce([]);
+    const browser = {
+      ...browserMock(),
+      scripting: { executeScript },
     };
     browser.tabs.query.mockResolvedValue([{ id: 3 }]);
 

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -32,7 +32,7 @@ function browserMock() {
       get: vi.fn(),
       update: vi.fn(async () => undefined),
       remove: vi.fn(async () => undefined),
-      query: vi.fn<() => Promise<Array<{ id?: number }>>>(async () => []),
+      query: vi.fn<() => Promise<Array<{ id?: number; url?: string; status?: string }>>>(async () => []),
       create: vi.fn(async () => ({ id: 9 })),
     },
   };
@@ -483,6 +483,7 @@ describe("tab manager", () => {
     ).catch((caught: unknown) => caught);
 
     expect(isSafeFetchError(error)).toBe(true);
+    if (!isSafeFetchError(error)) throw new Error("Expected SafeFetchError");
     expect(error.failure).toEqual({
       kind: "security_policy_blocked",
       status: 403,
@@ -1079,6 +1080,7 @@ describe("fetchKickInBackgroundWith", () => {
       .catch((caught: unknown) => caught);
 
     expect(error).toBeInstanceOf(KickWafBlockedError);
+    if (!(error instanceof KickWafBlockedError)) throw new Error("Expected KickWafBlockedError");
     expect(error.failure).toEqual({
       kind: "security_policy_blocked",
       status: 403,
@@ -1102,6 +1104,7 @@ describe("fetchKickInBackgroundWith", () => {
       .catch((caught: unknown) => caught);
 
     expect(isSafeFetchError(error)).toBe(true);
+    if (!isSafeFetchError(error)) throw new Error("Expected SafeFetchError");
     expect(error.failure).toEqual({ kind, status, reason });
     expect(JSON.stringify(error)).not.toContain("must-not-survive");
     vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary

- probe Kick's authenticated `/api/v1/user` endpoint and require a real account identity before reporting healthy authentication
- preserve bounded HTTP status, reason, and reference metadata across background and page-context failures without retaining credentials or response bodies
- reject completed Kick JSON/security-policy documents as page contexts and recover through a valid replacement context
- keep public campaign discovery independent from authentication health

## Root cause

Kick campaign discovery is public, so it could not prove that the browser session was authenticated. The fallback page-context selection also treated any completed `kick.com` document as usable, including Kick's JSON security-policy response, while the fetch boundary discarded the response's safe diagnostic reference.

## Validation

- `pnpm typecheck`
- `pnpm test` (739 extension tests, 105 CLI tests, site build/tests)
- `pnpm verify` (repository checks plus Chromium and Firefox production builds)

Closes #203