### PR TITLE
fix(kick): stop false ad detection stealing tab focus

### DIFF
--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -234,8 +234,16 @@ export async function stopWatchTabWithBrowser(browserApi: BrowserTabApi, session
 // bring the tab to focus for the duration of the ad and restore the user's
 // previous tab/window once every platform's ad has finished. Holds are tracked
 // per platform so two simultaneous ads don't restore focus prematurely.
-const adFocusHolds = new Set<Platform>();
+// Ad focus is re-evaluated on every playback telemetry report (several times a
+// second on a busy page), so the hold must be idempotent: we only issue browser
+// calls when the tab is not already where we want it. A hold is also capped —
+// a detector stuck reporting an ad must never pin the user's focus forever.
+const AD_FOCUS_MAX_HOLD_MS = 3 * 60 * 1000;
+const adFocusHolds = new Map<Platform, number>();
+const adFocusExpired = new Set<Platform>();
 let previousFocus: { tabId?: number; windowId?: number } | undefined;
+
+export { AD_FOCUS_MAX_HOLD_MS };
 
 export async function applyAdFocusWithBrowser(
   browserApi: BrowserTabApi,
@@ -246,6 +254,19 @@ export async function applyAdFocusWithBrowser(
   emit: EventEmitter = ignoreEvent,
 ): Promise<void> {
   if (mode === "none" || !adActive || tabId == null) {
+    adFocusExpired.delete(platform);
+    await releaseAdFocus(browserApi, platform, tabId, emit);
+    return;
+  }
+
+  // This ad episode already exhausted its cap; stay out of the user's way until
+  // the platform stops reporting an ad.
+  if (adFocusExpired.has(platform)) return;
+
+  const heldSince = adFocusHolds.get(platform);
+  if (heldSince != null && Date.now() - heldSince >= AD_FOCUS_MAX_HOLD_MS) {
+    adFocusExpired.add(platform);
+    diagnostic(emit, "warn", `Ad focus held for over ${Math.round(AD_FOCUS_MAX_HOLD_MS / 1000)}s; releasing it`, platform);
     await releaseAdFocus(browserApi, platform, tabId, emit);
     return;
   }
@@ -256,17 +277,29 @@ export async function applyAdFocusWithBrowser(
       previousFocus = { tabId: active?.id, windowId: active?.windowId };
     }
   }
-  const alreadyHeld = adFocusHolds.has(platform);
-  adFocusHolds.add(platform);
+  const alreadyHeld = heldSince != null;
+  if (!alreadyHeld) adFocusHolds.set(platform, Date.now());
 
   const tab = await browserApi.tabs.get(tabId).catch(() => undefined);
-  await browserApi.tabs.update(tabId, { active: true });
-  if (mode === "window" && tab?.windowId != null) {
+  const needsWindowFocus = mode === "window" && tab?.windowId != null && !(await isWindowFocused(browserApi, tab.windowId));
+  if (tab?.active === true && !needsWindowFocus) return;
+
+  if (tab?.active !== true) {
+    await browserApi.tabs.update(tabId, { active: true });
+  }
+  if (needsWindowFocus && tab?.windowId != null) {
     await browserApi.windows?.update(tab.windowId, { focused: true });
   }
   if (!alreadyHeld) {
     diagnostic(emit, "debug", `Focusing watch tab ${tabId} for an ad`, platform);
   }
+}
+
+// The tabs API has no "is this window focused" call, but the active tab of the
+// last focused window answers the same question without a windows.get binding.
+async function isWindowFocused(browserApi: BrowserTabApi, windowId: number): Promise<boolean> {
+  const [active] = await browserApi.tabs.query({ active: true, lastFocusedWindow: true }).catch(() => []);
+  return active?.windowId === windowId;
 }
 
 async function releaseAdFocus(browserApi: BrowserTabApi, platform: Platform, watchTabId: number | undefined, emit: EventEmitter): Promise<void> {

--- a/packages/extension/src/core/playbackContent.ts
+++ b/packages/extension/src/core/playbackContent.ts
@@ -101,9 +101,15 @@ async function controlPlaybackAndReport(platform: Platform): Promise<void> {
 }
 
 // Markers the platform leaves in the DOM while an ad is rolling. Twitch's are
-// stable data-attributes used by its own player; Kick's are best-effort
+// stable data-attributes used by its own player; Kick's are still best-effort
 // (video.js overlay classes / generic ad containers) and may need tuning. We
 // only read the DOM here — the platform is not otherwise modified.
+//
+// Every selector must be anchored: substring matching (`*=`) is not safe here
+// because "ad" occurs inside unrelated markers — `[data-testid*="ad"]` matched
+// Kick's chat `identity-badge-*` elements ("b-ad-ge") on every channel with
+// chat, which pinned `adActive` to true forever. Use `~=` for whole class
+// tokens and `^=`/`$=`/exact matches for testids instead.
 const AD_SELECTORS: Record<Platform, string[]> = {
   twitch: [
     '[data-a-target="video-ad-label"]',
@@ -115,13 +121,19 @@ const AD_SELECTORS: Record<Platform, string[]> = {
   kick: [
     ".vjs-ad-playing",
     ".vjs-ad-loading",
-    '[class*="ad-overlay"]',
-    '[data-testid*="ad"]',
+    '[class~="ad-overlay"]',
+    '[data-testid="ad"]',
+    '[data-testid^="ad-"]',
+    '[data-testid$="-ad"]',
   ],
 };
 
+export function detectAdIn(platform: Platform, root: ParentNode): boolean {
+  return AD_SELECTORS[platform].some((selector) => root.querySelector(selector) != null);
+}
+
 function detectAd(platform: Platform): boolean {
-  return AD_SELECTORS[platform].some((selector) => document.querySelector(selector) != null);
+  return detectAdIn(platform, document);
 }
 
 function setKeepAlive(active: boolean): void {

--- a/packages/extension/tests/adDetection.test.ts
+++ b/packages/extension/tests/adDetection.test.ts
@@ -1,0 +1,64 @@
+import { parseHTML } from "linkedom";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("wxt/browser", () => ({ browser: { runtime: { sendMessage: vi.fn() } } }));
+
+const { detectAdIn } = await import("../src/core/playbackContent");
+
+function documentFrom(html: string): ParentNode {
+  return parseHTML(`<html><body>${html}</body></html>`).document as unknown as ParentNode;
+}
+
+describe("ad detection", () => {
+  it("does not treat Kick chat identity badges as an ad", () => {
+    const root = documentFrom(`
+      <div data-testid="identity-badge-subscriber"></div>
+      <div data-testid="identity-badge-chat_identity"></div>
+    `);
+
+    expect(detectAdIn("kick", root)).toBe(false);
+  });
+
+  it("does not match unrelated elements whose class merely contains 'ad'", () => {
+    const root = documentFrom(`
+      <div class="header-loading"></div>
+      <div class="thread-overlay"></div>
+      <div data-testid="download-badge"></div>
+    `);
+
+    expect(detectAdIn("kick", root)).toBe(false);
+  });
+
+  it("detects a Kick ad from the video.js ad classes", () => {
+    expect(detectAdIn("kick", documentFrom(`<div class="vjs-ad-playing"></div>`))).toBe(true);
+    expect(detectAdIn("kick", documentFrom(`<div class="video-js vjs-ad-loading"></div>`))).toBe(true);
+  });
+
+  it("detects a Kick ad from an exact ad-overlay class token", () => {
+    expect(detectAdIn("kick", documentFrom(`<div class="ad-overlay"></div>`))).toBe(true);
+    expect(detectAdIn("kick", documentFrom(`<div class="player ad-overlay visible"></div>`))).toBe(true);
+  });
+
+  it("detects a Kick ad from an anchored ad testid", () => {
+    expect(detectAdIn("kick", documentFrom(`<div data-testid="ad-overlay"></div>`))).toBe(true);
+    expect(detectAdIn("kick", documentFrom(`<div data-testid="player-ad"></div>`))).toBe(true);
+  });
+
+  it("reports no ad on an empty Kick page", () => {
+    expect(detectAdIn("kick", documentFrom(`<div class="chat"></div>`))).toBe(false);
+  });
+
+  it("detects Twitch ads from their stable player attributes", () => {
+    expect(detectAdIn("twitch", documentFrom(`<div data-a-target="video-ad-label"></div>`))).toBe(true);
+    expect(detectAdIn("twitch", documentFrom(`<div class="video-player__ad-info-container"></div>`))).toBe(true);
+  });
+
+  it("does not fire on Twitch chat badges", () => {
+    const root = documentFrom(`
+      <div data-a-target="chat-badge"></div>
+      <div data-test-selector="chat-badge-subscriber"></div>
+    `);
+
+    expect(detectAdIn("twitch", root)).toBe(false);
+  });
+});

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EngineEvent } from "@lurkloot/shared/events";
 import type { ChannelCandidate } from "@lurkloot/shared/models";
 import {
+  AD_FOCUS_MAX_HOLD_MS,
   applyAdFocusWithBrowser,
   currentManagedPageContextTabs,
   ensureTwitchIntegrityWithBrowser,
@@ -1185,13 +1186,19 @@ describe("fetchKickInBackgroundWith", () => {
   });
 });
 
-function adFocusBrowserMock(activeTab: { id?: number; windowId?: number } = { id: 100, windowId: 1 }) {
+interface AdFocusMockTab {
+  id?: number;
+  windowId?: number;
+  active?: boolean;
+}
+
+function adFocusBrowserMock(activeTab: AdFocusMockTab = { id: 100, windowId: 1 }) {
   return {
     tabs: {
-      get: vi.fn(async (tabId: number) => ({ id: tabId, windowId: 2 })),
+      get: vi.fn(async (tabId: number): Promise<AdFocusMockTab> => ({ id: tabId, windowId: 2 })),
       update: vi.fn(async () => undefined),
       remove: vi.fn(async () => undefined),
-      query: vi.fn(async () => [activeTab]),
+      query: vi.fn(async (): Promise<AdFocusMockTab[]> => [activeTab]),
       create: vi.fn(async () => ({ id: 9 })),
     },
     windows: {
@@ -1269,5 +1276,101 @@ describe("ad focus manager", () => {
 
     await applyAdFocusWithBrowser(browser, "kick", 55, false, "tab");
     expect(browser.tabs.update).toHaveBeenCalledWith(100, { active: true });
+  });
+
+  it("does not re-activate the tab while the hold is already held and the tab is active", async () => {
+    const browser = adFocusBrowserMock({ id: 100, windowId: 1 });
+    await applyAdFocusWithBrowser(browser, "kick", 42, true, "tab");
+    expect(browser.tabs.update).toHaveBeenCalledWith(42, { active: true });
+
+    // The watch tab is now the active tab, so a repeated report must be a no-op.
+    browser.tabs.get.mockResolvedValue({ id: 42, windowId: 2, active: true });
+    browser.tabs.query.mockResolvedValue([{ id: 42, windowId: 2, active: true }]);
+    browser.tabs.update.mockClear();
+    browser.windows.update.mockClear();
+
+    await applyAdFocusWithBrowser(browser, "kick", 42, true, "tab");
+    await applyAdFocusWithBrowser(browser, "kick", 42, true, "tab");
+
+    expect(browser.tabs.update).not.toHaveBeenCalled();
+    expect(browser.windows.update).not.toHaveBeenCalled();
+  });
+
+  it("does not re-focus the window while the tab is active in the focused window", async () => {
+    const browser = adFocusBrowserMock({ id: 100, windowId: 1 });
+    await applyAdFocusWithBrowser(browser, "kick", 42, true, "window");
+
+    browser.tabs.get.mockResolvedValue({ id: 42, windowId: 2, active: true });
+    browser.tabs.query.mockResolvedValue([{ id: 42, windowId: 2, active: true }]);
+    browser.tabs.update.mockClear();
+    browser.windows.update.mockClear();
+
+    await applyAdFocusWithBrowser(browser, "kick", 42, true, "window");
+
+    expect(browser.tabs.update).not.toHaveBeenCalled();
+    expect(browser.windows.update).not.toHaveBeenCalled();
+  });
+
+  it("re-activates the tab when the user switched away during the ad", async () => {
+    const browser = adFocusBrowserMock({ id: 100, windowId: 1 });
+    await applyAdFocusWithBrowser(browser, "kick", 42, true, "tab");
+
+    browser.tabs.get.mockResolvedValue({ id: 42, windowId: 2, active: false });
+    browser.tabs.update.mockClear();
+
+    await applyAdFocusWithBrowser(browser, "kick", 42, true, "tab");
+
+    expect(browser.tabs.update).toHaveBeenCalledWith(42, { active: true });
+  });
+
+  it("releases the hold and stops re-focusing once the maximum hold elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+      const browser = adFocusBrowserMock({ id: 100, windowId: 1 });
+      await applyAdFocusWithBrowser(browser, "kick", 42, true, "window");
+
+      // A stuck detector keeps reporting an ad long past any real ad break.
+      browser.tabs.get.mockResolvedValue({ id: 42, windowId: 2, active: false });
+      browser.tabs.query.mockResolvedValue([{ id: 42, windowId: 2, active: true }]);
+      vi.setSystemTime(new Date(Date.now() + AD_FOCUS_MAX_HOLD_MS + 1));
+      browser.tabs.update.mockClear();
+      browser.windows.update.mockClear();
+
+      await applyAdFocusWithBrowser(browser, "kick", 42, true, "window");
+
+      // Focus goes back to the user and the watch tab is not raised again.
+      expect(browser.tabs.update).toHaveBeenCalledWith(100, { active: true });
+      expect(browser.tabs.update).not.toHaveBeenCalledWith(42, { active: true });
+
+      browser.tabs.update.mockClear();
+      browser.windows.update.mockClear();
+      await applyAdFocusWithBrowser(browser, "kick", 42, true, "window");
+      await applyAdFocusWithBrowser(browser, "kick", 42, true, "window");
+      expect(browser.tabs.update).not.toHaveBeenCalled();
+      expect(browser.windows.update).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("allows focus again for a new ad episode after the cap expired", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+      const browser = adFocusBrowserMock({ id: 100, windowId: 1 });
+      await applyAdFocusWithBrowser(browser, "kick", 42, true, "tab");
+      vi.setSystemTime(new Date(Date.now() + AD_FOCUS_MAX_HOLD_MS + 1));
+      await applyAdFocusWithBrowser(browser, "kick", 42, true, "tab");
+
+      // The ad ends, which clears the expiry, and a later ad may focus again.
+      await applyAdFocusWithBrowser(browser, "kick", 42, false, "tab");
+      browser.tabs.update.mockClear();
+      await applyAdFocusWithBrowser(browser, "kick", 42, true, "tab");
+
+      expect(browser.tabs.update).toHaveBeenCalledWith(42, { active: true });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
Closes #242

## Summary

Kick watch tabs pulled themselves to the foreground several times a second, making it hard to click the browser toolbar or the extensions menu. Three fixes:

- **Anchored Kick ad selectors** (`packages/extension/src/core/playbackContent.ts`). Replaced `[data-testid*="ad"]` with exact/`^=`/`$=` matches and `[class*="ad-overlay"]` with the whole-token `[class~="ad-overlay"]`. Extracted a pure `detectAdIn(platform, root)` so detection is unit-testable; `detectAd` now delegates to it. The Twitch list was reviewed and left unchanged — all five of its selectors are already exact attribute/class matches.
- **Idempotent ad focus** (`packages/core/src/core/tabs.ts`). `applyAdFocusWithBrowser` now queries the tab state and returns without issuing `tabs.update`/`windows.update` when the tab is already active and (in `window` mode) already in the focused window. Window focus is derived from `tabs.query({ active: true, lastFocusedWindow: true })`, so no new browser binding is needed.
- **Bounded hold**. Holds are tracked with a start timestamp in a `Map`; after `AD_FOCUS_MAX_HOLD_MS` (3 minutes, longer than a real ad break) the hold is released, a warning is emitted, and focus is not re-taken for that ad episode. The expiry clears when the platform stops reporting an ad, so the next genuine ad still gets focus.

Core stays browser-free — no browser globals or WXT imports were added, and the `*WithBrowser` injection seam is intact (`coreBoundary.test.ts` passes).

## Root cause

`[data-testid*="ad"]` is a substring match and hits Kick chat's `identity-badge-subscriber` / `identity-badge-chat_identity` elements (b-**ad**-ge), verified live on kick.com. Every Kick channel with chat therefore reported `adActive: true` forever. Playback telemetry is sent every 5s and on every DOM mutation (250ms debounce), and Kick chat mutates constantly, so `controller.ts` forwarded `adActive` to `applyAdFocus` several times a second. `applyAdFocusWithBrowser` re-issued `tabs.update(tabId, { active: true })` plus `windows.update({ focused: true })` on every call — the `alreadyHeld` flag only gated a debug log. `releaseAdFocus` only ran when `adActive` flipped false, which never happened, so the user's previous tab/window was never restored.

## User impact

Kick farming no longer steals tab or window focus at all (there is no false ad), and genuine Twitch ads now take focus at most once per ad instead of on every telemetry tick. Even if a future detector gets stuck, focus is returned after 3 minutes.

## Testing

TDD: tests written first, observed failing (11 failures, including the `identity-badge-subscriber` false positive), then implemented.

- New `packages/extension/tests/adDetection.test.ts` — linkedom DOM fixtures covering the Kick chat badge false positive, unrelated `ad` substrings, true positives for each Kick marker, and Twitch positives/negatives.
- Extended the ad-focus suite in `packages/extension/tests/tabs.test.ts` — idempotency in tab and window mode, re-activation when the user switched away, hold expiry releasing focus and staying quiet, and a new ad episode regaining focus after an expiry.
- `pnpm check`: all green — 47 extension test files / 862 tests, 9 CLI files / 125 tests, script tests 70 passed, all 6 package typechecks Done, Astro site build complete.

## Left out deliberately

- The telemetry cadence itself (5s interval plus 250ms-debounced mutation reports) is unchanged; with an idempotent focus path it no longer causes harm, and throttling it would be an unrelated behavior change.
- The popup Drops list is untouched (owned by #243).