### PR TITLE
fix(popup): collapse drops cards unless a campaign is farming

### DIFF
--- a/packages/extension/tests/dropsView.test.tsx
+++ b/packages/extension/tests/dropsView.test.tsx
@@ -5,7 +5,7 @@ import { parseHTML } from "linkedom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DropCampaign, WatchSession } from "@lurkloot/shared/models";
 import { I18nContext, PopupRuntimeContext } from "../../popup-ui/src/context";
-import { DropsPanel } from "../../popup-ui/src/drops";
+import { DropsPanel, initialExpandedIds } from "../../popup-ui/src/drops";
 import type { PopupAdapter } from "../../popup-ui/src/types";
 import { campaignViewFromCampaign } from "../../popup-ui/src/viewModels";
 import { createDemoPopupAdapter } from "../../popup-ui/src/demo";
@@ -82,8 +82,91 @@ function mount(url?: string) {
     );
   });
 
+  // Cards open collapsed unless a campaign is farming, so expand the card under
+  // test before asserting on its body.
+  const toggle = container.querySelector<HTMLButtonElement>("button[aria-expanded]");
+  act(() => toggle?.click());
+
   return { container, openLink };
 }
+
+function farmingSession(campaignId: string): WatchSession {
+  return {
+    platform: "kick",
+    offlineChecks: 0,
+    status: "watching",
+    campaignId,
+    channel: { platform: "kick", username: "somechannel", url: "https://kick.com/somechannel" },
+  };
+}
+
+describe("initial drops expansion", () => {
+  it("expands nothing when no campaign is farming", () => {
+    const campaigns = [
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "a" }, 0, idleSession, false),
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "b" }, 1, idleSession, false),
+    ];
+
+    expect(initialExpandedIds(campaigns)).toEqual({});
+  });
+
+  it("expands only the farming campaign, even when it is not first", () => {
+    const session = farmingSession("b");
+    const campaigns = [
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "a" }, 0, session, false),
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "b" }, 1, session, false),
+    ];
+
+    expect(campaigns[1]?.farmingChannel).toBeTruthy();
+    expect(initialExpandedIds(campaigns)).toEqual({ b: true });
+  });
+
+  it("expands no card on mount, then expands a campaign that starts farming later", () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const adapter = { openLink: vi.fn() } as unknown as PopupAdapter;
+    const container = document.getElementById("app")!;
+
+    function render(session: WatchSession) {
+      const campaign = campaignViewFromCampaign(sourceCampaign(), 0, session, false);
+      root!.render(
+        <I18nContext.Provider value={{ t: (key) => key, dir: "ltr", locale: "en" }}>
+          <PopupRuntimeContext.Provider value={{ adapter, preview: false }}>
+            <DropsPanel
+              campaigns={[campaign]}
+              gameMap={{}}
+              refreshing={false}
+              onRefreshCampaign={() => undefined}
+              onReorder={() => undefined}
+              onToggleExclude={() => undefined}
+            />
+          </PopupRuntimeContext.Provider>
+        </I18nContext.Provider>,
+      );
+    }
+
+    act(() => {
+      root = createRoot(container);
+      render(idleSession);
+    });
+
+    const expandedStates = () => Array.from(container.querySelectorAll("button[aria-expanded]")).map((toggle) => toggle.getAttribute("aria-expanded"));
+
+    expect(expandedStates()).toEqual(["false"]);
+
+    act(() => render(farmingSession("kick-campaign")));
+
+    expect(expandedStates()).toEqual(["true"]);
+  });
+});
 
 describe("claim-time account link guidance", () => {
   it("validates HTTPS again at the demo popup host boundary", () => {

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -62,6 +62,12 @@ const testT: TFunction = (key, substitutions) => {
   ), message);
 };
 
+// The drops panel only auto-expands the campaign it is currently farming, so mark
+// the view under test as farming to render its expanded body into static markup.
+function expandedView(view: CampaignView): CampaignView {
+  return { ...view, farmingChannel: { name: "test-channel" } };
+}
+
 function renderDrops(campaigns: CampaignView[], refreshing = false): string {
   return renderToStaticMarkup(createElement(
     I18nContext.Provider,
@@ -91,7 +97,7 @@ describe("subscription drop popup views", () => {
     });
 
     expect(view.rewards[0].ineligibilityReason).toBe("insufficient_time");
-    expect(renderDrops([view])).toContain("Insufficient time remaining");
+    expect(renderDrops([expandedView(view)])).toContain("Insufficient time remaining");
 
     const disabled = campaignViewFromCampaign(source, 0, idleSession, false, {
       skipUnfinishableRewards: false,
@@ -193,7 +199,7 @@ describe("subscription drop popup views", () => {
       reward({ id: "watch", name: "Watch Crown", requirement: "watch", requiredMinutes: 60, watchedMinutes: 30, status: "in_progress" }),
       reward({ id: "subscribe", name: "Subscriber Cape", requirement: "subscription", requiredSubs: 2 }),
     ]);
-    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)]);
+    const markup = renderDrops([expandedView(campaignViewFromCampaign(source, 0, idleSession, false))]);
 
     expect(markup).toContain("Subscription required");
     expect(markup).toContain("Watch Crown");
@@ -216,7 +222,7 @@ describe("subscription drop popup views", () => {
       }),
       reward({ id: "subscribe", name: "Subscriber Cape", requirement: "subscription", requiredSubs: 2 }),
     ]);
-    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)]);
+    const markup = renderDrops([expandedView(campaignViewFromCampaign(source, 0, idleSession, false))]);
 
     expect(markup).not.toContain("&lt;1m");
     expect(markup.match(/Progress unavailable/g)).toHaveLength(2);
@@ -226,7 +232,7 @@ describe("subscription drop popup views", () => {
     const source = campaign("earned-subscription", [
       reward({ id: "subscribe", name: "Earned Subscriber Badge", requirement: "subscription", requiredSubs: 1, status: "claimed" }),
     ]);
-    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)]);
+    const markup = renderDrops([expandedView(campaignViewFromCampaign(source, 0, idleSession, false))]);
 
     expect(markup).toContain("Earned");
     expect(markup).not.toContain("100%");
@@ -236,7 +242,7 @@ describe("subscription drop popup views", () => {
     const source = campaign("action-only", [
       reward({ id: "purchase", name: "Purchase Bonus", requirement: "action", isWatchBased: false }),
     ]);
-    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)]);
+    const markup = renderDrops([expandedView(campaignViewFromCampaign(source, 0, idleSession, false))]);
 
     expect(markup).toContain("Action required");
     expect(markup).toContain("Purchase Bonus");
@@ -249,7 +255,7 @@ describe("subscription drop popup views", () => {
     const source = campaign("subscription-only", [
       reward({ id: "subscribe", requirement: "subscription", requiredSubs: 1 }),
     ]);
-    const markup = renderDrops([campaignViewFromCampaign(source, 0, idleSession, false)], true);
+    const markup = renderDrops([expandedView(campaignViewFromCampaign(source, 0, idleSession, false))], true);
 
     expect(markup).toMatch(/<button[^>]*disabled=""[^>]*>.*subscribed — refresh status<\/button>/);
   });

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -37,13 +37,35 @@ import {
   useDndSensors,
 } from "./primitives";
 
+/** Cards start collapsed; only a campaign that is actively being farmed is worth
+ * opening on mount. Anything else (completed, upcoming, merely first) would bury
+ * the list under a reward grid the user did not ask for. */
+export function initialExpandedIds(campaigns: CampaignView[]): Record<string, boolean> {
+  const farmingId = farmingCampaignId(campaigns);
+  return farmingId ? { [farmingId]: true } : {};
+}
+
+function farmingCampaignId(campaigns: CampaignView[]): string | undefined {
+  return campaigns.find((campaign) => Boolean(campaign.farmingChannel))?.id;
+}
+
 export function DropsPanel({ campaigns, gameMap, focus, refreshing, onRefreshCampaign, onReorder, onToggleExclude }: { campaigns: CampaignView[]; gameMap: Record<string, GameItem>; focus?: { id: string; seq: number } | null; refreshing: boolean; onRefreshCampaign(id: string): void | Promise<void>; onReorder(campaigns: CampaignView[]): void | Promise<void>; onToggleExclude(id: string): void | Promise<void> }) {
   const t = useT();
   const sensors = useDndSensors();
   const [activeId, setActiveId] = useState<string | null>(null);
-  const firstId = campaigns[0]?.id;
-  const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>(firstId ? { [firstId]: true } : {});
+  const farmingId = farmingCampaignId(campaigns);
+  const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>(() => initialExpandedIds(campaigns));
+  const autoExpandedId = useRef<string | undefined>(farmingId);
   const listRef = useRef<HTMLDivElement>(null);
+
+  // Campaigns can arrive after mount, and the farmed campaign can change while the
+  // popup is open. Expand the new one when that happens, but never collapse anything:
+  // a card the user toggled by hand stays the way they left it.
+  useEffect(() => {
+    if (!farmingId || farmingId === autoExpandedId.current) return;
+    autoExpandedId.current = farmingId;
+    setExpandedIds((current) => ({ ...current, [farmingId]: true }));
+  }, [farmingId]);
 
   // Jump to a campaign requested from elsewhere (e.g. the "Farming {campaign}"
   // link in the hero): expand it and scroll its card into view.


### PR DESCRIPTION
## Summary

The Drops tab no longer force-expands the first campaign card. Only the campaign that is actually being farmed opens automatically; when nothing is farming, the list opens fully collapsed.

## Root cause

`packages/popup-ui/src/drops.tsx` seeded the expansion state from `campaigns[0]?.id` unconditionally, regardless of the campaign's state:

```ts
const firstId = campaigns[0]?.id;
const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>(firstId ? { [firstId]: true } : {});
```

## User impact

A user reported (with a screenshot) that their #1 campaign is already completed, so every visit to the Drops tab opened with a finished campaign's reward grid filling the panel, which they had to collapse by hand each time.

## Changes

- `packages/popup-ui/src/drops.tsx`
  - New exported pure helper `initialExpandedIds(campaigns)` returning `{ [farmingId]: true }` or `{}`.
  - Initial `useState` now uses that helper (lazy initializer).
  - New effect keyed on the farming campaign id: campaigns can arrive after mount or the farmed campaign can change while the popup is open, so the newly farmed card is expanded then. It only ever adds to `expandedIds` — it never collapses a card and never fights a manual toggle.
  - The existing `focus` effect (expand + scroll from the hero "Farming {campaign}" link) is untouched.
- `packages/extension/tests/dropsView.test.tsx` — new `initial drops expansion` suite covering the helper (nothing farming, farming campaign not first) and a rendered-panel test asserting all cards start with `aria-expanded="false"` and that a campaign which starts farming after mount becomes expanded. The pre-existing claim-guidance `mount()` helper now clicks the card toggle, since cards no longer open by default.
- `packages/extension/tests/subscriptionDropsView.test.ts` — these render static markup and relied on the first card being auto-expanded; they now go through a small `expandedView()` helper that marks the view under test as farming. No assertions were weakened.

## Testing

`pnpm check` passes locally:

```
packages/cli test:  Test Files  9 passed (9) / Tests 125 passed (125)
packages/extension test:  Test Files  46 passed (46) / Tests 852 passed (852)
packages/site test: [build] Complete!
```

Includes script tests, `pnpm -r typecheck`, the extension Vitest suite, and the Astro site build. TDD: the three new tests were written first and observed failing (`initialExpandedIds is not a function`, and `aria-expanded` being `true`) before the implementation landed.

## Screenshot

CLAUDE.md asks for a screenshot or recording on popup UI changes. I could not produce one — this was done headlessly with no browser session loaded with real campaign data. The behavior is covered by the rendered-panel test asserting `aria-expanded` instead. Worth a manual look in `pnpm dev` before merging.

Closes #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Drops panel now automatically expands the campaign currently being farmed.
  * When farming switches to another campaign, its card expands automatically while preserving manually expanded cards.

* **Bug Fixes**
  * Corrected Drops panel expansion behavior when the farming campaign is not first in the list or starts farming after the panel opens.
  * Improved the accuracy of subscription and watch-control displays in expanded campaign cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->