### PR TITLE
fix(kick): send session bearer to the identity probe endpoint

### DIFF
--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -485,12 +485,26 @@ export async function fetchTwitchInBackgroundWith<T>(api: CookieApi, url: string
   return (isUsableTwitchGql(json) ? json : twitchGqlErrorEnvelope("returned an unusable response", response.status, text, headers)) as T;
 }
 
-// Kick endpoints that replay the session_token cookie as a Bearer (mirrors
-// pageFetchJson). kick.com/api/v2/* and /api/search are public and do not need it.
-// kick.com/api/v1/user is listed by path rather than host because Kick serves it
-// anonymously as `200 {}` instead of a 401, so a missing Bearer there is
-// indistinguishable from a signed-out session (see KickAdapter.checkAuthHealth).
-const KICK_AUTH_HOSTS = ["web.kick.com", "websockets.kick.com", "kick.com/api/v1/user"];
+// Kick endpoints that replay the session_token cookie as a Bearer (mirrors the
+// predicate inlined in pageFetchJson). kick.com/api/v2/* and /api/search are public
+// and do not need it; kick.com/api/v1/user does, because Kick serves it anonymously
+// as `200 {}` instead of a 401, so a missing Bearer there is indistinguishable from a
+// signed-out session (see KickAdapter.checkAuthHealth).
+//
+// Matched on the parsed host and pathname rather than by substring: `includes` would
+// also attach the session token to hosts that merely mention a Kick host (e.g.
+// https://evil.example/?r=web.kick.com) and to unintended subpaths of /api/v1/user.
+function needsKickSessionBearer(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  if (parsed.host === "web.kick.com" || parsed.host === "websockets.kick.com") return true;
+  return parsed.host === "kick.com" && parsed.pathname === "/api/v1/user";
+}
 
 // Distinguishes "Kick's WAF / origin check rejected the service-worker request"
 // (fall back to the page-context tab) from a genuine error. Thrown by
@@ -538,7 +552,7 @@ function safeKickFailure(status: number, text: string): SafeFetchFailure {
 // stack is WAF-blocked for unrelated reasons).
 export async function fetchKickInBackgroundWith<T>(api: CookieApi, url: string, init?: RequestInit): Promise<T> {
   const headers = new Headers(init?.headers ?? {});
-  if (KICK_AUTH_HOSTS.some((host) => url.includes(host)) && !headers.has("authorization")) {
+  if (needsKickSessionBearer(url) && !headers.has("authorization")) {
     const sessionToken = (await api.cookies?.get({ url: "https://kick.com", name: "session_token" }))?.value;
     if (sessionToken) headers.set("authorization", `Bearer ${decodeURIComponent(sessionToken)}`);
   }
@@ -1025,11 +1039,20 @@ export type SchedulerManagedPageContexts = Partial<Record<Platform, ManagedPageC
 async function pageFetchJson(targetUrl: string, initJson?: string): Promise<unknown> {
   const parsedInit = initJson ? JSON.parse(initJson) : undefined;
   const headers = new Headers(parsedInit?.headers ?? {});
-  // Mirrors KICK_AUTH_HOSTS; inlined because executeScript only serializes this
-  // function's own source, so module-scope constants are unavailable in the page.
-  const needsKickBearer = targetUrl.includes("web.kick.com")
-    || targetUrl.includes("websockets.kick.com")
-    || targetUrl.includes("kick.com/api/v1/user");
+  // Mirrors needsKickSessionBearer; inlined because executeScript only serializes this
+  // function's own source, so module-scope helpers are unavailable in the page. Matches
+  // on parsed host/pathname so the session token is never attached to a look-alike host
+  // or to an unintended subpath of /api/v1/user.
+  let needsKickBearer = false;
+  try {
+    const parsedTarget = new URL(targetUrl);
+    needsKickBearer = parsedTarget.protocol === "https:"
+      && (parsedTarget.host === "web.kick.com"
+        || parsedTarget.host === "websockets.kick.com"
+        || (parsedTarget.host === "kick.com" && parsedTarget.pathname === "/api/v1/user"));
+  } catch {
+    needsKickBearer = false;
+  }
   if (needsKickBearer && !headers.has("authorization")) {
     const sessionToken = document.cookie
       .split(";")

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -485,9 +485,12 @@ export async function fetchTwitchInBackgroundWith<T>(api: CookieApi, url: string
   return (isUsableTwitchGql(json) ? json : twitchGqlErrorEnvelope("returned an unusable response", response.status, text, headers)) as T;
 }
 
-// Kick hosts whose endpoints replay the session_token cookie as a Bearer (mirrors
-// pageFetchJson). kick.com/api/v2/* is public and does not need it.
-const KICK_AUTH_HOSTS = ["web.kick.com", "websockets.kick.com"];
+// Kick endpoints that replay the session_token cookie as a Bearer (mirrors
+// pageFetchJson). kick.com/api/v2/* and /api/search are public and do not need it.
+// kick.com/api/v1/user is listed by path rather than host because Kick serves it
+// anonymously as `200 {}` instead of a 401, so a missing Bearer there is
+// indistinguishable from a signed-out session (see KickAdapter.checkAuthHealth).
+const KICK_AUTH_HOSTS = ["web.kick.com", "websockets.kick.com", "kick.com/api/v1/user"];
 
 // Distinguishes "Kick's WAF / origin check rejected the service-worker request"
 // (fall back to the page-context tab) from a genuine error. Thrown by
@@ -1022,7 +1025,12 @@ export type SchedulerManagedPageContexts = Partial<Record<Platform, ManagedPageC
 async function pageFetchJson(targetUrl: string, initJson?: string): Promise<unknown> {
   const parsedInit = initJson ? JSON.parse(initJson) : undefined;
   const headers = new Headers(parsedInit?.headers ?? {});
-  if ((targetUrl.includes("web.kick.com") || targetUrl.includes("websockets.kick.com")) && !headers.has("authorization")) {
+  // Mirrors KICK_AUTH_HOSTS; inlined because executeScript only serializes this
+  // function's own source, so module-scope constants are unavailable in the page.
+  const needsKickBearer = targetUrl.includes("web.kick.com")
+    || targetUrl.includes("websockets.kick.com")
+    || targetUrl.includes("kick.com/api/v1/user");
+  if (needsKickBearer && !headers.has("authorization")) {
     const sessionToken = document.cookie
       .split(";")
       .map((part) => part.trim())

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -189,13 +189,21 @@ export class KickAdapter implements PlatformAdapter {
   async checkAuthHealth(): Promise<PlatformAuthHealth> {
     const checkedAt = new Date().toISOString();
     try {
+      // Kick serves this endpoint anonymously as `200 {}` instead of rejecting it, so the
+      // identity check below is what separates a real session from a credential-free one.
+      // It only works because kick.com is in KICK_AUTH_HOSTS (core/tabs.ts) and therefore
+      // gets session_token replayed as a Bearer; without that header Kick returns the
+      // empty object and a signed-in account looks signed out.
       const response = await this.fetcher.fetchJson<KickIdentityResponse>("https://kick.com/api/v1/user", undefined, this.emit);
       if (hasKickIdentity(response)) return { status: "healthy", checkedAt };
+      // An empty/unrecognized body means the request went out without credentials, which
+      // is a transport fault rather than proof of a signed-out session. Only an explicit
+      // rejection below may suspend farming.
       return {
-        status: "invalid_credentials",
+        status: "unavailable",
         checkedAt,
-        reasonCode: "credentials_rejected",
-        message: { key: "authInvalidCredentials" },
+        reasonCode: "platform_unavailable",
+        message: { key: "authPlatformUnavailable" },
       };
     } catch (error) {
       if (isSafeFetchError(error)) {

--- a/packages/extension/tests/authHealth.test.ts
+++ b/packages/extension/tests/authHealth.test.ts
@@ -34,14 +34,17 @@ describe("authentication health normalization", () => {
     {},
     { data: [] },
     { data: [{ id: "public-campaign" }] },
-  ])("does not infer Kick authentication from identity-free JSON", async (response) => {
+  ])("treats an identity-free Kick body as unavailable, not signed out", async (response) => {
+    // Kick answers this endpoint `200 {}` when the Bearer is missing, so an empty body
+    // means the request lost its credentials in transport. Reporting invalid_credentials
+    // here is what suspended farming for signed-in users (regression from #213/#214).
     const fetcher = { fetchJson: async <T,>(): Promise<T> => response as T };
 
     await expect(new KickAdapter(fetcher).checkAuthHealth()).resolves.toMatchObject({
-      status: "invalid_credentials",
-      reasonCode: "credentials_rejected",
-      message: { key: "authInvalidCredentials" },
-  });
+      status: "unavailable",
+      reasonCode: "platform_unavailable",
+      message: { key: "authPlatformUnavailable" },
+    });
   });
   it("defaults both platforms to unchecked checking state", () => {
     expect(DEFAULT_STATE.authHealth).toEqual({

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1075,10 +1075,35 @@ describe("fetchKickInBackgroundWith", () => {
       return new Response(JSON.stringify({ id: 42 }), { status: 200, headers: { "content-type": "application/json" } });
     }));
 
-    await fetchKickInBackgroundWith(cookieApi, "https://kick.com/api/v1/user");
+    try {
+      await fetchKickInBackgroundWith(cookieApi, "https://kick.com/api/v1/user");
 
-    expect(new Headers(captured?.headers).get("authorization")).toBe("Bearer sess 789");
-    vi.unstubAllGlobals();
+      expect(new Headers(captured?.headers).get("authorization")).toBe("Bearer sess 789");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it.each([
+    "https://evil.example/?r=web.kick.com",
+    "https://web.kick.com.evil.example/api/v1/user",
+    "https://kick.com/api/v1/user/profile",
+    "http://web.kick.com/api/v1/drops/progress",
+  ])("never attaches the session token to %s", async (url) => {
+    let captured: RequestInit | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init: RequestInit) => {
+      captured = init;
+      return new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } });
+    }));
+
+    try {
+      await fetchKickInBackgroundWith(cookieApi, url);
+
+      expect(new Headers(captured?.headers).has("authorization")).toBe(false);
+      expect(cookieApi.cookies.get).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("throws KickWafBlockedError on a 403 security-policy block", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1084,12 +1084,15 @@ describe("fetchKickInBackgroundWith", () => {
     }
   });
 
+  // Every URL here is a near-miss for a genuinely authenticated endpoint: a look-alike
+  // host, an unintended subpath, or a plaintext downgrade of an endpoint that *does*
+  // receive the token over https (see the web.kick.com case above). None may receive it.
   it.each([
-    "https://evil.example/?r=web.kick.com",
-    "https://web.kick.com.evil.example/api/v1/user",
-    "https://kick.com/api/v1/user/profile",
-    "http://web.kick.com/api/v1/drops/progress",
-  ])("never attaches the session token to %s", async (url) => {
+    ["look-alike host mentioning a Kick host", "https://evil.example/?r=web.kick.com"],
+    ["look-alike host suffixing a Kick host", "https://web.kick.com.evil.example/api/v1/user"],
+    ["subpath of the identity endpoint", "https://kick.com/api/v1/user/profile"],
+    ["plaintext downgrade of an authenticated endpoint", "http://web.kick.com/api/v1/drops/progress"],
+  ])("never attaches the session token to a %s", async (_case, url) => {
     let captured: RequestInit | undefined;
     vi.stubGlobal("fetch", vi.fn(async (_url: string, init: RequestInit) => {
       captured = init;

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1066,6 +1066,21 @@ describe("fetchKickInBackgroundWith", () => {
     vi.unstubAllGlobals();
   });
 
+  it("replays the session_token cookie as a Bearer for the kick.com identity endpoint", async () => {
+    // Kick serves this endpoint anonymously as `200 {}` rather than a 401, so without the
+    // Bearer the auth probe cannot tell a signed-in account from a signed-out one.
+    let captured: RequestInit | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init: RequestInit) => {
+      captured = init;
+      return new Response(JSON.stringify({ id: 42 }), { status: 200, headers: { "content-type": "application/json" } });
+    }));
+
+    await fetchKickInBackgroundWith(cookieApi, "https://kick.com/api/v1/user");
+
+    expect(new Headers(captured?.headers).get("authorization")).toBe("Bearer sess 789");
+    vi.unstubAllGlobals();
+  });
+
   it("throws KickWafBlockedError on a 403 security-policy block", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response(
       JSON.stringify({


### PR DESCRIPTION
## Summary

- add `kick.com/api/v1/user` to `KICK_AUTH_HOSTS` so the authentication probe receives the `session_token` bearer, scoped by path so public `kick.com/api/v2/*` and `/api/search` calls stay anonymous
- mirror the same predicate in `pageFetchJson`, which must stay self-contained because `executeScript` only serializes that function's own source
- report an identity-free probe body as `unavailable` rather than `invalid_credentials`, so only an explicit 401/403 can suspend farming

## Root cause

`kick.com/api/v1/user` returns an identity only when `session_token` is replayed as an `Authorization: Bearer` header. With cookies alone Kick serves it anonymously as `200 {}` rather than rejecting it — it never returns 401.

`KICK_AUTH_HOSTS` covered only `web.kick.com` and `websockets.kick.com`, so the probe added in #213 went out credential-free. The service worker fetch *succeeded* with the empty object, which meant the fetcher never fell back to the page-context tab that carries the real session. `hasKickIdentity({})` then returned false and the adapter reported `invalid_credentials`.

Because #214 suspends farming on an unhealthy verdict and #215 surfaces it, signed-in users saw "Needs sign-in" and Kick farming stopped entirely, with no campaigns discovered. Diagnostics showed the tell: `Kick fetch kick.com → service worker OK (tabless-capable)` with no `web.kick.com` line following it.

The identity-free downgrade is the containment half of the fix: a probe that loses its credentials in transport is not evidence of a signed-out session, and should not be able to stop farming.

## Validation

- `pnpm test` (793 extension, 105 CLI, 3 site tests)
- `pnpm typecheck` across all packages
- verified in a real unpacked Chromium load: Kick authentication reports healthy and farming resumes

Regression coverage added in `tabs.test.ts` (bearer is attached to the identity endpoint) and `authHealth.test.ts` (an empty body maps to `unavailable`).

Closes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authenticated requests to Kick’s user identity endpoint.
  * Correctly handles anonymous or unavailable identity responses without reporting them as invalid credentials.
  * Preserves existing handling for explicit authentication failures and network errors.

* **Tests**
  * Added coverage for authentication headers and unavailable identity responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->