### PR TITLE
fix(scheduler): suspend farming when authentication is unhealthy

### DIFF
--- a/docs/superpowers/plans/2026-07-22-scheduler-auth-health.md
+++ b/docs/superpowers/plans/2026-07-22-scheduler-auth-health.md
@@ -1,0 +1,399 @@
+# Scheduler Authentication Health Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Suspend every account-dependent platform operation while authentication is unhealthy, preserve enabled settings, and resume automatically after a healthy recheck without entering ordinary error backoff.
+
+**Architecture:** The controller refreshes sanitized auth health before scheduler execution. The core scheduler treats persisted health as a per-platform gate, converts mid-tick authentication failures into auth transitions, and leaves non-auth failures on the existing backoff path. Session and campaign state are cleared when blocked so public or stale data cannot imply active farming.
+
+**Tech Stack:** TypeScript 7, pnpm workspaces, Vitest, browser-free `@lurkloot/core`, shared contracts in `@lurkloot/shared`.
+
+## Global Constraints
+
+- Keep enabled platforms enabled while authentication is unhealthy.
+- Only `healthy` authentication permits account-dependent work; every other auth status suspends it.
+- Authentication suspension must not increment `errorChecks` or set `retryAfter`.
+- Authentication transitions must remain activity events even when diagnostic logging is disabled.
+- Do not persist or log tokens, cookies, sensitive headers, or authenticated response bodies.
+- Popup UX is out of scope for issue #204.
+
+---
+
+### Task 1: Model and enforce the scheduler auth gate
+
+**Files:**
+- Modify: `packages/shared/src/models.ts`
+- Modify: `packages/shared/src/events.ts`
+- Modify: `packages/core/src/core/scheduler.ts`
+- Test: `packages/extension/tests/scheduler.test.ts`
+
+**Interfaces:**
+- Consumes: `SchedulerState.authHealth: Record<Platform, PlatformAuthHealth>`.
+- Produces: `WatchReasonCode` and `FarmingStopReason` member `authentication_unhealthy`; scheduler sessions use `{ status: "paused", reasonCode: "authentication_unhealthy" }`.
+
+- [ ] **Step 1: Write failing scheduler-gate tests**
+
+Add table-driven cases for `checking`, `missing_credentials`, `invalid_credentials`, `blocked`, and `unavailable`. Use an enabled platform with spies for `discoverCampaigns`, `readProgress`, `claimReward`, `claimChallenges`, `listCandidateChannels`, `checkChannel`, `prepareWatchTab`, and `claimChannelPoints`. Assert all remain uncalled, the platform setting object is unchanged, campaigns are empty, and the resulting session is:
+
+```ts
+expect(result.state.sessions.kick).toMatchObject({
+  status: "paused",
+  reasonCode: "authentication_unhealthy",
+  errorChecks: 2,
+  retryAfter: undefined,
+  channel: undefined,
+  campaignId: undefined,
+  rewardId: undefined,
+});
+```
+
+Add a logout-while-watching case asserting `stopWatchTab(previous)` and `stopPageContextTabs(..., { platforms: ["kick"], reason: "authentication_unhealthy", emit })` run and managed watch/page-context state is removed.
+
+- [ ] **Step 2: Verify the new tests fail for the missing gate**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- scheduler.test.ts
+```
+
+Expected: FAIL because discovery/challenge methods run and `authentication_unhealthy` is not a valid reason.
+
+- [ ] **Step 3: Add the reason contracts and minimal gate**
+
+Add `authentication_unhealthy` to `WatchReasonCode`, `FarmingStopReason`, and `PageContextCloseReason`. In `runSchedulerTick`, after disabled/manual-watch handling and before challenges/backoff, branch on:
+
+```ts
+if (nextState.authHealth[platform].status !== "healthy") {
+  try {
+    await adapter.stopWatchTab?.(previous);
+  } catch (error) {
+    emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop watch tab");
+  }
+  nextState.sessions[platform] = {
+    ...previous,
+    status: "paused",
+    channel: undefined,
+    campaignId: undefined,
+    rewardId: undefined,
+    tabId: undefined,
+    tabManagedByExtension: undefined,
+    playback: undefined,
+    playbackChecks: 0,
+    retryAfter: undefined,
+    message: "Authentication unavailable",
+    reasonCode: "authentication_unhealthy",
+    watchMode: undefined,
+    tablessFallback: undefined,
+    heartbeatChecks: 0,
+    lastHeartbeatAt: undefined,
+    lastHeartbeatOk: undefined,
+  };
+  nextState.campaigns[platform] = [];
+  nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
+  nextState.managedPageContextTabs = await stopPageContextTabs(
+    nextState.managedPageContextTabs ?? {},
+    { platforms: [platform], reason: "authentication_unhealthy", emit },
+  );
+  continue;
+}
+```
+
+Keep `errorChecks` unchanged and ensure cleanup errors cannot fall through into account work.
+
+- [ ] **Step 4: Run the focused tests to green**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- scheduler.test.ts
+```
+
+Expected: PASS, including existing scheduler behavior after updating healthy test fixtures to use explicit healthy auth state.
+
+- [ ] **Step 5: Commit the auth gate**
+
+```bash
+git add packages/shared/src/models.ts packages/shared/src/events.ts packages/core/src/core/scheduler.ts packages/extension/tests/scheduler.test.ts
+git commit -m "fix(scheduler): gate account work on authentication health"
+```
+
+### Task 2: Refresh auth health before each platform tick and recover automatically
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: `PlatformAdapter.checkAuthHealth(): Promise<PlatformAuthHealth>` and optional `checkCredentialAvailability(platform)`.
+- Produces: an internal `probeAuthHealth(platform, settings, emit): Promise<PlatformAuthHealth>` used by both explicit checks and scheduler ticks.
+
+- [ ] **Step 1: Write failing startup and recovery tests**
+
+Add a startup-logged-out test whose credential availability reports missing and assert a running/enabled platform calls neither its adapter probe nor discovery. Assert the setting remains enabled and state becomes `missing_credentials` plus `authentication_unhealthy`.
+
+Add a recovery sequence:
+
+```ts
+vi.mocked(env.twitch.checkAuthHealth)
+  .mockResolvedValueOnce({
+    status: "invalid_credentials",
+    checkedAt: "2026-07-22T12:00:00.000Z",
+    reasonCode: "credentials_rejected",
+    message: { key: "authInvalidCredentials" },
+  })
+  .mockResolvedValueOnce({
+    status: "healthy",
+    checkedAt: "2026-07-22T12:01:00.000Z",
+    message: { key: "authHealthy" },
+  });
+
+await env.controller.tickAndHandOff(["twitch"]);
+expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+await env.controller.tickAndHandOff(["twitch"]);
+expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+expect(env.settings.platform.twitch.enabled).toBe(true);
+```
+
+Assert both semantic health changes publish `auth_health_changed` activity events.
+
+- [ ] **Step 2: Verify the tests fail because tick does not probe**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+```
+
+Expected: FAIL because tick uses stale/default health and does not perform the expected probe/recovery.
+
+- [ ] **Step 3: Extract the probe and refresh selected platforms under the state lock**
+
+Extract the body shared by `checkAuthHealth` and `tick`:
+
+```ts
+async function probeAuthHealth(
+  platform: Platform,
+  settings: S,
+  adapter: PlatformAdapter,
+): Promise<PlatformAuthHealth> {
+  const availability = await deps.checkCredentialAvailability?.(platform);
+  if (availability?.status === "missing") return missingCredentialHealth();
+  if (availability?.status === "unavailable") return credentialLookupUnavailableHealth();
+  return adapter.checkAuthHealth();
+}
+```
+
+At the start of the locked tick, create adapters once, probe only requested/enabled platforms, apply every result with `applyPlatformAuthHealth`, emit transition events, and pass the updated state to `runSchedulerTick`. Disabled platforms retain current disabled cleanup semantics and need no authenticated request.
+
+Ensure `checkAuthHealth(platform)` reuses the helper without recursively acquiring the state lock.
+
+- [ ] **Step 4: Run controller and scheduler tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts scheduler.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit automatic auth refresh and recovery**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "fix(controller): refresh auth health before scheduler ticks"
+```
+
+### Task 3: Convert mid-tick auth failures instead of swallowing them
+
+**Files:**
+- Modify: `packages/core/src/core/fetchError.ts`
+- Modify: `packages/core/src/core/scheduler.ts`
+- Modify: `packages/core/src/platforms/kick/index.ts`
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Test: `packages/extension/tests/fetchError.test.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+- Test: `packages/extension/tests/scheduler.test.ts`
+
+**Interfaces:**
+- Produces: `authHealthFromError(error: unknown, checkedAt?: string): PlatformAuthHealth | undefined` in `fetchError.ts`.
+- Consumes: sanitized `SafeFetchError.failure`; Twitch converts credential GQL failure into a compatible sanitized error at its request boundary.
+
+- [ ] **Step 1: Write failing classifier tests**
+
+Test exact mappings:
+
+```ts
+expect(authHealthFromError(new SafeFetchError({ kind: "authentication_rejected", status: 401 })))
+  .toMatchObject({ status: "invalid_credentials", reasonCode: "credentials_rejected" });
+expect(authHealthFromError(new SafeFetchError({ kind: "security_policy_blocked", reference: "safe-ref" })))
+  .toMatchObject({
+    status: "blocked",
+    reasonCode: "security_policy_blocked",
+    message: { key: "authSecurityPolicyBlocked", values: { reference: "safe-ref" } },
+  });
+expect(authHealthFromError(new Error("ordinary failure"))).toBeUndefined();
+```
+
+Add scheduler tests for progress, challenges, and claims throwing classified auth errors. Assert health changes, `auth_health_changed` is present, the session suspends, and `errorChecks`/`retryAfter` do not advance. Add a normal `SafeFetchError({ kind: "http_error", status: 503 })` case proving ordinary backoff remains.
+
+- [ ] **Step 2: Verify classifier and scheduler tests fail**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- fetchError.test.ts scheduler.test.ts adapters.test.ts
+```
+
+Expected: FAIL because no classifier exists and Kick progress/challenges still swallow classified failures.
+
+- [ ] **Step 3: Implement the sanitized classifier**
+
+In `fetchError.ts`, return `undefined` for non-auth failures and map only authentication rejection and security-policy blocking:
+
+```ts
+export function authHealthFromError(error: unknown, checkedAt = new Date().toISOString()): PlatformAuthHealth | undefined {
+  if (!isSafeFetchError(error)) return undefined;
+  if (error.failure.kind === "authentication_rejected") {
+    return {
+      status: "invalid_credentials",
+      checkedAt,
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    };
+  }
+  if (error.failure.kind === "security_policy_blocked") {
+    const reference = error.failure.reference;
+    return {
+      status: "blocked",
+      checkedAt,
+      reasonCode: "security_policy_blocked",
+      message: {
+        key: "authSecurityPolicyBlocked",
+        ...(reference === undefined ? {} : { values: { reference } }),
+      },
+    };
+  }
+  return undefined;
+}
+```
+
+At platform boundaries, preserve classified `SafeFetchError`s. In Kick `readProgress` and `claimChallenges`, rethrow when `authHealthFromError(error)` is defined; keep existing best-effort behavior for ordinary failures. Convert Twitch credential rejection into `SafeFetchError({ kind: "authentication_rejected", status: 401, reason: "Authenticated session rejected" })` without including response bodies or tokens.
+
+- [ ] **Step 4: Handle classified failures in the scheduler catch path**
+
+Before ordinary backoff, apply classified health and construct the same paused/cleared auth-blocked state as Task 1. Emit the transition returned by `applyPlatformAuthHealth`. Extract a small `suspendForAuthentication(...)` helper so the preflight gate and mid-tick catch cannot drift.
+
+- [ ] **Step 5: Run focused tests to green**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- fetchError.test.ts scheduler.test.ts adapters.test.ts
+```
+
+Expected: PASS, including the invalid-token, WAF-blocked, swallowed-progress, swallowed-challenge, and transient-failure cases.
+
+- [ ] **Step 6: Commit mid-tick classification**
+
+```bash
+git add packages/core/src/core/fetchError.ts packages/core/src/core/scheduler.ts packages/core/src/platforms/kick/index.ts packages/core/src/platforms/twitch/index.ts packages/extension/tests/fetchError.test.ts packages/extension/tests/adapters.test.ts packages/extension/tests/scheduler.test.ts
+git commit -m "fix(scheduler): suspend on runtime authentication failures"
+```
+
+### Task 4: Stop tabless heartbeats and preserve user-visible transitions
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/extension/tests/activityStorage.test.ts`
+
+**Interfaces:**
+- Consumes: `SchedulerState.authHealth[platform].status` and the `authentication_unhealthy` session reason.
+- Produces: heartbeat execution that never calls `watcher.tick` unless auth is healthy; activity persistence independent of diagnostic logging.
+
+- [ ] **Step 1: Write failing heartbeat and activity tests**
+
+Start a tabless watcher in the controller harness, transition auth to `invalid_credentials`, then invoke the watch heartbeat. Assert `watcher.stop()` runs, `watcher.tick()` does not run again, and the session is not `watching`.
+
+With `diagnosticLogging: false`, run an invalid-to-healthy sequence and assert both `auth_health_changed` events reach `reportEvents`/activity storage while diagnostic-only events remain filtered.
+
+- [ ] **Step 2: Verify tests fail on the current heartbeat path**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts activityStorage.test.ts
+```
+
+Expected: FAIL if a watcher heartbeat can run after auth becomes unhealthy or an auth transition is filtered.
+
+- [ ] **Step 3: Add the heartbeat guard and use normal reconciliation**
+
+Before each watcher tick, require both:
+
+```ts
+if (
+  nextState.authHealth[platform].status !== "healthy"
+  || session.status !== "watching"
+  || session.watchMode !== "tabless"
+) {
+  await watcher.stop();
+  tablessWatchers.delete(platform);
+  continue;
+}
+```
+
+Keep auth transition events categorized as `activity`; do not add a diagnostic-logging condition around them.
+
+- [ ] **Step 4: Run controller and activity tests to green**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts activityStorage.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit heartbeat coordination**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/activityStorage.test.ts
+git commit -m "fix(controller): stop heartbeats when authentication degrades"
+```
+
+### Task 5: Verify the complete issue
+
+**Files:**
+- Modify only if verification exposes a regression in an already-touched file.
+
+**Interfaces:**
+- Consumes: all preceding tasks.
+- Produces: repository-wide evidence that issue #204 is complete.
+
+- [ ] **Step 1: Run formatting and diff checks**
+
+```bash
+git diff --check origin/develop...HEAD
+git status --short
+```
+
+Expected: no whitespace errors; only intentional files are modified.
+
+- [ ] **Step 2: Run the full repository verification**
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, workspace typechecks, extension/CLI/site tests, and Chromium/Firefox builds all pass.
+
+- [ ] **Step 3: Review acceptance-criteria coverage**
+
+Confirm tests explicitly demonstrate startup logged out, logout while farming, login recovery, invalid tokens, WAF blocking, transient platform failure, no backoff increment, no account calls while unhealthy, no misleading watching/farming session, and activity events with diagnostic logging disabled.
+
+- [ ] **Step 4: Commit any verification-only corrections**
+
+If verification required corrections, stage only those files and commit with a focused Conventional Commit subject. If no correction was needed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-22-scheduler-auth-health-design.md
+++ b/docs/superpowers/specs/2026-07-22-scheduler-auth-health-design.md
@@ -1,0 +1,83 @@
+# Scheduler Authentication Health Integration
+
+## Problem
+
+The scheduler currently runs account-dependent platform operations without consulting the persisted authentication-health state. This allows missing, rejected, blocked, or temporarily unavailable authentication to fall into ordinary platform-error handling. Kick can additionally continue from public campaign data and present a misleading active farming session after authenticated progress or challenge calls fail.
+
+Issue #204 requires enabled platforms to remain enabled while account automation is suspended, to recover automatically after authentication becomes healthy, and to keep authentication failures separate from ordinary retry backoff.
+
+## Design
+
+### Scheduler-level authentication gate
+
+`runSchedulerTick` will gate each enabled platform before challenge polling, backoff handling, discovery, progress, claiming, channel selection, watch setup, channel-point claiming, or heartbeat reconciliation can run.
+
+Only `healthy` authentication permits account automation. `checking`, `missing_credentials`, `invalid_credentials`, `blocked`, and `unavailable` are non-operational states. For a non-operational platform, the scheduler will:
+
+- preserve `settings.platform[platform].enabled`;
+- stop any existing watch tab and remove its managed-watch-tab record;
+- close managed page-context tabs for that platform;
+- replace the active presentation with a non-watching session;
+- clear retry timestamps and preserve the existing ordinary error count without incrementing it;
+- retain the authentication-health value as the authoritative explanation; and
+- skip every account-dependent adapter operation.
+
+The session will use `paused` with a new `authentication_unhealthy` reason code. This exposes an explicit operational state without conflating authentication with an ordinary platform failure or expanding the session status union solely for this issue.
+
+Campaign data for a non-operational platform will be cleared so stale or public-only inventory cannot imply that rewards are actively being farmed. Authentication-health data itself remains intact for the popup work in issue #205.
+
+### Recovery
+
+Credential observation and explicit probes already transition authentication health through `checking` to a terminal result. When a successful recheck stores `healthy`, the next platform-specific or ordinary scheduler tick passes the gate and resumes discovery and farming automatically. No settings toggle or error-backoff expiry is required.
+
+### Authentication failures during execution
+
+The scheduler gate prevents known unhealthy sessions from starting work. Authentication may nevertheless fail after a healthy probe because a token expires or the platform begins blocking requests during a tick.
+
+Adapters will expose a small, browser-free authentication-failure classification contract for errors raised by account-dependent operations. The scheduler will recognize those failures, map them to sanitized `PlatformAuthHealth`, update the platform health through the existing `applyPlatformAuthHealth` transition helper, emit the resulting user-visible activity event, and suspend the platform without entering ordinary backoff.
+
+This classification will be applied consistently to discovery, progress, reward claims, channel points, challenges, channel validation/watch setup, and tabless heartbeat failures. In particular, challenge and Kick progress handling must rethrow classified authentication failures instead of converting them into optional diagnostics or public-data fallback behavior. Non-authentication failures retain current behavior, including challenge best-effort diagnostics and ordinary platform backoff.
+
+### Controller and heartbeat coordination
+
+The core scheduler owns the gate so browser and future CLI hosts share the same behavior. The controller will reconcile tabless watchers only for sessions that remain operationally watching. When an authentication transition suspends a platform, existing watchers are stopped by normal reconciliation and cannot emit further heartbeats.
+
+Authentication transitions remain activity events regardless of the diagnostic logging setting. Ordinary diagnostics continue to respect existing persistence policy.
+
+## Data and API changes
+
+- Add `authentication_unhealthy` to `WatchReasonCode` and `FarmingStopReason`.
+- Add the same reason to page-context close reasons where platform cleanup reports why the context closed.
+- Add a sanitized core authentication-failure type/classifier that carries only status, reason code, safe message metadata, and optional troubleshooting reference.
+- Reuse `PlatformAuthHealth`, `applyPlatformAuthHealth`, and `auth_health_changed`; do not introduce a second authentication state.
+- Do not persist tokens, cookies, request headers, or authenticated response bodies.
+
+## Error handling
+
+Authentication failures are control flow for platform suspension, not scheduler errors. They do not increment `errorChecks`, set `retryAfter`, emit `platform_backoff`, or disable the platform.
+
+Transient non-authentication failures continue to use the existing exponential platform backoff. An authentication status of `unavailable` also suspends account work until a probe changes it; it is distinguishable through its reason code (`credential_lookup_failed`, `platform_unavailable`, or `network_unavailable`).
+
+If cleanup of an existing watch/page-context resource fails while suspending, the scheduler records a diagnostic but still commits the safe non-watching operational state. Cleanup failure must not allow additional account work in that tick.
+
+## Testing
+
+Focused deterministic scheduler and controller tests will cover:
+
+- startup with missing credentials: no account-dependent calls and no watching session;
+- logout while farming: watch resources stop, stale campaigns clear, and farming stops with the authentication reason;
+- login recovery: healthy recheck resumes automation without changing platform enablement;
+- invalid token: authentication activity transition and suspension without backoff;
+- Kick WAF/security-policy blocking: blocked health with safe reference and no public-data farming presentation;
+- transient platform failure: existing ordinary backoff remains unchanged;
+- challenge and progress authentication failures: neither path swallows the failure;
+- tabless watching: authentication suspension stops the watcher and prevents further heartbeats; and
+- diagnostic logging disabled: authentication transition activity still persists.
+
+Tests will follow the existing Vitest adapter mocks and controller harness. Each behavior will first be expressed as a failing test before production code changes.
+
+## Out of scope
+
+- Popup rendering and copy changes belong to issue #205.
+- CLI-specific credential observation and parity belong to issue #206.
+- Changes to platform enabled settings, credential storage, or browser permissions are not required.

--- a/packages/cli/src/events.ts
+++ b/packages/cli/src/events.ts
@@ -5,6 +5,7 @@ function formatStopReason(reason: FarmingStopReason): string {
   switch (reason) {
     case "automation_disabled": return "automation disabled";
     case "platform_disabled": return "platform disabled";
+    case "authentication_unhealthy": return "authentication unhealthy";
     case "platform_backoff": return "platform backoff";
     case "platform_error": return "platform error";
     case "campaign_ineligible": return "campaign ineligible";
@@ -43,6 +44,7 @@ function formatPageContextCloseReason(reason: PageContextCloseReason): string {
     case "platform_disabled": return "platform disabled";
     case "automation_disabled": return "automation disabled";
     case "manual_watch": return "manual watch detected";
+    case "authentication_unhealthy": return "authentication unavailable";
     case "runtime_restart": return "extension runtime restarted";
     case "managed_context_unusable": return "background context unusable";
     default: {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -131,7 +131,7 @@ describe("CLI engine event reporting", () => {
 
   it("formats every stable stop reason", () => {
     const reasons: FarmingStopReason[] = [
-      "automation_disabled", "platform_disabled", "platform_backoff", "platform_error",
+      "automation_disabled", "platform_disabled", "authentication_unhealthy", "platform_backoff", "platform_error",
       "campaign_ineligible", "channel_excluded", "channel_offline", "channel_mismatch",
       "watch_unhealthy", "higher_priority_reward", "higher_priority_idle_watchlist",
       "watch_requirement_completed", "runtime_restart", "target_changed", "manual_watch",

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -598,6 +598,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       const adapter = adapters[platform];
       const wantsTabless = settings.running
         && settings.platform[platform].enabled
+        && state.authHealth[platform].status === "healthy"
         && session.status === "watching"
         && session.watchMode === "tabless"
         && Boolean(session.channel);
@@ -674,7 +675,21 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
       for (const [platform, watcher] of [...tablessWatchers]) {
         const session = nextState.sessions[platform];
-        if (session.status !== "watching" || session.watchMode !== "tabless") continue;
+        if (
+          nextState.authHealth[platform].status !== "healthy"
+          || session.status !== "watching"
+          || session.watchMode !== "tabless"
+        ) {
+          try {
+            await watcher.stop();
+          } catch (error) {
+            emitHostCallbackError(emit, platform, error, "Could not stop the tabless watcher");
+          } finally {
+            drainWatcherEvents(watcher, emit);
+            tablessWatchers.delete(platform);
+          }
+          continue;
+        }
 
         let ok = false;
         let message: string | undefined;

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -41,6 +41,7 @@ const PLATFORMS: Platform[] = ["twitch", "kick"];
 const FARMING_STOP_REASON_CODES: Record<FarmingStopReason, true> = {
   automation_disabled: true,
   platform_disabled: true,
+  authentication_unhealthy: true,
   platform_backoff: true,
   platform_error: true,
   campaign_ineligible: true,

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -41,7 +41,6 @@ const PLATFORMS: Platform[] = ["twitch", "kick"];
 const FARMING_STOP_REASON_CODES: Record<FarmingStopReason, true> = {
   automation_disabled: true,
   platform_disabled: true,
-  authentication_unhealthy: true,
   platform_backoff: true,
   platform_error: true,
   campaign_ineligible: true,

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1,5 +1,5 @@
 import type { CategorySearchResult, CoreRuntimeMessage, PlaybackControl, RuntimeSnapshot } from "@lurkloot/shared/messages";
-import type { DropCampaign, DropReward, EngineSettings, ManagedWatchTab, Platform, PlaybackTelemetry, SchedulerState, WatchReasonCode, WatchSession } from "@lurkloot/shared/models";
+import type { DropCampaign, DropReward, EngineSettings, ManagedWatchTab, Platform, PlatformAuthHealth, PlaybackTelemetry, SchedulerState, WatchReasonCode, WatchSession } from "@lurkloot/shared/models";
 import type { ActivityEvent, DiagnosticEvent, EngineEvent, EventEmitter, EventReporter, FarmingStopReason } from "@lurkloot/shared/events";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
@@ -41,6 +41,7 @@ const PLATFORMS: Platform[] = ["twitch", "kick"];
 const FARMING_STOP_REASON_CODES: Record<FarmingStopReason, true> = {
   automation_disabled: true,
   platform_disabled: true,
+  authentication_unhealthy: true,
   platform_backoff: true,
   platform_error: true,
   campaign_ineligible: true,
@@ -423,6 +424,27 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     });
   }
 
+  async function probeAuthHealth(platform: Platform, adapter: PlatformAdapter): Promise<PlatformAuthHealth> {
+    const availability = await deps.checkCredentialAvailability?.(platform);
+    if (availability?.status === "missing") {
+      return {
+        status: "missing_credentials",
+        checkedAt: new Date().toISOString(),
+        reasonCode: "credentials_missing",
+        message: { key: "authMissingCredentials" },
+      };
+    }
+    if (availability?.status === "unavailable") {
+      return {
+        status: "unavailable",
+        checkedAt: new Date().toISOString(),
+        reasonCode: "credential_lookup_failed",
+        message: { key: "authCredentialLookupFailed" },
+      };
+    }
+    return adapter.checkAuthHealth();
+  }
+
   async function tick(platforms?: Platform[]): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
     await withStateLock(() => withEventCollector(async (emit, events) => {
@@ -435,6 +457,20 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       let nextState: SchedulerState;
       try {
         const adapters = createAdapters(settings, emit);
+        let schedulerState = state;
+        const tickPlatforms = platforms ?? PLATFORMS;
+        if (settings.running) {
+          for (const platform of tickPlatforms) {
+            if (!settings.platform[platform].enabled) continue;
+            const transition = applyPlatformAuthHealth(
+              schedulerState,
+              platform,
+              await probeAuthHealth(platform, adapters[platform]),
+            );
+            schedulerState = transition.state;
+            if (transition.event) emit(transition.event);
+          }
+        }
         // Observed here rather than returned by the scheduler: the controller
         // already sees every emitted event, and the post-claim handoff only
         // needs to know which platforms claimed.
@@ -444,7 +480,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           }
           emit(event);
         };
-        const result = await runSchedulerTick(state, settings, adapters, {
+        const result = await runSchedulerTick(schedulerState, settings, adapters, {
           ...(platforms ? { platforms } : {}),
           stopPageContextTabs: deps.stopPageContextTabs,
           waitingClaimRewardIds: nextWaitingClaimRewardIds,
@@ -480,22 +516,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function checkAuthHealth(platform: Platform): Promise<void> {
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
-      const availability = await deps.checkCredentialAvailability?.(platform);
-      const health = availability?.status === "missing"
-        ? {
-            status: "missing_credentials" as const,
-            checkedAt: new Date().toISOString(),
-            reasonCode: "credentials_missing" as const,
-            message: { key: "authMissingCredentials" as const },
-          }
-        : availability?.status === "unavailable"
-          ? {
-              status: "unavailable" as const,
-              checkedAt: new Date().toISOString(),
-              reasonCode: "credential_lookup_failed" as const,
-              message: { key: "authCredentialLookupFailed" as const },
-            }
-          : await deps.createAdapters(emit, settings).adapters[platform].checkAuthHealth();
+      const health = await probeAuthHealth(platform, deps.createAdapters(emit, settings).adapters[platform]);
       const transition = applyPlatformAuthHealth(state, platform, health);
       if (transition.event) emit(transition.event);
       await persistAndReport(transition.state, events);

--- a/packages/core/src/core/fetchError.ts
+++ b/packages/core/src/core/fetchError.ts
@@ -57,3 +57,32 @@ export class SafeFetchError extends Error {
 export function isSafeFetchError(error: unknown): error is SafeFetchError {
   return error instanceof SafeFetchError;
 }
+
+export function authHealthFromError(
+  error: unknown,
+  checkedAt = new Date().toISOString(),
+): PlatformAuthHealth | undefined {
+  if (!isSafeFetchError(error)) return undefined;
+  if (error.failure.kind === "authentication_rejected") {
+    return {
+      status: "invalid_credentials",
+      checkedAt,
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    };
+  }
+  if (error.failure.kind === "security_policy_blocked") {
+    const reference = error.failure.reference;
+    return {
+      status: "blocked",
+      checkedAt,
+      reasonCode: "security_policy_blocked",
+      message: {
+        key: "authSecurityPolicyBlocked",
+        ...(reference === undefined ? {} : { values: { reference } }),
+      },
+    };
+  }
+  return undefined;
+}
+import type { PlatformAuthHealth } from "@lurkloot/shared/models";

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -433,7 +433,7 @@ export async function runSchedulerTick(
     try {
       nextState.managedPageContextTabs = await stopPageContextTabs(nextState.managedPageContextTabs ?? {}, {
         platforms: [platform],
-        reason: "managed_context_unusable",
+        reason: "authentication_unhealthy",
         emit,
       });
     } catch (error) {

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -438,6 +438,11 @@ export async function runSchedulerTick(
       });
     } catch (error) {
       emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop page context");
+      nextState.managedPageContextTabs = forgetManagedPageContextTabs(nextState.managedPageContextTabs ?? {}, {
+        platforms: [platform],
+        reason: "authentication_unhealthy",
+        emit,
+      });
     }
   }
 
@@ -556,6 +561,7 @@ export async function runSchedulerTick(
         const discovered = await adapter.discoverCampaigns();
         campaigns = await adapter.readProgress(discovered, previous);
       } catch (error) {
+        if (authHealthFromError(error)) throw error;
         if (!hasIdleWatchlistChannels(settings, platform)) throw error;
         campaigns = [];
         const message = error instanceof Error ? error.message : "Drop discovery failed";

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -463,6 +463,45 @@ export async function runSchedulerTick(
         continue;
       }
 
+      if (nextState.authHealth[platform].status !== "healthy") {
+        try {
+          await adapter.stopWatchTab?.(previous);
+        } catch (error) {
+          emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop watch tab");
+        }
+        nextState.sessions[platform] = {
+          ...previous,
+          status: "paused",
+          channel: undefined,
+          campaignId: undefined,
+          rewardId: undefined,
+          tabId: undefined,
+          tabManagedByExtension: undefined,
+          playback: undefined,
+          playbackChecks: 0,
+          retryAfter: undefined,
+          message: "Authentication unavailable",
+          reasonCode: "authentication_unhealthy",
+          watchMode: undefined,
+          tablessFallback: undefined,
+          heartbeatChecks: 0,
+          lastHeartbeatAt: undefined,
+          lastHeartbeatOk: undefined,
+        };
+        nextState.campaigns[platform] = [];
+        nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
+        try {
+          nextState.managedPageContextTabs = await stopPageContextTabs(nextState.managedPageContextTabs ?? {}, {
+            platforms: [platform],
+            reason: "authentication_unhealthy",
+            emit,
+          });
+        } catch (error) {
+          emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop page context");
+        }
+        continue;
+      }
+
       // Account-level, so it runs whether or not this platform ends up watching:
       // the watch-time threshold is usually met by a session that has already
       // stopped. Failures are swallowed — gamification is strictly additive to

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -16,6 +16,8 @@ import { autoClaimChallengesFor, autoClaimChannelPointsFor } from "@lurkloot/sha
 import type { EngineEvent, EventEmitter, FarmingStopReason, PageContextCloseReason } from "@lurkloot/shared/events";
 import { currentManagedPageContextTabs, forgetManagedPageContextTabs, registerManagedPageContextTabs, type SchedulerManagedPageContexts } from "./tabs";
 import type { LogLevel } from "@lurkloot/shared/logging";
+import { authHealthFromError } from "./fetchError";
+import { applyPlatformAuthHealth } from "./authHealth";
 
 const PLATFORMS: Platform[] = ["twitch", "kick"];
 const MAX_PLATFORM_BACKOFF_MINUTES = 30;
@@ -397,6 +399,48 @@ export async function runSchedulerTick(
     options.emit?.(event);
   };
 
+  async function suspendPlatformForAuthentication(
+    platform: Platform,
+    previous: WatchSession,
+    adapter: PlatformAdapter,
+  ): Promise<void> {
+    try {
+      await adapter.stopWatchTab?.(previous);
+    } catch (error) {
+      emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop watch tab");
+    }
+    nextState.sessions[platform] = {
+      ...previous,
+      status: "paused",
+      channel: undefined,
+      campaignId: undefined,
+      rewardId: undefined,
+      tabId: undefined,
+      tabManagedByExtension: undefined,
+      playback: undefined,
+      playbackChecks: 0,
+      retryAfter: undefined,
+      message: "Authentication unavailable",
+      reasonCode: "authentication_unhealthy",
+      watchMode: undefined,
+      tablessFallback: undefined,
+      heartbeatChecks: 0,
+      lastHeartbeatAt: undefined,
+      lastHeartbeatOk: undefined,
+    };
+    nextState.campaigns[platform] = [];
+    nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
+    try {
+      nextState.managedPageContextTabs = await stopPageContextTabs(nextState.managedPageContextTabs ?? {}, {
+        platforms: [platform],
+        reason: "managed_context_unusable",
+        emit,
+      });
+    } catch (error) {
+      emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop page context");
+    }
+  }
+
   const platforms = options.platforms ?? PLATFORMS;
   for (const platform of platforms) {
     const previous = nextState.sessions[platform];
@@ -464,41 +508,7 @@ export async function runSchedulerTick(
       }
 
       if (nextState.authHealth[platform].status !== "healthy") {
-        try {
-          await adapter.stopWatchTab?.(previous);
-        } catch (error) {
-          emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop watch tab");
-        }
-        nextState.sessions[platform] = {
-          ...previous,
-          status: "paused",
-          channel: undefined,
-          campaignId: undefined,
-          rewardId: undefined,
-          tabId: undefined,
-          tabManagedByExtension: undefined,
-          playback: undefined,
-          playbackChecks: 0,
-          retryAfter: undefined,
-          message: "Authentication unavailable",
-          reasonCode: "authentication_unhealthy",
-          watchMode: undefined,
-          tablessFallback: undefined,
-          heartbeatChecks: 0,
-          lastHeartbeatAt: undefined,
-          lastHeartbeatOk: undefined,
-        };
-        nextState.campaigns[platform] = [];
-        nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
-        try {
-          nextState.managedPageContextTabs = await stopPageContextTabs(nextState.managedPageContextTabs ?? {}, {
-            platforms: [platform],
-            reason: "authentication_unhealthy",
-            emit,
-          });
-        } catch (error) {
-          emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop page context");
-        }
+        await suspendPlatformForAuthentication(platform, previous, adapter);
         continue;
       }
 
@@ -524,6 +534,7 @@ export async function runSchedulerTick(
             });
           }
         } catch (error) {
+          if (authHealthFromError(error)) throw error;
           emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Challenge claim failed");
         }
       }
@@ -738,6 +749,7 @@ export async function runSchedulerTick(
               emitDiagnostic(emit, platform, "info", `Claimed channel points for ${decision.channel.displayName ?? decision.channel.username}`);
             }
           } catch (error) {
+            if (authHealthFromError(error)) throw error;
             emitDiagnostic(
               emit,
               platform,
@@ -753,6 +765,14 @@ export async function runSchedulerTick(
       nextState.sessions[platform] = session;
       nextState.managedPageContextTabs = currentManagedPageContextTabs();
     } catch (error) {
+      const authHealth = authHealthFromError(error);
+      if (authHealth) {
+        const transition = applyPlatformAuthHealth(nextState, platform, authHealth);
+        nextState = transition.state;
+        if (transition.event) emit(transition.event);
+        await suspendPlatformForAuthentication(platform, previous, adapter);
+        continue;
+      }
       const message = error instanceof Error ? error.message : "Platform scheduler failed";
       const errorChecks = (previous.errorChecks ?? 0) + 1;
       nextState.sessions[platform] = {

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -349,6 +349,7 @@ export class KickAdapter implements PlatformAdapter {
         },
       };
     } catch (error) {
+      if (authHealthFromError(error)) throw error;
       return this.checkChannelFromPage(channel, campaign, error);
     }
   }

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -2,6 +2,7 @@ import type { CategorySelection, ChannelCandidate, ChannelCheck, DropCampaign, D
 import type { EventEmitter } from "@lurkloot/shared/events";
 import type { TablessWatchController } from "../../core/tablessWatch";
 import { KickWafBlockedError } from "../../core/tabs";
+import { authHealthFromError } from "../../core/fetchError";
 import { diagnostic, ignoreEvent, unavailableWatchTabPort, type ClaimedChallenge, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { kickCandidatesFromCampaign, mergeKickProgress, parseKickCampaigns } from "./parser";
 import { KICK_CLIENT_TOKEN, KickWatcher, type WebSocketFactory } from "./watch";
@@ -272,6 +273,7 @@ export class KickAdapter implements PlatformAdapter {
       const progress = mergeKickProgress(campaigns, data as Parameters<typeof mergeKickProgress>[1]);
       return this.claimCapability.reconcileProgress?.(progress, affirmativelyLinkedCampaignIds(data)) ?? progress;
     } catch (error) {
+      if (authHealthFromError(error)) throw error;
       const message = error instanceof Error ? error.message : String(error);
       diagnostic(this.emit, "warn", `Could not read Kick drop progress; using last-known progress: ${message}`, "kick");
       return campaigns;
@@ -387,6 +389,7 @@ export class KickAdapter implements PlatformAdapter {
       }
       return false;
     } catch (error) {
+      if (authHealthFromError(error)) throw error;
       // Kick accrues watch progress before the account is linked, but rejects
       // the claim until you connect the org account. Turn that into actionable
       // guidance instead of a raw error, and swallow it so the scheduler does
@@ -432,6 +435,7 @@ export class KickAdapter implements PlatformAdapter {
           recurrence: typeof challenge.recurrence === "string" && challenge.recurrence.trim() ? challenge.recurrence.trim() : "unknown",
         });
       } catch (error) {
+        if (authHealthFromError(error)) throw error;
         diagnostic(this.emit, "warn", `Kick challenge ${id} claim failed: ${error instanceof Error ? error.message : String(error)}`, "kick");
       }
     }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -1,6 +1,7 @@
 import type { CategorySelection, ChannelCandidate, ChannelCheck, DropCampaign, DropReward, PlatformAuthHealth, WatchSession } from "@lurkloot/shared/models";
 import type { EventEmitter } from "@lurkloot/shared/events";
 import type { LogLevel } from "@lurkloot/shared/logging";
+import { authHealthFromError, SafeFetchError } from "../../core/fetchError";
 import { PendingWatcherDiagnostics, type HeartbeatResult, type TablessWatchController, type WatchContext } from "../../core/tablessWatch";
 import { diagnostic, ignoreEvent, unavailableWatchTabPort, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { campaignHasClaimableReward, mergeTwitchCampaignProgress, parseTwitchInventory, twitchCandidatesFromCampaign, withCampaignStatus } from "./parser";
@@ -329,10 +330,14 @@ export function createTwitchGqlTransport(
       try {
         raw = await fetcher.fetchJson<unknown>("https://gql.twitch.tv/gql", request, emit);
       } catch (error) {
+        if (authHealthFromError(error)) throw error;
         const message = error instanceof Error ? error.message : `${operationName} request failed`;
         throw new TwitchGqlFailure("network", message);
       }
       const pageError = twitchPageFetchError(raw);
+      if (pageError?.kind === "credentials") {
+        throw new SafeFetchError({ kind: "authentication_rejected", status: 401, reason: "Authenticated session rejected" });
+      }
       if (pageError) throw new TwitchGqlFailure(pageError.kind, `${operationName}: ${pageError.message}`);
       return normalizeTwitchGqlResponse<T>(raw);
     };
@@ -359,11 +364,17 @@ export function createTwitchGqlTransport(
     }
     if (response.error || (response.message && response.data === undefined)) {
       const message = [response.error, response.message].filter(Boolean).join(": ") || `${operationName} failed`;
-      throw new TwitchGqlFailure(isCredentialRejection(message) ? "credentials" : "platform", message);
+      if (isCredentialRejection(message)) {
+        throw new SafeFetchError({ kind: "authentication_rejected", status: 401, reason: "Authenticated session rejected" });
+      }
+      throw new TwitchGqlFailure("platform", message);
     }
     if (response.errors?.length) {
       const message = response.errors.map((error) => error.message).filter(Boolean).join("; ") || `${operationName} failed`;
-      throw new TwitchGqlFailure(isCredentialRejection(message) ? "credentials" : "platform", message);
+      if (isCredentialRejection(message)) {
+        throw new SafeFetchError({ kind: "authentication_rejected", status: 401, reason: "Authenticated session rejected" });
+      }
+      throw new TwitchGqlFailure("platform", message);
     }
     return response;
   };
@@ -394,7 +405,7 @@ export class TwitchAdapter implements PlatformAdapter {
         message: { key: "authInvalidCredentials" },
       };
     } catch (error) {
-      if (error instanceof TwitchGqlFailure && error.kind === "credentials") {
+      if (authHealthFromError(error)?.status === "invalid_credentials") {
         return {
           status: "invalid_credentials",
           checkedAt,
@@ -465,7 +476,10 @@ export class TwitchAdapter implements PlatformAdapter {
     }
 
     if (!twitchHasCurrentUser(inventory) && !dashboard.data?.currentUser) {
-      throw new Error("Twitch did not return a logged-in current user; open twitch.tv and confirm you are signed in");
+      throw new SafeFetchError({
+        kind: "authentication_rejected",
+        reason: "Twitch did not return a logged-in current user; open twitch.tv and confirm you are signed in",
+      });
     }
 
     const userLogin = twitchCurrentUserId(inventory) ?? dashboard.data?.currentUser?.id ?? dashboard.data?.currentUser?.login ?? "";

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -502,6 +502,9 @@ export class TwitchAdapter implements PlatformAdapter {
         }),
       ),
     );
+    for (const result of details) {
+      if (result.status === "rejected" && authHealthFromError(result.reason)) throw result.reason;
+    }
     const detailedCampaigns = details
       .map((result) => result.status === "fulfilled" ? result.value.data?.dropCampaign ?? result.value.data?.user?.dropCampaign : undefined)
       .filter((campaign): campaign is NonNullable<typeof campaign> => Boolean(campaign));
@@ -658,6 +661,7 @@ export class TwitchAdapter implements PlatformAdapter {
       });
       return campaignIds.has(campaignId);
     } catch (error) {
+      if (authHealthFromError(error)) throw error;
       const message = error instanceof Error ? error.message : String(error);
       diagnostic(this.emit, "debug", `Could not confirm available Twitch campaigns for ${channelLogin}; using live/category validation: ${message}`, "twitch");
       return undefined;
@@ -702,7 +706,8 @@ export class TwitchAdapter implements PlatformAdapter {
   ): Promise<TwitchGqlResponse<T>> {
     try {
       return await this.gql(operationName, sha256Hash, variables);
-    } catch {
+    } catch (error) {
+      if (authHealthFromError(error)) throw error;
       return {};
     }
   }

--- a/packages/extension/tests/activityView.test.ts
+++ b/packages/extension/tests/activityView.test.ts
@@ -100,6 +100,7 @@ describe("activity view model", () => {
     const reasons: FarmingStopReason[] = [
       "automation_disabled",
       "platform_disabled",
+      "authentication_unhealthy",
       "platform_backoff",
       "platform_error",
       "campaign_ineligible",
@@ -129,6 +130,7 @@ describe("activity view model", () => {
     expect(t.mock.calls.map(([key]) => key)).toEqual([
       "activityReasonAutomationDisabled", "activityInterruption",
       "activityReasonPlatformDisabled", "activityInterruption",
+      "activityReasonAuthenticationUnhealthy", "activityInterruption",
       "activityReasonPlatformBackoff", "activityInterruption",
       "activityReasonPlatformError", "activityInterruption",
       "activityReasonCampaignIneligible", "activityInterruption",

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -27,6 +27,25 @@ function requestBody(init?: RequestInit): Record<string, unknown> {
 }
 
 describe("KickAdapter", () => {
+  it("does not swallow authentication failures while reading progress", async () => {
+    const failure = new SafeFetchError({ kind: "authentication_rejected", status: 401 });
+    const adapter = new KickAdapter(jsonFetcher(() => { throw failure; }));
+
+    await expect(adapter.readProgress([])).rejects.toBe(failure);
+  });
+
+  it("does not swallow security-policy failures while claiming challenges", async () => {
+    const failure = new SafeFetchError({ kind: "security_policy_blocked", status: 403, reference: "safe-ref" });
+    const adapter = new KickAdapter(jsonFetcher((url) => {
+      if (url.endsWith("/gamification/challenges")) {
+        return { data: [{ id: "daily", claimed_at: null, recurrence: "daily", condition: { progress: 1, threshold: 1 } }] };
+      }
+      throw failure;
+    }));
+
+    await expect(adapter.claimChallenges()).rejects.toBe(failure);
+  });
+
   it.each([
     ["authentication_rejected", "invalid_credentials", "credentials_rejected", "authInvalidCredentials"],
     ["security_policy_blocked", "blocked", "security_policy_blocked", "authSecurityPolicyBlocked"],
@@ -1529,7 +1548,9 @@ describe("TwitchAdapter", () => {
     });
 
     await expect(new TwitchAdapter(fetcher).discoverCampaigns())
-      .rejects.toThrow("Unauthorized: invalid OAuth token");
+      .rejects.toMatchObject({
+        failure: { kind: "authentication_rejected", status: 401 },
+      });
   });
 
   it("guides signed-out users when inventory returns a null current user", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -225,6 +225,25 @@ describe("background controller", () => {
     ]));
   });
 
+  it("publishes authentication transitions when diagnostic logging is disabled", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false, diagnosticLogging: false });
+    vi.mocked(env.kick.checkAuthHealth).mockResolvedValueOnce({
+      status: "blocked",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode: "security_policy_blocked",
+      message: { key: "authSecurityPolicyBlocked", values: { reference: "safe-ref" } },
+    });
+
+    await env.controller.checkAuthHealth("kick");
+
+    expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(expect.objectContaining({
+      category: "activity",
+      code: "auth_health_changed",
+      platform: "kick",
+      data: expect.objectContaining({ to: "blocked" }),
+    }));
+  });
+
   it("recovers Twitch authentication health after login without changing enabled settings", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true }, {
       checkCredentialAvailability: async () => ({ status: "available" }),
@@ -2188,6 +2207,35 @@ describe("background controller", () => {
     return watcher;
   }
 
+  it("stops a tabless watcher without another heartbeat when authentication degrades", async () => {
+    const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      tablessMode: true,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
+      },
+    });
+    env.twitch.supportsTabless = true;
+    env.twitch.createTablessWatcher = vi.fn(() => watcher);
+
+    await env.controller.tick();
+    expect(env.state.sessions.twitch.watchMode).toBe("tabless");
+    env.state.authHealth.twitch = {
+      status: "invalid_credentials",
+      checkedAt: "2026-07-22T12:00:00.000Z",
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    };
+
+    await env.controller.runWatchHeartbeat();
+
+    expect(watcher.stop).toHaveBeenCalledOnce();
+    expect(watcher.tick).not.toHaveBeenCalled();
+  });
+
   // Drains every pending microtask. setTimeout stays real under the Date-only
   // fake timers these handoff tests install, so one turn of the macrotask queue
   // is enough to let an async loop run to its next park.
@@ -2364,6 +2412,7 @@ describe("background controller", () => {
     env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
     // Simulate a fresh service worker: a tabless watch session is persisted, but
     // no tick() has run this lifetime to populate the in-memory watcher map.
+    env.state.authHealth.twitch = { status: "healthy" };
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -41,7 +41,7 @@ function asSnapshot(value: unknown): RuntimeSnapshot {
 function adapter(platform: Platform): PlatformAdapter {
   return {
     platform,
-    checkAuthHealth: vi.fn(async () => ({ status: "checking" as const })),
+    checkAuthHealth: vi.fn(async () => ({ status: "healthy" as const })),
     discoverCampaigns: vi.fn(async () => [campaign(platform)]),
     readProgress: vi.fn(async (campaigns) => campaigns),
     listCandidateChannels: vi.fn(async () => [channel(platform)]),
@@ -153,7 +153,76 @@ describe("background controller", () => {
     await env.controller.checkAuthHealth("twitch");
 
     expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
-    expect(env.state.authHealth.twitch.status).toBe("checking");
+    expect(env.state.authHealth.twitch.status).toBe("healthy");
+  });
+
+  it("blocks startup account work when credentials are missing without disabling the platform", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
+      },
+    }, {
+      checkCredentialAvailability: async () => ({ status: "missing" }),
+    });
+
+    await env.controller.tickAndHandOff(["twitch"]);
+
+    expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
+    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.settings.platform.twitch.enabled).toBe(true);
+    expect(env.state.authHealth.twitch).toMatchObject({
+      status: "missing_credentials",
+      reasonCode: "credentials_missing",
+    });
+    expect(env.state.sessions.twitch).toMatchObject({
+      status: "paused",
+      reasonCode: "authentication_unhealthy",
+    });
+  });
+
+  it("automatically resumes a platform after a healthy authentication recheck", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
+      },
+    }, {
+      checkCredentialAvailability: async () => ({ status: "available" }),
+    });
+    vi.mocked(env.twitch.checkAuthHealth)
+      .mockResolvedValueOnce({
+        status: "invalid_credentials",
+        checkedAt: "2026-07-22T12:00:00.000Z",
+        reasonCode: "credentials_rejected",
+        message: { key: "authInvalidCredentials" },
+      })
+      .mockResolvedValueOnce({
+        status: "healthy",
+        checkedAt: "2026-07-22T12:01:00.000Z",
+        message: { key: "authHealthy" },
+      });
+
+    await env.controller.tickAndHandOff(["twitch"]);
+    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+
+    await env.controller.tickAndHandOff(["twitch"]);
+
+    expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.settings.platform.twitch.enabled).toBe(true);
+    expect(env.state.authHealth.twitch.status).toBe("healthy");
+    expect(env.reportEvents.mock.calls.flatMap(([events]) => events).filter((event) =>
+      event.category === "activity" && event.code === "auth_health_changed"
+    )).toEqual(expect.arrayContaining([
+      expect.objectContaining({ data: expect.objectContaining({ to: "invalid_credentials" }) }),
+      expect.objectContaining({ data: expect.objectContaining({ to: "healthy" }) }),
+    ]));
   });
 
   it("recovers Twitch authentication health after login without changing enabled settings", async () => {
@@ -605,6 +674,9 @@ describe("background controller", () => {
     let affirmativelyLinked = false;
     const fetcher: PageFetcher = {
       fetchJson: vi.fn(async (url: string) => {
+        if (url === "https://kick.com/api/v1/user") {
+          return { id: 123, username: "tester" };
+        }
         if (url === "https://web.kick.com/api/v1/drops/claim") {
           claimPosts += 1;
           return { data: { connect_url: "https://accounts.example/link" } };

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -244,6 +244,36 @@ describe("background controller", () => {
     }));
   });
 
+  it("reports authentication as the reason farming stopped after logout", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
+      },
+    });
+    vi.mocked(env.twitch.checkAuthHealth)
+      .mockResolvedValueOnce({ status: "healthy", checkedAt: "2026-07-22T12:00:00.000Z" })
+      .mockResolvedValueOnce({
+        status: "invalid_credentials",
+        checkedAt: "2026-07-22T12:01:00.000Z",
+        reasonCode: "credentials_rejected",
+        message: { key: "authInvalidCredentials" },
+      });
+
+    await env.controller.tickAndHandOff(["twitch"]);
+    await env.controller.tickAndHandOff(["twitch"]);
+
+    expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(expect.objectContaining({
+      category: "activity",
+      code: "farming_stopped",
+      platform: "twitch",
+      data: expect.objectContaining({ reason: "authentication_unhealthy" }),
+    }));
+  });
+
   it("recovers Twitch authentication health after login without changing enabled settings", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true }, {
       checkCredentialAvailability: async () => ({ status: "available" }),

--- a/packages/extension/tests/fetchError.test.ts
+++ b/packages/extension/tests/fetchError.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isSafeFetchError, SafeFetchError, safeFetchFailure } from "@lurkloot/core/fetchError";
+import { authHealthFromError, isSafeFetchError, SafeFetchError, safeFetchFailure } from "@lurkloot/core/fetchError";
 
 describe("sanitized fetch failures", () => {
   it("retains only bounded troubleshooting metadata", () => {
@@ -50,5 +50,18 @@ describe("sanitized fetch failures", () => {
     expect(isSafeFetchError(new Error("HTTP 401"))).toBe(false);
     expect(error.message).toBe("HTTP 401 Unauthenticated");
     expect(JSON.stringify(error)).not.toContain("secret");
+  });
+
+  it("maps only authentication failures into sanitized health", () => {
+    expect(authHealthFromError(new SafeFetchError({ kind: "authentication_rejected", status: 401 })))
+      .toMatchObject({ status: "invalid_credentials", reasonCode: "credentials_rejected" });
+    expect(authHealthFromError(new SafeFetchError({ kind: "security_policy_blocked", reference: "safe-ref" })))
+      .toMatchObject({
+        status: "blocked",
+        reasonCode: "security_policy_blocked",
+        message: { key: "authSecurityPolicyBlocked", values: { reference: "safe-ref" } },
+      });
+    expect(authHealthFromError(new SafeFetchError({ kind: "http_error", status: 503 }))).toBeUndefined();
+    expect(authHealthFromError(new Error("ordinary failure"))).toBeUndefined();
   });
 });

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -2314,6 +2314,72 @@ describe("scheduler tick", () => {
     });
     expect(result.state.sessions.kick.retryAfter).toBeDefined();
   });
+
+  it("does not turn an authentication failure into an Idle Watchlist session", async () => {
+    const kick = adapter("kick", [], []);
+    vi.mocked(kick.discoverCampaigns).mockRejectedValueOnce(
+      new SafeFetchError({ kind: "authentication_rejected", status: 401 }),
+    );
+
+    const result = await runSchedulerTick(
+      baseState,
+      settings({
+        platform: {
+          twitch: { enabled: false },
+          kick: { enabled: true, idleWatchlistChannels: ["public-creator"] },
+        },
+      }),
+      { twitch: adapter("twitch", [], []), kick },
+      { platforms: ["kick"] },
+    );
+
+    expect(kick.listCandidateChannels).not.toHaveBeenCalled();
+    expect(kick.checkChannel).not.toHaveBeenCalled();
+    expect(result.state.sessions.kick).toMatchObject({
+      status: "paused",
+      reasonCode: "authentication_unhealthy",
+      retryAfter: undefined,
+    });
+  });
+
+  it("forgets managed page-context state when authentication cleanup fails", async () => {
+    const stopPageContextTabs = vi.fn(async () => {
+      throw new Error("tab close failed");
+    });
+    const managedContext = {
+      platform: "kick" as const,
+      tabId: 91,
+      originUrl: "https://kick.com/drops/inventory",
+      origin: "https://kick.com",
+      ownedByExtension: true as const,
+      muteFarmingTabs: true,
+      keepFarmingVideosUnmuted: false,
+      autoCloseFinishedDrops: true,
+      adFocusMode: "off" as const,
+      languageOverride: "auto" as const,
+    };
+
+    const result = await runSchedulerTick(
+      {
+        ...baseState,
+        authHealth: {
+          ...HEALTHY_AUTH,
+          kick: { status: "invalid_credentials", reasonCode: "credentials_rejected" },
+        },
+        managedPageContextTabs: { kick: managedContext },
+      },
+      settings({ platform: { twitch: { enabled: false }, kick: { enabled: true } } }),
+      { twitch: adapter("twitch", [], []), kick: adapter("kick", [], []) },
+      { platforms: ["kick"], stopPageContextTabs },
+    );
+
+    expect(result.state.managedPageContextTabs?.kick).toBeUndefined();
+    expect(result.events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      level: "warn",
+      message: "tab close failed",
+    }));
+  });
 });
 
 describe("scheduler tabless mode", () => {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -5,7 +5,6 @@ import { NO_CATEGORY_ID } from "@lurkloot/shared/categories";
 import { chooseCampaignDecision, runSchedulerTick, sortCampaigns } from "@lurkloot/core/scheduler";
 import type { PlatformAdapter } from "@lurkloot/core/adapter";
 import { forgetManagedPageContextTabs } from "@lurkloot/core/tabs";
-import { DEFAULT_STATE } from "@lurkloot/core/defaults";
 
 const reward = (status: DropReward["status"] = "in_progress"): DropReward => ({
   id: `reward-${status}`,
@@ -62,6 +61,11 @@ function adapter(platform: Platform, campaigns: DropCampaign[], candidates: Chan
     stopWatchTab: vi.fn(async () => undefined),
   };
 }
+
+const HEALTHY_AUTH: SchedulerState["authHealth"] = {
+  twitch: { status: "healthy" },
+  kick: { status: "healthy" },
+};
 
 describe("scheduler campaign selection", () => {
   it("skips an infeasible in-progress reward for a feasible locked reward", async () => {
@@ -631,13 +635,79 @@ describe("scheduler campaign selection", () => {
 
 describe("scheduler tick", () => {
   const baseState: SchedulerState = {
-    authHealth: DEFAULT_STATE.authHealth,
+    authHealth: HEALTHY_AUTH,
     sessions: {
       twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
       kick: { platform: "kick", status: "idle", offlineChecks: 0 },
     },
     campaigns: { twitch: [], kick: [] },
   };
+
+  it.each([
+    ["checking", undefined],
+    ["missing_credentials", "credentials_missing"],
+    ["invalid_credentials", "credentials_rejected"],
+    ["blocked", "security_policy_blocked"],
+    ["unavailable", "platform_unavailable"],
+  ] as const)("suspends account work while authentication is %s", async (status, reasonCode) => {
+    const kick = {
+      ...adapter("kick", [campaign("public", { platform: "kick" })], [channel("creator", { platform: "kick" })]),
+      claimChallenges: vi.fn(async () => []),
+      claimChannelPoints: vi.fn(async () => true),
+    };
+    const stopPageContextTabs = vi.fn(forgetManagedPageContextTabs);
+    const previous = {
+      platform: "kick" as const,
+      status: "watching" as const,
+      offlineChecks: 0,
+      errorChecks: 2,
+      retryAfter: "2099-01-01T00:00:00.000Z",
+      channel: channel("creator", { platform: "kick" }),
+      campaignId: "stale",
+      rewardId: "reward",
+      tabId: 42,
+      tabManagedByExtension: true,
+    };
+
+    const result = await runSchedulerTick(
+      {
+        ...baseState,
+        authHealth: {
+          ...HEALTHY_AUTH,
+          kick: { status, ...(reasonCode ? { reasonCode } : {}) },
+        },
+        sessions: { ...baseState.sessions, kick: previous },
+        campaigns: { ...baseState.campaigns, kick: [campaign("stale", { platform: "kick" })] },
+        managedWatchTabs: {
+          kick: { platform: "kick", tabId: 42, channelUrl: previous.channel.url, ownedByExtension: true },
+        },
+      },
+      settings({ platform: { twitch: { enabled: false }, kick: { enabled: true } } }),
+      { twitch: adapter("twitch", [], []), kick },
+      { platforms: ["kick"], stopPageContextTabs },
+    );
+
+    expect(kick.stopWatchTab).toHaveBeenCalledWith(previous);
+    expect(kick.discoverCampaigns).not.toHaveBeenCalled();
+    expect(kick.readProgress).not.toHaveBeenCalled();
+    expect(kick.claimReward).not.toHaveBeenCalled();
+    expect(kick.claimChallenges).not.toHaveBeenCalled();
+    expect(kick.listCandidateChannels).not.toHaveBeenCalled();
+    expect(kick.checkChannel).not.toHaveBeenCalled();
+    expect(kick.prepareWatchTab).not.toHaveBeenCalled();
+    expect(kick.claimChannelPoints).not.toHaveBeenCalled();
+    expect(result.state.campaigns.kick).toEqual([]);
+    expect(result.state.managedWatchTabs?.kick).toBeUndefined();
+    expect(result.state.sessions.kick).toMatchObject({
+      status: "paused",
+      reasonCode: "authentication_unhealthy",
+      errorChecks: 2,
+      retryAfter: undefined,
+      channel: undefined,
+      campaignId: undefined,
+      rewardId: undefined,
+    });
+  });
 
   it("returns claim activity in the event batch without mutating scheduler state", async () => {
     const ready = campaign("drops", { rewards: [reward("claimable")] });
@@ -728,7 +798,7 @@ describe("scheduler tick", () => {
     const result = await runSchedulerTick(
       {
         ...baseState,
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           ...baseState.sessions,
           twitch: {
@@ -765,7 +835,7 @@ describe("scheduler tick", () => {
     const result = await runSchedulerTick(
       {
         ...baseState,
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           ...baseState.sessions,
           twitch: {
@@ -796,7 +866,7 @@ describe("scheduler tick", () => {
     const result = await runSchedulerTick(
       {
         ...baseState,
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           ...baseState.sessions,
           twitch: {
@@ -832,7 +902,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: first, offlineChecks: 2, tabId: 7 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -861,7 +931,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: channel("old"), offlineChecks: 0, tabId: 7, tabManagedByExtension: true },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -892,7 +962,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -932,7 +1002,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: old, offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -954,7 +1024,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: toonyx, offlineChecks: 0, tabId: 7 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -976,7 +1046,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1011,7 +1081,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1052,7 +1122,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1093,7 +1163,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1143,7 +1213,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1187,7 +1257,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1240,7 +1310,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1274,7 +1344,7 @@ describe("scheduler tick", () => {
 
     await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1306,7 +1376,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1340,7 +1410,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1374,7 +1444,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1452,7 +1522,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -1505,7 +1575,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1534,7 +1604,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1560,7 +1630,7 @@ describe("scheduler tick", () => {
     const waitingClaimRewardIds = { twitch: new Set<string>(), kick: new Set<string>() };
     const options = { waitingClaimRewardIds };
     const initialState: SchedulerState = {
-      authHealth: DEFAULT_STATE.authHealth,
+      authHealth: HEALTHY_AUTH,
       sessions: {
         twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
         kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1593,7 +1663,7 @@ describe("scheduler tick", () => {
     const waitingClaimRewardIds = { twitch: new Set<string>(), kick: new Set<string>() };
     const options = { waitingClaimRewardIds };
     const initialState: SchedulerState = {
-      authHealth: DEFAULT_STATE.authHealth,
+      authHealth: HEALTHY_AUTH,
       sessions: {
         twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
         kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1624,7 +1694,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1645,7 +1715,7 @@ describe("scheduler tick", () => {
 
     await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1665,7 +1735,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1688,7 +1758,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1711,7 +1781,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1735,7 +1805,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1768,7 +1838,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1794,7 +1864,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: channel("current"), offlineChecks: 0, tabId: 42, tabManagedByExtension: true },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1820,7 +1890,7 @@ describe("scheduler tick", () => {
   it("passes the existing managed tab into repeated ticks instead of creating an untracked tab", async () => {
     const twitch = adapter("twitch", [campaign("drops")], [channel("allowed")]);
     const initialState = {
-      authHealth: DEFAULT_STATE.authHealth,
+      authHealth: HEALTHY_AUTH,
       sessions: {
         twitch: { platform: "twitch" as const, status: "idle" as const, offlineChecks: 0 },
         kick: { platform: "kick" as const, status: "idle" as const, offlineChecks: 0 },
@@ -1848,7 +1918,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: channel("old"), offlineChecks: 0, tabId: 7, tabManagedByExtension: true },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1884,7 +1954,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "watching", channel: channel("old"), offlineChecks: 0, tabId: 7, tabManagedByExtension: true },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1906,7 +1976,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1933,7 +2003,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1962,7 +2032,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -1994,7 +2064,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -2022,7 +2092,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -2053,7 +2123,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2076,7 +2146,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2099,7 +2169,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2124,7 +2194,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2145,7 +2215,7 @@ describe("scheduler tick", () => {
 
     await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2167,7 +2237,7 @@ describe("scheduler tick", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2194,7 +2264,7 @@ describe("scheduler tabless mode", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },
@@ -2218,7 +2288,7 @@ describe("scheduler tabless mode", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -2251,7 +2321,7 @@ describe("scheduler tabless mode", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: {
             platform: "twitch",
@@ -2282,7 +2352,7 @@ describe("scheduler tabless mode", () => {
 
     const result = await runSchedulerTick(
       {
-        authHealth: DEFAULT_STATE.authHealth,
+        authHealth: HEALTHY_AUTH,
         sessions: {
           twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
           kick: { platform: "kick", status: "idle", offlineChecks: 0 },

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -699,6 +699,10 @@ describe("scheduler tick", () => {
     expect(kick.claimChannelPoints).not.toHaveBeenCalled();
     expect(result.state.campaigns.kick).toEqual([]);
     expect(result.state.managedWatchTabs?.kick).toBeUndefined();
+    expect(stopPageContextTabs).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ platforms: ["kick"], reason: "authentication_unhealthy" }),
+    );
     expect(result.state.sessions.kick).toMatchObject({
       status: "paused",
       reasonCode: "authentication_unhealthy",

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -5,6 +5,7 @@ import { NO_CATEGORY_ID } from "@lurkloot/shared/categories";
 import { chooseCampaignDecision, runSchedulerTick, sortCampaigns } from "@lurkloot/core/scheduler";
 import type { PlatformAdapter } from "@lurkloot/core/adapter";
 import { forgetManagedPageContextTabs } from "@lurkloot/core/tabs";
+import { SafeFetchError } from "@lurkloot/core/fetchError";
 
 const reward = (status: DropReward["status"] = "in_progress"): DropReward => ({
   id: `reward-${status}`,
@@ -2251,6 +2252,67 @@ describe("scheduler tick", () => {
     expect(result.state.sessions.kick.status).not.toBe("error");
     expect(result.state.sessions.kick.errorChecks).toBe(0);
     expect(result.events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("gamification down"))).toBe(true);
+  });
+
+  it("suspends without backoff when a challenge reports an authentication failure", async () => {
+    const kick = {
+      ...adapter("kick", [], []),
+      claimChallenges: vi.fn(async () => {
+        throw new SafeFetchError({ kind: "security_policy_blocked", status: 403, reference: "safe-ref" });
+      }),
+    };
+
+    const result = await runSchedulerTick(
+      {
+        ...baseState,
+        sessions: {
+          ...baseState.sessions,
+          kick: { platform: "kick", status: "idle", offlineChecks: 0, errorChecks: 2 },
+        },
+      },
+      settings({ platform: { twitch: { enabled: false }, kick: { enabled: true } } }),
+      { twitch: adapter("twitch", [], []), kick },
+      { platforms: ["kick"] },
+    );
+
+    expect(result.state.authHealth.kick).toMatchObject({
+      status: "blocked",
+      reasonCode: "security_policy_blocked",
+      message: { values: { reference: "safe-ref" } },
+    });
+    expect(result.state.sessions.kick).toMatchObject({
+      status: "paused",
+      reasonCode: "authentication_unhealthy",
+      errorChecks: 2,
+      retryAfter: undefined,
+    });
+    expect(result.events).toContainEqual(expect.objectContaining({
+      category: "activity",
+      code: "auth_health_changed",
+      data: expect.objectContaining({ to: "blocked" }),
+    }));
+  });
+
+  it("keeps transient platform failures on ordinary backoff", async () => {
+    const kick = adapter("kick", [], []);
+    vi.mocked(kick.discoverCampaigns).mockRejectedValueOnce(
+      new SafeFetchError({ kind: "http_error", status: 503 }),
+    );
+
+    const result = await runSchedulerTick(
+      baseState,
+      settings({ platform: { twitch: { enabled: false }, kick: { enabled: true } } }),
+      { twitch: adapter("twitch", [], []), kick },
+      { platforms: ["kick"] },
+    );
+
+    expect(result.state.authHealth.kick.status).toBe("healthy");
+    expect(result.state.sessions.kick).toMatchObject({
+      status: "error",
+      reasonCode: "platform_error",
+      errorChecks: 1,
+    });
+    expect(result.state.sessions.kick.retryAfter).toBeDefined();
   });
 });
 

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "تم تعطيل المنصة"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "المصادقة غير متاحة" },
   "activityReasonPlatformBackoff": {
     "message": "المنصة في انتظار مؤقت"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "die Plattform wurde deaktiviert"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "die Authentifizierung ist nicht verfügbar" },
   "activityReasonPlatformBackoff": {
     "message": "die Plattform wartet vorübergehend"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "the platform was disabled"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "authentication is unavailable" },
   "activityReasonPlatformBackoff": {
     "message": "the platform is temporarily backing off"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "se desactivó la plataforma"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "la autenticación no está disponible" },
   "activityReasonPlatformBackoff": {
     "message": "la plataforma está esperando temporalmente"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "la plateforme a été désactivée"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "l’authentification est indisponible" },
   "activityReasonPlatformBackoff": {
     "message": "la plateforme est temporairement en attente"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "प्लेटफ़ॉर्म बंद किया गया"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "प्रमाणीकरण उपलब्ध नहीं है" },
   "activityReasonPlatformBackoff": {
     "message": "प्लेटफ़ॉर्म कुछ समय के लिए प्रतीक्षा कर रहा है"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "la piattaforma è stata disattivata"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "l’autenticazione non è disponibile" },
   "activityReasonPlatformBackoff": {
     "message": "la piattaforma è temporaneamente in attesa"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "a plataforma foi desativada"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "a autenticação não está disponível" },
   "activityReasonPlatformBackoff": {
     "message": "a plataforma está aguardando temporariamente"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "платформа отключена"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "аутентификация недоступна" },
   "activityReasonPlatformBackoff": {
     "message": "платформа временно ожидает"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -810,6 +810,7 @@
   "activityReasonPlatformDisabled": {
     "message": "platform devre dışı bırakıldı"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "kimlik doğrulama kullanılamıyor" },
   "activityReasonPlatformBackoff": {
     "message": "platform geçici olarak geri çekiliyor"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -752,6 +752,7 @@
   "activityReasonPlatformDisabled": {
     "message": "平台已停用"
   },
+  "activityReasonAuthenticationUnhealthy": { "message": "身份验证不可用" },
   "activityReasonPlatformBackoff": {
     "message": "平台正在暂时等待"
   },

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -104,6 +104,7 @@ function formatStopReason(reason: FarmingStopReason, t: TFunction): string {
   switch (reason) {
     case "automation_disabled": return t("activityReasonAutomationDisabled");
     case "platform_disabled": return t("activityReasonPlatformDisabled");
+    case "authentication_unhealthy": return t("activityReasonAuthenticationUnhealthy");
     case "platform_backoff": return t("activityReasonPlatformBackoff");
     case "platform_error": return t("activityReasonPlatformError");
     case "campaign_ineligible": return t("activityReasonCampaignIneligible");
@@ -117,6 +118,7 @@ function formatStopReason(reason: FarmingStopReason, t: TFunction): string {
     case "runtime_restart": return t("activityReasonRuntimeRestart");
     case "target_changed": return t("activityReasonTargetChanged");
     case "manual_watch": return t("activityReasonManualWatch");
+    case "authentication_unhealthy": return t("activityReasonAuthenticationUnhealthy");
     default: {
       const exhaustive: never = reason;
       return exhaustive;
@@ -142,6 +144,7 @@ function formatPageContextCloseReason(reason: PageContextCloseReason, t: TFuncti
     case "platform_disabled": return t("activityReasonPlatformDisabled");
     case "automation_disabled": return t("activityReasonAutomationDisabled");
     case "manual_watch": return t("activityReasonManualWatch");
+    case "authentication_unhealthy": return t("activityReasonAuthenticationUnhealthy");
     case "runtime_restart": return t("activityReasonRuntimeRestart");
     case "managed_context_unusable": return t("activityPageContextReasonManagedContextUnusable");
     default: {

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -4,6 +4,7 @@ import type { Platform, PlatformAuthReasonCode, PlatformAuthStatus } from "./mod
 export type FarmingStopReason =
   | "automation_disabled"
   | "platform_disabled"
+  | "authentication_unhealthy"
   | "platform_backoff"
   | "platform_error"
   | "campaign_ineligible"
@@ -33,6 +34,7 @@ export type PageContextCloseReason =
   | "platform_disabled"
   | "automation_disabled"
   | "manual_watch"
+  | "authentication_unhealthy"
   | "runtime_restart"
   | "managed_context_unusable";
 

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -4,7 +4,6 @@ import type { Platform, PlatformAuthReasonCode, PlatformAuthStatus } from "./mod
 export type FarmingStopReason =
   | "automation_disabled"
   | "platform_disabled"
-  | "authentication_unhealthy"
   | "platform_backoff"
   | "platform_error"
   | "campaign_ineligible"
@@ -34,7 +33,6 @@ export type PageContextCloseReason =
   | "platform_disabled"
   | "automation_disabled"
   | "manual_watch"
-  | "authentication_unhealthy"
   | "runtime_restart"
   | "managed_context_unusable";
 

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -150,6 +150,7 @@ export type WatchReasonCode =
   | "manual_watch"
   | "automation_disabled"
   | "platform_disabled"
+  | "authentication_unhealthy"
   | "platform_backoff"
   | "platform_error"
   | "campaign_ineligible"


### PR DESCRIPTION
## Summary

- gate scheduler account work on healthy platform authentication
- detect and persist authentication degradation from proactive probes and runtime failures
- suspend farming, clear stale state and managed page contexts, and recover automatically when authentication becomes healthy
- surface the authentication suspension reason in the popup, CLI, and localized activity messages

## Root cause

The scheduler treated platform enablement and authentication health independently. Missing, expired, blocked, or unavailable credentials could therefore leave farming state active, allow follow-up account work, and preserve stale campaigns or managed page contexts.

## Impact

Account-dependent work now stops consistently whenever authentication is unhealthy and resumes without disabling the configured platform after authentication recovers.

Closes #204

## Testing

- `pnpm verify`
- `git diff --check origin/develop...HEAD`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication health checks before platform activity begins.
  * Automatically pauses account-dependent activity when authentication is unavailable and resumes it after recovery.
  * Stops related watchers and heartbeats when authentication degrades.
  * Added clear activity and CLI messages for authentication-related interruptions across supported languages.

* **Bug Fixes**
  * Authentication failures no longer trigger standard retry backoff or get silently treated as ordinary platform errors.

* **Tests**
  * Expanded coverage for authentication failures, recovery, cleanup, watcher shutdown, and localized messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->