### PR TITLE
feat(activity): copy the visible log and record diagnostics by default

### DIFF
--- a/packages/extension/tests/activityLogView.test.tsx
+++ b/packages/extension/tests/activityLogView.test.tsx
@@ -39,12 +39,18 @@ const DIAGNOSTICS: ActivityHistoryRecord[] = [{
   message: "Kick fetch kick.com failed with HTTP 503",
 }];
 
-function mount(options: { showDiagnostics: boolean; diagnosticLogging?: boolean }) {
+function mount(options: {
+  showDiagnostics: boolean;
+  diagnosticLogging?: boolean;
+  writeClipboard?: (text: string) => Promise<boolean>;
+  omitClipboard?: boolean;
+}) {
   const { document, window } = parseHTML("<div id=app></div>");
   vi.stubGlobal("window", window);
   vi.stubGlobal("document", document);
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   const onShowDiagnosticsChange = vi.fn();
+  const writeClipboard = options.writeClipboard ?? vi.fn(async () => true);
   const container = document.getElementById("app")!;
 
   act(() => {
@@ -59,6 +65,9 @@ function mount(options: { showDiagnostics: boolean; diagnosticLogging?: boolean 
           diagnosticsViewTab: "Diagnostics",
           noActivity: "No activity recorded yet.",
           noDiagnostics: "No diagnostics recorded yet.",
+          copyActivityLog: "Copy log",
+          copyActivityLogCopied: `Copied ${String(substitutions)} events`,
+          copyActivityLogFailed: "Could not copy the log. Try again.",
         })[key] ?? `${key}${substitutions ? "" : ""}`,
         dir: "ltr",
         locale: "en",
@@ -74,16 +83,23 @@ function mount(options: { showDiagnostics: boolean; diagnosticLogging?: boolean 
           clearFailed={false}
           loadingMore={false}
           clearing={false}
+          version="1.9.0"
+          locale="en"
           onShowDiagnosticsChange={onShowDiagnosticsChange}
           onLoadMore={() => undefined}
           onClear={() => undefined}
+          writeClipboard={options.omitClipboard ? undefined : writeClipboard}
         />
       </I18nContext.Provider>,
     );
   });
 
-  return { container, onShowDiagnosticsChange };
+  return { container, onShowDiagnosticsChange, writeClipboard };
 }
+
+const copyButton = (container: Element) =>
+  [...container.querySelectorAll<HTMLButtonElement>("button")]
+    .find((button) => button.textContent?.includes("Copy log") || button.textContent?.includes("Copied"));
 
 describe("activity log view", () => {
   it("shows only activity entries while the activity view is selected", () => {
@@ -158,6 +174,8 @@ describe("activity log view", () => {
             clearFailed={false}
             loadingMore={false}
             clearing={false}
+            version="1.9.0"
+            locale="en"
             onShowDiagnosticsChange={() => undefined}
             onLoadMore={() => undefined}
             onClear={() => undefined}
@@ -167,5 +185,45 @@ describe("activity log view", () => {
     });
 
     expect(container.textContent).toContain("No diagnostics recorded yet.");
+  });
+
+  it("copies the visible view as plain text and confirms the count", async () => {
+    const { container, writeClipboard } = mount({ showDiagnostics: true });
+
+    await act(async () => { copyButton(container)?.click(); });
+
+    expect(writeClipboard).toHaveBeenCalledTimes(1);
+    const text = (writeClipboard as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(text).toContain("Lurkloot diagnostics log");
+    expect(text).toContain("version: 1.9.0");
+    expect(text).toContain("2026-07-25T12:00:01.000Z [error] Kick fetch kick.com failed with HTTP 503");
+    expect(text).not.toContain("<");
+    expect(copyButton(container)?.textContent).toContain("Copied 1 events");
+  });
+
+  it("copies the activity view with localized event text when that view is shown", async () => {
+    const { container, writeClipboard } = mount({ showDiagnostics: false });
+
+    await act(async () => { copyButton(container)?.click(); });
+
+    const text = (writeClipboard as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(text).toContain("Lurkloot activity log");
+    expect(text).toContain("Started farming a reward");
+    expect(text).not.toContain("HTTP 503");
+  });
+
+  it("reports a failed clipboard write instead of confirming", async () => {
+    const { container } = mount({ showDiagnostics: false, writeClipboard: vi.fn(async () => false) });
+
+    await act(async () => { copyButton(container)?.click(); });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("Could not copy the log. Try again.");
+    expect(copyButton(container)?.textContent).toContain("Copy log");
+  });
+
+  it("hides the copy control for hosts without a clipboard", () => {
+    const { container } = mount({ showDiagnostics: false, omitClipboard: true });
+
+    expect(copyButton(container)).toBeUndefined();
   });
 });

--- a/packages/extension/tests/activityView.test.ts
+++ b/packages/extension/tests/activityView.test.ts
@@ -6,6 +6,7 @@ import {
   applyActivityPage,
   applyActivityPageForRequest,
   beginActivityMutation,
+  buildActivityExport,
   createActivityMutationSequence,
   createActivityRequestScope,
   createActivityStream,
@@ -315,5 +316,50 @@ describe("activity view model", () => {
       [event("a", "2026-07-14T11:00:00.000Z")],
       [event("c"), event("b")],
     ).map((entry) => entry.id)).toEqual(["c", "b", "a"]);
+  });
+});
+
+describe("activity export", () => {
+  const exportInput = {
+    platform: "kick" as const,
+    diagnostics: false,
+    version: "1.9.0",
+    userAgent: "Mozilla/5.0 (X11; Linux x86_64)",
+    locale: "en",
+    at: "2026-07-26T09:00:00.000Z",
+  };
+  const t = (key: string) => key;
+
+  it("writes a header and the events oldest first, one per line", () => {
+    const text = buildActivityExport({
+      ...exportInput,
+      // Held newest first, as the popup state does.
+      events: [
+        { id: "b", at: "2026-07-14T12:00:00.000Z", legacy: true, level: "warn", message: "second" },
+        { id: "a", at: "2026-07-14T11:00:00.000Z", legacy: true, level: "info", message: "first" },
+      ],
+    }, t);
+
+    expect(text.split("\n\n")[0].split("\n")).toEqual([
+      "Lurkloot activity log",
+      "version: 1.9.0",
+      "platform: kick",
+      "locale: en",
+      "exported: 2026-07-26T09:00:00.000Z",
+      "browser: Mozilla/5.0 (X11; Linux x86_64)",
+      "events: 2",
+    ]);
+    expect(text.trimEnd().split("\n").slice(-2)).toEqual([
+      "2026-07-14T11:00:00.000Z [info] first",
+      "2026-07-14T12:00:00.000Z [warn] second",
+    ]);
+  });
+
+  it("labels the diagnostics view and handles an empty list", () => {
+    const text = buildActivityExport({ ...exportInput, diagnostics: true, events: [] }, t);
+
+    expect(text).toContain("Lurkloot diagnostics log");
+    expect(text).toContain("events: 0");
+    expect(text.trimEnd().endsWith("(no events)")).toBe(true);
   });
 });

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -42,7 +42,8 @@ describe("settings", () => {
       platform: { ...DEFAULT_SETTINGS.platform, twitch: { ...DEFAULT_SETTINGS.platform.twitch, watchQueueChannels: ["legacy"] } },
     } as never);
     expect(merged.idleWatchlistFallbackOnly).toBe(DEFAULT_SETTINGS.idleWatchlistFallbackOnly);
-    expect(merged.diagnosticLogging).toBe(false);
+    // verboseLogging is not read here; the default applies.
+    expect(merged.diagnosticLogging).toBe(true);
     expect(merged.platform.twitch.autoClaimChannelPoints).toBe(true);
     expect(merged.platform.twitch.idleWatchlistChannels).toEqual([]);
     expect(merged).not.toHaveProperty("watchQueueFallbackOnly");
@@ -102,7 +103,7 @@ describe("settings", () => {
       languageOverride: "browser",
       idleWatchlistFallbackOnly: true,
       pollIntervalMinutes: 1,
-      diagnosticLogging: false,
+      diagnosticLogging: true,
       platform: {
         twitch: { excludedChannels: [], farmAllCategories: true, categories: [] },
         kick: { excludedChannels: [], farmAllCategories: true, categories: [] },
@@ -175,7 +176,7 @@ describe("settings", () => {
   });
 
   it("keeps diagnostic logging independent from the removed engine log-level setting", () => {
-    expect(mergeSettings(undefined).diagnosticLogging).toBe(false);
+    expect(mergeSettings(undefined).diagnosticLogging).toBe(true);
     expect(mergeSettings({ diagnosticLogging: true }).diagnosticLogging).toBe(true);
     expect(mergeSettings({ diagnosticLogging: false, enabledLogLevels: ["debug"] } as never).diagnosticLogging).toBe(false);
     expect("enabledLogLevels" in mergeSettings({ enabledLogLevels: ["debug"] } as never)).toBe(false);

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "تعذر مسح سجل النشاط. حاول مرة أخرى."
   },
+  "copyActivityLog": {
+    "message": "نسخ السجل"
+  },
+  "copyActivityLogCopied": {
+    "message": "تم نسخ $1 حدثًا"
+  },
+  "copyActivityLogFailed": {
+    "message": "تعذّر نسخ السجل. حاول مرة أخرى."
+  },
   "activityViewTab": {
     "message": "النشاط"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "Der Aktivitätsverlauf konnte nicht gelöscht werden. Erneut versuchen."
   },
+  "copyActivityLog": {
+    "message": "Protokoll kopieren"
+  },
+  "copyActivityLogCopied": {
+    "message": "$1 Ereignisse kopiert"
+  },
+  "copyActivityLogFailed": {
+    "message": "Das Protokoll konnte nicht kopiert werden. Bitte erneut versuchen."
+  },
   "activityViewTab": {
     "message": "Aktivität"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "Could not clear activity history. Try again."
   },
+  "copyActivityLog": {
+    "message": "Copy log"
+  },
+  "copyActivityLogCopied": {
+    "message": "Copied $1 events"
+  },
+  "copyActivityLogFailed": {
+    "message": "Could not copy the log. Try again."
+  },
   "activityViewTab": {
     "message": "Activity"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "No se pudo borrar el historial. Inténtalo de nuevo."
   },
+  "copyActivityLog": {
+    "message": "Copiar registro"
+  },
+  "copyActivityLogCopied": {
+    "message": "$1 eventos copiados"
+  },
+  "copyActivityLogFailed": {
+    "message": "No se pudo copiar el registro. Inténtalo de nuevo."
+  },
   "activityViewTab": {
     "message": "Actividad"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "Impossible d’effacer l’historique. Réessayez."
   },
+  "copyActivityLog": {
+    "message": "Copier le journal"
+  },
+  "copyActivityLogCopied": {
+    "message": "$1 événements copiés"
+  },
+  "copyActivityLogFailed": {
+    "message": "Impossible de copier le journal. Réessayez."
+  },
   "activityViewTab": {
     "message": "Activité"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "गतिविधि इतिहास साफ़ नहीं हो सका। फिर कोशिश करें।"
   },
+  "copyActivityLog": {
+    "message": "लॉग कॉपी करें"
+  },
+  "copyActivityLogCopied": {
+    "message": "$1 इवेंट कॉपी किए गए"
+  },
+  "copyActivityLogFailed": {
+    "message": "लॉग कॉपी नहीं हो सका। फिर से कोशिश करें।"
+  },
   "activityViewTab": {
     "message": "गतिविधि"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "Impossibile cancellare la cronologia. Riprova."
   },
+  "copyActivityLog": {
+    "message": "Copia registro"
+  },
+  "copyActivityLogCopied": {
+    "message": "$1 eventi copiati"
+  },
+  "copyActivityLogFailed": {
+    "message": "Impossibile copiare il registro. Riprova."
+  },
   "activityViewTab": {
     "message": "Attività"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "Não foi possível limpar o histórico. Tente novamente."
   },
+  "copyActivityLog": {
+    "message": "Copiar registro"
+  },
+  "copyActivityLogCopied": {
+    "message": "$1 eventos copiados"
+  },
+  "copyActivityLogFailed": {
+    "message": "Não foi possível copiar o registro. Tente novamente."
+  },
   "activityViewTab": {
     "message": "Atividade"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "Не удалось очистить историю. Повторите попытку."
   },
+  "copyActivityLog": {
+    "message": "Копировать журнал"
+  },
+  "copyActivityLogCopied": {
+    "message": "Скопировано событий: $1"
+  },
+  "copyActivityLogFailed": {
+    "message": "Не удалось скопировать журнал. Попробуйте ещё раз."
+  },
   "activityViewTab": {
     "message": "Активность"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -938,6 +938,15 @@
   "clearActivityFailed": {
     "message": "Geçmiş temizlenemedi. Tekrar deneyin."
   },
+  "copyActivityLog": {
+    "message": "Günlüğü kopyala"
+  },
+  "copyActivityLogCopied": {
+    "message": "$1 olay kopyalandı"
+  },
+  "copyActivityLogFailed": {
+    "message": "Günlük kopyalanamadı. Tekrar deneyin."
+  },
   "activityViewTab": {
     "message": "Geçmiş"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -838,6 +838,15 @@
   "clearActivityFailed": {
     "message": "无法清除活动历史记录，请重试。"
   },
+  "copyActivityLog": {
+    "message": "复制日志"
+  },
+  "copyActivityLogCopied": {
+    "message": "已复制 $1 条事件"
+  },
+  "copyActivityLogFailed": {
+    "message": "无法复制日志，请重试。"
+  },
   "activityViewTab": {
     "message": "活动"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -624,9 +624,12 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                   clearFailed={clearActivityFailed}
                   loadingMore={loadingMoreActivity}
                   clearing={clearingActivity}
+                  version={adapter.version}
+                  locale={locale}
                   onShowDiagnosticsChange={setShowDiagnostics}
                   onLoadMore={loadMoreActivity}
                   onClear={clearActivityHistory}
+                  writeClipboard={adapter.writeClipboard}
                 />
               </motion.div>
             ) : (

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -211,6 +211,45 @@ export function formatActivityEvent(event: ActivityHistoryRecord, t: TFunction):
   return formatCurrentActivity(event, t);
 }
 
+export interface ActivityExportInput {
+  // The full loaded list for the visible view, newest first (as held in state).
+  events: readonly ActivityHistoryRecord[];
+  platform: Platform;
+  diagnostics: boolean;
+  version: string;
+  userAgent: string;
+  locale: string;
+  at: string;
+}
+
+// Plain text, not markup: this is pasted into email, Discord and issue bodies,
+// and it has to read as-is in all of them. The header carries the environment
+// facts a bug report is usually missing (version first) and nothing else — the
+// event bodies already decide what user data leaves the machine, and this adds
+// no identity, account or channel information of its own.
+export function buildActivityExport(input: ActivityExportInput, t: TFunction): string {
+  const header = [
+    `Lurkloot ${input.diagnostics ? "diagnostics" : "activity"} log`,
+    `version: ${input.version}`,
+    `platform: ${input.platform}`,
+    `locale: ${input.locale}`,
+    `exported: ${input.at}`,
+    `browser: ${input.userAgent}`,
+    `events: ${input.events.length}`,
+  ].join("\n");
+
+  // Oldest first: a log is read top-down when you are reconstructing what
+  // happened, even though the popup lists newest first.
+  const body = input.events.length === 0
+    ? "(no events)"
+    : [...input.events]
+      .reverse()
+      .map((event) => `${event.at} [${event.level}] ${formatActivityEvent(event, t)}`)
+      .join("\n");
+
+  return `${header}\n\n${body}\n`;
+}
+
 export function mergeActivityPages(
   current: readonly ActivityHistoryRecord[],
   incoming: readonly ActivityHistoryRecord[],

--- a/packages/popup-ui/src/activity.tsx
+++ b/packages/popup-ui/src/activity.tsx
@@ -1,11 +1,14 @@
-import React, { useMemo } from "react";
-import { Clock3 } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import { Check, Clipboard, Clock3 } from "lucide-react";
 import type { ActivityHistoryRecord } from "@lurkloot/shared/events";
 import type { Platform } from "@lurkloot/shared/models";
 import { EVENT_LEVEL_COLOR, PLATFORMS } from "./constants";
 import { useT } from "./context";
 import { formatEventTime } from "./format";
-import { formatActivityEvent } from "./activity.logic";
+import { buildActivityExport, formatActivityEvent } from "./activity.logic";
+
+// How long the button stays in its confirmation state after a successful copy.
+const COPY_FEEDBACK_MS = 2500;
 
 export function ActivityLog({
   activityEvents,
@@ -19,9 +22,12 @@ export function ActivityLog({
   clearFailed,
   loadingMore,
   clearing,
+  version,
+  locale,
   onShowDiagnosticsChange,
   onLoadMore,
   onClear,
+  writeClipboard,
 }: {
   activityEvents: ActivityHistoryRecord[];
   diagnosticEvents: ActivityHistoryRecord[];
@@ -34,9 +40,14 @@ export function ActivityLog({
   clearFailed: boolean;
   loadingMore: boolean;
   clearing: boolean;
+  version: string;
+  locale: string;
   onShowDiagnosticsChange(show: boolean): void;
   onLoadMore(): void;
   onClear(): void;
+  // Omitted by hosts without a clipboard (the site demo), which hides the copy
+  // control rather than offering a button that can only fail.
+  writeClipboard?(text: string): Promise<boolean>;
 }): React.ReactElement {
   const t = useT();
   const forPlatform = useMemo(
@@ -52,6 +63,39 @@ export function ActivityLog({
   // same thing twice and buried the high-level story in plumbing detail.
   const visible = showDiagnostics ? diagnosticsForPlatform : forPlatform;
   const errorCount = visible.filter((event) => event.level === "error").length;
+  const [copied, setCopied] = useState<number | null>(null);
+  const [copyFailed, setCopyFailed] = useState(false);
+
+  // Confirmation is transient, and it must not survive a switch between the two
+  // views: "Copied 42 events" next to a different list is a lie.
+  useEffect(() => {
+    setCopied(null);
+    setCopyFailed(false);
+  }, [showDiagnostics, platform]);
+
+  useEffect(() => {
+    if (copied === null) return;
+    const timer = setTimeout(() => setCopied(null), COPY_FEEDBACK_MS);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  async function copyVisible(): Promise<void> {
+    if (!writeClipboard) return;
+    // Built and written inside the click gesture: navigator.clipboard in the
+    // popup needs the user activation, and nothing here needs a permission.
+    const text = buildActivityExport({
+      events: visible,
+      platform,
+      diagnostics: showDiagnostics,
+      version,
+      userAgent: typeof navigator === "undefined" ? "unknown" : navigator.userAgent,
+      locale,
+      at: new Date().toISOString(),
+    }, t);
+    const ok = await writeClipboard(text);
+    setCopyFailed(!ok);
+    setCopied(ok ? visible.length : null);
+  }
 
   return (
     <div className="space-y-2.5">
@@ -86,6 +130,17 @@ export function ActivityLog({
             ))}
           </div>
         ) : null}
+        {writeClipboard ? (
+          <button
+            type="button"
+            onClick={() => void copyVisible()}
+            disabled={visible.length === 0}
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[9px] font-semibold transition disabled:opacity-50 ${copied === null ? "border-zinc-200 text-zinc-400 dark:border-zinc-700" : "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300"}`}
+          >
+            {copied === null ? <Clipboard size={10} /> : <Check size={10} />}
+            {copied === null ? t("copyActivityLog") : t("copyActivityLogCopied", String(copied))}
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={onClear}
@@ -97,6 +152,9 @@ export function ActivityLog({
       </div>
       {clearFailed ? (
         <p role="alert" className="px-0.5 text-[10px] font-medium text-red-500">{t("clearActivityFailed")}</p>
+      ) : null}
+      {copyFailed ? (
+        <p role="alert" className="px-0.5 text-[10px] font-medium text-red-500">{t("copyActivityLogFailed")}</p>
       ) : null}
       <div className="overflow-hidden rounded-xl border border-zinc-200/70 bg-white/70 dark:border-zinc-800 dark:bg-zinc-900/50">
         {visible.length === 0 ? (

--- a/packages/popup-ui/src/index.ts
+++ b/packages/popup-ui/src/index.ts
@@ -12,6 +12,7 @@ export {
   applyActivityPage,
   applyActivityPageForRequest,
   beginActivityMutation,
+  buildActivityExport,
   createActivityMutationSequence,
   createActivityRequestScope,
   createActivityStream,

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -102,7 +102,14 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
   languageOverride: "browser",
   rateNudgeStatus: "pending",
   showTips: true,
-  diagnosticLogging: false,
+  // On by default: diagnostics only capture after they are enabled, so leaving
+  // this off meant the first occurrence of any bug — the one being reported —
+  // was always already lost. Recording is bounded (IndexedDB, capped records,
+  // 7-day diagnostic retention, daily prune) and stays user-controllable, and
+  // recording is independent of the activity view's display toggle. Existing
+  // installs are unaffected: they have persisted an explicit value already, and
+  // no migration overrides it.
+  diagnosticLogging: true,
 };
 
 // Normalizes the universal engine contract. The engine (packages/core) and any

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,12 +1,14 @@
 # Lurkloot Privacy Policy
 
-Last updated: May 31, 2026
+Last updated: July 26, 2026
 
 Lurkloot does not collect, transmit, sell, or share user data.
 
 ## Local Storage
 
 The extension stores its settings, scheduler state, campaign progress, managed-tab identifiers, and a compact diagnostic event log locally in the user's browser using extension storage. It also stores a short-lived Twitch "Client-Integrity" token bundle so it can replay the same page-issued headers Twitch requires when claiming a drop; this bundle expires and is refreshed from the user's own Twitch page traffic. All of this data remains on the user's device and is not sent to the developer or to any third-party or analytics service.
+
+The diagnostic event log records the extension's own activity — campaign and reward names and ids, channel names, managed-tab identifiers, reason codes and timings — so a problem can be diagnosed after the fact. It is bounded and pruned automatically, it never contains passwords, cookies or session tokens, and it can be turned off or cleared at any time in the extension. The extension never uploads it. The activity view offers a "Copy log" button that places its contents on the user's clipboard; where the user then pastes it is entirely the user's choice.
 
 ## Platform Access
 


### PR DESCRIPTION
Closes #253.

## Part 1 — Copy button

`ActivityLog` gets a copy control next to the clear button.

- Copies the **full loaded list** for whichever view is selected (activity or diagnostics), so what lands on the clipboard matches what the user sees, not just the viewport.
- Plain text only. A header carries the facts bug reports usually miss — `version`, `platform`, `locale`, `exported`, `browser`, `events` — followed by one `2026-07-25T12:00:01.000Z [error] message` line per event, **oldest first** (a log is read top-down when reconstructing what happened, even though the popup lists newest first).
- Confirms with the count (“Copied 42 events”) for 2.5s; the confirmation resets when the view or platform switches so it can never sit next to a different list. A failed write shows an alert row instead of a false confirmation.
- Adds nothing identifying of its own: the event bodies already decide what leaves the machine.

### Permissions — none added

`navigator.clipboard.writeText()` is called **from the popup document inside the click gesture**, through the `adapter.writeClipboard` hook the critical-failure panel already uses. No `document.execCommand("copy")` fallback and no background-worker write, so no `clipboardWrite` entry and no re-review / permission prompt for existing users. `wxt.config.ts` is untouched. Hosts with no clipboard (the site demo) hide the button rather than offer one that can only fail.

## Part 2 — `diagnosticLogging` defaults to true

`packages/shared/src/settings.ts` only. **No migration** — and that is the deliberate choice, so it needs stating plainly:

`loadSettings`/`saveSettings` write the whole normalized settings object, so **every existing install already has an explicit `diagnosticLogging: false` persisted**. There is no way to distinguish “never touched it” from “deliberately turned it off”. Rather than override a possible opt-out, this change reaches fresh installs only; existing users still get diagnostics by flipping the setting. A v4 migration could widen that later if the opt-out risk is judged acceptable.

Review points from the issue:

- **Display stays independent.** `showDiagnostics` still initializes `false` and `Popup.tsx` only forces it off when logging is off, so recording by default does not show debug noise by default.
- **Content audit.** Diagnostics carry campaign/reward names and ids, channel names, hosts, reason codes and managed-tab ids — the user's own local activity. Token-related entries record *existence and expiry only*; no cookie, token or credential value is ever written. Nothing sensitive becomes shareable via the new button.
- **Privacy policy.** `privacy-policy.md` (the single source the site renders) now describes what the diagnostic log contains, that it is bounded/prunable/clearable, that it is never uploaded, and that the copy button puts it on the user's clipboard for the user to place wherever they choose.
- **Write volume.** Unchanged bounds: `MAX_RECORDS_PER_CATEGORY = 2000`, 7-day diagnostic retention vs 30-day activity, daily prune, all in IndexedDB.

## Testing

- `pnpm check` — 974 extension tests, 126 CLI tests, workspace typecheck, Astro site build. All green.
- New coverage: export header/ordering/empty-list (`activityView.test.ts`), and copy behaviour in `activityLogView.test.tsx` — copies the selected view as plain text with the right count, uses localized activity text in the activity view and English diagnostics in the diagnostics view, reports a failed write instead of confirming, and hides the control for clipboard-less hosts.
- Updated `settings.test.ts` for the new default, including the assertion that a stored `false` survives normalization.

Locale copy (`copyActivityLog`, `copyActivityLogCopied`, `copyActivityLogFailed`) added to all 11 catalogs, passing the key-parity and “not left as English” catalog tests.

## Not included

No popup screenshot yet, and no changelog entry — `docs/version-1-10-changelog` is a separate branch.