### PR TITLE
fix(kick): keep ended campaigns so visibility filters apply

### DIFF
--- a/packages/core/src/platforms/kick/parser.ts
+++ b/packages/core/src/platforms/kick/parser.ts
@@ -118,6 +118,10 @@ interface KickProgressReward {
   claim_id?: string;
 }
 
+// Ended (expired/completed) campaigns are kept, as on Twitch: the popup's
+// "Visible campaigns" toggles own that decision, and dropping them here made
+// the `finished` and `expired` filters dead on Kick. Farming is unaffected —
+// the scheduler's eligibility check only ever picks active, unended campaigns.
 export function parseKickCampaigns(input: KickCampaignResponse | KickCampaign[]): DropCampaign[] {
   const campaigns = collectKickCampaigns(input);
 
@@ -158,7 +162,7 @@ export function parseKickCampaigns(input: KickCampaignResponse | KickCampaign[])
       isGeneralDrop: !allowedChannels?.length,
       rewards: rewards.map(parseKickReward),
     };
-  }).filter((campaign) => campaign.status !== "expired" && campaign.status !== "completed");
+  });
 }
 
 // Kick's drops API returns reward images as relative paths

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -32,6 +32,18 @@ describe("Kick parsers", () => {
     expect(merged[0].rewards[0].isWatchBased).toBe(true);
   });
 
+  it("keeps a fully claimed Kick campaign so the finished filter can decide", () => {
+    const campaigns = parseKickCampaigns({
+      data: [{
+        id: "completed",
+        status: "active",
+        rewards: [{ id: "reward", required_units: 30, claimed: true }],
+      }],
+    });
+
+    expect(campaigns.map((campaign) => [campaign.id, campaign.status])).toEqual([["completed", "completed"]]);
+  });
+
   it("resolves relative reward image paths to absolute ext.kick.com URLs", () => {
     const campaigns = parseKickCampaigns({
       data: [{
@@ -197,7 +209,7 @@ describe("Kick parsers", () => {
     expect(merged[1].status).toBe("upcoming");
   });
 
-  it("filters ended Kick campaigns from discovery", () => {
+  it("classifies ended Kick campaigns without dropping them from discovery", () => {
     const campaigns = parseKickCampaigns({
       data: {
         campaigns: [{
@@ -222,7 +234,12 @@ describe("Kick parsers", () => {
       },
     });
 
-    expect(campaigns.map((campaign) => campaign.id)).toEqual(["active-campaign"]);
+    expect(campaigns.map((campaign) => [campaign.id, campaign.status])).toEqual([
+      ["active-campaign", "active"],
+      ["ended-status", "expired"],
+      ["past-end", "expired"],
+      ["finished-status", "expired"],
+    ]);
   });
 
   it("treats whole-number Kick progress values as percentages", () => {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -364,6 +364,28 @@ describe("scheduler campaign selection", () => {
     expect(kick.action).toBe("watch");
   });
 
+  // The Kick parser keeps ended campaigns so the popup visibility filters can
+  // show them; farming must still ignore them.
+  it("never selects an expired or completed Kick campaign for farming", async () => {
+    const listCandidateChannels = vi.fn(async () => [channel("creator", { platform: "kick", url: "https://kick.com/creator" })]);
+
+    const decision = await chooseCampaignDecision(
+      "kick",
+      [
+        campaign("expired", { platform: "kick", status: "expired", endsAt: "2000-01-01T00:00:00.000Z" }),
+        campaign("completed", { platform: "kick", status: "completed", rewards: [reward("claimed")] }),
+      ],
+      settings(),
+      {
+        listCandidateChannels,
+        checkChannel: vi.fn(async (candidate) => ({ live: true, categoryMatches: true, candidate })),
+      },
+    );
+
+    expect(decision.action).toBe("idle");
+    expect(listCandidateChannels).not.toHaveBeenCalled();
+  });
+
   it("keeps upcoming campaigns visible but does not select them for farming", async () => {
     const listCandidateChannels = vi.fn(async () => [channel("creator")]);
 

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -273,6 +273,42 @@ describe("subscription drop popup views", () => {
     }, settings, excludedIds)).toBe(true);
   });
 
+  // Kick used to drop ended campaigns at parse time, which made these two
+  // toggles dead on that platform; they must behave exactly as on Twitch.
+  it("applies the finished filter to a completed Kick campaign", () => {
+    const source: DropCampaign = {
+      ...campaign("kick-completed", [reward({ status: "claimed" })]),
+      platform: "kick",
+      status: "completed",
+    };
+    const excludedIds = new Set<string>();
+    const settings = mergeSettings(undefined);
+
+    expect(campaignFilterCategories(source, excludedIds)).toEqual(["finished"]);
+    expect(settings.campaignVisibility.finished).toBe(true);
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(true);
+
+    settings.campaignVisibility.finished = false;
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(false);
+  });
+
+  it("applies the expired filter to an expired Kick campaign", () => {
+    const source: DropCampaign = {
+      ...campaign("kick-expired", [reward({ requiredMinutes: 30 })]),
+      platform: "kick",
+      status: "expired",
+    };
+    const excludedIds = new Set<string>();
+    const settings = mergeSettings(undefined);
+
+    expect(campaignFilterCategories(source, excludedIds)).toEqual(["expired"]);
+    expect(settings.campaignVisibility.expired).toBe(false);
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(false);
+
+    settings.campaignVisibility.expired = true;
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(true);
+  });
+
   it("exposes the subscription campaign filter", () => {
     expect(CAMPAIGN_FILTERS).toContainEqual({ key: "subscription", label: "subscriptionCampaigns" });
   });


### PR DESCRIPTION
## Summary

`parseKickCampaigns` discarded expired and completed campaigns at parse time, so they never reached `state.campaigns.kick` and the popup could never render them. That made two "Visible campaigns" toggles dead on Kick — `finished` (default on: a completed campaign vanished instead of showing as finished) and `expired` (opting in showed nothing) — and left Kick and Twitch disagreeing about what the same setting means.

The fix is the one-line filter removal plus a why-comment. Visibility is the popup's decision via `isCampaignVisible`, exactly as on Twitch; farming stays guarded by scheduler eligibility.

## Verified downstream, nothing else needed changing

- **`isEligible`** rejects `status !== "active"` *and* `hasCampaignEnded`, independently of the parser. Locked in with a scheduler test asserting `decision.action === "idle"` and that `listCandidateChannels` is never called.
- **CLI** — `campaignCanWaitForSubscription` already guards non-active and past-`endsAt`, so `subscriptionWaitKeys` is unaffected.
- **`mergeKickProgress`** / **`KickClaimV2.reconcileProgress`** are per-campaign maps with no status assumptions. `mergeKickProgress` already re-derives `completed` when all rewards are claimed, so a campaign finishing mid-session now transitions to `completed` and stays in the list instead of disappearing at the next discovery.
- **Popup drops view** already renders ended lifecycle states (`expiredPill`, the completed counter), so ended Kick cards render like ended Twitch cards.

## Testing

TDD, and the first run was itself the diagnosis: the new visibility and scheduler tests **passed unchanged against the old code**, proving `isCampaignVisible` and `isEligible` were always correct and the defect was purely the parser destroying the data before anything could decide. Only the parser test failed.

`pnpm test` — extension 45 files / 801 tests, cli 117, site 3, zero failures. `pnpm typecheck` — all 7 packages clean. Independently re-run on review: parsers + scheduler + dropsView 170 passed.

## Review notes

- The pre-existing test `filters ended Kick campaigns from discovery` encoded the buggy behaviour and is rewritten as `classifies ended Kick campaigns without dropping them from discovery`. That is the deliberate contract change in this PR and the thing most worth a second look.
- A Kick campaign whose raw API status is the literal string `"finished"` classifies as `expired` (`parser.ts` status mapping, untouched here), so it lands under the `expired` toggle rather than `finished`. Defensible — a campaign that *ended* is not one you *completed*, and the user-completed path derives `completed` from all-rewards-claimed — but it means those particular campaigns still will not appear by default.
- `lurkloot discover` now lists ended Kick campaigns within its 20-campaign slice, so ended ones can push live ones out of the printed list. Left as-is to match Twitch's existing behaviour; a one-line filter if you would rather it stayed live-only.

Closes #231
