### PR TITLE
fix(core): apply the critical failure prompt review findings

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1307,7 +1307,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       return snapshot();
     }
     if (message.type === "dismissCriticalFailure") {
-      await withEventCollector(async (emit, events) => {
+      // Serialized like every other load→mutate→persist handler here: a dismiss
+      // racing an alarm-driven tick would otherwise interleave loads and drop
+      // one side's write to the persisted state.
+      await withStateLock(() => withEventCollector(async (emit, events) => {
         const state = await deps.loadState();
         const transition = dismissCriticalFailure(state, message.platform, Date.now());
         if (transition.event) emit(transition.event);
@@ -1315,7 +1318,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         // instead of waiting for the next tick to sync the registry.
         syncManagedTabBreakers(transition.state);
         await persistAndReport(transition.state, events);
-      });
+      }));
       await tickAndHandOff();
       return snapshot();
     }

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -511,7 +511,12 @@ export async function runSchedulerTick(
   // scheduler state, so the breaker flags are mirrored into a module registry
   // once per tick — and again after every observation, since an observation can
   // release the breaker.
-  syncManagedTabBreakers(nextState);
+  //
+  // When the kill switch is off the registry is cleared instead of mirrored.
+  // Otherwise a breaker latched before the switch was flipped would keep blocking
+  // page-context creation forever: observations no longer run to release it, and
+  // the popup no longer renders the panel that would dismiss it.
+  syncManagedTabBreakers(settings.criticalFailurePromptEnabled ? nextState : {});
 
   const platforms = options.platforms ?? PLATFORMS;
   for (const platform of platforms) {

--- a/packages/extension/tests/criticalFailureView.test.tsx
+++ b/packages/extension/tests/criticalFailureView.test.tsx
@@ -78,6 +78,23 @@ describe("critical failure panel", () => {
     expect(props.openLink).not.toHaveBeenCalled();
   });
 
+  it("treats a rejected clipboard write as a failed copy", async () => {
+    // A denied or unavailable clipboard rejects rather than resolving false; if
+    // that escaped, the user would get neither the issue form nor the textarea.
+    const { props, container, buttons } = await mountPanel({
+      writeClipboard: vi.fn(async () => {
+        throw new Error("Clipboard write denied");
+      }),
+    });
+
+    await act(async () => {
+      buttons()[0].click();
+    });
+
+    expect(container.querySelector("textarea")).not.toBeNull();
+    expect(props.openLink).not.toHaveBeenCalled();
+  });
+
   it("dismisses on request without building a report", async () => {
     const { props, buttons } = await mountPanel();
 

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -3068,6 +3068,24 @@ describe("scheduler managed tab circuit breaker", () => {
     expect(result.state.sessions.twitch.status).toBe("watching");
   });
 
+  it("clears the page-context registry when the prompt is disabled", async () => {
+    const twitch = adapter("twitch", [campaign("drops")], [channel("creator")]);
+    // A breaker latched before the kill switch was flipped would otherwise keep
+    // blocking page-context creation forever: observations no longer run to
+    // release it, and the popup no longer offers the panel that dismisses it.
+    syncManagedTabBreakers({ criticalHealth: { twitch: openBreakerHealth() } });
+    expect(managedTabBreakerOpen("twitch")).toBe(true);
+
+    await runSchedulerTick(
+      { ...watchingState(), criticalHealth: { twitch: openBreakerHealth() } },
+      breakerSettings({ criticalFailurePromptEnabled: false }),
+      { twitch, kick: adapter("kick", [], []) },
+      { platforms: ["twitch"] },
+    );
+
+    expect(managedTabBreakerOpen("twitch")).toBe(false);
+  });
+
   it("records each newly created managed watch tab", async () => {
     const twitch = adapter("twitch", [campaign("drops")], [channel("creator")]);
 

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -9,6 +9,7 @@ import {
   Settings as SettingsIcon,
 } from "lucide-react";
 import type { ActivityPage, CategorySearchResult, CliCredentialBlob, RuntimeSnapshot } from "@lurkloot/shared/messages";
+import type { ActivityHistoryRecord } from "@lurkloot/shared/events";
 import type { CategorySelection, ExtensionSettings, Platform } from "@lurkloot/shared/models";
 import { applySettingsPatch, DEFAULT_SETTINGS, mergeSettings, type SettingsPatch } from "@lurkloot/shared/settings";
 import { effectiveLocale, isRtlLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
@@ -83,6 +84,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const [activityOpen, setActivityOpen] = useState(preview && initialVariant.view === "activity");
   const [activityStream, setActivityStream] = useState<ActivityStream>(createActivityStream);
   const [diagnosticStream, setDiagnosticStream] = useState<ActivityStream>(createActivityStream);
+  const [reportEvents, setReportEvents] = useState<ActivityHistoryRecord[]>([]);
   const [showDiagnostics, setShowDiagnostics] = useState(false);
   const [loadingMoreActivity, setLoadingMoreActivity] = useState(false);
   const [clearActivityArmed, setClearActivityArmed] = useState(false);
@@ -219,6 +221,24 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   useEffect(() => {
     if (!snapshot?.settings.diagnosticLogging) setShowDiagnostics(false);
   }, [snapshot?.settings.diagnosticLogging]);
+
+  // The failure report needs recent activity, but the Activity view's stream is
+  // only populated once the user opens that tab — and the panel lives on the
+  // drops tab, so the report would otherwise be emptiest for exactly the user who
+  // is about to file an issue. Fetch a page of our own while the panel is up.
+  const criticalFailureFlagged = snapshot?.state.criticalHealth?.[platform]?.status === "flagged";
+  useEffect(() => {
+    if (!criticalFailureFlagged || preview) return undefined;
+    let cancelled = false;
+    void adapter.send<ActivityPage>({ type: "getActivity", platform, category: "activity", limit: 40 })
+      .then((page) => {
+        if (!cancelled) setReportEvents(page.events);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [adapter, platform, preview, criticalFailureFlagged]);
 
   useEffect(() => {
     if (!activityOpen || preview || clearingActivity || !showDiagnostics || !snapshot?.settings.diagnosticLogging) return;
@@ -652,11 +672,12 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                           at: new Date().toISOString(),
                           settings,
                           state: snapshot.state,
-                          events: activityStream.events,
+                          events: reportEvents.length > 0 ? reportEvents : activityStream.events,
                         })}
                         onDismiss={() => {
                           void adapter.send({ type: "dismissCriticalFailure", platform })
-                            .then(() => refreshNow());
+                            .then(() => refreshNow())
+                            .catch(() => undefined);
                         }}
                         openLink={adapter.openLink}
                         writeClipboard={adapter.writeClipboard ?? (async () => false)}

--- a/packages/popup-ui/src/criticalFailure.tsx
+++ b/packages/popup-ui/src/criticalFailure.tsx
@@ -40,7 +40,11 @@ export function CriticalFailurePanel({
     // The clipboard write happens inside the click gesture, and the issue only
     // opens once it succeeds. Sending someone to a blank issue form with an empty
     // clipboard is worse than showing them the text to copy by hand.
-    if (await writeClipboard(report)) {
+    // A denied or unavailable clipboard can reject rather than resolve false, and
+    // an unhandled rejection here would leave the user with neither the issue form
+    // nor the manual-copy textarea — so treat any failure the same way.
+    const copied = await writeClipboard(report).catch(() => false);
+    if (copied) {
       setFallbackReport(null);
       openHttpsLink(issueUrl(platform, reason), openLink);
       return;


### PR DESCRIPTION
Follow-up to #261. Those fixes were pushed to the branch **after** GitHub had already registered the PR head, so the squash merge (`eb79214`) landed without them. This applies them on top of `develop`.

All five come from CodeRabbit's review of #261 and were verified against the code before being applied.

## Fixes

**🔴 Critical — `dismissCriticalFailure` runs outside `withStateLock`.** Every other load→mutate→persist handler in `controller.ts` (`tick`, `checkAuthHealth`, `handleTabRemoved`, `claimRewardNow`, `recordPlaybackTelemetry`, …) serializes under the state lock. This one did not, so a dismiss racing an alarm-driven tick could interleave loads and persists and silently drop one side's write to `SchedulerState`.

**🟠 Major — the kill switch could strand page-context creation.** `syncManagedTabBreakers(nextState)` mirrored a persisted `breakerOpen` into the module registry unconditionally. With `criticalFailurePromptEnabled` off, `applyObservation()` no longer runs to release the breaker and the popup no longer renders the panel that would dismiss it — so a breaker latched before the switch was flipped blocked page-context tab creation indefinitely, with no way back. The registry is now cleared instead of mirrored when the prompt is disabled. Regression test added.

**🟠 Major — a rejected clipboard write was swallowed.** A denied or unavailable clipboard rejects rather than resolving `false`, and the click handler discarded the promise, leaving the user with neither the prefilled issue nor the manual-copy textarea. Any failure is now treated as a failed copy. Regression test added.

**🟡 Minor — the report's "Recent events" was emptiest when it mattered most.** `activityStream.events` is only populated by the effect gated on the Activity tab being open, but the panel renders on the drops tab — so a user who never opened Activity produced a report with no recent context, on their first interaction after being flagged. The panel now fetches its own page of activity events while it is up.

**🟡 Minor — unhandled rejection** on the `dismissCriticalFailure` send, unlike every other `adapter.send(...)` in that component.

## Testing

`pnpm check` green: typecheck across all packages, extension **970** tests, CLI **126**, site build.

Two new regression tests: the page-context registry is cleared when the prompt is disabled, and a rejected clipboard write still shows the fallback textarea without opening an issue.

## Still outstanding from #261

- No manual smoke test has been done on the critical-failure feature as a whole.
- The reason code is still `page_context_churn` even when a watch-tab storm triggers it, so it appears in the prefilled issue title. Panel copy is generic and reads correctly; renaming touches all 11 catalogs.
