### PR TITLE
feat(popup): surface platform authentication health

### DIFF
--- a/docs/superpowers/plans/2026-07-22-popup-auth-health.md
+++ b/docs/superpowers/plans/2026-07-22-popup-auth-health.md
@@ -12,7 +12,7 @@
 
 - Work only in `.worktrees/popup-auth-health` on `feat/popup-auth-health`.
 - Running appears only when the platform is enabled and authenticated.
-- Missing and rejected credentials use explicit first-party sign-in buttons: `https://www.twitch.tv/login` and `https://kick.com/`.
+- Missing and rejected credentials use explicit first-party sign-in buttons: `https://www.twitch.tv/login` and `https://kick.com/login`.
 - Kick security-policy blocking must say the browser profile was rejected and must not offer sign-in as the fix.
 - Degraded authentication must not disable or change the platform automation setting.
 - Do not render credentials, raw errors, authenticated response bodies, or optional auth message values.
@@ -120,7 +120,7 @@ export interface AutomationPresentation {
 }
 export const AUTH_SIGN_IN_URLS: Record<Platform, string> = {
   twitch: "https://www.twitch.tv/login",
-  kick: "https://kick.com/",
+  kick: "https://kick.com/login",
 };
 export function automationPresentation(input: { platform: Platform; enabled: boolean; pending: boolean; authHealth: PlatformAuthHealth }): AutomationPresentation;
 ```

--- a/docs/superpowers/plans/2026-07-22-popup-auth-health.md
+++ b/docs/superpowers/plans/2026-07-22-popup-auth-health.md
@@ -1,0 +1,449 @@
+# Popup Authentication Health Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make popup status surfaces distinguish healthy automation from authentication checking, sign-in requirements, security-policy blocking, and temporary unavailability while preserving the user's automation toggle.
+
+**Architecture:** A pure `automationStatus` module maps settings and normalized `PlatformAuthHealth` into a typed presentation model. `Popup` derives one model per platform and passes it to the existing header, switcher, and hero; rendering never consumes raw credentials or errors. Existing five-second snapshot refreshes provide automatic recovery with no new transport or polling mechanism.
+
+**Tech Stack:** TypeScript 7, React 19, Vitest 4, linkedom, Tailwind CSS, pnpm workspace packages.
+
+## Global Constraints
+
+- Work only in `.worktrees/popup-auth-health` on `feat/popup-auth-health`.
+- Running appears only when the platform is enabled and authenticated.
+- Missing and rejected credentials use explicit first-party sign-in buttons: `https://www.twitch.tv/login` and `https://kick.com/`.
+- Kick security-policy blocking must say the browser profile was rejected and must not offer sign-in as the fix.
+- Degraded authentication must not disable or change the platform automation setting.
+- Do not render credentials, raw errors, authenticated response bodies, or optional auth message values.
+- Add no popup authentication polling; consume the existing runtime snapshot refresh.
+- Every new user-facing key must exist with a genuine translation in all eleven locale catalogs.
+
+---
+
+## File Structure
+
+- Create `packages/popup-ui/src/automationStatus.ts`: pure status derivation, fixed sign-in URLs, and exhaustive presentation types.
+- Create `packages/extension/tests/automationStatus.test.ts`: unit coverage for precedence, every auth state/reason, action mapping, and sensitive-value omission.
+- Modify `packages/popup-ui/src/automation.tsx`: render the derived status in the hero and platform switcher.
+- Create `packages/extension/tests/automationView.test.tsx`: focused component coverage for badge, copy, action click, visual indicator, and toggle availability.
+- Modify `packages/popup-ui/src/Popup.tsx`: derive platform presentations and share them across header, switcher, and hero.
+- Create `packages/extension/tests/popupAuthHealth.test.tsx`: integration coverage for header consistency and snapshot-driven recovery.
+- Modify `packages/popup-ui/src/primitives.tsx`: add an amber `warning` pill tone.
+- Modify `packages/locales/messages/{ar,de,en,es,fr,hi,it,pt_BR,ru,tr,zh_CN}.json`: complete auth-health UI copy.
+- Modify `packages/extension/tests/i18n.test.ts`: pin English wording and require all auth UI keys in every catalog.
+
+---
+
+### Task 1: Pure Authentication Presentation Model
+
+**Files:**
+- Create: `packages/popup-ui/src/automationStatus.ts`
+- Create: `packages/extension/tests/automationStatus.test.ts`
+
+**Interfaces:**
+- Consumes: `Platform`, `PlatformAuthHealth`, and `PlatformAuthReasonCode` from `@lurkloot/shared/models`.
+- Produces: `AutomationPresentation`, `AutomationPresentationState`, `AUTH_SIGN_IN_URLS`, and `automationPresentation(input)`.
+
+- [ ] **Step 1: Write the failing presentation tests**
+
+Create `packages/extension/tests/automationStatus.test.ts` with table-driven tests equivalent to:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { PlatformAuthHealth } from "@lurkloot/shared/models";
+import { AUTH_SIGN_IN_URLS, automationPresentation } from "../../popup-ui/src/automationStatus";
+
+const health = (status: PlatformAuthHealth["status"], reasonCode?: PlatformAuthHealth["reasonCode"]): PlatformAuthHealth => ({
+  status,
+  reasonCode,
+  message: { key: status === "blocked" ? "authSecurityPolicyBlocked" : "authPlatformUnavailable", values: { reference: "must-not-render" } },
+});
+
+describe("automation authentication presentation", () => {
+  it("gives pending and paused states precedence", () => {
+    expect(automationPresentation({ platform: "twitch", enabled: true, pending: true, authHealth: health("missing_credentials") }).state).toBe("starting");
+    expect(automationPresentation({ platform: "twitch", enabled: false, pending: true, authHealth: health("healthy") }).state).toBe("stopping");
+    expect(automationPresentation({ platform: "kick", enabled: false, pending: false, authHealth: health("blocked") }).state).toBe("paused");
+  });
+
+  it.each([
+    ["healthy", undefined, "running", "automationRunning", "accent", undefined],
+    ["checking", undefined, "checking", "automationChecking", "muted", "authCheckingDetail"],
+    ["missing_credentials", "credentials_missing", "needs_sign_in", "automationNeedsSignIn", "warning", "authSignInMissing"],
+    ["invalid_credentials", "credentials_rejected", "needs_sign_in", "automationNeedsSignIn", "warning", "authSignInRejected"],
+    ["blocked", "security_policy_blocked", "blocked", "automationBlocked", "danger", "authBrowserProfileBlocked"],
+    ["unavailable", "credential_lookup_failed", "unavailable", "automationUnavailable", "warning", "authCredentialCheckUnavailable"],
+    ["unavailable", "network_unavailable", "unavailable", "automationUnavailable", "warning", "authNetworkTemporarilyUnavailable"],
+    ["unavailable", "platform_unavailable", "unavailable", "automationUnavailable", "warning", "authPlatformTemporarilyUnavailable"],
+  ] as const)("maps %s/%s", (status, reasonCode, state, badgeKey, tone, detailKey) => {
+    expect(automationPresentation({ platform: "kick", enabled: true, pending: false, authHealth: health(status, reasonCode) })).toMatchObject({ state, badgeKey, tone, detailKey });
+  });
+
+  it.each(["missing_credentials", "invalid_credentials"] as const)("provides fixed sign-in actions for %s", (status) => {
+    expect(automationPresentation({ platform: "twitch", enabled: true, pending: false, authHealth: health(status) }).action).toEqual({ labelKey: "signInToTwitch", url: AUTH_SIGN_IN_URLS.twitch });
+    expect(automationPresentation({ platform: "kick", enabled: true, pending: false, authHealth: health(status) }).action).toEqual({ labelKey: "signInToKick", url: AUTH_SIGN_IN_URLS.kick });
+  });
+
+  it.each(["checking", "healthy", "blocked", "unavailable"] as const)("does not offer sign-in for %s", (status) => {
+    expect(automationPresentation({ platform: "kick", enabled: true, pending: false, authHealth: health(status) }).action).toBeUndefined();
+  });
+
+  it("does not propagate auth message values", () => {
+    expect(JSON.stringify(automationPresentation({ platform: "kick", enabled: true, pending: false, authHealth: health("blocked", "security_policy_blocked") }))).not.toContain("must-not-render");
+  });
+});
+```
+
+- [ ] **Step 2: Run the unit test and confirm the module is missing**
+
+Run: `pnpm --filter @lurkloot/extension test -- automationStatus.test.ts`
+
+Expected: FAIL because `../../popup-ui/src/automationStatus` does not exist.
+
+- [ ] **Step 3: Implement the exhaustive pure mapper**
+
+Create `packages/popup-ui/src/automationStatus.ts` with these public types and constants:
+
+```ts
+import type { Platform, PlatformAuthHealth } from "@lurkloot/shared/models";
+
+export type AutomationPresentationState = "starting" | "stopping" | "paused" | "running" | "checking" | "needs_sign_in" | "blocked" | "unavailable";
+export type AutomationTone = "muted" | "accent" | "warning" | "danger";
+export interface AutomationPresentation {
+  state: AutomationPresentationState;
+  badgeKey: string;
+  detailKey?: string;
+  tone: AutomationTone;
+  operational: boolean;
+  action?: { labelKey: "signInToTwitch" | "signInToKick"; url: string };
+}
+export const AUTH_SIGN_IN_URLS: Record<Platform, string> = {
+  twitch: "https://www.twitch.tv/login",
+  kick: "https://kick.com/",
+};
+export function automationPresentation(input: { platform: Platform; enabled: boolean; pending: boolean; authHealth: PlatformAuthHealth }): AutomationPresentation;
+```
+
+Implement priority as pending → paused → auth status. Starting uses `{ badgeKey: "automationStarting", detailKey: "startingAutomation", tone: "muted", operational: false }`; stopping uses the corresponding existing `automationStopping`/`pausingAutomation` keys; paused uses `pausedStatus`/`watchingPausedHint`. Use a `switch` over all six `PlatformAuthStatus` values. For `unavailable`, map `credential_lookup_failed`, `network_unavailable`, and the fallback `platform_unavailable` to their exact detail keys from Step 1. Construct the action only for missing/rejected credentials. Never copy `authHealth.message`, `checkedAt`, or message values into the return object.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- automationStatus.test.ts`
+
+Expected: PASS with all presentation cases green.
+
+- [ ] **Step 5: Commit the pure model**
+
+```bash
+git add packages/popup-ui/src/automationStatus.ts packages/extension/tests/automationStatus.test.ts
+git commit -m "feat(popup): derive authentication status presentation"
+```
+
+---
+
+### Task 2: Render Hero and Switcher Authentication States
+
+**Files:**
+- Modify: `packages/popup-ui/src/primitives.tsx:41-50`
+- Modify: `packages/popup-ui/src/automation.tsx:1-88`
+- Create: `packages/extension/tests/automationView.test.tsx`
+
+**Interfaces:**
+- Consumes: `AutomationPresentation` from Task 1, `PopupAdapter.openLink`, and the existing `I18nContext`/`PopupRuntimeContext`.
+- Produces: `PlatformSwitcher` accepting `presentation: Record<Platform, AutomationPresentation>` and `AutomationHero` accepting one `presentation` plus the existing content/toggle props.
+
+- [ ] **Step 1: Write failing component tests**
+
+Create a linkedom mount helper in `automationView.test.tsx` following `dropsView.test.tsx`: install DOM globals, render both components inside `I18nContext` and `PopupRuntimeContext`, and unmount in `afterEach`. Use a translator that maps the new keys to readable English.
+
+Assert these exact behaviors:
+
+```ts
+expect(container.textContent).toContain("Needs sign-in");
+expect(container.textContent).toContain("Sign in to Twitch");
+expect(container.querySelector('[data-auth-action="twitch"]')).not.toBeNull();
+act(() => container.querySelector<HTMLButtonElement>('[data-auth-action="twitch"]')?.click());
+expect(openLink).toHaveBeenCalledWith("https://www.twitch.tv/login");
+
+expect(container.querySelector('[role="switch"]')?.hasAttribute("disabled")).toBe(false);
+expect(container.querySelector('[data-automation-state="blocked"]')).not.toBeNull();
+expect(container.textContent).toContain("Kick rejected this browser profile");
+expect(container.querySelector("[data-auth-action]")).toBeNull();
+
+expect(container.querySelector('[data-platform-status="twitch"]')?.getAttribute("data-state")).toBe("running");
+expect(container.querySelector('[data-platform-status="kick"]')?.getAttribute("data-state")).toBe("unavailable");
+```
+
+Also rerender a healthy hero with a `farmingChannel` and verify watching/farming detail is shown only for `presentation.state === "running"`; degraded states must show `detailKey` even if stale farming props are supplied.
+
+- [ ] **Step 2: Run the component test and confirm prop/render failures**
+
+Run: `pnpm --filter @lurkloot/extension test -- automationView.test.tsx`
+
+Expected: FAIL because the components do not accept or render `presentation`.
+
+- [ ] **Step 3: Add the warning pill tone**
+
+Extend the `Pill` tone union in `primitives.tsx` with `warning` and add:
+
+```ts
+warning: "bg-amber-500/12 text-amber-700 dark:text-amber-400",
+```
+
+- [ ] **Step 4: Update the switcher contract and indicators**
+
+Change `PlatformSwitcher` to accept:
+
+```ts
+export function PlatformSwitcher({ active, presentation, onChange }: {
+  active: Platform;
+  presentation: Record<Platform, AutomationPresentation>;
+  onChange(platform: Platform): void;
+})
+```
+
+For each platform, set `data-platform-status={id}` and `data-state={status.state}`. Use the accent-filled/glowing dot only when `status.operational` is true, an amber dot for `needs_sign_in`/`unavailable`, red for `blocked`, and the existing outlined neutral dot otherwise. Localize the button title from the presentation badge rather than interpolating hard-coded English.
+
+- [ ] **Step 5: Update the hero contract and degraded rendering**
+
+Change `AutomationHero` to accept `platform`, `enabled`, `pending`, and `presentation`. Put `data-automation-state={presentation.state}` on its root. Render `t(presentation.badgeKey)` with `Pill tone={presentation.tone}`. Apply glow/accent icon styling only when `presentation.operational` is true.
+
+Keep the existing pending and paused detail branches. Render watching/farming details only for `running`. For all other enabled states render `t(presentation.detailKey!)`; when `presentation.action` exists, add:
+
+```tsx
+<button
+  type="button"
+  data-auth-action={platform}
+  onClick={() => runtime?.adapter.openLink(presentation.action!.url)}
+  className="mt-1 w-fit rounded-md bg-[var(--accent-soft)] px-2 py-1 text-[11px] font-semibold text-[var(--accent-text)] outline-none hover:underline focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+>
+  {t(presentation.action.labelKey)}
+</button>
+```
+
+Use `usePopupRuntime()` (or the existing context access pattern) to obtain the adapter. Keep `Toggle disabled={pending}` exactly so degraded states remain interactive.
+
+- [ ] **Step 6: Run component and pure tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- automationView.test.tsx automationStatus.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit component rendering**
+
+```bash
+git add packages/popup-ui/src/primitives.tsx packages/popup-ui/src/automation.tsx packages/extension/tests/automationView.test.tsx
+git commit -m "feat(popup): render authentication health actions"
+```
+
+---
+
+### Task 3: Integrate Consistent Popup Status and Recovery
+
+**Files:**
+- Modify: `packages/popup-ui/src/Popup.tsx:476-512,538-543,592`
+- Create: `packages/extension/tests/popupAuthHealth.test.tsx`
+
+**Interfaces:**
+- Consumes: `automationPresentation` and the component contracts from Tasks 1–2.
+- Produces: consistent header, switcher, and hero status derived from `snapshot.state.authHealth`.
+
+- [ ] **Step 1: Write the failing popup integration tests**
+
+Create `popupAuthHealth.test.tsx` with the same linkedom/React setup as other popup integration tests. Build snapshots from `demoSnapshot()` with `settings.running = true`, both platform settings enabled, empty/stale sessions, and controlled `authHealth`. Make `adapter.send({ type: "getSnapshot" })` return queued snapshots and use fake timers for the existing 5,000 ms refresh.
+
+Test initial degraded consistency:
+
+```ts
+expect(container.querySelector('[data-automation-state="needs_sign_in"]')).not.toBeNull();
+expect(container.textContent).toContain("Needs sign-in · Twitch");
+expect(container.querySelector('[data-platform-status="twitch"]')?.getAttribute("data-state")).toBe("needs_sign_in");
+expect(container.textContent).not.toContain("Farming stale campaign");
+```
+
+Test recovery without settings mutation:
+
+```ts
+await act(async () => { vi.advanceTimersByTime(5_000); await Promise.resolve(); });
+expect(container.querySelector('[data-automation-state="running"]')).not.toBeNull();
+expect(container.textContent).toContain("Running · Twitch");
+expect(adapter.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: "setAutomation" }));
+```
+
+Test blocked Kick with a hostile safe-reference value and assert neither that value nor any stale session message appears in `container.textContent`.
+
+- [ ] **Step 2: Run the integration test and confirm it fails**
+
+Run: `pnpm --filter @lurkloot/extension test -- popupAuthHealth.test.tsx`
+
+Expected: FAIL because `Popup` still derives status from automation booleans.
+
+- [ ] **Step 3: Derive one presentation per platform in Popup**
+
+Immediately after `automation`, derive:
+
+```ts
+const automationPresentationByPlatform = Object.fromEntries(
+  (Object.keys(PLATFORMS) as Platform[]).map((id) => [id, automationPresentation({
+    platform: id,
+    enabled: automation[id],
+    pending: pendingAutomation[id] != null,
+    authHealth: snapshot.state.authHealth[id],
+  })]),
+) as Record<Platform, AutomationPresentation>;
+const presentation = automationPresentationByPlatform[platform];
+```
+
+Import the mapper and type from `automationStatus.ts`.
+
+- [ ] **Step 4: Wire all three status surfaces to the presentation**
+
+Replace the header dot and label checks with `presentation.operational`, the state-specific indicator color, and `${t(presentation.badgeKey)} · ${PLATFORMS[platform].label}`. Pass `presentation={automationPresentationByPlatform}` to `PlatformSwitcher`. Pass `platform` and `presentation` to `AutomationHero` while retaining `enabled`, `pending`, content, and toggle props.
+
+- [ ] **Step 5: Run integration and component tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- popupAuthHealth.test.tsx automationView.test.tsx automationStatus.test.ts`
+
+Expected: PASS, including degraded-to-healthy recovery after the existing refresh interval.
+
+- [ ] **Step 6: Commit popup integration**
+
+```bash
+git add packages/popup-ui/src/Popup.tsx packages/extension/tests/popupAuthHealth.test.tsx
+git commit -m "feat(popup): synchronize authentication health status"
+```
+
+---
+
+### Task 4: Localize Authentication Health UI
+
+**Files:**
+- Modify: `packages/locales/messages/ar.json`
+- Modify: `packages/locales/messages/de.json`
+- Modify: `packages/locales/messages/en.json`
+- Modify: `packages/locales/messages/es.json`
+- Modify: `packages/locales/messages/fr.json`
+- Modify: `packages/locales/messages/hi.json`
+- Modify: `packages/locales/messages/it.json`
+- Modify: `packages/locales/messages/pt_BR.json`
+- Modify: `packages/locales/messages/ru.json`
+- Modify: `packages/locales/messages/tr.json`
+- Modify: `packages/locales/messages/zh_CN.json`
+- Modify: `packages/extension/tests/i18n.test.ts`
+
+**Interfaces:**
+- Consumes: the exact message keys emitted by `automationStatus.ts`.
+- Produces: complete localized copy for all popup auth states and actions.
+
+- [ ] **Step 1: Add failing catalog assertions**
+
+Add an i18n test with this exact English contract:
+
+```ts
+const authUiEnglish = {
+  automationChecking: "Checking",
+  automationNeedsSignIn: "Needs sign-in",
+  automationBlocked: "Blocked",
+  automationUnavailable: "Unavailable",
+  authCheckingDetail: "Checking your signed-in session…",
+  authSignInMissing: "Sign in to continue farming drops.",
+  authSignInRejected: "Your session is no longer valid. Sign in again to continue.",
+  signInToTwitch: "Sign in to Twitch",
+  signInToKick: "Sign in to Kick",
+  authBrowserProfileBlocked: "Kick rejected this browser profile. Signing in alone may not resolve it.",
+  authCredentialCheckUnavailable: "Your browser session could not be checked. Lurkloot will retry automatically.",
+  authNetworkTemporarilyUnavailable: "The network is temporarily unavailable. Lurkloot will retry automatically.",
+  authPlatformTemporarilyUnavailable: "The platform is temporarily unavailable. Lurkloot will retry automatically.",
+};
+```
+
+Assert the English messages equal this object and each key is a non-empty string in every catalog. The existing catalog parity and unchanged-English tests remain enabled.
+
+- [ ] **Step 2: Run i18n tests and confirm missing keys**
+
+Run: `pnpm --filter @lurkloot/extension test -- i18n.test.ts`
+
+Expected: FAIL because the thirteen keys are absent.
+
+- [ ] **Step 3: Add English and genuine translations to every catalog**
+
+Add the thirteen keys from Step 1 to `en.json`. Add natural translations carrying the same meaning to all ten non-English catalogs. Keep brand names `Twitch`, `Kick`, and `Lurkloot` unchanged. In particular, each `authBrowserProfileBlocked` translation must preserve both claims: Kick rejected the browser profile, and signing in alone may not fix it. Each unavailable translation must say Lurkloot retries automatically.
+
+Use these reviewed translations in key order (`automationChecking`, `automationNeedsSignIn`, `automationBlocked`, `automationUnavailable`, `authCheckingDetail`, `authSignInMissing`, `authSignInRejected`, `signInToTwitch`, `signInToKick`, `authBrowserProfileBlocked`, `authCredentialCheckUnavailable`, `authNetworkTemporarilyUnavailable`, `authPlatformTemporarilyUnavailable`):
+
+- `es`: “Comprobando”; “Necesita iniciar sesión”; “Bloqueado”; “No disponible”; “Comprobando tu sesión iniciada…”; “Inicia sesión para seguir consiguiendo drops.”; “Tu sesión ya no es válida. Vuelve a iniciar sesión para continuar.”; “Iniciar sesión en Twitch”; “Iniciar sesión en Kick”; “Kick rechazó este perfil del navegador. Puede que iniciar sesión no sea suficiente para resolverlo.”; “No se pudo comprobar la sesión del navegador. Lurkloot volverá a intentarlo automáticamente.”; “La red no está disponible temporalmente. Lurkloot volverá a intentarlo automáticamente.”; “La plataforma no está disponible temporalmente. Lurkloot volverá a intentarlo automáticamente.”
+- `de`: “Wird geprüft”; “Anmeldung erforderlich”; “Blockiert”; “Nicht verfügbar”; “Deine angemeldete Sitzung wird geprüft…”; “Melde dich an, um weiter Drops zu farmen.”; “Deine Sitzung ist nicht mehr gültig. Melde dich erneut an, um fortzufahren.”; “Bei Twitch anmelden”; “Bei Kick anmelden”; “Kick hat dieses Browserprofil abgelehnt. Eine Anmeldung allein behebt das Problem möglicherweise nicht.”; “Deine Browsersitzung konnte nicht geprüft werden. Lurkloot versucht es automatisch erneut.”; “Das Netzwerk ist vorübergehend nicht verfügbar. Lurkloot versucht es automatisch erneut.”; “Die Plattform ist vorübergehend nicht verfügbar. Lurkloot versucht es automatisch erneut.”
+- `fr`: “Vérification”; “Connexion requise”; “Bloqué”; “Indisponible”; “Vérification de votre session connectée…”; “Connectez-vous pour continuer à récupérer des drops.”; “Votre session n’est plus valide. Reconnectez-vous pour continuer.”; “Se connecter à Twitch”; “Se connecter à Kick”; “Kick a rejeté ce profil de navigateur. Se reconnecter uniquement ne suffira peut-être pas.”; “Votre session de navigateur n’a pas pu être vérifiée. Lurkloot réessaiera automatiquement.”; “Le réseau est temporairement indisponible. Lurkloot réessaiera automatiquement.”; “La plateforme est temporairement indisponible. Lurkloot réessaiera automatiquement.”
+- `it`: “Verifica”; “Accesso necessario”; “Bloccato”; “Non disponibile”; “Verifica della sessione connessa…”; “Accedi per continuare a ottenere drop.”; “La sessione non è più valida. Accedi di nuovo per continuare.”; “Accedi a Twitch”; “Accedi a Kick”; “Kick ha rifiutato questo profilo del browser. Il solo accesso potrebbe non risolvere il problema.”; “Non è stato possibile verificare la sessione del browser. Lurkloot riproverà automaticamente.”; “La rete è temporaneamente non disponibile. Lurkloot riproverà automaticamente.”; “La piattaforma è temporaneamente non disponibile. Lurkloot riproverà automaticamente.”
+- `pt_BR`: “Verificando”; “Login necessário”; “Bloqueado”; “Indisponível”; “Verificando sua sessão conectada…”; “Entre na sua conta para continuar coletando drops.”; “Sua sessão não é mais válida. Entre novamente para continuar.”; “Entrar na Twitch”; “Entrar na Kick”; “A Kick rejeitou este perfil do navegador. Apenas entrar na conta pode não resolver o problema.”; “Não foi possível verificar a sessão do navegador. O Lurkloot tentará novamente automaticamente.”; “A rede está temporariamente indisponível. O Lurkloot tentará novamente automaticamente.”; “A plataforma está temporariamente indisponível. O Lurkloot tentará novamente automaticamente.”
+- `ru`: “Проверка”; “Требуется вход”; “Заблокировано”; “Недоступно”; “Проверяем активный сеанс…”; “Войдите, чтобы продолжить получать награды.”; “Сеанс больше недействителен. Войдите снова, чтобы продолжить.”; “Войти в Twitch”; “Войти в Kick”; “Kick отклонил этот профиль браузера. Одного входа может быть недостаточно для решения проблемы.”; “Не удалось проверить сеанс браузера. Lurkloot повторит попытку автоматически.”; “Сеть временно недоступна. Lurkloot повторит попытку автоматически.”; “Платформа временно недоступна. Lurkloot повторит попытку автоматически.”
+- `tr`: “Kontrol ediliyor”; “Oturum açılmalı”; “Engellendi”; “Kullanılamıyor”; “Oturumunuz kontrol ediliyor…”; “Drop toplamaya devam etmek için oturum açın.”; “Oturumunuz artık geçerli değil. Devam etmek için yeniden oturum açın.”; “Twitch'te oturum aç”; “Kick'te oturum aç”; “Kick bu tarayıcı profilini reddetti. Yalnızca oturum açmak sorunu çözmeyebilir.”; “Tarayıcı oturumunuz kontrol edilemedi. Lurkloot otomatik olarak yeniden deneyecek.”; “Ağ geçici olarak kullanılamıyor. Lurkloot otomatik olarak yeniden deneyecek.”; “Platform geçici olarak kullanılamıyor. Lurkloot otomatik olarak yeniden deneyecek.”
+- `zh_CN`: “正在检查”; “需要登录”; “已阻止”; “暂时不可用”; “正在检查你的登录会话…”; “请登录以继续获取掉宝。”; “你的会话已失效。请重新登录以继续。”; “登录 Twitch”; “登录 Kick”; “Kick 拒绝了此浏览器配置文件。仅重新登录可能无法解决问题。”; “无法检查浏览器会话。Lurkloot 将自动重试。”; “网络暂时不可用。Lurkloot 将自动重试。”; “平台暂时不可用。Lurkloot 将自动重试。”
+- `hi`: “जाँच जारी है”; “साइन इन आवश्यक”; “अवरुद्ध”; “अनुपलब्ध”; “आपके साइन-इन सत्र की जाँच हो रही है…”; “ड्रॉप पाना जारी रखने के लिए साइन इन करें।”; “आपका सत्र अब मान्य नहीं है। जारी रखने के लिए फिर से साइन इन करें।”; “Twitch में साइन इन करें”; “Kick में साइन इन करें”; “Kick ने इस ब्राउज़र प्रोफ़ाइल को अस्वीकार कर दिया। केवल साइन इन करने से समस्या हल न हो सके।”; “आपके ब्राउज़र सत्र की जाँच नहीं हो सकी। Lurkloot अपने आप फिर प्रयास करेगा।”; “नेटवर्क अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।”; “प्लेटफ़ॉर्म अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।”
+- `ar`: “جارٍ التحقق”; “يلزم تسجيل الدخول”; “محظور”; “غير متاح”; “جارٍ التحقق من جلسة تسجيل دخولك…”; “سجّل الدخول لمواصلة جمع المكافآت.”; “لم تعد جلستك صالحة. سجّل الدخول مجددًا للمتابعة.”; “تسجيل الدخول إلى Twitch”; “تسجيل الدخول إلى Kick”; “رفض Kick ملف تعريف المتصفح هذا. قد لا يكفي تسجيل الدخول وحده لحل المشكلة.”; “تعذر التحقق من جلسة المتصفح. سيعيد Lurkloot المحاولة تلقائيًا.”; “الشبكة غير متاحة مؤقتًا. سيعيد Lurkloot المحاولة تلقائيًا.”; “المنصة غير متاحة مؤقتًا. سيعيد Lurkloot المحاولة تلقائيًا.”
+
+After editing, validate JSON mechanically:
+
+```bash
+node -e 'for (const f of require("fs").readdirSync("packages/locales/messages")) JSON.parse(require("fs").readFileSync(`packages/locales/messages/${f}`, "utf8"))'
+```
+
+Expected: exit 0 with no output.
+
+- [ ] **Step 4: Run localization and popup tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- i18n.test.ts automationStatus.test.ts automationView.test.tsx popupAuthHealth.test.tsx`
+
+Expected: PASS with catalog parity and unchanged-English checks green.
+
+- [ ] **Step 5: Commit translations**
+
+```bash
+git add packages/locales/messages packages/extension/tests/i18n.test.ts
+git commit -m "feat(locales): translate authentication health guidance"
+```
+
+---
+
+### Task 5: Full Verification and Final Review
+
+**Files:**
+- Review only: all files changed by Tasks 1–4.
+
+**Interfaces:**
+- Consumes: complete implementation.
+- Produces: verified issue #205 acceptance criteria with no uncommitted fixes.
+
+- [ ] **Step 1: Run formatting and diff hygiene checks**
+
+Run: `git diff origin/develop --check && git status --short`
+
+Expected: no whitespace errors; only intentional committed branch changes are listed by the comparison, and the worktree itself is clean.
+
+- [ ] **Step 2: Run the repository check suite**
+
+Run: `pnpm check`
+
+Expected: script tests, all workspace typechecks, extension tests, and Astro site build pass.
+
+- [ ] **Step 3: Build both extension targets**
+
+Run: `pnpm build && pnpm build:firefox`
+
+Expected: Chromium and Firefox WXT production builds complete successfully.
+
+- [ ] **Step 4: Inspect the final diff for safety and scope**
+
+Run:
+
+```bash
+git diff --stat origin/develop...HEAD
+git diff origin/develop...HEAD -- packages/popup-ui/src packages/locales/messages packages/extension/tests
+```
+
+Confirm the diff contains no credential fields, raw errors, response payload rendering, new permissions, auth polling, or automation-setting mutation caused by health changes.
+
+- [ ] **Step 5: Commit any verification-only correction, if required**
+
+If verification required a code correction, repeat its focused test and `pnpm check`, then commit only that correction with a scoped Conventional Commit. If no correction was required, do not create an empty commit.

--- a/docs/superpowers/plans/2026-07-22-popup-auth-health.md
+++ b/docs/superpowers/plans/2026-07-22-popup-auth-health.md
@@ -417,9 +417,9 @@ git commit -m "feat(locales): translate authentication health guidance"
 
 - [ ] **Step 1: Run formatting and diff hygiene checks**
 
-Run: `git diff origin/develop --check && git status --short`
+Run: `git diff origin/develop --check && test -z "$(git status --short)"`
 
-Expected: no whitespace errors; only intentional committed branch changes are listed by the comparison, and the worktree itself is clean.
+Expected: no whitespace errors and the command exits successfully (the worktree is clean with no uncommitted changes).
 
 - [ ] **Step 2: Run the repository check suite**
 

--- a/docs/superpowers/specs/2026-07-22-popup-auth-health-design.md
+++ b/docs/superpowers/specs/2026-07-22-popup-auth-health-design.md
@@ -1,0 +1,89 @@
+# Popup Authentication Health Design
+
+## Context
+
+The popup currently derives its Running presentation from the global and per-platform automation settings. That can label an enabled platform as Running or Farming while its account-dependent work is suspended because authentication is being checked, credentials are absent or rejected, Kick has rejected the browser profile, or the platform is temporarily unavailable.
+
+The scheduler already exposes a normalized `PlatformAuthHealth` for Twitch and Kick in `RuntimeSnapshot.state.authHealth`. Cookie changes trigger a platform-only authentication recheck and publish a fresh snapshot, so this work only needs to present that existing state safely and reactively. It must not change the user's automation setting or expose credential or response content.
+
+## Goals
+
+- Make the selected platform's hero accurately distinguish Running, Checking, Needs sign-in, Blocked, Unavailable, and Paused.
+- Show Running only when automation is enabled and authentication is healthy.
+- Give missing or rejected credentials an explicit platform-specific sign-in action.
+- Explain Kick security-policy blocking without implying that signing in is sufficient.
+- Keep the automation toggle available in every degraded authentication state.
+- Update naturally when a fresh runtime snapshot reports authentication recovery.
+- Localize all new user-facing copy in every catalog.
+
+## Non-goals
+
+- Changing authentication probes, scheduler blocking, cookie observation, or retry behavior.
+- Adding credential entry, storage, or rendering to the popup.
+- Adding manual authentication recheck controls.
+- Changing the CLI authentication experience.
+
+## Approach
+
+Add a pure popup presentation function that maps automation state, toggle-pending state, platform, and `PlatformAuthHealth` to a small view model. The view model owns the badge label key, visual tone, explanatory message key, and optional action. `AutomationHero` renders this model while remaining responsible for layout and toggle interaction.
+
+This keeps authentication policy out of JSX, provides one exhaustive mapping for all shared health statuses, and allows focused deterministic tests. Handling the statuses inline in `AutomationHero` would save a small file but couple rendering and policy. A separate warning card would duplicate status information and leave the hero badge misleading, so neither alternative is preferred.
+
+## State Mapping
+
+State priority is:
+
+1. A pending toggle operation shows the existing Starting or Stopping state.
+2. Disabled automation shows Paused, independent of retained authentication health.
+3. Enabled automation maps authentication health as follows:
+   - `healthy`: Running, with the existing watching/farming or waiting detail.
+   - `checking`: Checking, with neutral progress copy.
+   - `missing_credentials`: Needs sign-in, with an explicit Sign in to Twitch or Sign in to Kick action.
+   - `invalid_credentials`: Needs sign-in, with rejected-session copy and the same platform-specific action.
+   - `blocked`: Blocked, with copy explaining that Kick rejected this browser profile and that signing in alone may not resolve it. No sign-in action is shown.
+   - `unavailable`: Unavailable, with reason-specific safe copy for credential lookup, platform, or network failure. No sign-in action is shown.
+
+Unknown or absent persisted health is already normalized to `checking` by the shared state boundary.
+
+## UI Behavior
+
+The existing automation hero remains the single status surface. Its badge tone follows the derived presentation rather than the enabled flag: accent for Running, muted for Paused or Checking, warning for Needs sign-in or Unavailable, and danger for Blocked. The hero glow and power icon should likewise avoid presenting degraded states as healthy.
+
+For missing or rejected credentials, a compact explicit button appears alongside the explanatory copy. It opens the selected platform's HTTPS sign-in page through the existing popup adapter and HTTPS boundary helper. The action is a real button with a localized accessible label. Twitch and Kick use fixed first-party sign-in URLs; runtime state never supplies the destination.
+
+The automation toggle remains enabled unless an automation setting change is already pending. Clicking it in a degraded state changes automation exactly as it does today.
+
+The header summary and platform-switcher indicator must use the same derived operational presentation so they do not continue to claim Active or show a healthy dot while the hero is degraded.
+
+## Data Flow and Recovery
+
+`Popup` reads `snapshot.state.authHealth[platform]` and derives the presentation for the selected platform. It passes that presentation to the header, platform switcher, and automation hero. Existing snapshot updates replace the health value. When cookie-triggered recovery changes the status from degraded to healthy, React recomputes the presentation and returns the UI to Running without toggling automation or adding a popup polling loop.
+
+Preview/demo snapshots continue to provide explicit health values and therefore exercise the same rendering path.
+
+## Safety and Error Handling
+
+Only the normalized status, reason code, and allowlisted localized message key influence rendering. Credentials, raw errors, and authenticated response bodies are never accepted by the presentation model or rendered. Optional safe message values such as an opaque reference are not required in the popup copy and will not be displayed.
+
+External actions use hard-coded HTTPS destinations and the existing validated link-opening boundary. Temporarily unavailable states do not claim a fix; they explain that Lurkloot will retry automatically.
+
+## Localization
+
+Add keys for the five enabled-state badge labels, missing-credential and rejected-credential explanations, the two explicit sign-in button labels, Kick browser-profile rejection guidance, and temporary failure explanations. Every catalog receives the complete key set, and catalog parity remains enforced by the existing i18n tests.
+
+## Testing
+
+Add focused popup component and presentation tests that cover:
+
+- Paused and pending-operation precedence.
+- Healthy, checking, missing, invalid, blocked, and each unavailable reason.
+- Running appearing only for enabled plus healthy.
+- Twitch and Kick sign-in button labels and fixed HTTPS destinations.
+- No sign-in action for blocked or unavailable states.
+- The toggle remaining enabled throughout degraded states.
+- Safe omission of message values and any unrelated data.
+- Rerendering from a degraded snapshot to healthy after the adapter publishes recovery, without changing automation settings.
+- Header and platform-switcher indicators agreeing with the hero.
+- Complete locale key parity.
+
+Run the focused tests during development, then `pnpm check` and the relevant extension build verification before completion.

--- a/packages/extension/tests/automationStatus.test.ts
+++ b/packages/extension/tests/automationStatus.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { PlatformAuthHealth } from "@lurkloot/shared/models";
+import {
+  AUTH_SIGN_IN_URLS,
+  automationPresentation,
+} from "../../popup-ui/src/automationStatus";
+
+function health(
+  status: PlatformAuthHealth["status"],
+  reasonCode?: PlatformAuthHealth["reasonCode"],
+): PlatformAuthHealth {
+  return {
+    status,
+    reasonCode,
+    message: {
+      key: status === "blocked" ? "authSecurityPolicyBlocked" : "authPlatformUnavailable",
+      values: { reference: "must-not-render" },
+    },
+  };
+}
+
+describe("automation authentication presentation", () => {
+  it("gives pending and paused states precedence", () => {
+    expect(automationPresentation({
+      platform: "twitch",
+      enabled: true,
+      pending: true,
+      authHealth: health("missing_credentials"),
+    }).state).toBe("starting");
+    expect(automationPresentation({
+      platform: "twitch",
+      enabled: false,
+      pending: true,
+      authHealth: health("healthy"),
+    }).state).toBe("stopping");
+    expect(automationPresentation({
+      platform: "kick",
+      enabled: false,
+      pending: false,
+      authHealth: health("blocked"),
+    }).state).toBe("paused");
+  });
+
+  it.each([
+    ["healthy", undefined, "running", "automationRunning", "accent", undefined],
+    ["checking", undefined, "checking", "automationChecking", "muted", "authCheckingDetail"],
+    ["missing_credentials", "credentials_missing", "needs_sign_in", "automationNeedsSignIn", "warning", "authSignInMissing"],
+    ["invalid_credentials", "credentials_rejected", "needs_sign_in", "automationNeedsSignIn", "warning", "authSignInRejected"],
+    ["blocked", "security_policy_blocked", "blocked", "automationBlocked", "danger", "authBrowserProfileBlocked"],
+    ["unavailable", "credential_lookup_failed", "unavailable", "automationUnavailable", "warning", "authCredentialCheckUnavailable"],
+    ["unavailable", "network_unavailable", "unavailable", "automationUnavailable", "warning", "authNetworkTemporarilyUnavailable"],
+    ["unavailable", "platform_unavailable", "unavailable", "automationUnavailable", "warning", "authPlatformTemporarilyUnavailable"],
+  ] as const)("maps %s/%s", (status, reasonCode, state, badgeKey, tone, detailKey) => {
+    expect(automationPresentation({
+      platform: "kick",
+      enabled: true,
+      pending: false,
+      authHealth: health(status, reasonCode),
+    })).toMatchObject({ state, badgeKey, tone, detailKey });
+  });
+
+  it.each(["missing_credentials", "invalid_credentials"] as const)(
+    "provides fixed sign-in actions for %s",
+    (status) => {
+      expect(automationPresentation({
+        platform: "twitch",
+        enabled: true,
+        pending: false,
+        authHealth: health(status),
+      }).action).toEqual({ labelKey: "signInToTwitch", url: AUTH_SIGN_IN_URLS.twitch });
+      expect(automationPresentation({
+        platform: "kick",
+        enabled: true,
+        pending: false,
+        authHealth: health(status),
+      }).action).toEqual({ labelKey: "signInToKick", url: AUTH_SIGN_IN_URLS.kick });
+    },
+  );
+
+  it.each(["checking", "healthy", "blocked", "unavailable"] as const)(
+    "does not offer sign-in for %s",
+    (status) => {
+      expect(automationPresentation({
+        platform: "kick",
+        enabled: true,
+        pending: false,
+        authHealth: health(status),
+      }).action).toBeUndefined();
+    },
+  );
+
+  it("does not propagate authentication message values", () => {
+    expect(JSON.stringify(automationPresentation({
+      platform: "kick",
+      enabled: true,
+      pending: false,
+      authHealth: health("blocked", "security_policy_blocked"),
+    }))).not.toContain("must-not-render");
+  });
+});

--- a/packages/extension/tests/automationStatus.test.ts
+++ b/packages/extension/tests/automationStatus.test.ts
@@ -42,21 +42,21 @@ describe("automation authentication presentation", () => {
   });
 
   it.each([
-    ["healthy", undefined, "running", "automationRunning", "accent", undefined],
-    ["checking", undefined, "checking", "automationChecking", "muted", "authCheckingDetail"],
-    ["missing_credentials", "credentials_missing", "needs_sign_in", "automationNeedsSignIn", "warning", "authSignInMissing"],
-    ["invalid_credentials", "credentials_rejected", "needs_sign_in", "automationNeedsSignIn", "warning", "authSignInRejected"],
-    ["blocked", "security_policy_blocked", "blocked", "automationBlocked", "danger", "authBrowserProfileBlocked"],
-    ["unavailable", "credential_lookup_failed", "unavailable", "automationUnavailable", "warning", "authCredentialCheckUnavailable"],
-    ["unavailable", "network_unavailable", "unavailable", "automationUnavailable", "warning", "authNetworkTemporarilyUnavailable"],
-    ["unavailable", "platform_unavailable", "unavailable", "automationUnavailable", "warning", "authPlatformTemporarilyUnavailable"],
-  ] as const)("maps %s/%s", (status, reasonCode, state, badgeKey, tone, detailKey) => {
+    ["healthy", undefined, "running", "automationRunning", "accent", undefined, true],
+    ["checking", undefined, "checking", "automationChecking", "muted", "authCheckingDetail", false],
+    ["missing_credentials", "credentials_missing", "needs_sign_in", "automationNeedsSignIn", "warning", "authSignInMissing", false],
+    ["invalid_credentials", "credentials_rejected", "needs_sign_in", "automationNeedsSignIn", "warning", "authSignInRejected", false],
+    ["blocked", "security_policy_blocked", "blocked", "automationBlocked", "danger", "authBrowserProfileBlocked", false],
+    ["unavailable", "credential_lookup_failed", "unavailable", "automationUnavailable", "warning", "authCredentialCheckUnavailable", false],
+    ["unavailable", "network_unavailable", "unavailable", "automationUnavailable", "warning", "authNetworkTemporarilyUnavailable", false],
+    ["unavailable", "platform_unavailable", "unavailable", "automationUnavailable", "warning", "authPlatformTemporarilyUnavailable", false],
+  ] as const)("maps %s/%s", (status, reasonCode, state, badgeKey, tone, detailKey, operational) => {
     expect(automationPresentation({
       platform: "kick",
       enabled: true,
       pending: false,
       authHealth: health(status, reasonCode),
-    })).toMatchObject({ state, badgeKey, tone, detailKey });
+    })).toMatchObject({ state, badgeKey, tone, detailKey, operational });
   });
 
   it.each(["missing_credentials", "invalid_credentials"] as const)(
@@ -67,13 +67,13 @@ describe("automation authentication presentation", () => {
         enabled: true,
         pending: false,
         authHealth: health(status),
-      }).action).toEqual({ labelKey: "signInToTwitch", url: AUTH_SIGN_IN_URLS.twitch });
+      }).action).toEqual({ labelKey: "signInToTwitch", url: "https://www.twitch.tv/login" });
       expect(automationPresentation({
         platform: "kick",
         enabled: true,
         pending: false,
         authHealth: health(status),
-      }).action).toEqual({ labelKey: "signInToKick", url: AUTH_SIGN_IN_URLS.kick });
+      }).action).toEqual({ labelKey: "signInToKick", url: "https://kick.com/login" });
     },
   );
 
@@ -90,11 +90,13 @@ describe("automation authentication presentation", () => {
   );
 
   it("does not propagate authentication message values", () => {
-    expect(JSON.stringify(automationPresentation({
+    const result = automationPresentation({
       platform: "kick",
       enabled: true,
       pending: false,
       authHealth: health("blocked", "security_policy_blocked"),
-    }))).not.toContain("must-not-render");
+    });
+    expect(JSON.stringify(result)).not.toContain("must-not-render");
+    expect(result).not.toHaveProperty("message");
   });
 });

--- a/packages/extension/tests/automationView.test.tsx
+++ b/packages/extension/tests/automationView.test.tsx
@@ -1,0 +1,145 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Platform, PlatformAuthHealth } from "@lurkloot/shared/models";
+import { AutomationHero, PlatformSwitcher } from "../../popup-ui/src/automation";
+import { automationPresentation } from "../../popup-ui/src/automationStatus";
+import { I18nContext, PopupRuntimeContext } from "../../popup-ui/src/context";
+import type { PopupAdapter } from "../../popup-ui/src/types";
+
+const messages: Record<string, string> = {
+  automationTitle: "$1 automation",
+  automationRunning: "Running",
+  automationChecking: "Checking",
+  automationNeedsSignIn: "Needs sign-in",
+  automationBlocked: "Blocked",
+  automationUnavailable: "Unavailable",
+  authSignInMissing: "Sign in to continue farming drops.",
+  authSignInRejected: "Your session is no longer valid. Sign in again to continue.",
+  authBrowserProfileBlocked: "Kick rejected this browser profile. Signing in alone may not resolve it.",
+  authPlatformTemporarilyUnavailable: "The platform is temporarily unavailable. Lurkloot will retry automatically.",
+  signInToTwitch: "Sign in to Twitch",
+  signInToKick: "Sign in to Kick",
+  watchingLabel: "Watching",
+  farmingLabel: "Farming",
+};
+
+let root: Root | undefined;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+function presentation(platform: Platform, authHealth: PlatformAuthHealth) {
+  return automationPresentation({ platform, enabled: true, pending: false, authHealth });
+}
+
+function mount(element: React.ReactElement) {
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr" }));
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const openLink = vi.fn();
+  const adapter = { openLink } as unknown as PopupAdapter;
+  const container = document.getElementById("app")!;
+  act(() => {
+    root = createRoot(container);
+    root.render(
+      <I18nContext.Provider value={{
+        t: (key, substitutions) => (messages[key] ?? key).replace("$1", typeof substitutions === "string" ? substitutions : ""),
+        dir: "ltr",
+        locale: "en",
+      }}>
+        <PopupRuntimeContext.Provider value={{ adapter, preview: false }}>
+          {element}
+        </PopupRuntimeContext.Provider>
+      </I18nContext.Provider>,
+    );
+  });
+  return { container, openLink };
+}
+
+describe("automation authentication status UI", () => {
+  it("shows an explicit Twitch sign-in action and keeps the toggle enabled", () => {
+    const { container, openLink } = mount(
+      <AutomationHero
+        platform="twitch"
+        platformLabel="Twitch"
+        enabled
+        pending={false}
+        presentation={presentation("twitch", { status: "missing_credentials" })}
+        onChange={async () => undefined}
+      />,
+    );
+
+    expect(container.textContent).toContain("Needs sign-in");
+    expect(container.textContent).toContain("Sign in to Twitch");
+    const action = container.querySelector<HTMLButtonElement>('[data-auth-action="twitch"]');
+    expect(action).not.toBeNull();
+    act(() => action?.click());
+    expect(openLink).toHaveBeenCalledWith("https://www.twitch.tv/login");
+    expect(container.querySelector('[role="switch"]')?.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("explains a Kick browser-profile block without offering sign-in", () => {
+    const { container } = mount(
+      <AutomationHero
+        platform="kick"
+        platformLabel="Kick"
+        enabled
+        pending={false}
+        presentation={presentation("kick", { status: "blocked", reasonCode: "security_policy_blocked" })}
+        onChange={async () => undefined}
+      />,
+    );
+
+    expect(container.querySelector('[data-automation-state="blocked"]')).not.toBeNull();
+    expect(container.textContent).toContain("Kick rejected this browser profile");
+    expect(container.querySelector("[data-auth-action]")).toBeNull();
+    expect(container.querySelector('[role="switch"]')?.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("shows operational state independently for each platform", () => {
+    const { container } = mount(
+      <PlatformSwitcher
+        active="twitch"
+        presentation={{
+          twitch: presentation("twitch", { status: "healthy" }),
+          kick: presentation("kick", { status: "unavailable", reasonCode: "platform_unavailable" }),
+        }}
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(container.querySelector('[data-platform-status="twitch"]')?.getAttribute("data-state")).toBe("running");
+    expect(container.querySelector('[data-platform-status="kick"]')?.getAttribute("data-state")).toBe("unavailable");
+  });
+
+  it("hides stale farming detail while authentication is degraded", () => {
+    const { container } = mount(
+      <AutomationHero
+        platform="kick"
+        platformLabel="Kick"
+        enabled
+        pending={false}
+        presentation={presentation("kick", { status: "unavailable" })}
+        farmingTitle="Stale campaign"
+        farmingChannel={{ name: "stale-channel" }}
+        onChange={async () => undefined}
+      />,
+    );
+
+    expect(container.textContent).toContain("temporarily unavailable");
+    expect(container.textContent).not.toContain("Stale campaign");
+    expect(container.textContent).not.toContain("stale-channel");
+  });
+});

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -60,6 +60,36 @@ describe("i18n", () => {
     }
   });
 
+  it("localizes popup authentication health in every catalog", () => {
+    const englishMessages: Record<string, string> = {
+      automationChecking: "Checking",
+      automationNeedsSignIn: "Needs sign-in",
+      automationBlocked: "Blocked",
+      automationUnavailable: "Unavailable",
+      authCheckingDetail: "Checking your signed-in session…",
+      authSignInMissing: "Sign in to continue farming drops.",
+      authSignInRejected: "Your session is no longer valid. Sign in again to continue.",
+      signInToTwitch: "Sign in to Twitch",
+      signInToKick: "Sign in to Kick",
+      authBrowserProfileBlocked: "Kick rejected this browser profile. Signing in alone may not resolve it.",
+      authCredentialCheckUnavailable: "Your browser session could not be checked. Lurkloot will retry automatically.",
+      authNetworkTemporarilyUnavailable: "The network is temporarily unavailable. Lurkloot will retry automatically.",
+      authPlatformTemporarilyUnavailable: "The platform is temporarily unavailable. Lurkloot will retry automatically.",
+    };
+    const english = readCatalog("en");
+
+    for (const [key, message] of Object.entries(englishMessages)) {
+      expect(english[key]?.message, key).toBe(message);
+    }
+    for (const locale of localeCodes()) {
+      const catalog = readCatalog(locale);
+      for (const key of Object.keys(englishMessages)) {
+        expect(catalog[key]?.message, `${locale}:${key}`).toBeTypeOf("string");
+        expect(catalog[key].message.trim(), `${locale}:${key}`).not.toBe("");
+      }
+    }
+  });
+
   it("localizes the subscription campaign filter in every catalog", () => {
     const translations: Record<string, string> = {
       ar: "حملات الاشتراك",

--- a/packages/extension/tests/popupAuthHealth.test.tsx
+++ b/packages/extension/tests/popupAuthHealth.test.tsx
@@ -53,14 +53,16 @@ async function mountWithSnapshots(authStatuses: Array<RuntimeSnapshot["state"]["
       },
     },
   }));
-  const send = vi.fn(async <T,>(message: RuntimeMessage): Promise<T> => {
+  const sent: RuntimeMessage[] = [];
+  const send = async <T,>(message: RuntimeMessage): Promise<T> => {
+    sent.push(message);
     if (message.type === "getSnapshot") {
       const result = snapshots[Math.min(index, snapshots.length - 1)];
       index += 1;
       return result as T;
     }
     return demo.send<T>(message);
-  });
+  };
   const adapter: PopupAdapter = {
     ...demo,
     send,
@@ -73,7 +75,7 @@ async function mountWithSnapshots(authStatuses: Array<RuntimeSnapshot["state"]["
     await Promise.resolve();
     await Promise.resolve();
   });
-  return { container, send };
+  return { container, sent };
 }
 
 describe("popup authentication health", () => {
@@ -90,7 +92,7 @@ describe("popup authentication health", () => {
   });
 
   it("recovers from sign-in on the existing snapshot refresh without changing automation", async () => {
-    const { container, send } = await mountWithSnapshots([
+    const { container, sent } = await mountWithSnapshots([
       { status: "missing_credentials", reasonCode: "credentials_missing" },
       { status: "healthy", checkedAt: "2026-07-22T20:00:00.000Z" },
     ]);
@@ -101,6 +103,6 @@ describe("popup authentication health", () => {
     });
     expect(container.querySelector('[data-automation-state="running"]')).not.toBeNull();
     expect(container.textContent).toContain("Running · Twitch");
-    expect(send).not.toHaveBeenCalledWith(expect.objectContaining({ type: "setAutomation" }));
+    expect(sent).not.toContainEqual(expect.objectContaining({ type: "setAutomation" }));
   });
 });

--- a/packages/extension/tests/popupAuthHealth.test.tsx
+++ b/packages/extension/tests/popupAuthHealth.test.tsx
@@ -1,0 +1,106 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
+import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
+
+let root: Root | undefined;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+async function mountWithSnapshots(authStatuses: Array<RuntimeSnapshot["state"]["authHealth"]["twitch"]>) {
+  vi.useFakeTimers();
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(Date.now());
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+
+  const demo = createDemoPopupAdapter();
+  const base = await demo.send<RuntimeSnapshot>({ type: "getSnapshot" });
+  let index = 0;
+  const snapshots = authStatuses.map((authHealth) => ({
+    ...base,
+    settings: {
+      ...base.settings,
+      running: true,
+      platform: {
+        ...base.settings.platform,
+        twitch: { ...base.settings.platform.twitch, enabled: true },
+      },
+    },
+    state: {
+      ...base.state,
+      authHealth: { ...base.state.authHealth, twitch: authHealth },
+      sessions: {
+        ...base.state.sessions,
+        twitch: {
+          ...base.state.sessions.twitch,
+          message: "secret-cookie=must-not-render",
+          status: "watching" as const,
+        },
+      },
+    },
+  }));
+  const send = vi.fn(async <T,>(message: RuntimeMessage): Promise<T> => {
+    if (message.type === "getSnapshot") {
+      const result = snapshots[Math.min(index, snapshots.length - 1)];
+      index += 1;
+      return result as T;
+    }
+    return demo.send<T>(message);
+  });
+  const adapter: PopupAdapter = {
+    ...demo,
+    send,
+    getStorage: async () => ({ "popup:selectedPlatform": "twitch" }),
+  };
+  const container = document.getElementById("app")!;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} />);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, send };
+}
+
+describe("popup authentication health", () => {
+  it("keeps the header, switcher, and hero consistent in a degraded state", async () => {
+    const { container } = await mountWithSnapshots([{
+      status: "missing_credentials",
+      reasonCode: "credentials_missing",
+    }]);
+
+    expect(container.querySelector('[data-automation-state="needs_sign_in"]')).not.toBeNull();
+    expect(container.textContent).toContain("Needs sign-in · Twitch");
+    expect(container.querySelector('[data-platform-status="twitch"]')?.getAttribute("data-state")).toBe("needs_sign_in");
+    expect(container.textContent).not.toContain("secret-cookie=must-not-render");
+  });
+
+  it("recovers from sign-in on the existing snapshot refresh without changing automation", async () => {
+    const { container, send } = await mountWithSnapshots([
+      { status: "missing_credentials", reasonCode: "credentials_missing" },
+      { status: "healthy", checkedAt: "2026-07-22T20:00:00.000Z" },
+    ]);
+
+    expect(container.querySelector('[data-automation-state="needs_sign_in"]')).not.toBeNull();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(container.querySelector('[data-automation-state="running"]')).not.toBeNull();
+    expect(container.textContent).toContain("Running · Twitch");
+    expect(send).not.toHaveBeenCalledWith(expect.objectContaining({ type: "setAutomation" }));
+  });
+});

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "معالجة الروابط الإصدار 2"
-  }
+  },
+  "automationChecking": { "message": "جارٍ التحقق" },
+  "automationNeedsSignIn": { "message": "يلزم تسجيل الدخول" },
+  "automationBlocked": { "message": "محظور" },
+  "automationUnavailable": { "message": "غير متاح" },
+  "authCheckingDetail": { "message": "جارٍ التحقق من جلسة تسجيل دخولك…" },
+  "authSignInMissing": { "message": "سجّل الدخول لمواصلة جمع المكافآت." },
+  "authSignInRejected": { "message": "لم تعد جلستك صالحة. سجّل الدخول مجددًا للمتابعة." },
+  "signInToTwitch": { "message": "تسجيل الدخول إلى Twitch" },
+  "signInToKick": { "message": "تسجيل الدخول إلى Kick" },
+  "authBrowserProfileBlocked": { "message": "رفض Kick ملف تعريف المتصفح هذا. قد لا يكفي تسجيل الدخول وحده لحل المشكلة." },
+  "authCredentialCheckUnavailable": { "message": "تعذر التحقق من جلسة المتصفح. سيعيد Lurkloot المحاولة تلقائيًا." },
+  "authNetworkTemporarilyUnavailable": { "message": "الشبكة غير متاحة مؤقتًا. سيعيد Lurkloot المحاولة تلقائيًا." },
+  "authPlatformTemporarilyUnavailable": { "message": "المنصة غير متاحة مؤقتًا. سيعيد Lurkloot المحاولة تلقائيًا." }
 }

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "Verknüpfungsverarbeitung v2"
-  }
+  },
+  "automationChecking": { "message": "Wird geprüft" },
+  "automationNeedsSignIn": { "message": "Anmeldung erforderlich" },
+  "automationBlocked": { "message": "Blockiert" },
+  "automationUnavailable": { "message": "Nicht verfügbar" },
+  "authCheckingDetail": { "message": "Deine angemeldete Sitzung wird geprüft…" },
+  "authSignInMissing": { "message": "Melde dich an, um weiter Drops zu farmen." },
+  "authSignInRejected": { "message": "Deine Sitzung ist nicht mehr gültig. Melde dich erneut an, um fortzufahren." },
+  "signInToTwitch": { "message": "Bei Twitch anmelden" },
+  "signInToKick": { "message": "Bei Kick anmelden" },
+  "authBrowserProfileBlocked": { "message": "Kick hat dieses Browserprofil abgelehnt. Eine Anmeldung allein behebt das Problem möglicherweise nicht." },
+  "authCredentialCheckUnavailable": { "message": "Deine Browsersitzung konnte nicht geprüft werden. Lurkloot versucht es automatisch erneut." },
+  "authNetworkTemporarilyUnavailable": { "message": "Das Netzwerk ist vorübergehend nicht verfügbar. Lurkloot versucht es automatisch erneut." },
+  "authPlatformTemporarilyUnavailable": { "message": "Die Plattform ist vorübergehend nicht verfügbar. Lurkloot versucht es automatisch erneut." }
 }

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "Claim handling v2"
-  }
+  },
+  "automationChecking": { "message": "Checking" },
+  "automationNeedsSignIn": { "message": "Needs sign-in" },
+  "automationBlocked": { "message": "Blocked" },
+  "automationUnavailable": { "message": "Unavailable" },
+  "authCheckingDetail": { "message": "Checking your signed-in session…" },
+  "authSignInMissing": { "message": "Sign in to continue farming drops." },
+  "authSignInRejected": { "message": "Your session is no longer valid. Sign in again to continue." },
+  "signInToTwitch": { "message": "Sign in to Twitch" },
+  "signInToKick": { "message": "Sign in to Kick" },
+  "authBrowserProfileBlocked": { "message": "Kick rejected this browser profile. Signing in alone may not resolve it." },
+  "authCredentialCheckUnavailable": { "message": "Your browser session could not be checked. Lurkloot will retry automatically." },
+  "authNetworkTemporarilyUnavailable": { "message": "The network is temporarily unavailable. Lurkloot will retry automatically." },
+  "authPlatformTemporarilyUnavailable": { "message": "The platform is temporarily unavailable. Lurkloot will retry automatically." }
 }

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "Gestión de enlaces v2"
-  }
+  },
+  "automationChecking": { "message": "Comprobando" },
+  "automationNeedsSignIn": { "message": "Necesita iniciar sesión" },
+  "automationBlocked": { "message": "Bloqueado" },
+  "automationUnavailable": { "message": "No disponible" },
+  "authCheckingDetail": { "message": "Comprobando tu sesión iniciada…" },
+  "authSignInMissing": { "message": "Inicia sesión para seguir consiguiendo drops." },
+  "authSignInRejected": { "message": "Tu sesión ya no es válida. Vuelve a iniciar sesión para continuar." },
+  "signInToTwitch": { "message": "Iniciar sesión en Twitch" },
+  "signInToKick": { "message": "Iniciar sesión en Kick" },
+  "authBrowserProfileBlocked": { "message": "Kick rechazó este perfil del navegador. Puede que iniciar sesión no sea suficiente para resolverlo." },
+  "authCredentialCheckUnavailable": { "message": "No se pudo comprobar la sesión del navegador. Lurkloot volverá a intentarlo automáticamente." },
+  "authNetworkTemporarilyUnavailable": { "message": "La red no está disponible temporalmente. Lurkloot volverá a intentarlo automáticamente." },
+  "authPlatformTemporarilyUnavailable": { "message": "La plataforma no está disponible temporalmente. Lurkloot volverá a intentarlo automáticamente." }
 }

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "Gestion des liens v2"
-  }
+  },
+  "automationChecking": { "message": "Vérification" },
+  "automationNeedsSignIn": { "message": "Connexion requise" },
+  "automationBlocked": { "message": "Bloqué" },
+  "automationUnavailable": { "message": "Indisponible" },
+  "authCheckingDetail": { "message": "Vérification de votre session connectée…" },
+  "authSignInMissing": { "message": "Connectez-vous pour continuer à récupérer des drops." },
+  "authSignInRejected": { "message": "Votre session n’est plus valide. Reconnectez-vous pour continuer." },
+  "signInToTwitch": { "message": "Se connecter à Twitch" },
+  "signInToKick": { "message": "Se connecter à Kick" },
+  "authBrowserProfileBlocked": { "message": "Kick a rejeté ce profil de navigateur. Se reconnecter uniquement ne suffira peut-être pas." },
+  "authCredentialCheckUnavailable": { "message": "Votre session de navigateur n’a pas pu être vérifiée. Lurkloot réessaiera automatiquement." },
+  "authNetworkTemporarilyUnavailable": { "message": "Le réseau est temporairement indisponible. Lurkloot réessaiera automatiquement." },
+  "authPlatformTemporarilyUnavailable": { "message": "La plateforme est temporairement indisponible. Lurkloot réessaiera automatiquement." }
 }

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "लिंक प्रबंधन v2"
-  }
+  },
+  "automationChecking": { "message": "जाँच जारी है" },
+  "automationNeedsSignIn": { "message": "साइन इन आवश्यक" },
+  "automationBlocked": { "message": "अवरुद्ध" },
+  "automationUnavailable": { "message": "अनुपलब्ध" },
+  "authCheckingDetail": { "message": "आपके साइन-इन सत्र की जाँच हो रही है…" },
+  "authSignInMissing": { "message": "ड्रॉप पाना जारी रखने के लिए साइन इन करें।" },
+  "authSignInRejected": { "message": "आपका सत्र अब मान्य नहीं है। जारी रखने के लिए फिर से साइन इन करें।" },
+  "signInToTwitch": { "message": "Twitch में साइन इन करें" },
+  "signInToKick": { "message": "Kick में साइन इन करें" },
+  "authBrowserProfileBlocked": { "message": "Kick ने इस ब्राउज़र प्रोफ़ाइल को अस्वीकार कर दिया। केवल साइन इन करने से समस्या हल न हो सके।" },
+  "authCredentialCheckUnavailable": { "message": "आपके ब्राउज़र सत्र की जाँच नहीं हो सकी। Lurkloot अपने आप फिर प्रयास करेगा।" },
+  "authNetworkTemporarilyUnavailable": { "message": "नेटवर्क अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।" },
+  "authPlatformTemporarilyUnavailable": { "message": "प्लेटफ़ॉर्म अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।" }
 }

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -921,7 +921,7 @@
   "authSignInRejected": { "message": "आपका सत्र अब मान्य नहीं है। जारी रखने के लिए फिर से साइन इन करें।" },
   "signInToTwitch": { "message": "Twitch में साइन इन करें" },
   "signInToKick": { "message": "Kick में साइन इन करें" },
-  "authBrowserProfileBlocked": { "message": "Kick ने इस ब्राउज़र प्रोफ़ाइल को अस्वीकार कर दिया। केवल साइन इन करने से समस्या हल न हो सके।" },
+  "authBrowserProfileBlocked": { "message": "Kick ने इस ब्राउज़र प्रोफ़ाइल को अस्वीकार कर दिया। केवल साइन इन करने से समस्या शायद हल न हो।" },
   "authCredentialCheckUnavailable": { "message": "आपके ब्राउज़र सत्र की जाँच नहीं हो सकी। Lurkloot अपने आप फिर प्रयास करेगा।" },
   "authNetworkTemporarilyUnavailable": { "message": "नेटवर्क अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।" },
   "authPlatformTemporarilyUnavailable": { "message": "प्लेटफ़ॉर्म अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।" }

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "Gestione link v2"
-  }
+  },
+  "automationChecking": { "message": "Verifica" },
+  "automationNeedsSignIn": { "message": "Accesso necessario" },
+  "automationBlocked": { "message": "Bloccato" },
+  "automationUnavailable": { "message": "Non disponibile" },
+  "authCheckingDetail": { "message": "Verifica della sessione connessa…" },
+  "authSignInMissing": { "message": "Accedi per continuare a ottenere drop." },
+  "authSignInRejected": { "message": "La sessione non è più valida. Accedi di nuovo per continuare." },
+  "signInToTwitch": { "message": "Accedi a Twitch" },
+  "signInToKick": { "message": "Accedi a Kick" },
+  "authBrowserProfileBlocked": { "message": "Kick ha rifiutato questo profilo del browser. Il solo accesso potrebbe non risolvere il problema." },
+  "authCredentialCheckUnavailable": { "message": "Non è stato possibile verificare la sessione del browser. Lurkloot riproverà automaticamente." },
+  "authNetworkTemporarilyUnavailable": { "message": "La rete è temporaneamente non disponibile. Lurkloot riproverà automaticamente." },
+  "authPlatformTemporarilyUnavailable": { "message": "La piattaforma è temporaneamente non disponibile. Lurkloot riproverà automaticamente." }
 }

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "Tratamento de links v2"
-  }
+  },
+  "automationChecking": { "message": "Verificando" },
+  "automationNeedsSignIn": { "message": "Login necessário" },
+  "automationBlocked": { "message": "Bloqueado" },
+  "automationUnavailable": { "message": "Indisponível" },
+  "authCheckingDetail": { "message": "Verificando sua sessão conectada…" },
+  "authSignInMissing": { "message": "Entre na sua conta para continuar coletando drops." },
+  "authSignInRejected": { "message": "Sua sessão não é mais válida. Entre novamente para continuar." },
+  "signInToTwitch": { "message": "Entrar na Twitch" },
+  "signInToKick": { "message": "Entrar na Kick" },
+  "authBrowserProfileBlocked": { "message": "A Kick rejeitou este perfil do navegador. Apenas entrar na conta pode não resolver o problema." },
+  "authCredentialCheckUnavailable": { "message": "Não foi possível verificar a sessão do navegador. O Lurkloot tentará novamente automaticamente." },
+  "authNetworkTemporarilyUnavailable": { "message": "A rede está temporariamente indisponível. O Lurkloot tentará novamente automaticamente." },
+  "authPlatformTemporarilyUnavailable": { "message": "A plataforma está temporariamente indisponível. O Lurkloot tentará novamente automaticamente." }
 }

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "Обработка ссылок v2"
-  }
+  },
+  "automationChecking": { "message": "Проверка" },
+  "automationNeedsSignIn": { "message": "Требуется вход" },
+  "automationBlocked": { "message": "Заблокировано" },
+  "automationUnavailable": { "message": "Недоступно" },
+  "authCheckingDetail": { "message": "Проверяем активный сеанс…" },
+  "authSignInMissing": { "message": "Войдите, чтобы продолжить получать награды." },
+  "authSignInRejected": { "message": "Сеанс больше недействителен. Войдите снова, чтобы продолжить." },
+  "signInToTwitch": { "message": "Войти в Twitch" },
+  "signInToKick": { "message": "Войти в Kick" },
+  "authBrowserProfileBlocked": { "message": "Kick отклонил этот профиль браузера. Одного входа может быть недостаточно для решения проблемы." },
+  "authCredentialCheckUnavailable": { "message": "Не удалось проверить сеанс браузера. Lurkloot повторит попытку автоматически." },
+  "authNetworkTemporarilyUnavailable": { "message": "Сеть временно недоступна. Lurkloot повторит попытку автоматически." },
+  "authPlatformTemporarilyUnavailable": { "message": "Платформа временно недоступна. Lurkloot повторит попытку автоматически." }
 }

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -969,5 +969,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "Talep işleme v2"
-  }
+  },
+  "automationChecking": { "message": "Kontrol ediliyor" },
+  "automationNeedsSignIn": { "message": "Oturum açılmalı" },
+  "automationBlocked": { "message": "Engellendi" },
+  "automationUnavailable": { "message": "Kullanılamıyor" },
+  "authCheckingDetail": { "message": "Oturumunuz kontrol ediliyor…" },
+  "authSignInMissing": { "message": "Drop toplamaya devam etmek için oturum açın." },
+  "authSignInRejected": { "message": "Oturumunuz artık geçerli değil. Devam etmek için yeniden oturum açın." },
+  "signInToTwitch": { "message": "Twitch'te oturum aç" },
+  "signInToKick": { "message": "Kick'te oturum aç" },
+  "authBrowserProfileBlocked": { "message": "Kick bu tarayıcı profilini reddetti. Yalnızca oturum açmak sorunu çözmeyebilir." },
+  "authCredentialCheckUnavailable": { "message": "Tarayıcı oturumunuz kontrol edilemedi. Lurkloot otomatik olarak yeniden deneyecek." },
+  "authNetworkTemporarilyUnavailable": { "message": "Ağ geçici olarak kullanılamıyor. Lurkloot otomatik olarak yeniden deneyecek." },
+  "authPlatformTemporarilyUnavailable": { "message": "Platform geçici olarak kullanılamıyor. Lurkloot otomatik olarak yeniden deneyecek." }
 }

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -911,5 +911,18 @@
   },
   "compatibilityOptionKickClaimV2": {
     "message": "链接处理 v2"
-  }
+  },
+  "automationChecking": { "message": "正在检查" },
+  "automationNeedsSignIn": { "message": "需要登录" },
+  "automationBlocked": { "message": "已阻止" },
+  "automationUnavailable": { "message": "暂时不可用" },
+  "authCheckingDetail": { "message": "正在检查你的登录会话…" },
+  "authSignInMissing": { "message": "请登录以继续获取掉宝。" },
+  "authSignInRejected": { "message": "你的会话已失效。请重新登录以继续。" },
+  "signInToTwitch": { "message": "登录 Twitch" },
+  "signInToKick": { "message": "登录 Kick" },
+  "authBrowserProfileBlocked": { "message": "Kick 拒绝了此浏览器配置文件。仅重新登录可能无法解决问题。" },
+  "authCredentialCheckUnavailable": { "message": "无法检查浏览器会话。Lurkloot 将自动重试。" },
+  "authNetworkTemporarilyUnavailable": { "message": "网络暂时不可用。Lurkloot 将自动重试。" },
+  "authPlatformTemporarilyUnavailable": { "message": "平台暂时不可用。Lurkloot 将自动重试。" }
 }

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -57,6 +57,7 @@ import { UpdateNotice } from "./updateNotice";
 import { DropsPanel } from "./drops";
 import { IdleWatchlistPanel } from "./idleWatchlist";
 import { AutomationHero, PlatformSwitcher } from "./automation";
+import { automationPresentation, type AutomationPresentation } from "./automationStatus";
 import { SettingsView } from "./settings";
 import { TipsBanner } from "./tips";
 export function screenshotVariant(id: string | null | undefined): ScreenshotVariant {
@@ -479,6 +480,22 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   };
   const enabled = automation[platform];
   const automationPending = pendingAutomation[platform] != null;
+  const automationPresentationByPlatform = Object.fromEntries(
+    (Object.keys(PLATFORMS) as Platform[]).map((id) => [id, automationPresentation({
+      platform: id,
+      enabled: automation[id],
+      pending: pendingAutomation[id] != null,
+      authHealth: snapshot.state.authHealth[id],
+    })]),
+  ) as Record<Platform, AutomationPresentation>;
+  const presentation = automationPresentationByPlatform[platform];
+  const headerStatusColor = presentation.operational
+    ? "var(--accent)"
+    : presentation.state === "blocked"
+      ? "#ef4444"
+      : presentation.state === "needs_sign_in" || presentation.state === "unavailable"
+        ? "#f59e0b"
+        : "#a1a1aa";
   const activeCampaign = campaigns.find((campaign) => campaign.farmingChannel);
   const farmingChannel = activeCampaign?.farmingChannel ?? sessionChannel;
   const onFarmingTitleClick = activeCampaign
@@ -507,8 +524,8 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
             <div className="min-w-0 leading-tight">
               <div className="font-display truncate text-[15px] font-bold tracking-normal text-zinc-900 dark:text-zinc-50">Lurkloot</div>
               <div className="flex items-center gap-1 text-[10px] font-medium text-zinc-400 dark:text-zinc-500">
-                <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: enabled ? "var(--accent)" : "#a1a1aa" }} />
-                {settingsOpen ? t("settingsTitle") : activityOpen ? t("activityTitle") : `${enabled ? t("activeStatus") : t("pausedStatus")} · ${PLATFORMS[platform].label}`}
+                <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: headerStatusColor }} />
+                {settingsOpen ? t("settingsTitle") : activityOpen ? t("activityTitle") : `${t(presentation.badgeKey)} · ${PLATFORMS[platform].label}`}
               </div>
             </div>
           </div>
@@ -538,7 +555,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
         {!settingsOpen && !activityOpen ? (
           <PlatformSwitcher
             active={platform}
-            automation={automation}
+            presentation={automationPresentationByPlatform}
             onChange={selectPlatform}
           />
         ) : null}
@@ -589,7 +606,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                     />
                   ) : null}
                 </AnimatePresence>
-                <AutomationHero platformLabel={PLATFORMS[platform].label} enabled={enabled} pending={automationPending} farmingTitle={activeCampaign?.title} farmingChannel={farmingChannel} onFarmingTitleClick={onFarmingTitleClick} statusMessage={session.message} onChange={setAutomation} />
+                <AutomationHero platform={platform} platformLabel={PLATFORMS[platform].label} enabled={enabled} pending={automationPending} presentation={presentation} farmingTitle={activeCampaign?.title} farmingChannel={farmingChannel} onFarmingTitleClick={onFarmingTitleClick} statusMessage={session.message} onChange={setAutomation} />
                 {settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} /> : null}
                 <SubTabs
                   tabs={[

--- a/packages/popup-ui/src/automation.tsx
+++ b/packages/popup-ui/src/automation.tsx
@@ -1,27 +1,36 @@
 import { motion } from "motion/react";
 import { Power, Radio } from "lucide-react";
 import type { Platform } from "@lurkloot/shared/models";
+import type { AutomationPresentation } from "./automationStatus";
 import { PLATFORMS } from "./constants";
-import { useT } from "./context";
+import { usePopupRuntime, useT } from "./context";
 import { formatViewers } from "./format";
 import type { FarmingChannelView } from "./types";
 import { Pill, Toggle, cn } from "./primitives";
 
-export function PlatformSwitcher({ active, automation, onChange }: { active: Platform; automation: Record<Platform, boolean>; onChange(platform: Platform): void }) {
+export function PlatformSwitcher({ active, presentation, onChange }: { active: Platform; presentation: Record<Platform, AutomationPresentation>; onChange(platform: Platform): void }) {
+  const t = useT();
   return (
     <div className="mt-3 grid grid-cols-2 gap-1 rounded-xl bg-zinc-100/80 p-1 dark:bg-zinc-800/60">
       {Object.entries(PLATFORMS).map(([id, platform]) => {
         const selected = active === id;
-        const running = automation[id as Platform];
+        const status = presentation[id as Platform];
+        const indicatorColor = status.operational
+          ? platform.color
+          : status.state === "blocked"
+            ? "#ef4444"
+            : status.state === "needs_sign_in" || status.state === "unavailable"
+              ? "#f59e0b"
+              : undefined;
         return (
-          <button key={id} type="button" onClick={() => onChange(id as Platform)} title={`${platform.label} automation ${running ? "running" : "paused"}`} className={cn("relative flex items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-[13px] font-semibold transition-colors outline-none", selected ? "text-zinc-900 dark:text-white" : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200")}>
+          <button key={id} type="button" data-platform-status={id} data-state={status.state} onClick={() => onChange(id as Platform)} title={`${platform.label}: ${t(status.badgeKey)}`} className={cn("relative flex items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-[13px] font-semibold transition-colors outline-none", selected ? "text-zinc-900 dark:text-white" : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200")}>
             {selected && <motion.span layoutId="platform-pill" transition={{ type: "spring", stiffness: 520, damping: 38 }} className="absolute inset-0 rounded-lg bg-white shadow-sm dark:bg-zinc-700" />}
             <span className="relative z-10 flex h-4 w-4 items-center justify-center rounded text-[10px] font-black" style={{ backgroundColor: selected ? platform.color : "transparent", color: selected ? (id === "kick" ? "#07140a" : "#fff") : platform.color, boxShadow: selected ? `0 0 12px -2px ${platform.color}` : undefined }}>
               {platform.mark}
             </span>
             <span className="relative z-10">{platform.label}</span>
             <span className="relative z-10 ml-0.5 flex items-center" aria-hidden>
-              {running ? <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: platform.color, boxShadow: `0 0 6px ${platform.color}` }} /> : <span className="h-1.5 w-1.5 rounded-full border border-zinc-400 dark:border-zinc-500" />}
+              {indicatorColor ? <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: indicatorColor, boxShadow: `0 0 6px ${indicatorColor}` }} /> : <span className="h-1.5 w-1.5 rounded-full border border-zinc-400 dark:border-zinc-500" />}
             </span>
           </button>
         );
@@ -30,26 +39,24 @@ export function PlatformSwitcher({ active, automation, onChange }: { active: Pla
   );
 }
 
-export function AutomationHero({ platformLabel, enabled, pending, onChange, farmingTitle, farmingChannel, onFarmingTitleClick, statusMessage }: { platformLabel: string; enabled: boolean; pending: boolean; onChange(value: boolean): Promise<void>; farmingTitle?: string; farmingChannel?: FarmingChannelView; onFarmingTitleClick?(): void; statusMessage?: string }) {
+export function AutomationHero({ platform, platformLabel, enabled, pending, presentation, onChange, farmingTitle, farmingChannel, onFarmingTitleClick, statusMessage }: { platform: Platform; platformLabel: string; enabled: boolean; pending: boolean; presentation: AutomationPresentation; onChange(value: boolean): Promise<void>; farmingTitle?: string; farmingChannel?: FarmingChannelView; onFarmingTitleClick?(): void; statusMessage?: string }) {
   const t = useT();
-  const status = pending ? (enabled ? t("automationStarting") : t("automationStopping")) : enabled ? t("automationRunning") : t("pausedStatus");
+  const runtime = usePopupRuntime();
 
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white p-3.5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900" style={{ boxShadow: enabled ? "0 1px 2px rgba(0,0,0,0.04), 0 0 0 1px var(--accent-ring)" : undefined }}>
-      {enabled && <div aria-hidden className="pointer-events-none absolute -right-10 -top-12 h-32 w-32 rounded-full blur-2xl" style={{ backgroundColor: "var(--accent-glow)", opacity: 0.5 }} />}
+    <div data-automation-state={presentation.state} className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white p-3.5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900" style={{ boxShadow: presentation.operational ? "0 1px 2px rgba(0,0,0,0.04), 0 0 0 1px var(--accent-ring)" : undefined }}>
+      {presentation.operational && <div aria-hidden className="pointer-events-none absolute -right-10 -top-12 h-32 w-32 rounded-full blur-2xl" style={{ backgroundColor: "var(--accent-glow)", opacity: 0.5 }} />}
       <div className="relative flex items-center gap-3">
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-colors" style={{ backgroundColor: enabled ? "var(--accent)" : "var(--accent-soft)", color: enabled ? "var(--accent-contrast)" : "var(--accent-text)" }}>
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-colors" style={{ backgroundColor: presentation.operational ? "var(--accent)" : "var(--accent-soft)", color: presentation.operational ? "var(--accent-contrast)" : "var(--accent-text)" }}>
           <Power size={20} strokeWidth={2.4} />
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">{t("automationTitle", platformLabel)}</span>
-            <Pill tone={enabled ? "accent" : "muted"}>{status}</Pill>
+            <Pill tone={presentation.tone}>{t(presentation.badgeKey)}</Pill>
           </div>
-          <div className="mt-0.5 flex h-[34px] flex-col justify-center text-xs text-zinc-500 dark:text-zinc-400">
-            {pending ? (
-              <p className="line-clamp-2 leading-snug">{enabled ? t("startingAutomation") : t("pausingAutomation")}</p>
-            ) : enabled ? (
+          <div className="mt-0.5 flex min-h-[34px] flex-col justify-center text-xs text-zinc-500 dark:text-zinc-400">
+            {presentation.state === "running" ? (
               <>
                 {farmingChannel ? (
                   <p className="flex items-center gap-1 truncate">
@@ -77,7 +84,14 @@ export function AutomationHero({ platformLabel, enabled, pending, onChange, farm
                 )}
               </>
             ) : (
-              <p className="line-clamp-2 leading-snug">{t("watchingPausedHint")}</p>
+              <>
+                <p className="line-clamp-2 leading-snug">{presentation.detailKey ? t(presentation.detailKey) : null}</p>
+                {presentation.action ? (
+                  <button type="button" data-auth-action={platform} onClick={() => runtime.adapter.openLink(presentation.action!.url)} className="mt-1 w-fit rounded-md bg-[var(--accent-soft)] px-2 py-1 text-[11px] font-semibold text-[var(--accent-text)] outline-none hover:underline focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]">
+                    {t(presentation.action.labelKey)}
+                  </button>
+                ) : null}
+              </>
             )}
           </div>
         </div>

--- a/packages/popup-ui/src/automationStatus.ts
+++ b/packages/popup-ui/src/automationStatus.ts
@@ -1,0 +1,98 @@
+import type { Platform, PlatformAuthHealth } from "@lurkloot/shared/models";
+
+export type AutomationPresentationState =
+  | "starting"
+  | "stopping"
+  | "paused"
+  | "running"
+  | "checking"
+  | "needs_sign_in"
+  | "blocked"
+  | "unavailable";
+
+export type AutomationTone = "muted" | "accent" | "warning" | "danger";
+
+export interface AutomationPresentation {
+  state: AutomationPresentationState;
+  badgeKey: string;
+  detailKey?: string;
+  tone: AutomationTone;
+  operational: boolean;
+  action?: {
+    labelKey: "signInToTwitch" | "signInToKick";
+    url: string;
+  };
+}
+
+export const AUTH_SIGN_IN_URLS: Record<Platform, string> = {
+  twitch: "https://www.twitch.tv/login",
+  kick: "https://kick.com/login",
+};
+
+export function automationPresentation({
+  platform,
+  enabled,
+  pending,
+  authHealth,
+}: {
+  platform: Platform;
+  enabled: boolean;
+  pending: boolean;
+  authHealth: PlatformAuthHealth;
+}): AutomationPresentation {
+  if (pending) {
+    return enabled
+      ? presentation("starting", "automationStarting", "startingAutomation")
+      : presentation("stopping", "automationStopping", "pausingAutomation");
+  }
+  if (!enabled) return presentation("paused", "pausedStatus", "watchingPausedHint");
+
+  switch (authHealth.status) {
+    case "healthy":
+      return {
+        state: "running",
+        badgeKey: "automationRunning",
+        detailKey: undefined,
+        tone: "accent",
+        operational: true,
+      };
+    case "checking":
+      return presentation("checking", "automationChecking", "authCheckingDetail");
+    case "missing_credentials":
+      return signInPresentation(platform, "authSignInMissing");
+    case "invalid_credentials":
+      return signInPresentation(platform, "authSignInRejected");
+    case "blocked":
+      return presentation("blocked", "automationBlocked", "authBrowserProfileBlocked", "danger");
+    case "unavailable": {
+      const detailKey = authHealth.reasonCode === "credential_lookup_failed"
+        ? "authCredentialCheckUnavailable"
+        : authHealth.reasonCode === "network_unavailable"
+          ? "authNetworkTemporarilyUnavailable"
+          : "authPlatformTemporarilyUnavailable";
+      return presentation("unavailable", "automationUnavailable", detailKey, "warning");
+    }
+  }
+}
+
+function presentation(
+  state: AutomationPresentationState,
+  badgeKey: string,
+  detailKey: string,
+  tone: AutomationTone = "muted",
+): AutomationPresentation {
+  return { state, badgeKey, detailKey, tone, operational: false };
+}
+
+function signInPresentation(
+  platform: Platform,
+  detailKey: string,
+): AutomationPresentation {
+  return {
+    ...presentation("needs_sign_in", "automationNeedsSignIn", detailKey, "warning"),
+    action: {
+      labelKey: platform === "twitch" ? "signInToTwitch" : "signInToKick",
+      url: AUTH_SIGN_IN_URLS[platform],
+    },
+  };
+}

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -38,12 +38,13 @@ export function Toggle({ checked, onChange, label, disabled = false }: { checked
   );
 }
 
-export function Pill({ children, tone = "muted" }: { children: React.ReactNode; tone?: "muted" | "accent" | "live" | "danger" | "outline" }) {
+export function Pill({ children, tone = "muted" }: { children: React.ReactNode; tone?: "muted" | "accent" | "live" | "warning" | "danger" | "outline" }) {
   const tones = {
     muted: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300",
     outline: "border border-zinc-200 text-zinc-500 dark:border-zinc-700 dark:text-zinc-400",
     accent: "bg-[var(--accent-soft)] text-[var(--accent-text)]",
     live: "bg-emerald-500/12 text-emerald-600 dark:text-emerald-400",
+    warning: "bg-amber-500/12 text-amber-700 dark:text-amber-400",
     danger: "bg-red-500/12 text-red-600 dark:text-red-400",
   };
   return <span className={cn("inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold leading-none whitespace-nowrap", tones[tone])}>{children}</span>;


### PR DESCRIPTION
## Summary

Surfaces per-platform authentication health in the popup so users can tell when a Twitch or Kick session needs attention, instead of silently failing to farm.

- Derives authentication status presentation from the core auth health model (`packages/popup-ui/src/automationStatus.ts`)
- Renders status and recovery actions (sign-in links) in the automation view
- Keeps popup state synchronized with background auth health updates
- Adds localized guidance strings across all 11 message catalogs
- Includes design spec and implementation plan under `docs/`

## Testing

- `pnpm test` — new suites: `popupAuthHealth.test.tsx`, `automationStatus.test.ts`, `automationView.test.tsx`, plus `i18n.test.ts` coverage for the new keys
- `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication health status indicators for each platform in the popup.
  * Added clear sign-in actions for missing or rejected credentials.
  * Added recovery and temporary-unavailability messaging while keeping automation controls available.
  * Hidden stale farming details when authentication is degraded.
* **Localization**
  * Added authentication and automation status translations across all supported languages.
* **Tests**
  * Added coverage for status precedence, sign-in actions, recovery updates, platform consistency, privacy-safe messaging, and translation completeness.
* **Documentation**
  * Added design and implementation documentation for popup authentication health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->