### PR TITLE
feat(scheduler): configure tabless fallback failure threshold

### DIFF
--- a/docs/superpowers/plans/2026-07-26-tabless-fallback-failure-limit.md
+++ b/docs/superpowers/plans/2026-07-26-tabless-fallback-failure-limit.md
@@ -1,0 +1,481 @@
+# Tabless Fallback Failure Limit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persisted 1–10 setting, defaulting to 5, that independently controls how many consecutive tabless heartbeat failures occur before Lurkloot opens a watch tab.
+
+**Architecture:** The setting belongs to the shared `EngineSettings` contract so every core host receives the same normalized policy. The background heartbeat loop triggers a scheduler tick at the threshold, and the scheduler uses the same threshold to choose the sticky tab fallback; `offlineRetryLimit` remains exclusive to channel and playback health. The popup exposes the value through the existing advanced settings registry, while Client-Integrity capture remains an immediate, separately tested page-context operation.
+
+**Tech Stack:** TypeScript 7, React 19, Vitest, pnpm workspace, JSON locale catalogs.
+
+## Global Constraints
+
+- Name the setting `tablessFallbackFailureLimit`.
+- Default to `5`; normalize to an integer from `1` through `10`.
+- Do not add a settings migration; missing values must default through `mergeEngineSettings`.
+- Do not change heartbeat cadence, offline detection, playback-health thresholds, or sticky fallback semantics.
+- Do not change `ensureTwitchIntegrityWithBrowser`; a missing token must open or reuse Twitch page context immediately.
+- Keep all eleven locale catalogs in key parity.
+- Follow test-driven development and run `pnpm verify` before completion.
+
+---
+
+### Task 1: Shared settings contract and normalization
+
+**Files:**
+- Modify: `packages/shared/src/models.ts:136-149,306-346`
+- Modify: `packages/shared/src/settings.ts:22-75,105-170`
+- Test: `packages/extension/tests/settings.test.ts:139-150`
+- Test: `packages/extension/tests/backgroundController.test.ts:1270-1290`
+
+**Interfaces:**
+- Consumes: existing `clampInteger(value, min, max, fallback): number`.
+- Produces: `EngineSettings.tablessFallbackFailureLimit: number`, defaulted and normalized by `DEFAULT_ENGINE_SETTINGS` and `mergeEngineSettings`.
+
+- [ ] **Step 1: Write failing normalization tests**
+
+Extend the numeric-settings test with explicit default, clamp, rounding, and independence assertions:
+
+```ts
+expect(DEFAULT_ENGINE_SETTINGS.tablessFallbackFailureLimit).toBe(5);
+expect(mergeEngineSettings({}).tablessFallbackFailureLimit).toBe(5);
+expect(mergeEngineSettings({ tablessFallbackFailureLimit: 0 }).tablessFallbackFailureLimit).toBe(1);
+expect(mergeEngineSettings({ tablessFallbackFailureLimit: 11 }).tablessFallbackFailureLimit).toBe(10);
+expect(mergeEngineSettings({ tablessFallbackFailureLimit: 4.6 }).tablessFallbackFailureLimit).toBe(5);
+expect(mergeEngineSettings({ tablessFallbackFailureLimit: Number.NaN }).tablessFallbackFailureLimit).toBe(5);
+expect(mergeEngineSettings({
+  offlineRetryLimit: 9,
+  tablessFallbackFailureLimit: 2,
+})).toMatchObject({
+  offlineRetryLimit: 9,
+  tablessFallbackFailureLimit: 2,
+});
+```
+
+In the controller save-settings test, include an invalid incoming value and assert the normalized value is persisted in the harness:
+
+```ts
+const nextSettings = {
+  ...DEFAULT_SETTINGS,
+  running: true,
+  pollIntervalMinutes: Number.NaN,
+  offlineRetryLimit: 0,
+  tablessFallbackFailureLimit: 99,
+};
+// after handleMessage(...)
+expect(env.settings.tablessFallbackFailureLimit).toBe(10);
+expect(env.deps.saveSettings).toHaveBeenCalledWith(
+  expect.objectContaining({ tablessFallbackFailureLimit: 10 }),
+);
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/settings.test.ts tests/backgroundController.test.ts
+```
+
+Expected: TypeScript/runtime assertions fail because `tablessFallbackFailureLimit` is absent.
+
+- [ ] **Step 3: Add the shared setting**
+
+Add the field beside `offlineRetryLimit` in `EngineSettings`, documenting that it counts consecutive failed tabless heartbeats. Update the `WatchSession.heartbeatChecks` comment to name `tablessFallbackFailureLimit`.
+
+Add the default:
+
+```ts
+offlineRetryLimit: 3,
+tablessFallbackFailureLimit: 5,
+pollIntervalMinutes: 1,
+```
+
+Normalize it:
+
+```ts
+offlineRetryLimit: clampInteger(value?.offlineRetryLimit, 1, 10, DEFAULT_ENGINE_SETTINGS.offlineRetryLimit),
+tablessFallbackFailureLimit: clampInteger(
+  value?.tablessFallbackFailureLimit,
+  1,
+  10,
+  DEFAULT_ENGINE_SETTINGS.tablessFallbackFailureLimit,
+),
+```
+
+- [ ] **Step 4: Run the focused tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/settings.test.ts tests/backgroundController.test.ts
+pnpm typecheck
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 5: Commit the shared contract**
+
+```bash
+git add packages/shared/src/models.ts packages/shared/src/settings.ts packages/extension/tests/settings.test.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(settings): add tabless fallback failure limit"
+```
+
+---
+
+### Task 2: Scheduler and heartbeat fallback behavior
+
+**Files:**
+- Modify: `packages/core/src/core/scheduler.ts:51-66`
+- Modify: `packages/core/src/background/controller.ts:730-820`
+- Test: `packages/extension/tests/scheduler.test.ts:2757-2848`
+- Test: `packages/extension/tests/backgroundController.test.ts:2570-2610`
+
+**Interfaces:**
+- Consumes: normalized `EngineSettings.tablessFallbackFailureLimit`.
+- Produces: consistent controller trigger and scheduler fallback decisions based only on that setting.
+
+- [ ] **Step 1: Write failing scheduler threshold tests**
+
+Refactor the existing fallback fixture into a local helper that accepts `heartbeatChecks` and settings overrides, then cover below/at threshold and independence:
+
+```ts
+it("stays tabless below its configured fallback threshold", async () => {
+  const { result, twitch } = await runTablessFallbackCase(4, {
+    offlineRetryLimit: 1,
+    tablessFallbackFailureLimit: 5,
+  });
+  expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
+  expect(result.state.sessions.twitch.watchMode).toBe("tabless");
+});
+
+it("falls back exactly at its configured fallback threshold", async () => {
+  const { result, twitch } = await runTablessFallbackCase(5, {
+    offlineRetryLimit: 10,
+    tablessFallbackFailureLimit: 5,
+  });
+  expect(twitch.prepareWatchTab).toHaveBeenCalledOnce();
+  expect(result.state.sessions.twitch).toMatchObject({
+    watchMode: "tab",
+    tablessFallback: true,
+  });
+});
+
+it("honors a non-default tabless fallback threshold", async () => {
+  const { result } = await runTablessFallbackCase(2, {
+    offlineRetryLimit: 9,
+    tablessFallbackFailureLimit: 2,
+  });
+  expect(result.state.sessions.twitch.watchMode).toBe("tab");
+});
+```
+
+The helper must build the same healthy-auth, same-channel state used by the current fallback test and return `{ result, twitch }`.
+
+- [ ] **Step 2: Update the controller test to fail on the old coupling**
+
+Change the existing heartbeat fallback test to use deliberately different values:
+
+```ts
+const env = tablessEnv({
+  offlineRetryLimit: 1,
+  tablessFallbackFailureLimit: 2,
+});
+```
+
+Keep the assertion that the first failed heartbeat does not prepare a tab and the second does. This fails while the controller still reads `offlineRetryLimit`.
+
+- [ ] **Step 3: Run focused tests and verify the threshold assertions fail**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/scheduler.test.ts tests/backgroundController.test.ts
+```
+
+Expected: the below-threshold scheduler case and first controller heartbeat fall back too early.
+
+- [ ] **Step 4: Replace only tabless fallback reads**
+
+In `chooseTablessWatch`:
+
+```ts
+if (
+  sameChannel
+  && previous.watchMode === "tabless"
+  && (previous.heartbeatChecks ?? 0) >= settings.tablessFallbackFailureLimit
+) return false;
+```
+
+In `runWatchHeartbeat`:
+
+```ts
+if (
+  !ok
+  && heartbeatChecks >= settings.tablessFallbackFailureLimit
+  && !fallbacks.includes(platform)
+) {
+  fallbacks.push(platform);
+  emit({ category: "diagnostic", platform, level: "warn", message: "Tabless watch heartbeat keeps failing; falling back to a watch tab" });
+}
+```
+
+Update the nearby controller comment to say that `chooseTablessWatch` sees checks past the tabless fallback limit. Confirm with:
+
+```bash
+rg -n "offlineRetryLimit" packages/core/src/core/scheduler.ts packages/core/src/background/controller.ts
+```
+
+Every remaining match must concern offline or playback health, not tabless heartbeat fallback.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/scheduler.test.ts tests/backgroundController.test.ts
+```
+
+Expected: both files pass.
+
+- [ ] **Step 6: Commit runtime behavior**
+
+```bash
+git add packages/core/src/core/scheduler.ts packages/core/src/background/controller.ts packages/extension/tests/scheduler.test.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(scheduler): honor tabless fallback threshold"
+```
+
+---
+
+### Task 3: Advanced popup control and localization
+
+**Files:**
+- Modify: `packages/popup-ui/src/settingsRegistry.tsx:260-310`
+- Modify: `packages/locales/messages/{en,es,fr,it,ru,de,zh_CN,hi,pt_BR,ar,tr}.json`
+- Test: `packages/extension/tests/settingsRegistry.test.ts:110-165`
+- Test: `packages/extension/tests/settingsView.test.tsx:19-105,130-190`
+- Test: `packages/extension/tests/settingsSearchView.test.tsx:11-90,170-205`
+- Test: `packages/extension/tests/i18n.test.ts:45-62`
+
+**Interfaces:**
+- Consumes: `ExtensionSettings.tablessFallbackFailureLimit` and existing `NumberSettingRow`.
+- Produces: registry entry `general.advanced.tablessFallbackFailureLimit` plus locale keys `tablessFallbackFailureLimitTitle`, `tablessFallbackFailureLimitDescription`, `tablessFallbackFailureLimitDisabledReason`, and `failuresSuffix`.
+
+- [ ] **Step 1: Write failing registry and render tests**
+
+Add the registry ID immediately after `general.advanced.pollInterval` in the stable tree snapshot:
+
+```ts
+"general.advanced.pollInterval",
+"general.advanced.tablessFallbackFailureLimit",
+"general.advanced.postClaimHandoff",
+```
+
+Add these labels to both view-test label maps:
+
+```ts
+tablessFallbackFailureLimitTitle: "Tabless fallback threshold",
+tablessFallbackFailureLimitDescription: "Open a video tab after this many consecutive failed tabless watch signals.",
+tablessFallbackFailureLimitDisabledReason: "Enable tabless low-resource mode to change this setting.",
+failuresSuffix: "failures",
+```
+
+Add a settings view test:
+
+```ts
+function setNumberInput(input: HTMLInputElement, value: string): void {
+  input.value = value;
+  input.dispatchEvent(new window.Event("input", { bubbles: true }));
+  input.dispatchEvent(new window.Event("change", { bubbles: true }));
+}
+
+it("renders and saves the tabless fallback threshold", () => {
+  const { container, onSettingsChange } = mountSettings();
+  const input = container.querySelector(
+    'input[aria-label="Tabless fallback threshold"]',
+  ) as HTMLInputElement;
+  expect(input.value).toBe("5");
+  expect(input.min).toBe("1");
+  expect(input.max).toBe("10");
+
+  act(() => setNumberInput(input, "7"));
+  expect(onSettingsChange).toHaveBeenCalledWith(
+    { tablessFallbackFailureLimit: 7 },
+    { tickAfterSave: true },
+  );
+});
+```
+
+Add a second test mounting `tablessMode: false` and asserting the same input is disabled. Add a search-view assertion that searching for `tabless fallback` reveals this advanced entry while the advanced switch remains off.
+
+- [ ] **Step 2: Run UI tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/settingsRegistry.test.ts tests/settingsView.test.tsx tests/settingsSearchView.test.tsx
+```
+
+Expected: the registry snapshot and control queries fail because the entry does not exist.
+
+- [ ] **Step 3: Add the registry entry**
+
+Insert after the scheduler interval:
+
+```tsx
+{
+  id: "general.advanced.tablessFallbackFailureLimit",
+  titleKey: "tablessFallbackFailureLimitTitle",
+  descriptionKey: "tablessFallbackFailureLimitDescription",
+  render: () => (
+    <NumberSettingRow
+      title={t("tablessFallbackFailureLimitTitle")}
+      description={t("tablessFallbackFailureLimitDescription")}
+      value={settings.tablessFallbackFailureLimit}
+      min={1}
+      max={10}
+      suffix={t("failuresSuffix")}
+      disabled={!settings.tablessMode}
+      disabledReason={t("tablessFallbackFailureLimitDisabledReason")}
+      onChange={(value) => void onSettingsChange(
+        { tablessFallbackFailureLimit: value },
+        { tickAfterSave: true },
+      )}
+    />
+  ),
+},
+```
+
+- [ ] **Step 4: Add localized copy to every catalog**
+
+Keep the keys beside the existing `tablessTitle`/`tablessDescription` entries
+in every catalog. Use these exact messages:
+
+| Locale | Title | Description | Disabled reason | Suffix |
+|---|---|---|---|---|
+| `en` | Tabless fallback threshold | Open a video tab after this many consecutive failed tabless watch signals. | Enable tabless low-resource mode to change this setting. | failures |
+| `es` | Umbral de cambio desde el modo sin pestañas | Abre una pestaña de vídeo después de esta cantidad de señales de visualización sin pestañas fallidas consecutivas. | Activa el modo de bajo consumo sin pestañas para cambiar este ajuste. | fallos |
+| `fr` | Seuil de repli du mode sans onglet | Ouvre un onglet vidéo après ce nombre d’échecs consécutifs des signaux de visionnage sans onglet. | Activez le mode basse consommation sans onglet pour modifier ce réglage. | échecs |
+| `it` | Soglia di fallback della modalità senza schede | Apre una scheda video dopo questo numero di segnali di visione senza schede falliti consecutivamente. | Attiva la modalità a basso consumo senza schede per modificare questa impostazione. | errori |
+| `ru` | Порог перехода из режима без вкладок | Открывает вкладку с видео после указанного числа последовательных сбоев сигналов просмотра без вкладки. | Включите ресурсосберегающий режим без вкладок, чтобы изменить эту настройку. | сбоев |
+| `de` | Schwellenwert für den Tabless-Rückfall | Öffnet nach dieser Anzahl aufeinanderfolgender fehlgeschlagener Tabless-Wiedergabesignale einen Video-Tab. | Aktiviere den ressourcenschonenden Tabless-Modus, um diese Einstellung zu ändern. | Fehler |
+| `zh_CN` | 无标签页回退阈值 | 连续发生这么多次无标签页观看信号失败后打开视频标签页。 | 启用无标签页低资源模式以更改此设置。 | 次失败 |
+| `hi` | टैबलेस फ़ॉलबैक सीमा | लगातार इतनी टैबलेस वॉच सिग्नल विफलताओं के बाद वीडियो टैब खोलें। | यह सेटिंग बदलने के लिए कम-संसाधन टैबलेस मोड चालू करें। | विफलताएँ |
+| `pt_BR` | Limite de fallback do modo sem abas | Abre uma aba de vídeo após esta quantidade de falhas consecutivas nos sinais de visualização sem abas. | Ative o modo de baixo consumo sem abas para alterar esta configuração. | falhas |
+| `ar` | حد الرجوع عن وضع بلا علامات تبويب | يفتح علامة تبويب فيديو بعد هذا العدد من حالات فشل إشارات المشاهدة المتتالية بلا علامة تبويب. | فعّل وضع الموارد المنخفضة بلا علامات تبويب لتغيير هذا الإعداد. | حالات فشل |
+| `tr` | Sekmesiz moddan geri dönüş eşiği | Art arda bu sayıda sekmesiz izleme sinyali başarısız olduğunda bir video sekmesi açar. | Bu ayarı değiştirmek için düşük kaynak kullanan sekmesiz modu etkinleştirin. | hata |
+
+Map the columns respectively to
+`tablessFallbackFailureLimitTitle`,
+`tablessFallbackFailureLimitDescription`,
+`tablessFallbackFailureLimitDisabledReason`, and `failuresSuffix`.
+
+- [ ] **Step 5: Run UI and locale tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/settingsRegistry.test.ts tests/settingsView.test.tsx tests/settingsSearchView.test.tsx tests/i18n.test.ts
+```
+
+Expected: all four files pass, including locale key parity.
+
+- [ ] **Step 6: Commit the popup setting**
+
+```bash
+git add packages/popup-ui/src/settingsRegistry.tsx packages/locales/messages packages/extension/tests/settingsRegistry.test.ts packages/extension/tests/settingsView.test.tsx packages/extension/tests/settingsSearchView.test.tsx packages/extension/tests/i18n.test.ts
+git commit -m "feat(popup): expose tabless fallback threshold"
+```
+
+---
+
+### Task 4: Client-Integrity exception regression and full verification
+
+**Files:**
+- Test: `packages/extension/tests/tabs.test.ts:998-1055`
+- Verify only: `packages/core/src/core/tabs.ts:510-543`
+
+**Interfaces:**
+- Consumes: existing `ensureTwitchIntegrityWithBrowser(browserApi, originUrl, timeoutMs?, emit?): Promise<boolean>`.
+- Produces: regression coverage proving the first missing-token invocation immediately opens Twitch page context.
+
+- [ ] **Step 1: Add the explicit first-miss regression test**
+
+Add this test beside the existing Client-Integrity creation test:
+
+```ts
+it("opens page context immediately on the first missing-token check", async () => {
+  const browser = browserMock();
+  browser.tabs.query.mockResolvedValue([]);
+  browser.tabs.create.mockResolvedValue({ id: 14 });
+
+  const pending = ensureTwitchIntegrityWithBrowser(
+    browser,
+    "https://www.twitch.tv/drops/inventory",
+    50,
+  );
+
+  await vi.waitFor(() => {
+    expect(browser.tabs.create).toHaveBeenCalledTimes(1);
+  });
+  expect(browser.tabs.create).toHaveBeenCalledWith({
+    url: "https://www.twitch.tv/drops/inventory",
+    pinned: false,
+    active: false,
+  });
+  await expect(pending).resolves.toBe(false);
+});
+```
+
+Do not modify `ensureTwitchIntegrityWithBrowser`.
+
+- [ ] **Step 2: Run the Client-Integrity test**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts
+```
+
+Expected: pass, demonstrating the deliberate exception remains intact.
+
+- [ ] **Step 3: Audit the final diff**
+
+Run:
+
+```bash
+git diff origin/develop...HEAD --check
+git diff origin/develop...HEAD -- packages/core/src/core/tabs.ts
+rg -n "tablessFallbackFailureLimit|offlineRetryLimit" packages/core packages/shared packages/popup-ui packages/extension/tests
+git status --short
+```
+
+Expected: no whitespace errors; no production diff in `tabs.ts`; tabless fallback reads the new setting; offline/playback health retains `offlineRetryLimit`; only the intended uncommitted test remains.
+
+- [ ] **Step 4: Run full verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, workspace typechecks, extension tests, site build, and Chromium/Firefox production builds all pass.
+
+- [ ] **Step 5: Commit the regression test**
+
+```bash
+git add packages/extension/tests/tabs.test.ts
+git commit -m "test(twitch): preserve immediate integrity capture"
+```
+
+- [ ] **Step 6: Confirm clean completion state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate origin/develop..HEAD
+```
+
+Expected: clean worktree on `feat/tabless-fallback-failure-limit` with the design, plan, and four focused implementation commits ahead of `origin/develop`.

--- a/docs/superpowers/specs/2026-07-26-tabless-fallback-failure-limit-design.md
+++ b/docs/superpowers/specs/2026-07-26-tabless-fallback-failure-limit-design.md
@@ -1,0 +1,125 @@
+# Configurable Tabless Fallback Failure Limit
+
+## Context
+
+Tabless farming currently falls back to a watch tab after
+`offlineRetryLimit` consecutive heartbeat failures. That setting is intended to
+decide when a channel is offline, so using it for tabless transport reliability
+couples two unrelated policies. A transient heartbeat failure can therefore
+open a sticky watch tab earlier than the user wants.
+
+Client-Integrity capture is a separate page-context mechanism. When Twitch has
+no valid integrity token, an authenticated mutation cannot succeed until a
+Twitch page mints one. That path must continue opening or reusing a Twitch tab
+on the first token miss.
+
+## Goals
+
+- Give tabless fallback its own persisted, user-configurable threshold.
+- Default to five consecutive failures and accept values from one through ten.
+- Keep channel-offline detection controlled exclusively by
+  `offlineRetryLimit`.
+- Preserve immediate Client-Integrity page-context acquisition.
+- Cover engine behavior, settings normalization and UI exposure with
+  deterministic tests.
+
+## Non-goals
+
+- Changing heartbeat cadence or health semantics.
+- Changing when a channel is considered offline.
+- Retrying or otherwise altering Client-Integrity token capture.
+- Adding a settings migration for existing users.
+- Generalizing all scheduler retry limits behind a new policy abstraction.
+
+## Settings Contract
+
+Add `tablessFallbackFailureLimit: number` to `EngineSettings`, because both the
+extension and CLI-hosted engine use tabless watchers. Add it to
+`DEFAULT_ENGINE_SETTINGS` with a value of `5`.
+
+`mergeEngineSettings` clamps the setting to an integer from `1` through `10`,
+using the default when the stored value is missing or invalid. Existing stored
+settings therefore gain the new value through the normal merge path without a
+schema migration. The existing settings patch and persistence paths already
+carry scalar engine fields, so no special persistence logic is required.
+
+## Runtime Behavior
+
+The setting replaces `offlineRetryLimit` at both tabless fallback decision
+points:
+
+1. `runWatchHeartbeat` increments consecutive failed heartbeat checks and
+   requests a scheduler tick once the new threshold is reached.
+2. `chooseTablessWatch` uses the same threshold to decide that the tick must
+   select a watch tab for the current channel.
+
+Using the same value at both points keeps the trigger and scheduler decision
+consistent. A successful heartbeat continues resetting the consecutive failure
+count to zero. Once fallback occurs, the existing `tablessFallback` flag keeps
+the session on its watch tab until the target changes.
+
+All other reads of `offlineRetryLimit`, including channel-offline and playback
+health checks, remain unchanged. Comments in shared models, the scheduler, and
+the controller will name the new setting where they describe tabless fallback.
+
+## Popup UI and Localization
+
+Add a `NumberSettingRow` to the existing Advanced settings group:
+
+- title: “Tabless fallback threshold”
+- description: explain that this is the number of consecutive failed watch
+  signals allowed before opening a video tab
+- value: `settings.tablessFallbackFailureLimit`
+- minimum/maximum: `1` and `10`
+- suffix: localized “failures”
+- disabled while tabless mode is off, with a localized reason
+- save through `onSettingsChange` with `tickAfterSave: true`, so lowering the
+  threshold can take effect against an already unhealthy tabless session
+
+Add the title, description, suffix, and disabled-reason message keys to every
+catalog in `packages/locales/messages/`, preserving catalog key parity. The
+entry also participates in the settings registry and search like the existing
+advanced numeric settings.
+
+## Client-Integrity Exception
+
+Do not change `ensureTwitchIntegrityWithBrowser` or route it through tabless
+fallback policy. It remains an immediate call to acquire a Twitch page-context
+tab when no valid token exists.
+
+Add an explicit regression test that starts without a valid token or existing
+Twitch tab and asserts `browser.tabs.create` is called immediately on the first
+invocation. The test documents that no heartbeat or settings retry budget gates
+this acquisition.
+
+## Testing
+
+Add or update focused tests for:
+
+- defaulting missing `tablessFallbackFailureLimit` to `5`
+- clamping low, high, fractional, and invalid values to the `1`–`10` integer
+  contract
+- preserving the value through the existing settings save/load path
+- remaining tabless below the configured threshold
+- falling back exactly at the configured threshold
+- honoring a non-default threshold independently of `offlineRetryLimit`
+- triggering controller fallback according to the new setting
+- rendering, searching, and changing the popup setting
+- maintaining localization catalog parity
+- opening the Client-Integrity page-context tab on the first missing-token
+  invocation
+
+Run targeted Vitest files during development, then `pnpm verify` before
+completion.
+
+## Risks and Mitigations
+
+- **Mismatched thresholds:** update both the controller trigger and scheduler
+  decision, with tests spanning both layers.
+- **Accidental offline-policy change:** leave all non-tabless
+  `offlineRetryLimit` reads intact and assert independence with non-default
+  values.
+- **Locale drift:** update every message catalog and rely on existing locale
+  parity/type checks.
+- **Integrity regression:** keep the implementation untouched and add a
+  first-miss tab-creation regression test.

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -805,7 +805,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         } else if (!ok && previousChecks === 0) {
           emit({ category: "diagnostic", platform, level: "warn", message: message ?? "Tabless watch heartbeat failed" });
         }
-        if (!ok && heartbeatChecks >= settings.offlineRetryLimit && !fallbacks.includes(platform)) {
+        if (!ok && heartbeatChecks >= settings.tablessFallbackFailureLimit && !fallbacks.includes(platform)) {
           fallbacks.push(platform);
           emit({ category: "diagnostic", platform, level: "warn", message: "Tabless watch heartbeat keeps failing; falling back to a watch tab" });
         }
@@ -821,7 +821,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       return fallbacks;
     }));
 
-    // chooseTablessWatch now sees heartbeatChecks past the limit and opens a tab.
+    // chooseTablessWatch now sees heartbeatChecks past the tabless fallback limit and opens a tab.
     // Run outside the lock: tick() acquires the lock itself.
     for (const platform of fallbackPlatforms) {
       await tick([platform]);

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -54,7 +54,7 @@ function activeReward(campaign: DropCampaign, settings: EngineSettings): DropRew
 // Decides whether to farm this channel without a tab. Off unless tabless mode is
 // enabled and the platform supports it; falls back to a tab (returns false) when
 // we deliberately switched to a tab for this same channel, or when tabless
-// heartbeats have been failing past the retry limit.
+// heartbeats have been failing past the tabless fallback limit.
 function chooseTablessWatch(
   previous: WatchSession,
   settings: EngineSettings,
@@ -63,7 +63,7 @@ function chooseTablessWatch(
 ): boolean {
   if (!settings.tablessMode || !adapter.supportsTabless) return false;
   if (sameChannel && previous.watchMode === "tab" && previous.tablessFallback) return false;
-  if (sameChannel && previous.watchMode === "tabless" && (previous.heartbeatChecks ?? 0) >= settings.offlineRetryLimit) return false;
+  if (sameChannel && previous.watchMode === "tabless" && (previous.heartbeatChecks ?? 0) >= settings.tablessFallbackFailureLimit) return false;
   return true;
 }
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1287,12 +1287,22 @@ describe("background controller", () => {
 
   it("saves and normalizes settings without forcing a scheduler tick", async () => {
     const env = harness();
-    const nextSettings = { ...DEFAULT_SETTINGS, running: true, pollIntervalMinutes: Number.NaN, offlineRetryLimit: 0 };
+    const nextSettings = {
+      ...DEFAULT_SETTINGS,
+      running: true,
+      pollIntervalMinutes: Number.NaN,
+      offlineRetryLimit: 0,
+      tablessFallbackFailureLimit: 99,
+    };
 
     await env.controller.handleMessage({ type: "saveSettings", settingsPatch: nextSettings });
 
     expect(env.settings.pollIntervalMinutes).toBe(DEFAULT_SETTINGS.pollIntervalMinutes);
     expect(env.settings.offlineRetryLimit).toBe(1);
+    expect(env.settings.tablessFallbackFailureLimit).toBe(10);
+    expect(env.deps.saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ tablessFallbackFailureLimit: 10 }),
+    );
     expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
   });

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -2597,7 +2597,7 @@ describe("background controller", () => {
 
   it("falls back to a watch tab once the tabless heartbeat keeps failing", async () => {
     const watcher = fakeTablessWatcher(async () => ({ ok: false, live: true }));
-    const env = tablessEnv({ offlineRetryLimit: 2 });
+    const env = tablessEnv({ offlineRetryLimit: 1, tablessFallbackFailureLimit: 2 });
     env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
 
     await env.controller.tick();

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -2759,6 +2759,41 @@ describe("scheduler tabless mode", () => {
     return { ...adapter("twitch", campaigns, candidates), supportsTabless: true };
   }
 
+  async function runTablessFallbackCase(heartbeatChecks: number, overrides: SettingsPatch) {
+    const twitch = tablessAdapter([campaign("drops")], [channel("creator")]);
+    vi.mocked(twitch.checkChannel).mockResolvedValue({ live: true, categoryMatches: true, candidate: channel("creator") });
+
+    const result = await runSchedulerTick(
+      {
+        authHealth: HEALTHY_AUTH,
+        sessions: {
+          twitch: {
+            platform: "twitch",
+            status: "watching",
+            channel: channel("creator"),
+            campaignId: "drops",
+            rewardId: "reward-in_progress",
+            offlineChecks: 0,
+            watchMode: "tabless",
+            heartbeatChecks,
+            lastHeartbeatOk: false,
+            lastHeartbeatAt: new Date().toISOString(),
+          },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [campaign("drops")], kick: [] },
+      },
+      settings({
+        ...overrides,
+        tablessMode: true,
+        platform: { twitch: { enabled: true, idleWatchlistChannels: [] }, kick: { enabled: false, idleWatchlistChannels: [] } },
+      }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    return { result, twitch };
+  }
+
   it("does not open a watch tab and marks the session tabless when tabless mode is on", async () => {
     const twitch = tablessAdapter([campaign("drops")], [channel("creator")]);
 
@@ -2782,37 +2817,36 @@ describe("scheduler tabless mode", () => {
     expect(result.state.managedWatchTabs?.twitch).toBeUndefined();
   });
 
-  it("falls back to a watch tab after the tabless heartbeat keeps failing", async () => {
-    const twitch = tablessAdapter([campaign("drops")], [channel("creator")]);
-    vi.mocked(twitch.checkChannel).mockResolvedValue({ live: true, categoryMatches: true, candidate: channel("creator") });
+  it("stays tabless below its configured fallback threshold", async () => {
+    const { result, twitch } = await runTablessFallbackCase(4, {
+      offlineRetryLimit: 1,
+      tablessFallbackFailureLimit: 5,
+    });
 
-    const result = await runSchedulerTick(
-      {
-        authHealth: HEALTHY_AUTH,
-        sessions: {
-          twitch: {
-            platform: "twitch",
-            status: "watching",
-            channel: channel("creator"),
-            campaignId: "drops",
-            rewardId: "reward-in_progress",
-            offlineChecks: 0,
-            watchMode: "tabless",
-            heartbeatChecks: 3,
-            lastHeartbeatOk: false,
-            lastHeartbeatAt: new Date().toISOString(),
-          },
-          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
-        },
-        campaigns: { twitch: [campaign("drops")], kick: [] },
-      },
-      settings({ offlineRetryLimit: 3, tablessMode: true, platform: { twitch: { enabled: true, idleWatchlistChannels: [] }, kick: { enabled: false, idleWatchlistChannels: [] } } }),
-      { twitch, kick: adapter("kick", [], []) },
-    );
+    expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
+    expect(result.state.sessions.twitch.watchMode).toBe("tabless");
+  });
 
-    expect(twitch.prepareWatchTab).toHaveBeenCalledTimes(1);
+  it("falls back exactly at its configured fallback threshold", async () => {
+    const { result, twitch } = await runTablessFallbackCase(5, {
+      offlineRetryLimit: 10,
+      tablessFallbackFailureLimit: 5,
+    });
+
+    expect(twitch.prepareWatchTab).toHaveBeenCalledOnce();
+    expect(result.state.sessions.twitch).toMatchObject({
+      watchMode: "tab",
+      tablessFallback: true,
+    });
+  });
+
+  it("honors a non-default tabless fallback threshold", async () => {
+    const { result } = await runTablessFallbackCase(2, {
+      offlineRetryLimit: 9,
+      tablessFallbackFailureLimit: 2,
+    });
+
     expect(result.state.sessions.twitch.watchMode).toBe("tab");
-    expect(result.state.sessions.twitch.tablessFallback).toBe(true);
   });
 
   it("stays tabless while heartbeats remain healthy on the same channel", async () => {

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -144,6 +144,20 @@ describe("settings", () => {
     expect(mergeSettings({ pollIntervalMinutes: Number.NaN, offlineRetryLimit: Number.NaN }).pollIntervalMinutes)
       .toBe(DEFAULT_SETTINGS.pollIntervalMinutes);
     expect(mergeSettings({ offlineRetryLimit: Number.NaN }).offlineRetryLimit).toBe(DEFAULT_SETTINGS.offlineRetryLimit);
+
+    expect(DEFAULT_ENGINE_SETTINGS.tablessFallbackFailureLimit).toBe(5);
+    expect(mergeEngineSettings({}).tablessFallbackFailureLimit).toBe(5);
+    expect(mergeEngineSettings({ tablessFallbackFailureLimit: 0 }).tablessFallbackFailureLimit).toBe(1);
+    expect(mergeEngineSettings({ tablessFallbackFailureLimit: 11 }).tablessFallbackFailureLimit).toBe(10);
+    expect(mergeEngineSettings({ tablessFallbackFailureLimit: 4.6 }).tablessFallbackFailureLimit).toBe(5);
+    expect(mergeEngineSettings({ tablessFallbackFailureLimit: Number.NaN }).tablessFallbackFailureLimit).toBe(5);
+    expect(mergeEngineSettings({
+      offlineRetryLimit: 9,
+      tablessFallbackFailureLimit: 2,
+    })).toMatchObject({
+      offlineRetryLimit: 9,
+      tablessFallbackFailureLimit: 2,
+    });
   });
 
   it("clamps post-claim handoff settings and defaults them when absent", () => {

--- a/packages/extension/tests/settingsRegistry.test.ts
+++ b/packages/extension/tests/settingsRegistry.test.ts
@@ -132,6 +132,7 @@ describe("settings registry", () => {
         "general.farmingTabs.keepUnmuted",
         "general.farmingTabs.adFocus",
         "general.advanced.pollInterval",
+        "general.advanced.tablessFallbackFailureLimit",
         "general.advanced.postClaimHandoff",
         "general.advanced.postClaimHandoffInterval",
         "general.advanced.postClaimHandoffMax",

--- a/packages/extension/tests/settingsSearchView.test.tsx
+++ b/packages/extension/tests/settingsSearchView.test.tsx
@@ -64,6 +64,10 @@ const labels: Record<string, string> = {
   adFocusDescription: "Ad countdowns freeze in background tabs.",
   schedulerIntervalTitle: "Scheduler interval",
   schedulerIntervalDescription: "How often campaign and streamer status refreshes.",
+  tablessFallbackFailureLimitTitle: "Tabless fallback threshold",
+  tablessFallbackFailureLimitDescription: "Open a video tab after this many consecutive failed tabless watch signals.",
+  tablessFallbackFailureLimitDisabledReason: "Enable tabless low-resource mode to change this setting.",
+  failuresSuffix: "failures",
   postClaimHandoffTitle: "Fast reward handoff",
   postClaimHandoffDescription: "After claiming a drop, briefly check for the next reward.",
   postClaimHandoffIntervalTitle: "Handoff check interval",
@@ -196,9 +200,9 @@ describe("settings search view", () => {
     const { container } = mountSettings();
     const search = container.querySelector("input[type=search]") as HTMLInputElement;
     act(() => {
-      setInputValue(search, "scheduler interval");
+      setInputValue(search, "tabless fallback");
     });
-    expect(container.textContent).toContain("Scheduler interval");
+    expect(container.textContent).toContain("Tabless fallback threshold");
     const advancedSwitch = [...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Show advanced settings");
     expect(advancedSwitch?.getAttribute("aria-checked")).toBe("false");
   });

--- a/packages/extension/tests/settingsView.test.tsx
+++ b/packages/extension/tests/settingsView.test.tsx
@@ -76,6 +76,10 @@ const labels: Record<string, string> = {
   adFocusDescription: "Ad countdowns freeze in background tabs.",
   schedulerIntervalTitle: "Scheduler interval",
   schedulerIntervalDescription: "How often campaign and streamer status refreshes.",
+  tablessFallbackFailureLimitTitle: "Tabless fallback threshold",
+  tablessFallbackFailureLimitDescription: "Open a video tab after this many consecutive failed tabless watch signals.",
+  tablessFallbackFailureLimitDisabledReason: "Enable tabless low-resource mode to change this setting.",
+  failuresSuffix: "failures",
   postClaimHandoffTitle: "Fast reward handoff",
   postClaimHandoffDescription: "After claiming a drop, briefly check for the next reward.",
   postClaimHandoffIntervalTitle: "Handoff check interval",
@@ -143,6 +147,19 @@ describe("deadline feasibility setting", () => {
     return { container, onSettingsChange };
   }
 
+  function setNumberInput(input: HTMLInputElement, value: string): void {
+    input.value = value;
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    input.dispatchEvent(new window.Event("change", { bubbles: true }));
+    // Linkedom does not route these events through React's ChangeEventPlugin,
+    // so mirror the browser's input-and-blur sequence through the stashed host
+    // props. The search-view test uses the same focused workaround.
+    const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+    const props = propsKey ? (input as unknown as Record<string, { onBlur?(event: unknown): void; onChange?(event: unknown): void }>)[propsKey] : undefined;
+    props?.onChange?.({ target: input, currentTarget: input });
+    props?.onBlur?.({ currentTarget: input });
+  }
+
   it("defaults the toggle on and saves changes immediately", () => {
     const { container, onSettingsChange } = mountSettings();
     const toggle = container.querySelector('[role="switch"][aria-label="Skip rewards that cannot be completed"]') as HTMLButtonElement;
@@ -159,6 +176,30 @@ describe("deadline feasibility setting", () => {
     const { container } = mountSettings({ ...DEFAULT_SETTINGS, skipUnfinishableRewards: false, deadlineSafetyMarginMinutes: 17 });
     const input = container.querySelector('input[aria-label="Deadline safety margin"]') as HTMLInputElement;
     expect(input.value).toBe("17");
+    expect(input.disabled).toBe(true);
+  });
+
+  it("renders and saves the tabless fallback threshold", () => {
+    const { container, onSettingsChange } = mountSettings();
+    const input = container.querySelector(
+      'input[aria-label="Tabless fallback threshold"]',
+    ) as HTMLInputElement;
+    expect(input.value).toBe("5");
+    expect(input.getAttribute("min")).toBe("1");
+    expect(input.getAttribute("max")).toBe("10");
+
+    act(() => setNumberInput(input, "7"));
+    expect(onSettingsChange).toHaveBeenCalledWith(
+      { tablessFallbackFailureLimit: 7 },
+      { tickAfterSave: true },
+    );
+  });
+
+  it("disables the tabless fallback threshold when tabless mode is off", () => {
+    const { container } = mountSettings({ ...DEFAULT_SETTINGS, tablessMode: false });
+    const input = container.querySelector(
+      'input[aria-label="Tabless fallback threshold"]',
+    ) as HTMLInputElement;
     expect(input.disabled).toBe(true);
   });
 

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1039,6 +1039,28 @@ describe("twitch integrity refresh", () => {
       expect(currentManagedPageContextTabs()).toMatchObject({ twitch: { tabId: 14 } });
     });
 
+    it("opens page context immediately on the first missing-token check", async () => {
+      const browser = browserMock();
+      browser.tabs.query.mockResolvedValue([]);
+      browser.tabs.create.mockResolvedValue({ id: 14 });
+
+      const pending = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        50,
+      );
+
+      await vi.waitFor(() => {
+        expect(browser.tabs.create).toHaveBeenCalledTimes(1);
+      });
+      expect(browser.tabs.create).toHaveBeenCalledWith({
+        url: "https://www.twitch.tv/drops/inventory",
+        pinned: false,
+        active: false,
+      });
+      await expect(pending).resolves.toBe(false);
+    });
+
     it("resolves false and warns when no token is captured before the timeout", async () => {
       const browser = browserMock();
       browser.tabs.query.mockResolvedValue([{ id: 3 }]);

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "فارم عبر إشارات مشاهدة خفيفة بدل تبويب فيديو. يستخدم Twitch نبضات مشاهدة؛ ويستخدم Kick اتصال مشاهد. يعود تلقائيًا إلى تبويب إذا توقف عن الاحتساب."
   },
+  "tablessFallbackFailureLimitTitle": { "message": "حد الرجوع عن وضع بلا علامات تبويب" },
+  "tablessFallbackFailureLimitDescription": { "message": "يفتح علامة تبويب فيديو بعد هذا العدد من حالات فشل إشارات المشاهدة المتتالية بلا علامة تبويب." },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "فعّل وضع الموارد المنخفضة بلا علامات تبويب لتغيير هذا الإعداد." },
+  "failuresSuffix": { "message": "حالات فشل" },
   "autoCloseTabsTitle": {
     "message": "إغلاق تبويبات الفارم تلقائيًا"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "Farmt über leichte Watch-Signale statt Video-Tab. Twitch nutzt Watch-Heartbeats; Kick nutzt eine Zuschauerverbindung. Fällt automatisch auf einen Tab zurück, wenn es nicht mehr zählt."
   },
+  "tablessFallbackFailureLimitTitle": { "message": "Schwellenwert für den Tabless-Rückfall" },
+  "tablessFallbackFailureLimitDescription": { "message": "Öffnet nach dieser Anzahl aufeinanderfolgender fehlgeschlagener Tabless-Wiedergabesignale einen Video-Tab." },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "Aktiviere den ressourcenschonenden Tabless-Modus, um diese Einstellung zu ändern." },
+  "failuresSuffix": { "message": "Fehler" },
   "autoCloseTabsTitle": {
     "message": "Farming-Tabs automatisch schließen"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "Farm via lightweight watch signals instead of a video tab. Twitch uses watch heartbeats; Kick uses a viewer connection. Falls back to a tab automatically if it stops earning."
   },
+  "tablessFallbackFailureLimitTitle": { "message": "Tabless fallback threshold" },
+  "tablessFallbackFailureLimitDescription": { "message": "Open a video tab after this many consecutive failed tabless watch signals." },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "Enable tabless low-resource mode to change this setting." },
+  "failuresSuffix": { "message": "failures" },
   "autoCloseTabsTitle": {
     "message": "Auto-close farming tabs"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "Farmea con señales ligeras de visualización en lugar de una pestaña de vídeo. Twitch usa heartbeats de visualización; Kick usa una conexión de espectador. Vuelve automáticamente a una pestaña si deja de contar."
   },
+  "tablessFallbackFailureLimitTitle": { "message": "Umbral de cambio desde el modo sin pestañas" },
+  "tablessFallbackFailureLimitDescription": { "message": "Abre una pestaña de vídeo después de esta cantidad de señales de visualización sin pestañas fallidas consecutivas." },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "Activa el modo de bajo consumo sin pestañas para cambiar este ajuste." },
+  "failuresSuffix": { "message": "fallos" },
   "autoCloseTabsTitle": {
     "message": "Cerrar pestañas de farmeo automáticamente"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "Farme via des signaux légers au lieu d’un onglet vidéo. Twitch utilise des heartbeats de visionnage ; Kick utilise une connexion spectateur. Revient automatiquement à un onglet si cela ne progresse plus."
   },
+  "tablessFallbackFailureLimitTitle": { "message": "Seuil de repli du mode sans onglet" },
+  "tablessFallbackFailureLimitDescription": { "message": "Ouvre un onglet vidéo après ce nombre d’échecs consécutifs des signaux de visionnage sans onglet." },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "Activez le mode basse consommation sans onglet pour modifier ce réglage." },
+  "failuresSuffix": { "message": "échecs" },
   "autoCloseTabsTitle": {
     "message": "Fermer automatiquement les onglets de farm"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "वीडियो टैब के बजाय हल्के watch signals से फ़ार्म करें। Twitch watch heartbeats उपयोग करता है; Kick viewer connection उपयोग करता है। कमाई रुकने पर अपने आप टैब पर लौटता है।"
   },
+  "tablessFallbackFailureLimitTitle": { "message": "टैबलेस फ़ॉलबैक सीमा" },
+  "tablessFallbackFailureLimitDescription": { "message": "लगातार इतनी टैबलेस वॉच सिग्नल विफलताओं के बाद वीडियो टैब खोलें।" },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "यह सेटिंग बदलने के लिए कम-संसाधन टैबलेस मोड चालू करें।" },
+  "failuresSuffix": { "message": "विफलताएँ" },
   "autoCloseTabsTitle": {
     "message": "फ़ार्मिंग टैब अपने आप बंद करें"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "Farma tramite segnali leggeri invece di una scheda video. Twitch usa heartbeat di visione; Kick usa una connessione viewer. Torna automaticamente a una scheda se smette di funzionare."
   },
+  "tablessFallbackFailureLimitTitle": { "message": "Soglia di fallback della modalità senza schede" },
+  "tablessFallbackFailureLimitDescription": { "message": "Apre una scheda video dopo questo numero di segnali di visione senza schede falliti consecutivamente." },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "Attiva la modalità a basso consumo senza schede per modificare questa impostazione." },
+  "failuresSuffix": { "message": "errori" },
   "autoCloseTabsTitle": {
     "message": "Chiudi automaticamente le schede di farming"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "Farma por sinais leves de visualização em vez de uma aba de vídeo. Twitch usa heartbeats; Kick usa uma conexão de espectador. Volta para uma aba automaticamente se parar de contar."
   },
+  "tablessFallbackFailureLimitTitle": { "message": "Limite de fallback do modo sem abas" },
+  "tablessFallbackFailureLimitDescription": { "message": "Abre uma aba de vídeo após esta quantidade de falhas consecutivas nos sinais de visualização sem abas." },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "Ative o modo de baixo consumo sem abas para alterar esta configuração." },
+  "failuresSuffix": { "message": "falhas" },
   "autoCloseTabsTitle": {
     "message": "Fechar abas de farming automaticamente"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "Фармит лёгкими сигналами просмотра вместо видеовкладки. Twitch использует heartbeats просмотра; Kick — соединение зрителя. Автоматически возвращается к вкладке, если прогресс останавливается."
   },
+  "tablessFallbackFailureLimitTitle": { "message": "Порог перехода из режима без вкладок" },
+  "tablessFallbackFailureLimitDescription": { "message": "Открывает вкладку с видео после указанного числа последовательных сбоев сигналов просмотра без вкладки." },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "Включите ресурсосберегающий режим без вкладок, чтобы изменить эту настройку." },
+  "failuresSuffix": { "message": "сбоев" },
   "autoCloseTabsTitle": {
     "message": "Автозакрытие вкладок фарма"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -437,6 +437,10 @@
   "tablessDescription": {
     "message": "Sekme açmadan sessizce arka planda toplar. (İşlem takılırsa otomatik sekme açar.)"
   },
+  "tablessFallbackFailureLimitTitle": { "message": "Sekmesiz moddan geri dönüş eşiği" },
+  "tablessFallbackFailureLimitDescription": { "message": "Art arda bu sayıda sekmesiz izleme sinyali başarısız olduğunda bir video sekmesi açar." },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "Bu ayarı değiştirmek için düşük kaynak kullanan sekmesiz modu etkinleştirin." },
+  "failuresSuffix": { "message": "hata" },
   "autoCloseTabsTitle": {
     "message": "Gereksiz sekmeleri kapat"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -413,6 +413,10 @@
   "tablessDescription": {
     "message": "通过轻量观看信号而不是视频标签页刷取。Twitch 使用观看心跳；Kick 使用观众连接。如果停止计数，会自动退回标签页。"
   },
+  "tablessFallbackFailureLimitTitle": { "message": "无标签页回退阈值" },
+  "tablessFallbackFailureLimitDescription": { "message": "连续发生这么多次无标签页观看信号失败后打开视频标签页。" },
+  "tablessFallbackFailureLimitDisabledReason": { "message": "启用无标签页低资源模式以更改此设置。" },
+  "failuresSuffix": { "message": "次失败" },
   "autoCloseTabsTitle": {
     "message": "自动关闭刷取标签页"
   },

--- a/packages/popup-ui/src/settingsRegistry.tsx
+++ b/packages/popup-ui/src/settingsRegistry.tsx
@@ -272,6 +272,27 @@ export function buildSettingsRegistry(ctx: SettingsRegistryContext): SettingsSec
             render: () => <NumberSettingRow title={t("schedulerIntervalTitle")} description={t("schedulerIntervalDescription")} value={Math.round(settings.pollIntervalMinutes * 60)} min={30} max={3600} suffix={t("secondsSuffix")} onChange={(value) => void onSettingsChange({ pollIntervalMinutes: value / 60 })} />,
           },
           {
+            id: "general.advanced.tablessFallbackFailureLimit",
+            titleKey: "tablessFallbackFailureLimitTitle",
+            descriptionKey: "tablessFallbackFailureLimitDescription",
+            render: () => (
+              <NumberSettingRow
+                title={t("tablessFallbackFailureLimitTitle")}
+                description={t("tablessFallbackFailureLimitDescription")}
+                value={settings.tablessFallbackFailureLimit}
+                min={1}
+                max={10}
+                suffix={t("failuresSuffix")}
+                disabled={!settings.tablessMode}
+                disabledReason={t("tablessFallbackFailureLimitDisabledReason")}
+                onChange={(value) => void onSettingsChange(
+                  { tablessFallbackFailureLimit: value },
+                  { tickAfterSave: true },
+                )}
+              />
+            ),
+          },
+          {
             id: "general.advanced.postClaimHandoff",
             titleKey: "postClaimHandoffTitle",
             descriptionKey: "postClaimHandoffDescription",

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -143,7 +143,7 @@ export interface WatchSession {
   tablessFallback?: boolean;
   // Health of the tabless heartbeat. lastHeartbeatOk is whether the last watch
   // signal was accepted; heartbeatChecks counts consecutive unhealthy checks so
-  // the scheduler can fall back to a real tab after offlineRetryLimit.
+  // the scheduler can fall back to a real tab after tablessFallbackFailureLimit.
   lastHeartbeatAt?: string;
   lastHeartbeatOk?: boolean;
   heartbeatChecks?: number;
@@ -330,6 +330,8 @@ export interface EngineSettings {
     farmSubscriptionCampaigns: boolean;
   };
   offlineRetryLimit: number;
+  // Consecutive failed tabless heartbeats before falling back to a watch tab.
+  tablessFallbackFailureLimit: number;
   pollIntervalMinutes: number;
   // Bounded post-claim handoff. After a reward is claimed, re-run discovery for
   // that platform on this cadence until the next eligible reward appears, then

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -68,6 +68,7 @@ export const DEFAULT_ENGINE_SETTINGS: EngineSettings = {
     farmSubscriptionCampaigns: true,
   },
   offlineRetryLimit: 3,
+  tablessFallbackFailureLimit: 5,
   pollIntervalMinutes: 1,
   postClaimHandoff: true,
   // Nine refreshes at most, always finishing before the next one-minute watch
@@ -165,6 +166,12 @@ export function mergeEngineSettings(value: Partial<EngineSettings> | undefined):
     excludedCampaignIds: normalizeIdList(value?.excludedCampaignIds),
     farmingEligibility: normalizeFarmingEligibility(value?.farmingEligibility),
     offlineRetryLimit: clampInteger(value?.offlineRetryLimit, 1, 10, DEFAULT_ENGINE_SETTINGS.offlineRetryLimit),
+    tablessFallbackFailureLimit: clampInteger(
+      value?.tablessFallbackFailureLimit,
+      1,
+      10,
+      DEFAULT_ENGINE_SETTINGS.tablessFallbackFailureLimit,
+    ),
     // chrome.alarms floors periodInMinutes at 1, so sub-minute values are inert.
     pollIntervalMinutes: clampNumber(value?.pollIntervalMinutes, 1, 60, DEFAULT_ENGINE_SETTINGS.pollIntervalMinutes),
     postClaimHandoff: booleanOr(value?.postClaimHandoff, DEFAULT_ENGINE_SETTINGS.postClaimHandoff),


### PR DESCRIPTION
## Summary

- add a dedicated `tablessFallbackFailureLimit` engine setting, defaulting to 5 and clamped from 1 to 10
- use the new threshold consistently in the heartbeat controller and scheduler while leaving `offlineRetryLimit` for channel/playback health
- expose the threshold in Advanced popup settings with localized copy across all supported locales
- preserve immediate Twitch Client-Integrity page-context acquisition and cover it with an explicit regression test

## Impact

Users can choose how patient tabless farming should be before Lurkloot opens a sticky watch tab. Existing users require no migration because missing values normalize to the new default.

## Testing

- `pnpm verify`
- 979 extension tests and 126 CLI tests passed
- workspace typechecks passed
- site, Chromium extension, and Firefox extension builds passed
- task-scoped and whole-branch code reviews reported no findings

The existing Vite large-chunk advisory remains non-fatal and unchanged.

Closes #255