### PR TITLE
fix(scheduler): keep discovered campaigns when discovery fails

### DIFF
--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -557,22 +557,31 @@ export async function runSchedulerTick(
       }
 
       let campaigns: DropCampaign[];
+      let discoveryFailed = false;
       try {
         const discovered = await adapter.discoverCampaigns();
         campaigns = await adapter.readProgress(discovered, previous);
       } catch (error) {
         if (authHealthFromError(error)) throw error;
         if (!hasIdleWatchlistChannels(settings, platform)) throw error;
+        // Nothing is farmable this tick, so the decision logic below runs
+        // against an empty list and the Idle Watchlist channel wins. State
+        // keeps the campaigns from the last good discovery — same retention the
+        // rethrow path gets for free — so a transient outage does not blank the
+        // popup until the next successful tick.
         campaigns = [];
+        discoveryFailed = true;
         const message = error instanceof Error ? error.message : "Drop discovery failed";
         emitDiagnostic(emit, platform, "warn", `${message}; checking Idle Watchlist fallback`);
         emitDiagnostic(emit, platform, "debug", `Drop discovery error (Idle Watchlist fallback): ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
       }
-      nextState.campaigns[platform] = campaigns;
-      if (campaignDiagnosticFingerprint(campaigns) !== campaignDiagnosticFingerprint(state.campaigns[platform])) {
-        emitDiagnostic(emit, platform, "debug", `Campaign inventory changed (${campaigns.length} discovered)`);
-        const eligibleCount = campaigns.filter((campaign) => isEligible(campaign, settings)).length;
-        emitDiagnostic(emit, platform, "debug", `${eligibleCount} of ${campaigns.length} campaigns eligible after filtering`);
+      if (!discoveryFailed) {
+        nextState.campaigns[platform] = campaigns;
+        if (campaignDiagnosticFingerprint(campaigns) !== campaignDiagnosticFingerprint(state.campaigns[platform])) {
+          emitDiagnostic(emit, platform, "debug", `Campaign inventory changed (${campaigns.length} discovered)`);
+          const eligibleCount = campaigns.filter((campaign) => isEligible(campaign, settings)).length;
+          emitDiagnostic(emit, platform, "debug", `${eligibleCount} of ${campaigns.length} campaigns eligible after filtering`);
+        }
       }
 
       const previousInfeasibleRewardIds = new Set(state.deadlineInfeasibleRewardIds?.[platform]);
@@ -619,7 +628,9 @@ export async function runSchedulerTick(
           options.waitingClaimRewardIds?.[platform] ?? new Set<string>(),
         );
         campaigns = claimResult.campaigns;
-        nextState.campaigns[platform] = campaigns;
+        if (!discoveryFailed) {
+          nextState.campaigns[platform] = campaigns;
+        }
         for (const event of claimResult.events) {
           if (event.claimed) {
             emit({

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -2063,6 +2063,60 @@ describe("scheduler tick", () => {
     expect(result.events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("checking Idle Watchlist fallback"))).toBe(true);
   });
 
+  it("keeps previously discovered campaigns when discovery fails and the Idle Watchlist takes over", async () => {
+    const known = campaign("known-drops");
+    const twitch = adapter("twitch", [], []);
+    vi.mocked(twitch.discoverCampaigns).mockRejectedValue(new Error("Twitch drops unavailable"));
+    vi.mocked(twitch.checkChannel).mockResolvedValue({
+      live: true,
+      categoryMatches: true,
+      candidate: channel("fallback"),
+    });
+
+    const result = await runSchedulerTick(
+      {
+        authHealth: HEALTHY_AUTH,
+        sessions: {
+          twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [known], kick: [] },
+      },
+      settings({ platform: { twitch: { enabled: true, idleWatchlistChannels: ["fallback"] }, kick: { enabled: false, idleWatchlistChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(result.state.campaigns.twitch).toEqual([known]);
+    expect(result.state.sessions.twitch).toMatchObject({
+      status: "watching",
+      channel: expect.objectContaining({ username: "fallback" }),
+      campaignId: undefined,
+    });
+    expect(result.events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("checking Idle Watchlist fallback"))).toBe(true);
+  });
+
+  it("keeps previously discovered campaigns when discovery fails without idle watchlist channels", async () => {
+    const known = campaign("known-drops");
+    const twitch = adapter("twitch", [], []);
+    vi.mocked(twitch.discoverCampaigns).mockRejectedValue(new Error("Twitch drops unavailable"));
+
+    const result = await runSchedulerTick(
+      {
+        authHealth: HEALTHY_AUTH,
+        sessions: {
+          twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [known], kick: [] },
+      },
+      settings({ platform: { twitch: { enabled: true, idleWatchlistChannels: [] }, kick: { enabled: false, idleWatchlistChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(result.state.campaigns.twitch).toEqual([known]);
+    expect(result.state.sessions.twitch.status).toBe("error");
+  });
+
   it("backs off failed platforms until their retry time", async () => {
     const twitch = adapter("twitch", [campaign("drops")], [channel("allowed")]);
     const retryAfter = new Date(Date.now() + 10 * 60 * 1000).toISOString();


### PR DESCRIPTION
## Summary

Enabling the Idle Watchlist silently cost you campaign retention on a failed tick.

When discovery threw, `runSchedulerTick` behaved in two different ways: without idle-watchlist channels the error rethrew, `nextState.campaigns[platform]` was never assigned, and the previous campaigns were correctly retained; *with* idle-watchlist channels the catch set `campaigns = []`, which was then written to state, wiping the whole campaign list for that platform. It self-healed on the next successful tick, which reads to a user as flaky caching.

A `discoveryFailed` flag now gates the state write. `campaigns = []` still flows into the decision logic, so `chooseCampaignDecision` / `shouldKeepWatching` / `claimReadyRewards` see exactly what they saw before and the Idle Watchlist channel still wins — only the *persisted* list is retained.

Two details worth noting in review:

- The **second** `nextState.campaigns[platform] = ...` inside the `autoClaim` block is guarded too; without that it would have re-wiped state with the empty list.
- The "Campaign inventory changed (N discovered)" diagnostic moved inside the guard, since with state retained it would have falsely reported "0 discovered" for a change that never happened.

Both existing catch diagnostics are unchanged. Affects Twitch and Kick equally.

## Testing

TDD: the new tests failed first (`expected [] to equal [ known-drops ]`). Two cases in `scheduler.test.ts` — discovery throws *with* idle-watchlist channels (campaigns retained, fallback channel still watched with `campaignId: undefined`, fallback warn still emitted), and *without* them (retention plus `status: "error"`, locking in today's behaviour).

`pnpm test` — 45 files / 799 tests passed. `pnpm typecheck` — all 7 packages clean. Independently re-run on review: scheduler 95 passed.

## Out of scope

- No staleness marker on retained campaigns — the popup shows the last-good list with no indication it is stale. That needs a `SchedulerState`/popup contract decision and overlaps with #109.
- `deadlineInfeasibleRewardIds[platform]` still resets to `[]` on a failed tick, so an insufficient-time diagnostic can re-fire once after an outage clears. Pre-existing behaviour, unchanged.

Closes #230
