### PR TITLE
fix(tabs): bound playback priming so it stops stealing focus

### DIFF
--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -61,9 +61,10 @@ const PLAYBACK_PRIME_RESTORE_DELAY_MS = 1500;
 // become an open-ended loop: a tab whose player the browser permanently blocks
 // keeps reporting playingVideoCount === 0, which would otherwise flicker the tab
 // to the foreground on every scheduler tick and make the browser toolbar and the
-// extensions menu unusable. Attempts are counted per tab, spaced by a back-off,
-// and give up after the cap with a warning. The counter resets as soon as a tick
-// finds playback healthy, so a genuinely deferred player is still coaxed along.
+// extensions menu unusable. Attempts are counted per watch target, spaced by a
+// back-off, and give up after the cap with a warning. The counter resets as soon
+// as a tick finds playback healthy, so a genuinely deferred player is still
+// coaxed along.
 const PLAYBACK_PRIME_MAX_ATTEMPTS = 3;
 const PLAYBACK_PRIME_BACKOFF_MS = 5 * 60_000;
 const PAGE_CONTEXT_RECOVERY_SUCCESSES = 3;
@@ -87,12 +88,11 @@ export async function openPinnedMutedTabWithBrowser(
         if (Object.keys(updateProperties).length > 0) {
           await browserApi.tabs.update(tab.id, updateProperties);
         }
-        // A retargeted tab is a fresh player, so its priming budget starts over.
-        if (tab.url !== channel.url) resetPlaybackPriming(tab.id);
         if (!shouldPrimePlayback(tab, channel.url, session)) {
-          resetPlaybackPriming(tab.id);
+          // Playback is healthy, so the budget has served its purpose.
+          resetPlaybackPriming(channel.platform);
         } else if (tabOptions.keepVideosUnmuted) {
-          await maybePrimeTabPlayback(browserApi, tab.id, channel.platform, emit);
+          await maybePrimeTabPlayback(browserApi, tab.id, channel, emit);
         }
         diagnostic(emit, "debug", `Reusing managed watch tab ${tab.id} for ${channel.username}`, channel.platform);
         return {
@@ -113,11 +113,11 @@ export async function openPinnedMutedTabWithBrowser(
         if (Object.keys(updateProperties).length > 0) {
           await browserApi.tabs.update(tab.id, updateProperties);
         }
-        if (tab.url !== channel.url) resetPlaybackPriming(tab.id);
         if (!shouldPrimePlayback(tab, channel.url, session)) {
-          resetPlaybackPriming(tab.id);
+          // Playback is healthy, so the budget has served its purpose.
+          resetPlaybackPriming(channel.platform);
         } else if (tabOptions.keepVideosUnmuted) {
-          await maybePrimeTabPlayback(browserApi, tab.id, channel.platform, emit);
+          await maybePrimeTabPlayback(browserApi, tab.id, channel, emit);
         }
         diagnostic(emit, "debug", `Reusing your tab ${tab.id} for ${channel.username}`, channel.platform);
         return { tabId: tab.id, managedByExtension: false };
@@ -135,7 +135,6 @@ export async function openPinnedMutedTabWithBrowser(
     if (!browserApi.tabs.remove) continue;
     try {
       await browserApi.tabs.remove(tabId);
-      resetPlaybackPriming(tabId);
       diagnostic(emit, "debug", `Removed stale watch tab ${tabId}`, channel.platform);
     } catch {
       // Stale managed tab ids should not block creating the replacement.
@@ -153,10 +152,9 @@ export async function openPinnedMutedTabWithBrowser(
   }
   await browserApi.tabs.update(tab.id, { pinned: true, muted: tabOptions.muted, active: false });
   if (tabOptions.keepVideosUnmuted) {
-    // A brand new tab always starts with a full priming budget, even if the
-    // browser recycled a tab id we had given up on.
-    resetPlaybackPriming(tab.id);
-    await maybePrimeTabPlayback(browserApi, tab.id, channel.platform, emit);
+    // Deliberately no reset here: a replacement tab for the same failing channel
+    // keeps spending the same budget, or the cap never engages under tab churn.
+    await maybePrimeTabPlayback(browserApi, tab.id, channel, emit);
   }
   diagnostic(emit, "info", `Opened watch tab ${tab.id} for ${channel.username}`, channel.platform);
   return { tabId: tab.id, managedByExtension: true, managedTab: managedTab(channel, tab.id) };
@@ -185,40 +183,51 @@ function shouldPrimePlayback(tab: BrowserTab, url: string, session?: WatchSessio
 }
 
 interface PlaybackPrimeState {
+  channelUrl: string;
   attempts: number;
   lastAttemptAt: number;
   exhausted: boolean;
 }
 
-const playbackPrimeStates = new Map<number, PlaybackPrimeState>();
+// Keyed by platform, not by tab id: when playback never becomes healthy the
+// scheduler condemns the watch tab and opens a replacement, so the tab id is
+// different on every cycle. A per-tab budget would be reissued in full each time
+// and the cap would never engage. The watch target is what we rate-limit, so the
+// state carries the channel it was accrued for — a new tab for a *different*
+// channel is a legitimate reason to prime again, a new tab for the same channel
+// that keeps failing is the loop we must stop.
+const playbackPrimeStates = new Map<Platform, PlaybackPrimeState>();
 
 export { PLAYBACK_PRIME_BACKOFF_MS, PLAYBACK_PRIME_MAX_ATTEMPTS };
 
-// Forgets the priming budget for a tab (or for every tab when no id is given),
-// so the next request primes again. Called when a tick finds playback healthy,
-// when a managed tab is retargeted at another channel, and when a stale managed
-// tab is discarded.
-export function resetPlaybackPriming(tabId?: number): void {
-  if (tabId == null) playbackPrimeStates.clear();
-  else playbackPrimeStates.delete(tabId);
+// Forgets the priming budget for a platform (or for every platform when none is
+// given), so the next request primes again. Called when a tick finds playback
+// healthy — genuine recovery, not merely a new tab.
+export function resetPlaybackPriming(platform?: Platform): void {
+  if (platform == null) playbackPrimeStates.clear();
+  else playbackPrimeStates.delete(platform);
 }
 
 async function maybePrimeTabPlayback(
   browserApi: BrowserTabApi,
   tabId: number,
-  platform: Platform | undefined,
+  channel: ChannelCandidate,
   emit: EventEmitter,
   now: number = Date.now(),
 ): Promise<void> {
-  const state = playbackPrimeStates.get(tabId) ?? { attempts: 0, lastAttemptAt: 0, exhausted: false };
+  const platform = channel.platform;
+  const tracked = playbackPrimeStates.get(platform);
+  const state = tracked?.channelUrl === channel.url
+    ? tracked
+    : { channelUrl: channel.url, attempts: 0, lastAttemptAt: 0, exhausted: false };
   if (state.exhausted) return;
 
   if (state.attempts >= PLAYBACK_PRIME_MAX_ATTEMPTS) {
-    playbackPrimeStates.set(tabId, { ...state, exhausted: true });
+    playbackPrimeStates.set(platform, { ...state, exhausted: true });
     diagnostic(
       emit,
       "warn",
-      `Playback on watch tab ${tabId} did not start after ${PLAYBACK_PRIME_MAX_ATTEMPTS} priming attempts; leaving the tab in the background`,
+      `Playback for ${channel.username} did not start after ${PLAYBACK_PRIME_MAX_ATTEMPTS} priming attempts; leaving the watch tab in the background`,
       platform,
     );
     return;
@@ -229,7 +238,7 @@ async function maybePrimeTabPlayback(
     return;
   }
 
-  playbackPrimeStates.set(tabId, { attempts: state.attempts + 1, lastAttemptAt: now, exhausted: false });
+  playbackPrimeStates.set(platform, { ...state, attempts: state.attempts + 1, lastAttemptAt: now });
   await primeTabPlayback(browserApi, tabId, platform, emit);
 }
 

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -57,6 +57,15 @@ const DEFAULT_WATCH_TAB_OPTIONS: WatchTabOptions = {
   keepVideosUnmuted: true,
 };
 const PLAYBACK_PRIME_RESTORE_DELAY_MS = 1500;
+// Priming foreground-activates the watch tab for a moment, so it must never
+// become an open-ended loop: a tab whose player the browser permanently blocks
+// keeps reporting playingVideoCount === 0, which would otherwise flicker the tab
+// to the foreground on every scheduler tick and make the browser toolbar and the
+// extensions menu unusable. Attempts are counted per tab, spaced by a back-off,
+// and give up after the cap with a warning. The counter resets as soon as a tick
+// finds playback healthy, so a genuinely deferred player is still coaxed along.
+const PLAYBACK_PRIME_MAX_ATTEMPTS = 3;
+const PLAYBACK_PRIME_BACKOFF_MS = 5 * 60_000;
 const PAGE_CONTEXT_RECOVERY_SUCCESSES = 3;
 const PAGE_CONTEXT_RECOVERY_MIN_MS = 10 * 60_000;
 
@@ -78,8 +87,12 @@ export async function openPinnedMutedTabWithBrowser(
         if (Object.keys(updateProperties).length > 0) {
           await browserApi.tabs.update(tab.id, updateProperties);
         }
-        if (tabOptions.keepVideosUnmuted && shouldPrimePlayback(tab, channel.url, session)) {
-          await primeTabPlayback(browserApi, tab.id, channel.platform, emit);
+        // A retargeted tab is a fresh player, so its priming budget starts over.
+        if (tab.url !== channel.url) resetPlaybackPriming(tab.id);
+        if (!shouldPrimePlayback(tab, channel.url, session)) {
+          resetPlaybackPriming(tab.id);
+        } else if (tabOptions.keepVideosUnmuted) {
+          await maybePrimeTabPlayback(browserApi, tab.id, channel.platform, emit);
         }
         diagnostic(emit, "debug", `Reusing managed watch tab ${tab.id} for ${channel.username}`, channel.platform);
         return {
@@ -100,8 +113,11 @@ export async function openPinnedMutedTabWithBrowser(
         if (Object.keys(updateProperties).length > 0) {
           await browserApi.tabs.update(tab.id, updateProperties);
         }
-        if (tabOptions.keepVideosUnmuted && shouldPrimePlayback(tab, channel.url, session)) {
-          await primeTabPlayback(browserApi, tab.id, channel.platform, emit);
+        if (tab.url !== channel.url) resetPlaybackPriming(tab.id);
+        if (!shouldPrimePlayback(tab, channel.url, session)) {
+          resetPlaybackPriming(tab.id);
+        } else if (tabOptions.keepVideosUnmuted) {
+          await maybePrimeTabPlayback(browserApi, tab.id, channel.platform, emit);
         }
         diagnostic(emit, "debug", `Reusing your tab ${tab.id} for ${channel.username}`, channel.platform);
         return { tabId: tab.id, managedByExtension: false };
@@ -119,6 +135,7 @@ export async function openPinnedMutedTabWithBrowser(
     if (!browserApi.tabs.remove) continue;
     try {
       await browserApi.tabs.remove(tabId);
+      resetPlaybackPriming(tabId);
       diagnostic(emit, "debug", `Removed stale watch tab ${tabId}`, channel.platform);
     } catch {
       // Stale managed tab ids should not block creating the replacement.
@@ -136,7 +153,10 @@ export async function openPinnedMutedTabWithBrowser(
   }
   await browserApi.tabs.update(tab.id, { pinned: true, muted: tabOptions.muted, active: false });
   if (tabOptions.keepVideosUnmuted) {
-    await primeTabPlayback(browserApi, tab.id, channel.platform, emit);
+    // A brand new tab always starts with a full priming budget, even if the
+    // browser recycled a tab id we had given up on.
+    resetPlaybackPriming(tab.id);
+    await maybePrimeTabPlayback(browserApi, tab.id, channel.platform, emit);
   }
   diagnostic(emit, "info", `Opened watch tab ${tab.id} for ${channel.username}`, channel.platform);
   return { tabId: tab.id, managedByExtension: true, managedTab: managedTab(channel, tab.id) };
@@ -162,6 +182,55 @@ function shouldPrimePlayback(tab: BrowserTab, url: string, session?: WatchSessio
   // re-prime just because the browser kept it muted.
   return playback.videoCount === 0
     || playback.playingVideoCount === 0;
+}
+
+interface PlaybackPrimeState {
+  attempts: number;
+  lastAttemptAt: number;
+  exhausted: boolean;
+}
+
+const playbackPrimeStates = new Map<number, PlaybackPrimeState>();
+
+export { PLAYBACK_PRIME_BACKOFF_MS, PLAYBACK_PRIME_MAX_ATTEMPTS };
+
+// Forgets the priming budget for a tab (or for every tab when no id is given),
+// so the next request primes again. Called when a tick finds playback healthy,
+// when a managed tab is retargeted at another channel, and when a stale managed
+// tab is discarded.
+export function resetPlaybackPriming(tabId?: number): void {
+  if (tabId == null) playbackPrimeStates.clear();
+  else playbackPrimeStates.delete(tabId);
+}
+
+async function maybePrimeTabPlayback(
+  browserApi: BrowserTabApi,
+  tabId: number,
+  platform: Platform | undefined,
+  emit: EventEmitter,
+  now: number = Date.now(),
+): Promise<void> {
+  const state = playbackPrimeStates.get(tabId) ?? { attempts: 0, lastAttemptAt: 0, exhausted: false };
+  if (state.exhausted) return;
+
+  if (state.attempts >= PLAYBACK_PRIME_MAX_ATTEMPTS) {
+    playbackPrimeStates.set(tabId, { ...state, exhausted: true });
+    diagnostic(
+      emit,
+      "warn",
+      `Playback on watch tab ${tabId} did not start after ${PLAYBACK_PRIME_MAX_ATTEMPTS} priming attempts; leaving the tab in the background`,
+      platform,
+    );
+    return;
+  }
+
+  if (state.attempts > 0 && now - state.lastAttemptAt < PLAYBACK_PRIME_BACKOFF_MS) {
+    diagnostic(emit, "debug", `Skipping playback priming on watch tab ${tabId} until the back-off elapses`, platform);
+    return;
+  }
+
+  playbackPrimeStates.set(tabId, { attempts: state.attempts + 1, lastAttemptAt: now, exhausted: false });
+  await primeTabPlayback(browserApi, tabId, platform, emit);
 }
 
 async function primeTabPlayback(browserApi: BrowserTabApi, tabId: number, platform: Platform | undefined, emit: EventEmitter): Promise<void> {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -404,6 +404,61 @@ describe("tab manager", () => {
     }
   });
 
+  // The scheduler condemns a watch tab whose playback never reports healthy and
+  // recreates it, so the tab id is different on every cycle. The priming budget
+  // must survive that churn or the cap never engages.
+  it("stops priming across watch tab recreation for the same channel", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.parse("2026-07-21T12:00:00.000Z"));
+      const browser = browserMock();
+      browser.tabs.get.mockRejectedValue(new Error("missing"));
+      let nextTabId = 1450140654;
+      browser.tabs.create.mockImplementation(async () => ({ id: (nextTabId += 4) }));
+      const events: EngineEvent[] = [];
+
+      for (let cycle = 0; cycle < PLAYBACK_PRIME_MAX_ATTEMPTS + 3; cycle += 1) {
+        await openPinnedMutedTabWithBrowser(
+          browser,
+          channel,
+          { platform: "twitch", status: "watching", offlineChecks: 0, tabId: nextTabId, tabManagedByExtension: true },
+          undefined,
+          (event) => events.push(event),
+        );
+        vi.setSystemTime(Date.now() + PLAYBACK_PRIME_BACKOFF_MS);
+      }
+
+      expect(browser.tabs.create).toHaveBeenCalledTimes(PLAYBACK_PRIME_MAX_ATTEMPTS + 3);
+      expect(activationCalls(browser)).toHaveLength(PLAYBACK_PRIME_MAX_ATTEMPTS);
+      expect(events.filter((event) => event.category === "diagnostic" && event.level === "warn")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("primes a recreated watch tab again when the channel changed", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.parse("2026-07-21T12:00:00.000Z"));
+      const browser = browserMock();
+      browser.tabs.get.mockRejectedValue(new Error("missing"));
+      let nextTabId = 1450140654;
+      browser.tabs.create.mockImplementation(async () => ({ id: (nextTabId += 4) }));
+
+      for (let cycle = 0; cycle < PLAYBACK_PRIME_MAX_ATTEMPTS + 1; cycle += 1) {
+        await openPinnedMutedTabWithBrowser(browser, channel);
+        vi.setSystemTime(Date.now() + PLAYBACK_PRIME_BACKOFF_MS);
+      }
+      expect(activationCalls(browser)).toHaveLength(PLAYBACK_PRIME_MAX_ATTEMPTS);
+
+      await openPinnedMutedTabWithBrowser(browser, { ...channel, username: "next", url: "https://www.twitch.tv/next" });
+
+      expect(activationCalls(browser)).toHaveLength(PLAYBACK_PRIME_MAX_ATTEMPTS + 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("creates one new managed tab when the registered tab is stale", async () => {
     const browser = browserMock();
     browser.tabs.get.mockRejectedValue(new Error("missing"));

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EngineEvent } from "@lurkloot/shared/events";
-import type { ChannelCandidate } from "@lurkloot/shared/models";
+import type { ChannelCandidate, WatchSession } from "@lurkloot/shared/models";
 import {
   AD_FOCUS_MAX_HOLD_MS,
   applyAdFocusWithBrowser,
@@ -12,9 +12,12 @@ import {
   hasValidTwitchIntegrity,
   KickWafBlockedError,
   openPinnedMutedTabWithBrowser,
+  PLAYBACK_PRIME_BACKOFF_MS,
+  PLAYBACK_PRIME_MAX_ATTEMPTS,
   recordManagedPageContextBackgroundSuccessWithBrowser,
   recordManagedPageContextFallback,
   registerManagedPageContextTabs,
+  resetPlaybackPriming,
   setTwitchIntegrity,
   stopManagedPageContextTabsWithBrowser,
   stopWatchTabWithBrowser,
@@ -39,9 +42,40 @@ function browserMock() {
   };
 }
 
+// Foreground activations issued by playback priming (`tabs.update(id, { active: true })`).
+function activationCalls(browser: ReturnType<typeof browserMock>): unknown[][] {
+  return (browser.tabs.update.mock.calls as unknown as unknown[][])
+    .filter((call) => (call[1] as { active?: boolean } | undefined)?.active === true);
+}
+
+function managedSession(playingVideoCount: number): WatchSession {
+  return {
+    platform: "twitch",
+    status: "watching",
+    offlineChecks: 0,
+    tabId: 4,
+    tabManagedByExtension: true,
+    playback: {
+      platform: "twitch",
+      checkedAt: new Date().toISOString(),
+      videoCount: 1,
+      mutedVideoCount: 1,
+      unmutedVideoCount: 0,
+      playingVideoCount,
+      blockedPlaybackCount: 1 - playingVideoCount,
+      documentHidden: false,
+    },
+  };
+}
+
+// The player never starts, so shouldPrimePlayback stays true on every tick.
+const stalledSession = () => managedSession(0);
+const healthySession = () => managedSession(1);
+
 describe("tab manager", () => {
   beforeEach(() => {
     registerManagedPageContextTabs({});
+    resetPlaybackPriming();
   });
 
   it("reports tab lifecycle events to the supplied emitter", async () => {
@@ -288,6 +322,86 @@ describe("tab manager", () => {
 
     expect(browser.tabs.update).not.toHaveBeenCalled();
     expect(browser.tabs.query).not.toHaveBeenCalled();
+  });
+
+  it("stops priming a managed tab whose playback never starts", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.parse("2026-07-21T12:00:00.000Z"));
+      const browser = browserMock();
+      browser.tabs.get.mockResolvedValue({
+        id: 4,
+        url: channel.url,
+        pinned: true,
+        mutedInfo: { muted: true },
+        active: false,
+      });
+      const events: EngineEvent[] = [];
+
+      for (let tick = 0; tick < PLAYBACK_PRIME_MAX_ATTEMPTS + 3; tick += 1) {
+        await openPinnedMutedTabWithBrowser(browser, channel, stalledSession(), undefined, (event) => events.push(event));
+        vi.setSystemTime(Date.now() + PLAYBACK_PRIME_BACKOFF_MS);
+      }
+
+      expect(activationCalls(browser)).toHaveLength(PLAYBACK_PRIME_MAX_ATTEMPTS);
+      expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("priming"))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("backs off instead of priming a managed tab on every tick", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.parse("2026-07-21T12:00:00.000Z"));
+      const browser = browserMock();
+      browser.tabs.get.mockResolvedValue({
+        id: 4,
+        url: channel.url,
+        pinned: true,
+        mutedInfo: { muted: true },
+        active: false,
+      });
+
+      await openPinnedMutedTabWithBrowser(browser, channel, stalledSession());
+      vi.setSystemTime(Date.now() + 1_000);
+      await openPinnedMutedTabWithBrowser(browser, channel, stalledSession());
+
+      expect(activationCalls(browser)).toHaveLength(1);
+
+      vi.setSystemTime(Date.now() + PLAYBACK_PRIME_BACKOFF_MS);
+      await openPinnedMutedTabWithBrowser(browser, channel, stalledSession());
+      expect(activationCalls(browser)).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("allows priming again once playback recovers on a managed tab", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.parse("2026-07-21T12:00:00.000Z"));
+      const browser = browserMock();
+      browser.tabs.get.mockResolvedValue({
+        id: 4,
+        url: channel.url,
+        pinned: true,
+        mutedInfo: { muted: true },
+        active: false,
+      });
+
+      for (let tick = 0; tick < PLAYBACK_PRIME_MAX_ATTEMPTS; tick += 1) {
+        await openPinnedMutedTabWithBrowser(browser, channel, stalledSession());
+        vi.setSystemTime(Date.now() + PLAYBACK_PRIME_BACKOFF_MS);
+      }
+      await openPinnedMutedTabWithBrowser(browser, channel, healthySession());
+      vi.setSystemTime(Date.now() + PLAYBACK_PRIME_BACKOFF_MS);
+      await openPinnedMutedTabWithBrowser(browser, channel, stalledSession());
+
+      expect(activationCalls(browser)).toHaveLength(PLAYBACK_PRIME_MAX_ATTEMPTS + 1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("creates one new managed tab when the registered tab is stale", async () => {


### PR DESCRIPTION
Closes #246

## Summary

`primeTabPlayback` could foreground-activate the managed watch tab forever. It is now bounded and backed off, in `packages/core/src/core/tabs.ts`:

- **Per-tab priming budget.** A module-scope `Map<number, PlaybackPrimeState>` tracks attempts and the last attempt timestamp. New `maybePrimeTabPlayback` gates every call site; `primeTabPlayback` itself is unchanged.
- **Cap.** `PLAYBACK_PRIME_MAX_ATTEMPTS` (3), declared beside the existing `PLAYBACK_PRIME_RESTORE_DELAY_MS`. On the tick after the cap is reached the tab is marked exhausted, a `warn` diagnostic is emitted once, and the tab is never activated again for that session.
- **Back-off.** `PLAYBACK_PRIME_BACKOFF_MS` (5 minutes) between attempts, so priming no longer happens on every scheduler tick.
- **Reset points.** `resetPlaybackPriming(tabId?)` is exported and called when a tick finds playback healthy (`shouldPrimePlayback` false), when a managed/reused tab is retargeted at a different channel URL, when a stale managed tab is removed, and when a new tab is created (so a recycled tab id starts fresh). A deferred player on a fresh tab is still coaxed into loading exactly as before.

Core stays browser-free: no browser globals or WXT imports were added, only `Date.now()` and the existing `*WithBrowser` seam. `coreBoundary.test.ts` passes. `controller.ts` and `handleTabRemoved` were **not** touched (#247 owns those).

## Root cause

`shouldPrimePlayback` returns true whenever `playback.playingVideoCount === 0`. In a muted background tab whose playback the browser blocks or stalls, that condition never clears, and the scheduler calls `openPinnedMutedTab` on every tick with `keepVideosUnmuted` on (the default). Each call ran the full prime: `tabs.update(tabId, { active: true })`, wait 1500ms, restore the previous tab. Nothing counted attempts and nothing spaced them, so the flicker repeated indefinitely.

## User impact

A watch tab whose player will not start now pulls itself to the foreground at most 3 times, spaced 5 minutes apart, instead of every tick forever. The browser toolbar and the extensions menu stay reachable, and the log explains why priming stopped rather than leaving the user with an unexplained flicker.

## Not changed

The "skip priming when the video is playing but muted" idea from the issue is **already** the current behaviour and needed no change: `shouldPrimePlayback` only keys off `videoCount === 0 || playingVideoCount === 0`, never the muted counts, and `tabs.test.ts` already asserts it with "does not re-prime a matching managed tab that is playing but muted". The comment at `tabs.ts:160` documents this. Nothing was touched there.

## Testing

TDD: tests written first and observed failing (32 failures in `tabs.test.ts`, starting from the missing `resetPlaybackPriming` export), then implemented.

New cases in `packages/extension/tests/tabs.test.ts`, all with a mocked browser and `vi.useFakeTimers()` / `vi.setSystemTime` (no real timers, no live calls):

- *stops priming a managed tab whose playback never starts* — the unbounded-repeat regression: `PLAYBACK_PRIME_MAX_ATTEMPTS + 3` ticks with a permanently non-playing video produce exactly `PLAYBACK_PRIME_MAX_ATTEMPTS` foreground activations plus a `warn` diagnostic.
- *backs off instead of priming a managed tab on every tick* — a second tick 1s later does not prime; a tick after the back-off does.
- *allows priming again once playback recovers on a managed tab* — an exhausted budget is cleared by one healthy tick.

`pnpm check`: exit 0 — 6/6 package typechecks Done, 47 extension test files / 868 tests passed, 9 CLI files / 125 tests passed, script tests 17 + 70 passed with 0 failures, Astro site build complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback startup reliability by capping repeated watch-tab playback priming attempts and adding a retry backoff.
  - Prevented repeated tab activations when playback remains stalled, with automatic recovery once playback becomes healthy again.
  - Reset the priming attempt budget when switching channels or changing the target channel identity.

- **Tests**
  - Added timer-based test coverage for max retry limits, backoff behavior, state reset on recovery, and cap reset across channel changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->