### PR TITLE
fix(twitch): retain campaigns when discovery requests fail

### DIFF
--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -21,6 +21,10 @@ const CURRENT_USER_QUERY = "query CurrentUser { currentUser { id } }";
 // behind Client-Integrity (Kasada); non-web client ids (Android/TV) are not.
 const TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 const CHANNEL_CAMPAIGN_CACHE_TTL_MS = 60_000;
+// How long a discovery result stays usable when Twitch stops answering. Long
+// enough to ride out an outage of many ticks, short enough that a campaign
+// Twitch quietly stopped serving does not linger for a whole session.
+const DISCOVERY_RETENTION_TTL_MS = 30 * 60_000;
 
 export interface TwitchAdapterOptions {
   // GQL Client-ID. Defaults to the web client. A headless runtime passes a
@@ -273,6 +277,16 @@ interface CachedAvailableCampaigns {
   expiresAt: number;
 }
 
+interface CachedCampaignDetails {
+  campaign: unknown;
+  expiresAt: number;
+}
+
+interface CachedDashboardCampaigns {
+  campaignIds: string[];
+  expiresAt: number;
+}
+
 export type TwitchGqlTransport = <T>(
   operationName: string,
   sha256Hash: string,
@@ -426,6 +440,10 @@ export class TwitchAdapter implements PlatformAdapter {
   private readonly gqlTransport: TwitchGqlTransport;
   private readonly inventoryCapability: TwitchInventoryCapability;
   private readonly availableCampaignsByChannel = new Map<string, CachedAvailableCampaigns>();
+  // The adapter instance outlives a tick, so these carry the last discovery
+  // Twitch actually answered across the next few ticks' transient failures.
+  private readonly campaignDetailsByDropId = new Map<string, CachedCampaignDetails>();
+  private retainedDashboard?: CachedDashboardCampaigns;
 
   constructor(
     // Twitch GQL is unreachable from the twitch.tv page context (CORS / anti-
@@ -456,24 +474,17 @@ export class TwitchAdapter implements PlatformAdapter {
 
   async discoverCampaigns(): Promise<DropCampaign[]> {
     let inventory = await this.fetchInventory();
-    let dashboard = await this.optionalGql<TwitchDashboardData>(
-      TWITCH_QUERIES.dashboard.operationName,
-      TWITCH_QUERIES.dashboard.sha256Hash,
-      TWITCH_QUERIES.dashboard.variables,
-    );
+    let dashboardResult = await this.fetchDashboard(TWITCH_QUERIES.dashboard.variables);
     let inventoryCampaigns = this.inventoryCapability.parse(inventory);
-    let dashboardCampaigns = twitchDashboardCampaigns(dashboard);
+    let dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
 
     if (inventoryCampaigns.length === 0 && dashboardCampaigns.length === 0) {
       inventory = await this.fetchInventory({ fetchRewardCampaigns: true });
-      dashboard = await this.optionalGql<TwitchDashboardData>(
-        TWITCH_QUERIES.dashboard.operationName,
-        TWITCH_QUERIES.dashboard.sha256Hash,
-        { fetchRewardCampaigns: true },
-      );
+      dashboardResult = await this.fetchDashboard({ fetchRewardCampaigns: true });
       inventoryCampaigns = this.inventoryCapability.parse(inventory);
-      dashboardCampaigns = twitchDashboardCampaigns(dashboard);
+      dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
     }
+    const dashboard = dashboardResult.response;
 
     if (!twitchHasCurrentUser(inventory) && !dashboard.data?.currentUser) {
       throw new SafeFetchError({
@@ -483,12 +494,21 @@ export class TwitchAdapter implements PlatformAdapter {
     }
 
     const userLogin = twitchCurrentUserId(inventory) ?? dashboard.data?.currentUser?.id ?? dashboard.data?.currentUser?.login ?? "";
-    const discoverableCampaignIds = dashboardCampaigns
+    const freshCampaignIds = dashboardCampaigns
       .filter((campaign) =>
         campaign.id
         && (campaign.status === "ACTIVE" || campaign.status === "UPCOMING")
       )
       .map((campaign) => campaign.id as string);
+
+    // A failed dashboard parses to the same empty list as a dashboard with no
+    // active drops, and the Inventory payload only carries campaigns the user
+    // already started — so falling back to it hides every campaign they have
+    // not. Reuse the last dashboard we did get instead. `dashboardResponded`
+    // stays false so the expiry stamping below never fires off a stale list.
+    if (dashboardResult.ok) this.rememberDashboardCampaignIds(freshCampaignIds);
+    const discoverableCampaignIds = dashboardResult.ok ? freshCampaignIds : this.retainedDashboardCampaignIds();
+    const dashboardResponded = dashboardResult.ok && dashboardCampaigns.length > 0;
 
     if (discoverableCampaignIds.length === 0) {
       return inventoryCampaigns;
@@ -505,9 +525,29 @@ export class TwitchAdapter implements PlatformAdapter {
     for (const result of details) {
       if (result.status === "rejected" && authHealthFromError(result.reason)) throw result.reason;
     }
-    const detailedCampaigns = details
-      .map((result) => result.status === "fulfilled" ? result.value.data?.dropCampaign ?? result.value.data?.user?.dropCampaign : undefined)
-      .filter((campaign): campaign is NonNullable<typeof campaign> => Boolean(campaign));
+    // A campaign the user has not started is only ever described by its detail
+    // request, so dropping a rejection loses the campaign entirely. Serve the
+    // last details we saw for it instead, and never lose the failure silently.
+    const detailedCampaigns: unknown[] = [];
+    details.forEach((result, index) => {
+      const dropID = discoverableCampaignIds[index];
+      if (result.status === "fulfilled") {
+        const campaign = result.value.data?.dropCampaign ?? result.value.data?.user?.dropCampaign;
+        if (!campaign) return;
+        this.rememberCampaignDetails(dropID, campaign);
+        detailedCampaigns.push(campaign);
+        return;
+      }
+      const retained = this.retainedCampaignDetails(dropID);
+      const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      diagnostic(
+        this.emit,
+        "warn",
+        `Twitch campaign details for ${dropID} failed; ${retained ? "reusing the last known details" : "leaving the campaign out of this refresh"}: ${message}`,
+        "twitch",
+      );
+      if (retained) detailedCampaigns.push(retained);
+    });
     if (detailedCampaigns.length === 0) {
       return inventoryCampaigns;
     }
@@ -521,7 +561,6 @@ export class TwitchAdapter implements PlatformAdapter {
     // inventory-only campaign as expired (unless it still has a claimable reward
     // we should keep surfacing so the user can claim it).
     const activeDashboardIds = new Set(discoverableCampaignIds);
-    const dashboardResponded = dashboardCampaigns.length > 0;
     const inventoryOnly = inventoryCampaigns
       .filter((campaign) => !detailedIds.has(campaign.id))
       .map((campaign) =>
@@ -699,17 +738,51 @@ export class TwitchAdapter implements PlatformAdapter {
     }
   }
 
-  private async optionalGql<T>(
-    operationName: string,
-    sha256Hash: string,
+  // Non-auth failures are tolerated, but reported: discovery has to tell
+  // "Twitch says there are no campaigns" from "Twitch did not answer".
+  private async fetchDashboard(
     variables: Record<string, unknown>,
-  ): Promise<TwitchGqlResponse<T>> {
+  ): Promise<{ response: TwitchGqlResponse<TwitchDashboardData>; ok: boolean }> {
     try {
-      return await this.gql(operationName, sha256Hash, variables);
+      const response = await this.gql<TwitchDashboardData>(
+        TWITCH_QUERIES.dashboard.operationName,
+        TWITCH_QUERIES.dashboard.sha256Hash,
+        variables,
+      );
+      return { response, ok: true };
     } catch (error) {
       if (authHealthFromError(error)) throw error;
-      return {};
+      const message = error instanceof Error ? error.message : String(error);
+      diagnostic(this.emit, "warn", `Twitch drops dashboard request failed; reusing the last campaign list it returned: ${message}`, "twitch");
+      return { response: {}, ok: false };
     }
+  }
+
+  private rememberDashboardCampaignIds(campaignIds: string[]): void {
+    this.retainedDashboard = { campaignIds, expiresAt: Date.now() + DISCOVERY_RETENTION_TTL_MS };
+  }
+
+  private retainedDashboardCampaignIds(): string[] {
+    if (!this.retainedDashboard) return [];
+    if (this.retainedDashboard.expiresAt <= Date.now()) {
+      this.retainedDashboard = undefined;
+      return [];
+    }
+    return this.retainedDashboard.campaignIds;
+  }
+
+  private rememberCampaignDetails(dropID: string, campaign: unknown): void {
+    this.campaignDetailsByDropId.set(dropID, { campaign, expiresAt: Date.now() + DISCOVERY_RETENTION_TTL_MS });
+  }
+
+  private retainedCampaignDetails(dropID: string): unknown {
+    const cached = this.campaignDetailsByDropId.get(dropID);
+    if (!cached) return undefined;
+    if (cached.expiresAt <= Date.now()) {
+      this.campaignDetailsByDropId.delete(dropID);
+      return undefined;
+    }
+    return cached.campaign;
   }
 
   // A "claimable" reward can only be claimed once Twitch has released its real

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -26,6 +26,58 @@ function requestBody(init?: RequestInit): Record<string, unknown> {
   return JSON.parse(String(init?.body)) as Record<string, unknown>;
 }
 
+function twitchInventory(campaignIds: string[]): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: "user-id",
+        inventory: {
+          dropCampaignsInProgress: campaignIds.map((id) => ({
+            id,
+            name: "Inventory Campaign",
+            game: { id: "game", slug: "game-slug", displayName: "Game" },
+            timeBasedDrops: [{
+              id: `${id}-drop`,
+              requiredMinutesWatched: 60,
+              self: { currentMinutesWatched: 20, isClaimed: false },
+              benefitEdges: [{ benefit: { id: "benefit", name: "Reward" } }],
+            }],
+          })),
+        },
+      },
+    },
+  };
+}
+
+function twitchDashboard(campaignIds: string[]): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: "user-id",
+        login: "viewer",
+        dropCampaigns: campaignIds.map((id) => ({ id, status: "ACTIVE", self: { isAccountConnected: true } })),
+      },
+    },
+  };
+}
+
+function twitchCampaignDetails(dropID: string): unknown {
+  return {
+    data: {
+      dropCampaign: {
+        id: dropID,
+        name: `Campaign ${dropID}`,
+        game: { id: "game", slug: "game-slug", displayName: "Game" },
+        timeBasedDrops: [{
+          id: `${dropID}-drop`,
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit: { id: "benefit", name: "Reward" } }],
+        }],
+      },
+    },
+  };
+}
+
 describe("KickAdapter", () => {
   it("does not swallow authentication failures while reading progress", async () => {
     const failure = new SafeFetchError({ kind: "authentication_rejected", status: 401 });
@@ -1058,6 +1110,114 @@ describe("TwitchAdapter", () => {
     const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
 
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Inventory Campaign", eligibility: "eligible" });
+  });
+
+  it("keeps a campaign whose details request fails once it has been seen successfully", async () => {
+    let failing: string | undefined;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([]);
+      if (op === "ViewerDropsDashboard") return twitchDashboard(["a", "b"]);
+      if (op === "DropCampaignDetails") {
+        const dropID = String((requestBody(init).variables as Record<string, unknown>).dropID);
+        if (dropID === failing) throw new Error("service unavailable");
+        return twitchCampaignDetails(dropID);
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const events: EngineEvent[] = [];
+    const adapter = new TwitchAdapter(fetcher, undefined, undefined, undefined, (event) => events.push(event));
+
+    expect((await adapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
+    failing = "b";
+    const campaigns = await adapter.discoverCampaigns();
+
+    expect(campaigns.map((campaign) => campaign.id)).toEqual(["a", "b"]);
+    expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("b"))).toBe(true);
+  });
+
+  it("omits a campaign whose details request fails before it was ever seen, but records it", async () => {
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([]);
+      if (op === "ViewerDropsDashboard") return twitchDashboard(["a", "b"]);
+      if (op === "DropCampaignDetails") {
+        const dropID = String((requestBody(init).variables as Record<string, unknown>).dropID);
+        if (dropID === "b") throw new Error("service unavailable");
+        return twitchCampaignDetails(dropID);
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const events: EngineEvent[] = [];
+    const adapter = new TwitchAdapter(fetcher, undefined, undefined, undefined, (event) => events.push(event));
+
+    const campaigns = await adapter.discoverCampaigns();
+
+    expect(campaigns.map((campaign) => campaign.id)).toEqual(["a"]);
+    expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("b"))).toBe(true);
+  });
+
+  it("still propagates auth failures from a campaign details request", async () => {
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([]);
+      if (op === "ViewerDropsDashboard") return twitchDashboard(["a"]);
+      if (op === "DropCampaignDetails") {
+        throw new SafeFetchError({ kind: "authentication_rejected", status: 401, reason: "rejected" });
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    await expect(new TwitchAdapter(fetcher).discoverCampaigns()).rejects.toThrow(SafeFetchError);
+  });
+
+  it("keeps not-yet-started campaigns when the dashboard request fails after a successful one", async () => {
+    let dashboardFails = false;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([]);
+      if (op === "ViewerDropsDashboard") {
+        if (dashboardFails) throw new Error("service unavailable");
+        return twitchDashboard(["a"]);
+      }
+      if (op === "DropCampaignDetails") {
+        return twitchCampaignDetails(String((requestBody(init).variables as Record<string, unknown>).dropID));
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const events: EngineEvent[] = [];
+    const adapter = new TwitchAdapter(fetcher, undefined, undefined, undefined, (event) => events.push(event));
+
+    expect((await adapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+    dashboardFails = true;
+    const campaigns = await adapter.discoverCampaigns();
+
+    expect(campaigns.map((campaign) => campaign.id)).toEqual(["a"]);
+    expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("dashboard"))).toBe(true);
+
+    dashboardFails = false;
+    expect((await adapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+  });
+
+  it("does not retain dashboard campaigns when the dashboard genuinely returns none", async () => {
+    let dashboardIds = ["campaign"];
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory(["campaign"]);
+      if (op === "ViewerDropsDashboard") return twitchDashboard(dashboardIds);
+      if (op === "DropCampaignDetails") {
+        return twitchCampaignDetails(String((requestBody(init).variables as Record<string, unknown>).dropID));
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const adapter = new TwitchAdapter(fetcher);
+
+    expect((await adapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["campaign"]);
+    dashboardIds = [];
+    const campaigns = await adapter.discoverCampaigns();
+
+    expect(campaigns).toHaveLength(1);
+    expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Inventory Campaign", status: "active" });
   });
 
   it("marks in-progress inventory campaigns the dashboard no longer lists active as expired", async () => {


### PR DESCRIPTION
## Summary

Transient Twitch discovery failures silently deleted campaigns from the popup. Two independent paths caused it, both fixed here.

**#228 — a failed `DropCampaignDetails` dropped that campaign.** The per-campaign fan-out used `Promise.allSettled` and discarded every non-auth rejection. A campaign the user has not started is only ever described by its detail request (it is absent from the Inventory payload), so one transient failure removed it entirely, with nothing logged. The adapter now keeps a TTL'd per-`dropID` cache of the last successful details and serves it when a refresh rejects, emitting a `warn` naming the campaign.

**#229 — a failed dashboard query hid every not-yet-started campaign.** `optionalGql` swallowed non-auth failures and returned `{}`, so `dashboardCampaigns` was `[]` and discovery early-returned inventory-only campaigns. `optionalGql` is replaced by `fetchDashboard`, which returns `{ response, ok }` so discovery can finally distinguish *"Twitch says there are no campaigns"* from *"Twitch did not answer"* — the old empty array collapsed both. On failure the last successful campaign-id list is reused.

Critically, `dashboardResponded` is now `ok && dashboardCampaigns.length > 0`, so a retained id list can never drive the `expired` stamping of inventory-only campaigns. A genuinely empty dashboard behaves exactly as before.

Users saw this as farmable campaigns intermittently missing, "fixed" by toggling a Visible campaigns filter — which only worked because that setting saves with `tickAfterSave: true` and forces a re-discovery. The popup filter was never at fault.

## Testing

TDD: both reproductions failed first against `develop` (`['a']` instead of `['a','b']`; `[]` instead of `['a']`). Five new tests in `adapters.test.ts` cover warm-cache detail failure, cold-cache detail failure (still omitted, but logged), auth failures still propagating, dashboard failure + recovery, and a genuinely empty dashboard producing no false retention and no `expired` stamp.

`pnpm test` — 45 files / 802 tests passed. `pnpm typecheck` — all 7 packages clean. Independently re-run on review: adapters + coreBoundary 105 passed.

## Review notes

- The 30-minute retention TTL is a judgement call; neither issue specified one. It bounds how long a campaign Twitch quietly stopped serving can linger.
- A sustained outage now emits one `warn` per failed campaign per tick — gated behind `diagnosticLogging`, but it is a change in log volume.
- If the first dashboard call fails and the `fetchRewardCampaigns: true` retry succeeds with genuinely zero campaigns, the retained list is overwritten with `[]`. Intended: a real empty answer should win over a stale one. Subtlest interaction in the change.

Closes #228
Closes #229

Related to #109, which covers transient inventory/progress failures rather than discovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch campaign discovery resilience during temporary dashboard or campaign-detail failures.
  * Previously discovered campaigns can remain available when refresh requests fail.
  * Campaigns are no longer retained when Twitch confirms the dashboard is genuinely empty.
  * Authentication errors continue to be surfaced instead of being silently filtered.
  * Added expiry handling so retained discovery results are eventually removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->