### PR TITLE
docs(site): add 1.9.0 changelog

### DIFF
--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -1,5 +1,31 @@
 [
   {
+    "version": "1.9.0",
+    "changes": [
+      {
+        "kind": "new",
+        "text": "Lurkloot now tracks your Twitch and Kick sign-in status, shows each platform's authentication health in the popup, and automatically pauses farming when you are signed out or blocked so it can resume cleanly once access is restored."
+      },
+      {
+        "kind": "new",
+        "text": "Added Turkish language support."
+      },
+      {
+        "kind": "new",
+        "text": "Added a factory reset action in Settings to restore all preferences to their defaults."
+      },
+      {
+        "kind": "improved",
+        "text": "Settings changes now apply immediately without pausing automation."
+      },
+      {
+        "kind": "fixed",
+        "text": "Stabilized Kick page-context tabs so they no longer get stuck in a bad state during farming."
+      }
+    ],
+    "date": "2026-07-23"
+  },
+  {
     "version": "1.8.1",
     "changes": [
       {


### PR DESCRIPTION
## Summary

Adds the changelog entry for version 1.9.0 to the marketing site, covering user-facing changes merged into `develop` since 1.8.1.

Highlights:
- **new** — Platform authentication health: Lurkloot tracks Twitch/Kick sign-in status, surfaces it in the popup, and suspends farming when access is unhealthy (#209, #211–#216, #220).
- **new** — Turkish language support (#198, #219).
- **new** — Factory reset action in Settings (#210).
- **improved** — Settings apply without pausing automation (#194).
- **fixed** — Stabilized Kick page-context tab lifecycle (#195).

## Testing
- Validated `changelog.json` parses as JSON.

## Notes
This only adds changelog copy; it does not bump the package version (that happens through the release flow).