### PR TITLE
fix(twitch): claim tiers that share a campaign benefit

### DIFF
--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -99,7 +99,10 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
     // Twitch includes subscription, purchase, and other action-gated rewards in
     // timeBasedDrops. Retain them internally so an obtained reward can still be
     // claimed, but mark them as non-watch rewards so they never drive farming.
-    const sharedBenefitIds = benefitIdsSharedAcrossRewards(campaign.timeBasedDrops ?? []);
+    const sharedBenefitIds = benefitIdsSharedAcrossRewards(
+      (campaign.timeBasedDrops ?? []).map((drop) =>
+        (drop.benefitEdges ?? []).map((edge) => edge.benefit?.id)),
+    );
     const parsedRewards = (campaign.timeBasedDrops ?? [])
       .map((drop) => parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops, sharedBenefitIds));
     const rewards = parsedRewards.map((reward) => ({
@@ -184,7 +187,7 @@ function parseTwitchReward(
   // claim, so those tiers defer to their own self edge.
   const benefitIdsForOwnership = benefits
     .map((benefit) => benefit.id)
-    .filter((id) => id == null || !sharedBenefitIds.has(id));
+    .filter((id) => id != null && !sharedBenefitIds.has(id));
   const ownsBenefit = isWatchBased && ownsRewardBenefit(benefitIdsForOwnership, gameEventDrops);
   const isClaimed = reward.self?.isClaimed === true || ownsBenefit;
   // Twitch's real dropInstanceID has the form `userID#campaignID#dropID` (see
@@ -251,7 +254,9 @@ export function mergeTwitchCampaignProgress(
   const gameEventDrops = Array.isArray(inventory) ? [] : inventory.data?.currentUser?.inventory?.gameEventDrops ?? [];
   return campaigns.map((campaign) => {
     const progress = progressCampaigns.find((item) => item.id === campaign.id);
-    const sharedBenefitIds = sharedBenefitIdsOfRewards(campaign.rewards);
+    const sharedBenefitIds = benefitIdsSharedAcrossRewards(
+      campaign.rewards.map((reward) => reward.benefitIds ?? []),
+    );
     const rewards = campaign.rewards.map((reward) => {
       const progressReward = progress?.rewards.find((item) => item.id === reward.id);
       const merged = progressReward ? { ...reward, ...progressReward } : reward;
@@ -297,41 +302,28 @@ function addHours(value: string, hours: number): string | undefined {
 // `<gameId>_CUSTOM_ID_BackpackCharmCannedTomatoes`); there is no `benefit`
 // sub-object. We match on `id` and keep `benefit.id` only as a defensive
 // fallback for the inline query shape.
-// Benefit ids that more than one reward of the same campaign awards. Ownership of
-// such a benefit cannot identify which of those rewards is still unclaimed.
+function ownsRewardBenefit(benefitIds: (string | undefined)[], gameEventDrops: TwitchGameEventDrop[]): boolean {
+  return benefitIds.some((id) =>
+    id != null && gameEventDrops.some((drop) => drop.id === id || drop.benefit?.id === id),
+  );
+}
+
+// Benefit ids that more than one reward of the same campaign awards, given one
+// entry of benefit ids per reward. Ownership of such a benefit cannot identify
+// which of those rewards is still unclaimed.
 function benefitIdsSharedAcrossRewards(
-  rewards: ReadonlyArray<{ benefitEdges?: TwitchReward["benefitEdges"] }>,
+  rewardBenefitIds: ReadonlyArray<ReadonlyArray<string | undefined>>,
 ): ReadonlySet<string> {
   const seen = new Set<string>();
   const shared = new Set<string>();
-  for (const reward of rewards) {
-    const ids = new Set(
-      (reward.benefitEdges ?? [])
-        .map((edge) => edge.benefit?.id)
-        .filter((id): id is string => Boolean(id)),
-    );
-    for (const id of ids) {
+  for (const benefitIds of rewardBenefitIds) {
+    // Deduplicate within a reward: the same id twice on one reward is not shared.
+    for (const id of new Set(benefitIds.filter((id): id is string => Boolean(id)))) {
       if (seen.has(id)) shared.add(id);
       else seen.add(id);
     }
   }
   return shared;
-}
-
-// Same rule as benefitIdsSharedAcrossRewards, for rewards already parsed into the
-// shared DropReward model.
-function sharedBenefitIdsOfRewards(rewards: ReadonlyArray<DropReward>): ReadonlySet<string> {
-  return benefitIdsSharedAcrossRewards(
-    rewards.map((reward) => ({
-      benefitEdges: (reward.benefitIds ?? []).map((id) => ({ benefit: { id } })),
-    })),
-  );
-}
-
-function ownsRewardBenefit(benefitIds: (string | undefined)[], gameEventDrops: TwitchGameEventDrop[]): boolean {
-  return benefitIds.some((id) =>
-    id != null && gameEventDrops.some((drop) => drop.id === id || drop.benefit?.id === id),
-  );
 }
 
 function eligibility(

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -99,8 +99,9 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
     // Twitch includes subscription, purchase, and other action-gated rewards in
     // timeBasedDrops. Retain them internally so an obtained reward can still be
     // claimed, but mark them as non-watch rewards so they never drive farming.
+    const sharedBenefitIds = benefitIdsSharedAcrossRewards(campaign.timeBasedDrops ?? []);
     const parsedRewards = (campaign.timeBasedDrops ?? [])
-      .map((drop) => parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops));
+      .map((drop) => parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops, sharedBenefitIds));
     const rewards = parsedRewards.map((reward) => ({
       ...reward,
       preconditionsMet: (reward.preconditionRewardIds ?? []).every((id) =>
@@ -156,6 +157,7 @@ function parseTwitchReward(
   userId?: string,
   campaignEndsAt?: string,
   gameEventDrops: TwitchGameEventDrop[] = [],
+  sharedBenefitIds: ReadonlySet<string> = new Set(),
 ): DropReward {
   const watchedMinutes = reward.self?.currentMinutesWatched ?? 0;
   const requiredMinutes = reward.requiredMinutesWatched ?? 0;
@@ -173,8 +175,17 @@ function parseTwitchReward(
   // user owns this reward even if Twitch still reports isClaimed=false. That
   // inventory is campaign-agnostic, so subscription rewards must rely only on
   // their campaign-specific self state / drop instance.
-  const ownsBenefit = isWatchBased
-    && ownsRewardBenefit(benefits.map((benefit) => benefit.id), gameEventDrops);
+  //
+  // The shortcut also cannot speak for a benefit that several tiers of the same
+  // campaign award (Hunt: Showdown hands out one "Supply Crate" benefit at 30 /
+  // 60 / 120 / 180 minutes): owning it proves only that *some* tier paid out,
+  // and gameEventDrops carries no per-tier count. Claiming the earliest tier
+  // would otherwise mark every later tier claimed and strand a real pending
+  // claim, so those tiers defer to their own self edge.
+  const benefitIdsForOwnership = benefits
+    .map((benefit) => benefit.id)
+    .filter((id) => id == null || !sharedBenefitIds.has(id));
+  const ownsBenefit = isWatchBased && ownsRewardBenefit(benefitIdsForOwnership, gameEventDrops);
   const isClaimed = reward.self?.isClaimed === true || ownsBenefit;
   // Twitch's real dropInstanceID has the form `userID#campaignID#dropID` (see
   // TwitchDropsMiner inventory.py generate_claim and its inventory dump, which
@@ -240,17 +251,22 @@ export function mergeTwitchCampaignProgress(
   const gameEventDrops = Array.isArray(inventory) ? [] : inventory.data?.currentUser?.inventory?.gameEventDrops ?? [];
   return campaigns.map((campaign) => {
     const progress = progressCampaigns.find((item) => item.id === campaign.id);
+    const sharedBenefitIds = sharedBenefitIdsOfRewards(campaign.rewards);
     const rewards = campaign.rewards.map((reward) => {
       const progressReward = progress?.rewards.find((item) => item.id === reward.id);
       const merged = progressReward ? { ...reward, ...progressReward } : reward;
       // A claimed watch campaign falls out of dropCampaignsInProgress, so the
       // merge above can't update it. gameEventDrops is always returned, so
       // cross-check watch ownership without applying its campaign-agnostic
-      // benefit ids to subscription rewards.
+      // benefit ids to subscription rewards, or to a benefit shared by several
+      // tiers of this campaign (see parseTwitchReward).
       if (
         merged.status !== "claimed"
         && isWatchReward(merged)
-        && ownsRewardBenefit(merged.benefitIds ?? [], gameEventDrops)
+        && ownsRewardBenefit(
+          (merged.benefitIds ?? []).filter((id) => !sharedBenefitIds.has(id)),
+          gameEventDrops,
+        )
       ) {
         return { ...merged, status: "claimed" as const, watchedMinutes: merged.requiredMinutes };
       }
@@ -281,6 +297,37 @@ function addHours(value: string, hours: number): string | undefined {
 // `<gameId>_CUSTOM_ID_BackpackCharmCannedTomatoes`); there is no `benefit`
 // sub-object. We match on `id` and keep `benefit.id` only as a defensive
 // fallback for the inline query shape.
+// Benefit ids that more than one reward of the same campaign awards. Ownership of
+// such a benefit cannot identify which of those rewards is still unclaimed.
+function benefitIdsSharedAcrossRewards(
+  rewards: ReadonlyArray<{ benefitEdges?: TwitchReward["benefitEdges"] }>,
+): ReadonlySet<string> {
+  const seen = new Set<string>();
+  const shared = new Set<string>();
+  for (const reward of rewards) {
+    const ids = new Set(
+      (reward.benefitEdges ?? [])
+        .map((edge) => edge.benefit?.id)
+        .filter((id): id is string => Boolean(id)),
+    );
+    for (const id of ids) {
+      if (seen.has(id)) shared.add(id);
+      else seen.add(id);
+    }
+  }
+  return shared;
+}
+
+// Same rule as benefitIdsSharedAcrossRewards, for rewards already parsed into the
+// shared DropReward model.
+function sharedBenefitIdsOfRewards(rewards: ReadonlyArray<DropReward>): ReadonlySet<string> {
+  return benefitIdsSharedAcrossRewards(
+    rewards.map((reward) => ({
+      benefitEdges: (reward.benefitIds ?? []).map((id) => ({ benefit: { id } })),
+    })),
+  );
+}
+
 function ownsRewardBenefit(benefitIds: (string | undefined)[], gameEventDrops: TwitchGameEventDrop[]): boolean {
   return benefitIds.some((id) =>
     id != null && gameEventDrops.some((drop) => drop.id === id || drop.benefit?.id === id),

--- a/packages/extension/tests/criticalFailurePopup.test.tsx
+++ b/packages/extension/tests/criticalFailurePopup.test.tsx
@@ -7,11 +7,30 @@ import type { Platform } from "@lurkloot/shared/models";
 import { DEFAULT_CRITICAL_HEALTH } from "@lurkloot/shared/criticalHealth";
 import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
 
+// Reproduces the cold module cache deterministically: the real loadCatalog is a
+// dynamic import(), so its resolution can take several macrotasks the first time
+// a worker loads the catalog. Tests set this to emulate that first load.
+const catalogDelay = { ticks: 0 };
+
+vi.mock("@lurkloot/locales", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lurkloot/locales")>();
+  return {
+    ...actual,
+    loadCatalog: async (locale: Parameters<typeof actual.loadCatalog>[0]) => {
+      for (let tick = 0; tick < catalogDelay.ticks; tick += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      return actual.loadCatalog(locale);
+    },
+  };
+});
+
 let root: Root | undefined;
 
 afterEach(() => {
   if (root) act(() => root?.unmount());
   root = undefined;
+  catalogDelay.ticks = 0;
   vi.unstubAllGlobals();
 });
 
@@ -70,11 +89,33 @@ async function mountPopup(options: { flagged: Platform | null; promptEnabled?: b
     root.render(<Popup adapter={adapter} />);
     await Promise.resolve();
   });
-  await act(async () => {
-    await Promise.resolve();
-  });
+  await waitForCatalog(container);
 
   return { container, sent, adapter };
+}
+
+// The popup fills its labels from loadCatalog(), a dynamic import() of a JSON
+// catalog. That needs real module resolution rather than a fixed number of
+// microtask flushes, so whether the labels are translated by the time the
+// assertions run depends on which test file warmed the module cache first. Until
+// it resolves the header status line renders its raw key ("automationRunning ·
+// Twitch" instead of "Running · Twitch") and every copy assertion fails.
+//
+// Yield to the macrotask queue until the status line is translated. Match on the
+// untranslated form: a raw "automationRunning" also appears elsewhere in the
+// header regardless of the catalog, and "Running · Twitch" is a substring of the
+// untranslated "automationRunning · Twitch", so neither works as a positive
+// signal.
+async function waitForCatalog(container: Element): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (!container.textContent?.includes("automationRunning · Twitch")) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  throw new Error(
+    `Popup message catalog never loaded; rendered text was: ${container.textContent?.slice(0, 200)}`,
+  );
 }
 
 describe("critical failure prompt in the popup", () => {
@@ -95,6 +136,18 @@ describe("critical failure prompt in the popup", () => {
     const { container } = await mountPopup({ flagged: "twitch", promptEnabled: false });
 
     expect(container.textContent).not.toContain("Copy logs & open issue");
+  });
+
+  // Regression guard for the intermittent failure this file used to produce: the
+  // assertions ran against raw message keys whenever the catalog import needed
+  // more than the microtask flushes the mount helper used to perform.
+  it("renders translated copy even when the catalog import resolves late", async () => {
+    catalogDelay.ticks = 5;
+
+    const { container } = await mountPopup({ flagged: "twitch" });
+
+    expect(container.textContent).toContain("Copy logs & open issue");
+    expect(container.textContent).not.toContain("automationRunning · Twitch");
   });
 
   it("asks the background to dismiss, then refreshes", async () => {

--- a/packages/extension/tests/fixtures/huntSharedBenefit.json
+++ b/packages/extension/tests/fixtures/huntSharedBenefit.json
@@ -1,0 +1,106 @@
+{
+  "data": {
+    "currentUser": {
+      "id": "sanitized-user",
+      "inventory": {
+        "gameEventDrops": [
+          {
+            "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02",
+            "benefit": { "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02" },
+            "lastAwardedAt": "2026-07-25T12:33:11.274Z"
+          },
+          {
+            "id": "8152c851-2605-11f1-b46f-0a58a9feac02",
+            "benefit": { "id": "8152c851-2605-11f1-b46f-0a58a9feac02" },
+            "lastAwardedAt": "2026-07-25T14:33:08.131Z"
+          }
+        ],
+        "dropCampaignsInProgress": [
+          {
+            "id": "26935687-0a71-4e48-a978-71f63abd8e1f",
+            "name": "Hunt 1896 (Week 1, Pt. 2)",
+            "status": "ACTIVE",
+            "endAt": "2099-07-26T14:59:59.999Z",
+            "timeBasedDrops": [
+              {
+                "id": "1eb61564-2614-11f1-9942-0a58a9feac02",
+                "name": "Supply Crate",
+                "requiredMinutesWatched": 30,
+                "requiredSubs": 0,
+                "preconditionDrops": null,
+                "benefitEdges": [
+                  { "benefit": { "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02", "name": "Supply Crate" } }
+                ],
+                "self": {
+                  "currentMinutesWatched": 240,
+                  "isClaimed": true,
+                  "dropInstanceID": "sanitized-user#26935687-0a71-4e48-a978-71f63abd8e1f#1eb61564-2614-11f1-9942-0a58a9feac02"
+                }
+              },
+              {
+                "id": "221e60c7-2614-11f1-ab67-0a58a9feac02",
+                "name": "Supply Crate",
+                "requiredMinutesWatched": 60,
+                "requiredSubs": 0,
+                "preconditionDrops": null,
+                "benefitEdges": [
+                  { "benefit": { "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02", "name": "Supply Crate" } }
+                ],
+                "self": {
+                  "currentMinutesWatched": 240,
+                  "isClaimed": true,
+                  "dropInstanceID": "sanitized-user#26935687-0a71-4e48-a978-71f63abd8e1f#221e60c7-2614-11f1-ab67-0a58a9feac02"
+                }
+              },
+              {
+                "id": "2741c22f-2614-11f1-8ab9-0a58a9feac02",
+                "name": "Supply Crate",
+                "requiredMinutesWatched": 120,
+                "requiredSubs": 0,
+                "preconditionDrops": null,
+                "benefitEdges": [
+                  { "benefit": { "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02", "name": "Supply Crate" } }
+                ],
+                "self": {
+                  "currentMinutesWatched": 240,
+                  "isClaimed": true,
+                  "dropInstanceID": "sanitized-user#26935687-0a71-4e48-a978-71f63abd8e1f#2741c22f-2614-11f1-8ab9-0a58a9feac02"
+                }
+              },
+              {
+                "id": "29773938-2614-11f1-a132-0a58a9feac02",
+                "name": "Supply Crate",
+                "requiredMinutesWatched": 180,
+                "requiredSubs": 0,
+                "preconditionDrops": null,
+                "benefitEdges": [
+                  { "benefit": { "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02", "name": "Supply Crate" } }
+                ],
+                "self": {
+                  "currentMinutesWatched": 240,
+                  "isClaimed": false,
+                  "dropInstanceID": "sanitized-user#26935687-0a71-4e48-a978-71f63abd8e1f#29773938-2614-11f1-a132-0a58a9feac02"
+                }
+              },
+              {
+                "id": "2bcf61f3-2614-11f1-95f7-0a58a9feac02",
+                "name": "Random Legendary Skin",
+                "requiredMinutesWatched": 240,
+                "requiredSubs": 0,
+                "preconditionDrops": null,
+                "benefitEdges": [
+                  { "benefit": { "id": "8152c851-2605-11f1-b46f-0a58a9feac02", "name": "Random Legendary Skin" } }
+                ],
+                "self": {
+                  "currentMinutesWatched": 240,
+                  "isClaimed": true,
+                  "dropInstanceID": "sanitized-user#26935687-0a71-4e48-a978-71f63abd8e1f#2bcf61f3-2614-11f1-95f7-0a58a9feac02"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -822,6 +822,116 @@ describe("Twitch parsers", () => {
     expect(campaigns[0].eligibility).toBe("completed");
   });
 
+  // Hunt: Showdown grants one "Supply Crate" benefit across several watch tiers, so
+  // owning the benefit says nothing about which tiers are still unclaimed. Only the
+  // per-tier self edge can answer that.
+  it("keeps a shared-benefit Twitch tier claimable when its self edge reports isClaimed false", () => {
+    const tier = (id: string, requiredMinutesWatched: number, isClaimed: boolean) => ({
+      id,
+      name: "Supply Crate",
+      requiredMinutesWatched,
+      benefitEdges: [{ benefit: { id: "supply-crate", name: "Supply Crate" } }],
+      self: { currentMinutesWatched: 240, isClaimed, dropInstanceID: `user#hunt#${id}` },
+    });
+    const campaigns = parseTwitchInventory({
+      data: {
+        currentUser: {
+          inventory: {
+            gameEventDrops: [{ id: "supply-crate", lastAwardedAt: "2026-07-25T12:33:11.274Z" }],
+            dropCampaignsInProgress: [{
+              id: "hunt",
+              name: "Hunt 1896 (Week 1, Pt. 2)",
+              status: "ACTIVE",
+              endAt: "2026-07-26T14:59:59.999Z",
+              timeBasedDrops: [
+                tier("tier-30", 30, true),
+                tier("tier-60", 60, true),
+                tier("tier-120", 120, true),
+                tier("tier-180", 180, false),
+              ],
+            }],
+          },
+        },
+      },
+    });
+
+    expect(campaigns[0].rewards.map((reward) => reward.status)).toEqual([
+      "claimed",
+      "claimed",
+      "claimed",
+      "claimable",
+    ]);
+    expect(campaigns[0].rewards[3].claimId).toBe("user#hunt#tier-180");
+    expect(campaigns[0].status).not.toBe("completed");
+    expect(campaignHasClaimableReward(campaigns[0])).toBe(true);
+  });
+
+  it("keeps the pending tier claimable for the captured shared-benefit inventory", () => {
+    // Real gql Inventory capture (user id sanitized, endAt pushed out so the
+    // campaign never expires): Hunt awards one Supply Crate benefit at 30/60/120/
+    // 180 minutes, the benefit is owned, and only the 180 tier is unclaimed.
+    const fixture = JSON.parse(readFileSync(new URL("./fixtures/huntSharedBenefit.json", import.meta.url), "utf8"));
+    const [campaign] = createTwitchInventory("twitch-inventory-v1").parse(fixture);
+
+    expect(campaign.rewards.map((reward) => reward.status)).toEqual([
+      "claimed",
+      "claimed",
+      "claimed",
+      "claimable",
+      "claimed",
+    ]);
+    expect(campaign.status).toBe("active");
+    expect(campaign.eligibility).toBe("eligible");
+    expect(campaignHasClaimableReward(campaign)).toBe(true);
+    expect(campaign.rewards[3].claimId)
+      .toBe("sanitized-user#26935687-0a71-4e48-a978-71f63abd8e1f#29773938-2614-11f1-a132-0a58a9feac02");
+  });
+
+  it("keeps a shared-benefit tier claimable when merging progress into campaign details", () => {
+    const details = parseTwitchInventory([{
+      id: "hunt",
+      name: "Hunt 1896 (Week 1, Pt. 2)",
+      timeBasedDrops: [{
+        id: "tier-120",
+        name: "Supply Crate",
+        requiredMinutesWatched: 120,
+        benefitEdges: [{ benefit: { id: "supply-crate", name: "Supply Crate" } }],
+      }, {
+        id: "tier-180",
+        name: "Supply Crate",
+        requiredMinutesWatched: 180,
+        benefitEdges: [{ benefit: { id: "supply-crate", name: "Supply Crate" } }],
+      }],
+    }]);
+
+    const merged = mergeTwitchCampaignProgress(details, {
+      data: {
+        currentUser: {
+          inventory: {
+            gameEventDrops: [{ id: "supply-crate", lastAwardedAt: "2026-07-25T12:33:11.274Z" }],
+            dropCampaignsInProgress: [{
+              id: "hunt",
+              timeBasedDrops: [{
+                id: "tier-120",
+                requiredMinutesWatched: 120,
+                benefitEdges: [{ benefit: { id: "supply-crate", name: "Supply Crate" } }],
+                self: { currentMinutesWatched: 240, isClaimed: true, dropInstanceID: "user#hunt#tier-120" },
+              }, {
+                id: "tier-180",
+                requiredMinutesWatched: 180,
+                benefitEdges: [{ benefit: { id: "supply-crate", name: "Supply Crate" } }],
+                self: { currentMinutesWatched: 240, isClaimed: false, dropInstanceID: "user#hunt#tier-180" },
+              }],
+            }],
+          },
+        },
+      },
+    });
+
+    expect(merged[0].rewards.map((reward) => reward.status)).toEqual(["claimed", "claimable"]);
+    expect(merged[0].status).not.toBe("completed");
+  });
+
   it("infers a Twitch reward is claimed from a matching benefit awarded during the drop window", () => {
     const campaigns = parseTwitchInventory({
       data: {


### PR DESCRIPTION
## Summary

A Twitch drop that was watched to completion was never claimed, while the popup showed the campaign at 100% / Finished.

Twitch's `gameEventDrops` inventory is campaign-agnostic and carries no per-tier award count, so owning a benefit proves only that *some* tier paid out. Campaigns that award one benefit across several watch tiers therefore had every later tier marked claimed as soon as the earliest one was.

Hunt 1896 (Week 1, Pt. 2) grants a single `Supply Crate` benefit at 30 / 60 / 120 / 180 minutes. Once the 30-minute tier paid out, the `ownsBenefit` shortcut in `parser.ts` matched that shared benefit id for all four tiers:

- all rewards read `claimed` → campaign `completed` / eligibility `completed`
- `claimReadyRewards` only acts on `status === "claimable"` (`scheduler.ts:1085`), so the pending claim was never attempted
- `hasUnclaimedWatchReward` (`controller.ts:1598`) also treated the campaign as done

Meanwhile Twitch reported that tier as `isClaimed: false` with a live `dropInstanceID` — claimable the whole time. Confirmed against a real `gql` `Inventory` capture.

## Fix

Restrict the ownership shortcut to benefits that only a single reward of the campaign awards. Shared benefits defer to their own `self` edge, which is the only per-tier claim signal available.

The shortcut keeps working for the case it exists for (see the comment at `parser.ts:246-249`): a unique-benefit campaign that falls out of `dropCampaignsInProgress` once claimed. Both affected paths are covered — `parseTwitchInventory` and `mergeTwitchCampaignProgress`.

## Testing

- 3 new tests in `parsers.test.ts`, each confirmed failing before the fix and passing after (verified by stashing the parser change, so they are not vacuous):
  - shared-benefit tiers keep the pending tier `claimable` in `parseTwitchInventory`
  - same through `mergeTwitchCampaignProgress`
  - the captured real inventory (`tests/fixtures/huntSharedBenefit.json`), driven through the production `twitch-inventory-v1` capability rather than the parser directly
- The pre-existing single-reward test (`parsers.test.ts:794`, owned benefit overriding `isClaimed: false`) still passes — unique-benefit behaviour is unchanged.
- `pnpm check` green: 988 extension tests, 126 CLI tests, all workspace typechecks, site build.

The fixture is a real capture with the user id sanitized to `sanitized-user` and `endAt` pushed to 2099 so the campaign never expires out from under the test.

## Notes

This silently drops claims on any campaign that reuses one benefit across watch tiers, which is a class of campaign rather than a one-off — affected users see 100% with rewards left behind, and no diagnostic. Worth considering for a `release/patch`.

Not verified: whether Twitch still returns such a campaign in `dropCampaignsInProgress` after `endAt` passes. If discovery drops it, an already-expired pending claim would not reach the claim loop even with this fix. That is a separate question from the parsing bug fixed here.

## Also included

Two follow-ups on top of the fix:

- `refactor(twitch)`: review cleanups — keep `ownsRewardBenefit` adjacent to the comment documenting it (the first cut inserted helpers between them), collapse the synthetic `benefitEdges` round-trip into one helper over benefit id lists, and stop threading null ids through the ownership filter.
- `test(popup)`: fixes a **pre-existing intermittent failure** in `criticalFailurePopup.test.tsx`, unrelated to the parser bug — it surfaced during verification of this branch. The tests asserted on translated copy after a fixed number of microtask flushes, but `loadCatalog` is a dynamic `import()` whose first resolution needs real module resolution, so whichever file warmed the module cache decided whether labels were still raw message keys (`automationRunning · Twitch` instead of `Running · Twitch`). Now it polls for the translated status line, plus a new test that delays the catalog import so the race is deterministic instead of ordering-dependent — verified failing against the old helper with the identical error message the flake produced.

The same fixed-microtask pattern exists in the sibling popup tests (`popupAuthHealth`, `popupSettingsLifecycle`, `settingsCredentialExport`, `settingsFactoryReset`), so they carry the same latent race. Left alone here to keep this PR scoped; worth a follow-up.
