### PR TITLE
feat(cli): report platform authentication health

### DIFF
--- a/packages/cli/src/authStore.ts
+++ b/packages/cli/src/authStore.ts
@@ -1,5 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { Platform, PlatformAuthReasonCode, PlatformAuthStatus } from "@lurkloot/shared/models";
+import type { CredentialAvailability } from "@lurkloot/core/controller";
 
 export interface TwitchCredentials {
   authToken?: string;
@@ -70,12 +72,29 @@ function pruneUndefined<T extends Record<string, unknown>>(value: T): T {
 }
 
 function readStore(path: string): PlatformCredentials {
+  return readStoreDetailed(path).store;
+}
+
+// Reads the store while distinguishing "there is no store yet" (a normal state —
+// env overrides may still supply credentials) from "the store exists but could
+// not be read/parsed" (a transient lookup failure worth surfacing as such). The
+// callers that only care about the resulting credentials use readStore above.
+function readStoreDetailed(path: string): { store: PlatformCredentials; lookupFailed: boolean } {
+  let raw: string;
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as PlatformCredentials;
-    return parsed && typeof parsed === "object" ? parsed : {};
+    raw = readFileSync(path, "utf8");
+  } catch (error) {
+    // A missing file is expected; anything else (permissions, I/O) is a failure.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { store: {}, lookupFailed: false };
+    return { store: {}, lookupFailed: true };
+  }
+  try {
+    const parsed = JSON.parse(raw) as PlatformCredentials;
+    return { store: parsed && typeof parsed === "object" ? parsed : {}, lookupFailed: false };
   } catch {
-    // No store yet (or unreadable) — env overrides may still supply credentials.
-    return {};
+    // The file is present but corrupt — the login flow can rewrite it, but for
+    // now the credential lookup has failed rather than come back empty.
+    return { store: {}, lookupFailed: true };
   }
 }
 
@@ -85,4 +104,63 @@ export function hasTwitchAuth(creds: PlatformCredentials): boolean {
 
 export function hasKickAuth(creds: PlatformCredentials): boolean {
   return Boolean(creds.kick?.sessionToken);
+}
+
+// Where the effective credential for a platform came from. Kept internal to the
+// CLI so status/logging can explain reachability without ever printing the value
+// itself: "environment" means an SA_* override won, "stored" means the on-disk
+// credentials.json supplied it, "none" means neither did.
+export type CredentialSource = "environment" | "stored" | "none";
+
+// A CLI-local, network-free reading of a platform's credential state, expressed
+// in the shared safe auth-health vocabulary. It never inspects browser cookies
+// and never carries a credential value — only whether one is present, where it
+// came from, and the resulting safe status/reason code.
+export interface LocalCredentialHealth {
+  present: boolean;
+  source: CredentialSource;
+  status: Extract<PlatformAuthStatus, "checking" | "missing_credentials" | "unavailable">;
+  reasonCode?: Extract<PlatformAuthReasonCode, "credentials_missing" | "credential_lookup_failed">;
+}
+
+const PRIMARY_ENV_KEY: Record<Platform, string> = {
+  twitch: "SA_TWITCH_AUTH_TOKEN",
+  kick: "SA_KICK_SESSION_TOKEN",
+};
+
+function primaryStoredValue(platform: Platform, store: PlatformCredentials): string | undefined {
+  return platform === "twitch" ? store.twitch?.authToken : store.kick?.sessionToken;
+}
+
+// Mirrors loadCredentials' nullish env-over-store merge so the reported source
+// matches the credential a transport would actually use.
+function credentialPresence(platform: Platform, store: PlatformCredentials, env: NodeJS.ProcessEnv): { present: boolean; source: CredentialSource } {
+  const envValue = env[PRIMARY_ENV_KEY[platform]];
+  const effective = envValue ?? primaryStoredValue(platform, store);
+  if (!effective) return { present: false, source: "none" };
+  return { present: true, source: envValue != null ? "environment" : "stored" };
+}
+
+// Describes each platform's credential state without touching the network or a
+// browser session: absent credentials map to missing_credentials, an unreadable
+// store maps to the transient credential_lookup_failed, and a present credential
+// stays "checking" until a live probe (adapter.checkAuthHealth) confirms it.
+export function describeCredentialHealth(authDir: string, env: NodeJS.ProcessEnv = process.env): Record<Platform, LocalCredentialHealth> {
+  const { store, lookupFailed } = readStoreDetailed(join(authDir, CREDENTIALS_FILE));
+  const describe = (platform: Platform): LocalCredentialHealth => {
+    const { present, source } = credentialPresence(platform, store, env);
+    if (present) return { present: true, source, status: "checking" };
+    if (lookupFailed) return { present: false, source, status: "unavailable", reasonCode: "credential_lookup_failed" };
+    return { present: false, source, status: "missing_credentials", reasonCode: "credentials_missing" };
+  };
+  return { twitch: describe("twitch"), kick: describe("kick") };
+}
+
+// Bridges the CLI-local credential reading to the engine's pre-probe gate: an
+// unreadable store is transiently unavailable, an absent credential is missing,
+// and a present credential is available (the live probe still validates it).
+export function credentialAvailabilityOf(health: LocalCredentialHealth): CredentialAvailability {
+  if (health.status === "unavailable") return { status: "unavailable" };
+  if (!health.present) return { status: "missing" };
+  return { status: "available" };
 }

--- a/packages/cli/src/events.ts
+++ b/packages/cli/src/events.ts
@@ -74,8 +74,10 @@ export function formatCliEvent(event: EngineEvent): string {
       return `Opened background context on ${event.data.host}: ${formatPageContextOpenReason(event.data.reason)}`;
     case "page_context_closed":
       return `Closed background context on ${event.data.host}: ${formatPageContextCloseReason(event.data.reason)}`;
-    case "auth_health_changed":
-      return `${event.platform} authentication changed from ${event.data.from} to ${event.data.to}`;
+    case "auth_health_changed": {
+      const reason = event.data.reason ? ` (${event.data.reason})` : "";
+      return `${event.platform} authentication changed from ${event.data.from} to ${event.data.to}${reason}`;
+    }
     default: {
       const exhaustive: never = event;
       return exhaustive;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,7 @@ import { hideBin } from "yargs/helpers";
 import type { DropCampaign, Platform } from "@lurkloot/shared/models";
 import { KickWafBlockedError } from "@lurkloot/core/tabs";
 import { loadConfig, TRANSPORTS, type CliConfig, type Transport } from "./config";
-import { forgetCredentials, hasKickAuth, hasTwitchAuth, loadCredentials } from "./authStore";
+import { credentialAvailabilityOf, describeCredentialHealth, forgetCredentials, hasKickAuth, hasTwitchAuth, loadCredentials } from "./authStore";
 import { createTransport, type EnabledPlatforms } from "./transport";
 import { runLoop } from "./runtime/run";
 import { formatDiscoveredCampaign } from "./runtime/status";
@@ -42,6 +42,13 @@ function enabledPlatforms(config: CliConfig): EnabledPlatforms {
 function statePath(stateArg: string | undefined, config: CliConfig): string {
   if (stateArg) return resolve(process.cwd(), stateArg);
   return join(dirname(config.configPath), "state.json");
+}
+
+// Re-reads the file/env credential store each tick (so a login mid-run is
+// noticed) and reports availability to the engine's pre-probe gate. Never
+// inspects browser cookies and never returns a credential value.
+function runCredentialAvailability(authDir: string, platform: Platform) {
+  return credentialAvailabilityOf(describeCredentialHealth(authDir)[platform]);
 }
 
 const validateConfigCommand: CommandModule = {
@@ -98,6 +105,7 @@ const runCommand: CommandModule = {
       transport: handle,
       logger,
       once: Boolean(argv.once),
+      checkCredentialAvailability: async (platform) => runCredentialAvailability(config.authDir, platform),
     });
   },
 };
@@ -168,10 +176,25 @@ const authCommand: CommandModule = {
         const logger = loggerOf(argv);
         const { authDir } = configOf(argv, logger);
         const creds = loadCredentials(authDir);
+        const health = describeCredentialHealth(authDir);
+        // Reports presence, source, and the shared safe status/reason code — never
+        // the credential values themselves. "checking" here means a credential is
+        // present but unverified; `run` performs the live probe.
         process.stdout.write(`${JSON.stringify({
           authDir,
-          twitch: { authToken: hasTwitchAuth(creds), deviceId: Boolean(creds.twitch?.deviceId) },
-          kick: { sessionToken: hasKickAuth(creds) },
+          twitch: {
+            authToken: hasTwitchAuth(creds),
+            deviceId: Boolean(creds.twitch?.deviceId),
+            source: health.twitch.source,
+            status: health.twitch.status,
+            ...(health.twitch.reasonCode ? { reasonCode: health.twitch.reasonCode } : {}),
+          },
+          kick: {
+            sessionToken: hasKickAuth(creds),
+            source: health.kick.source,
+            status: health.kick.status,
+            ...(health.kick.reasonCode ? { reasonCode: health.kick.reasonCode } : {}),
+          },
         }, null, 2)}\n`);
       },
     })

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -1,4 +1,4 @@
-import { createBackgroundController } from "@lurkloot/core/controller";
+import { createBackgroundController, type CredentialAvailability } from "@lurkloot/core/controller";
 import type { Platform, SchedulerState } from "@lurkloot/shared/models";
 import { loadState, saveState } from "../storage";
 import { toEngineSettings, type CliSettings } from "../settings";
@@ -15,6 +15,11 @@ export interface RunOptions {
   // Run a single tick and return (used by smoke checks); otherwise loop until a
   // termination signal.
   once?: boolean;
+  // Reports whether a platform has a credential available before each live probe,
+  // so the shared engine can distinguish missing_credentials from a rejected or
+  // transiently unavailable one. Stays independent of any browser cookie
+  // observation — it reads only the CLI's file/env credential store.
+  checkCredentialAvailability?: (platform: Platform) => Promise<CredentialAvailability>;
 }
 
 // Headless farming loop. Reuses the engine's background controller — the same
@@ -40,6 +45,7 @@ export async function runLoop(options: RunOptions): Promise<void> {
     createAlarm: async () => {},
     createAdapters: (emit, currentSettings) => transport.createAdapters(emit, currentSettings),
     createNotification: async ({ title, message }) => logger.info(`${title}: ${message}`, "notify"),
+    ...(options.checkCredentialAvailability ? { checkCredentialAvailability: options.checkCredentialAvailability } : {}),
   });
 
   const tickOnce = async () => {

--- a/packages/cli/tests/authStore.test.ts
+++ b/packages/cli/tests/authStore.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { forgetCredentials, hasKickAuth, hasTwitchAuth, loadCredentials } from "../src/authStore";
+import { credentialAvailabilityOf, describeCredentialHealth, forgetCredentials, hasKickAuth, hasTwitchAuth, loadCredentials } from "../src/authStore";
 
 let dir: string;
 beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), "lurkloot-auth-")); });
@@ -37,6 +37,65 @@ describe("loadCredentials", () => {
   it("ignores an unreadable/invalid store", () => {
     const creds = loadCredentials(join(dir, "does-not-exist"), { SA_TWITCH_AUTH_TOKEN: "env-only" });
     expect(creds.twitch?.authToken).toBe("env-only");
+  });
+});
+
+describe("describeCredentialHealth", () => {
+  it("reports missing credentials with the shared reason code when nothing is stored or set", () => {
+    const health = describeCredentialHealth(dir, {});
+    expect(health.twitch).toEqual({ present: false, source: "none", status: "missing_credentials", reasonCode: "credentials_missing" });
+    expect(health.kick).toEqual({ present: false, source: "none", status: "missing_credentials", reasonCode: "credentials_missing" });
+  });
+
+  it("marks stored credentials as present, sourced from the on-disk store, and awaiting a probe", async () => {
+    await writeFile(join(dir, "credentials.json"), JSON.stringify({
+      twitch: { authToken: "stored-twitch" },
+      kick: { sessionToken: "stored-kick" },
+    }));
+    const health = describeCredentialHealth(dir, {});
+    expect(health.twitch).toEqual({ present: true, source: "stored", status: "checking" });
+    expect(health.kick).toEqual({ present: true, source: "stored", status: "checking" });
+  });
+
+  it("attributes credentials to the environment when an SA_* override wins over the store", async () => {
+    await writeFile(join(dir, "credentials.json"), JSON.stringify({ twitch: { authToken: "stored" } }));
+    const health = describeCredentialHealth(dir, { SA_TWITCH_AUTH_TOKEN: "from-env" });
+    expect(health.twitch).toEqual({ present: true, source: "environment", status: "checking" });
+    expect(health.kick.status).toBe("missing_credentials");
+  });
+
+  it("treats an empty env override as absent rather than shadowing the store falsely", async () => {
+    await writeFile(join(dir, "credentials.json"), JSON.stringify({ twitch: { authToken: "stored" } }));
+    // An empty SA_* override wins the nullish merge in loadCredentials, so the
+    // effective credential is empty — report missing, not a stored credential.
+    const health = describeCredentialHealth(dir, { SA_TWITCH_AUTH_TOKEN: "" });
+    expect(health.twitch).toEqual({ present: false, source: "none", status: "missing_credentials", reasonCode: "credentials_missing" });
+  });
+
+  it("surfaces a corrupt store as a transient lookup failure, not missing credentials", async () => {
+    await writeFile(join(dir, "credentials.json"), "{ not json");
+    const health = describeCredentialHealth(dir, {});
+    expect(health.twitch).toEqual({ present: false, source: "none", status: "unavailable", reasonCode: "credential_lookup_failed" });
+  });
+
+  it("prefers an env credential even when the on-disk store is unreadable", async () => {
+    await writeFile(join(dir, "credentials.json"), "{ not json");
+    const health = describeCredentialHealth(dir, { SA_KICK_SESSION_TOKEN: "kick-env" });
+    expect(health.kick).toEqual({ present: true, source: "environment", status: "checking" });
+    expect(health.twitch.status).toBe("unavailable");
+  });
+
+  it("maps local health to the engine's pre-probe availability gate", () => {
+    expect(credentialAvailabilityOf({ present: false, source: "none", status: "missing_credentials", reasonCode: "credentials_missing" })).toEqual({ status: "missing" });
+    expect(credentialAvailabilityOf({ present: false, source: "none", status: "unavailable", reasonCode: "credential_lookup_failed" })).toEqual({ status: "unavailable" });
+    expect(credentialAvailabilityOf({ present: true, source: "stored", status: "checking" })).toEqual({ status: "available" });
+  });
+
+  it("never places a credential value in the reported health", async () => {
+    await writeFile(join(dir, "credentials.json"), JSON.stringify({ twitch: { authToken: "super-secret" } }));
+    const serialized = JSON.stringify(describeCredentialHealth(dir, { SA_KICK_SESSION_TOKEN: "another-secret" }));
+    expect(serialized).not.toContain("super-secret");
+    expect(serialized).not.toContain("another-secret");
   });
 });
 

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CredentialAvailability } from "@lurkloot/core/controller";
+import type { ChannelCandidate, ChannelCheck, DropCampaign, EngineSettings, Platform, PlatformAuthHealth, SchedulerState } from "@lurkloot/shared/models";
+import type { PlatformAdapter, PreparedWatchTab } from "@lurkloot/core/adapter";
+import type { EventEmitter } from "@lurkloot/shared/events";
+import { createTransport } from "../src/transport";
+import type { TransportHandle } from "../src/transport";
+import { DEFAULT_CLI_SETTINGS } from "../src/settings";
+import { runLoop } from "../src/runtime/run";
+import { createLogger } from "../src/logger";
+
+// A benign adapter whose only interesting behaviour is checkAuthHealth. Every
+// data method returns an empty result so an unhealthy (suspended) tick never
+// throws while we assert on the persisted auth health.
+function fakeAdapter(platform: Platform, health: PlatformAuthHealth): PlatformAdapter {
+  return {
+    platform,
+    checkAuthHealth: async () => health,
+    discoverCampaigns: async () => [],
+    readProgress: async (campaigns: DropCampaign[]) => campaigns,
+    listCandidateChannels: async () => [],
+    checkChannel: async (candidate: ChannelCandidate): Promise<ChannelCheck> => ({ live: false, categoryMatches: false, candidate }),
+    claimReward: async () => false,
+    prepareWatchTab: async (): Promise<PreparedWatchTab> => ({ tabId: 0, managedByExtension: false }),
+    stopWatchTab: async () => {},
+  };
+}
+
+// Reuses a real HTTP transport purely for its resolved compatibility (a
+// synchronous construction, no network), then swaps in fake adapters so ticks
+// stay deterministic and offline.
+async function fakeTransport(health: Record<Platform, PlatformAuthHealth>): Promise<TransportHandle> {
+  const real = await createTransport("http", {}, "/tmp/lurkloot-run-compat", { twitch: true, kick: true });
+  const build = (_emit: EventEmitter, settings: EngineSettings) => {
+    const { compatibility, warnings } = real.createAdapters(() => {}, settings);
+    return {
+      adapters: {
+        twitch: fakeAdapter("twitch", health.twitch),
+        kick: fakeAdapter("kick", health.kick),
+      } as Record<Platform, PlatformAdapter>,
+      compatibility,
+      warnings,
+    };
+  };
+  const initial = build(() => {}, DEFAULT_CLI_SETTINGS as unknown as EngineSettings);
+  return { adapters: initial.adapters, createAdapters: build, dispose: async () => { await real.dispose(); } };
+}
+
+const HEALTHY: PlatformAuthHealth = { status: "healthy", message: { key: "authHealthy" } };
+
+async function readAuthHealth(statePath: string): Promise<SchedulerState["authHealth"]> {
+  const state = JSON.parse(await readFile(statePath, "utf8")) as SchedulerState;
+  return state.authHealth;
+}
+
+let dir: string;
+beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), "lurkloot-run-")); });
+afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+async function runOnce(health: Record<Platform, PlatformAuthHealth>, availability: (platform: Platform) => CredentialAvailability): Promise<string> {
+  const statePath = join(dir, "state.json");
+  await runLoop({
+    settings: DEFAULT_CLI_SETTINGS,
+    statePath,
+    transport: await fakeTransport(health),
+    logger: createLogger("error"),
+    once: true,
+    checkCredentialAvailability: async (platform) => availability(platform),
+  });
+  return statePath;
+}
+
+describe("runLoop authentication health reporting", () => {
+  it("records missing credentials without invoking the live probe", async () => {
+    // If the probe ran it would report the adapter's healthy status; the missing
+    // gate must win, proving credential availability precedes the probe.
+    const statePath = await runOnce(
+      { twitch: HEALTHY, kick: HEALTHY },
+      (platform) => (platform === "twitch" ? { status: "missing" } : { status: "available" }),
+    );
+    const authHealth = await readAuthHealth(statePath);
+    expect(authHealth.twitch).toMatchObject({ status: "missing_credentials", reasonCode: "credentials_missing" });
+    expect(authHealth.kick.status).toBe("healthy");
+  });
+
+  it("reports rejected credentials from the live probe when a credential is available", async () => {
+    const rejected: PlatformAuthHealth = { status: "invalid_credentials", reasonCode: "credentials_rejected", message: { key: "authInvalidCredentials" } };
+    const statePath = await runOnce({ twitch: rejected, kick: HEALTHY }, () => ({ status: "available" }));
+    const authHealth = await readAuthHealth(statePath);
+    expect(authHealth.twitch).toMatchObject({ status: "invalid_credentials", reasonCode: "credentials_rejected" });
+  });
+
+  it("reports a transient probe failure as unavailable", async () => {
+    const transient: PlatformAuthHealth = { status: "unavailable", reasonCode: "network_unavailable", message: { key: "authNetworkUnavailable" } };
+    const statePath = await runOnce({ twitch: HEALTHY, kick: transient }, () => ({ status: "available" }));
+    const authHealth = await readAuthHealth(statePath);
+    expect(authHealth.kick).toMatchObject({ status: "unavailable", reasonCode: "network_unavailable" });
+  });
+
+  it("surfaces an unavailable credential lookup ahead of the probe", async () => {
+    const statePath = await runOnce(
+      { twitch: HEALTHY, kick: HEALTHY },
+      (platform) => (platform === "kick" ? { status: "unavailable" } : { status: "available" }),
+    );
+    const authHealth = await readAuthHealth(statePath);
+    expect(authHealth.kick).toMatchObject({ status: "unavailable", reasonCode: "credential_lookup_failed" });
+  });
+});


### PR DESCRIPTION
## Summary

Adopts the shared safe authentication-health vocabulary in the CLI (status + runtime reporting) while keeping CLI credential storage and transports independent of browser cookie observation. Follow-up to #199; conceptually depends on the shared auth-health contract (#200) but does not block the extension tracker.

Closes #206.

## Changes

- **`authStore.ts`** — `describeCredentialHealth(authDir, env)` gives a network-free, cookie-free reading of each platform's credential state in the shared vocabulary: absent → `missing_credentials`/`credentials_missing`, unreadable store → transient `unavailable`/`credential_lookup_failed`, present → `checking` (pending a live probe). It reports `source` (`environment` | `stored` | `none`) so env vs stored credentials stay distinguishable internally without ever exposing a value. `readStoreDetailed` separates a missing store (normal) from a corrupt one (lookup failure). `credentialAvailabilityOf` maps this to the engine's pre-probe gate.
- **`runtime/run.ts`** — new `checkCredentialAvailability` option forwarded to the shared controller, so `missing_credentials` surfaces ahead of rejected/blocked/transient probe results.
- **`index.ts`** — `run` wires the availability callback (re-read each tick, so a mid-run login is noticed); `auth status` reports `source` + `status` + `reasonCode` alongside the existing presence booleans, no values.
- **`events.ts`** — `auth_health_changed` log now includes the reason code.

## Acceptance criteria

- [x] Distinguishes missing / invalid / blocked / transient
- [x] Login/status output uses shared safe reason codes
- [x] Env vs stored distinguishable internally, no values printed
- [x] No credential values or authenticated response bodies logged
- [x] Behavior independent of browser cookie observation (file/env store only)
- [x] Tests cover stored credentials, environment overrides, rejected credentials, and transient failures

## Testing

- `pnpm --filter @lurkloot/cli test` → 117 passed
- `pnpm -r typecheck` → clean across all packages