### PR TITLE
fix(twitch): keep the owned-benefit fallback without progress data

### DIFF
--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -62,12 +62,19 @@ interface TwitchGameEventDrop {
 }
 
 export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]): DropCampaign[] {
+  const inProgress = Array.isArray(input)
+    ? undefined
+    : input.data?.currentUser?.inventory?.dropCampaignsInProgress;
   const campaigns = Array.isArray(input)
     ? input
-    : input.data?.currentUser?.inventory?.dropCampaignsInProgress
+    : inProgress
       ?? input.data?.currentUser?.inventory?.dropCampaigns
       ?? input.data?.currentUser?.dropCampaigns
       ?? [];
+  // Only dropCampaignsInProgress carries a per-tier self edge. Everything else
+  // (campaign details, reward campaigns) reports no per-user claim state, so
+  // shared-benefit tiers there must keep using the owned-benefit fallback.
+  const hasPerTierProgress = campaigns === inProgress;
   const gameEventDrops = Array.isArray(input) ? [] : input.data?.currentUser?.inventory?.gameEventDrops ?? [];
   const userId = Array.isArray(input) ? undefined : input.data?.currentUser?.id;
   const now = Date.now();
@@ -99,10 +106,12 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
     // Twitch includes subscription, purchase, and other action-gated rewards in
     // timeBasedDrops. Retain them internally so an obtained reward can still be
     // claimed, but mark them as non-watch rewards so they never drive farming.
-    const sharedBenefitIds = benefitIdsSharedAcrossRewards(
-      (campaign.timeBasedDrops ?? []).map((drop) =>
-        (drop.benefitEdges ?? []).map((edge) => edge.benefit?.id)),
-    );
+    const sharedBenefitIds = hasPerTierProgress
+      ? benefitIdsSharedAcrossRewards(
+        (campaign.timeBasedDrops ?? []).map((drop) =>
+          (drop.benefitEdges ?? []).map((edge) => edge.benefit?.id)),
+      )
+      : new Set<string>();
     const parsedRewards = (campaign.timeBasedDrops ?? [])
       .map((drop) => parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops, sharedBenefitIds));
     const rewards = parsedRewards.map((reward) => ({
@@ -254,9 +263,14 @@ export function mergeTwitchCampaignProgress(
   const gameEventDrops = Array.isArray(inventory) ? [] : inventory.data?.currentUser?.inventory?.gameEventDrops ?? [];
   return campaigns.map((campaign) => {
     const progress = progressCampaigns.find((item) => item.id === campaign.id);
-    const sharedBenefitIds = benefitIdsSharedAcrossRewards(
-      campaign.rewards.map((reward) => reward.benefitIds ?? []),
-    );
+    // Withholding the owned-benefit fallback from shared benefits is only safe
+    // while a per-tier self edge exists to answer in its place. A campaign absent
+    // from the progress payload has no such edge — every tier would read
+    // unclaimed forever and the scheduler would re-farm a finished campaign — so
+    // there the fallback still applies.
+    const sharedBenefitIds = progress
+      ? benefitIdsSharedAcrossRewards(campaign.rewards.map((reward) => reward.benefitIds ?? []))
+      : new Set<string>();
     const rewards = campaign.rewards.map((reward) => {
       const progressReward = progress?.rewards.find((item) => item.id === reward.id);
       const merged = progressReward ? { ...reward, ...progressReward } : reward;

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -887,6 +887,44 @@ describe("Twitch parsers", () => {
       .toBe("sanitized-user#26935687-0a71-4e48-a978-71f63abd8e1f#29773938-2614-11f1-a132-0a58a9feac02");
   });
 
+  // Regression: once every tier is claimed the campaign leaves
+  // dropCampaignsInProgress, so no self edge survives to say which tiers are
+  // claimed. Without the owned-benefit fallback the shared tiers read as
+  // unclaimed forever and the scheduler re-farms a finished campaign.
+  it("treats shared-benefit tiers as claimed when the campaign has no progress data", () => {
+    const details = parseTwitchInventory([{
+      id: "hunt",
+      name: "Hunt 1896 (Week 1, Pt. 2)",
+      timeBasedDrops: [30, 60, 120, 180].map((minutes) => ({
+        id: `tier-${minutes}`,
+        name: "Supply Crate",
+        requiredMinutesWatched: minutes,
+        benefitEdges: [{ benefit: { id: "supply-crate", name: "Supply Crate" } }],
+      })),
+    }]);
+
+    const merged = mergeTwitchCampaignProgress(details, {
+      data: {
+        currentUser: {
+          inventory: {
+            gameEventDrops: [{ id: "supply-crate", lastAwardedAt: "2026-07-25T13:33:09.586Z" }],
+            dropCampaignsInProgress: [],
+          },
+        },
+      },
+    });
+
+    expect(merged[0].rewards.map((reward) => reward.status)).toEqual([
+      "claimed",
+      "claimed",
+      "claimed",
+      "claimed",
+    ]);
+    expect(merged[0].status).toBe("completed");
+    expect(merged[0].eligibility).toBe("completed");
+    expect(campaignHasClaimableReward(merged[0])).toBe(false);
+  });
+
   it("keeps a shared-benefit tier claimable when merging progress into campaign details", () => {
     const details = parseTwitchInventory([{
       id: "hunt",


### PR DESCRIPTION
## Summary

Regression from #268. That PR stopped shared-benefit tiers from using the owned-benefit shortcut so a genuinely pending tier stays claimable — correct while Twitch still reports a per-tier `self` edge, but it was applied unconditionally.

Once every tier is claimed the campaign leaves `dropCampaignsInProgress`, and no `self` edge survives anywhere. With the shortcut withheld, nothing can mark those tiers claimed, so they read unclaimed forever and the scheduler re-farms a finished campaign.

Observed in the wild on `develop`, from a user diagnostics log:

```
[debug] Campaign inventory changed (128 discovered)
[info] Started farming "Supply Crate" from campaign "Hunt 1896 (Week 1, Pt. 2)"
       (reward 1eb61564-2614-11f1-9942-0a58a9feac02) on channel Khalamity
```

`1eb61564…` is the 30-minute tier, which was already `isClaimed: true`.

Parsing a captured inventory in which Hunt has left the progress payload, against `develop`:

```
statuses: locked,locked,locked,locked,claimed | campaign: active | eligibility: eligible
```

The four Supply Crate tiers share one benefit id, so all four read `locked`; the Legendary Skin has a unique benefit id and is correctly `claimed`.

## Fix

Withhold the owned-benefit fallback only where a per-tier `self` edge exists to answer in its place — i.e. campaigns sourced from `dropCampaignsInProgress`. Campaign details and reward campaigns carry no per-user claim state, so they keep the fallback and a finished campaign reads completed again.

Gating on the payload source rather than on `self.isClaimed` being present is deliberate: it does not depend on what `DropCampaignDetails` returns for a completed campaign, which is not established.

## Testing

- New regression test: shared-benefit tiers with no progress data parse as `claimed` / campaign `completed` / no claimable reward. Confirmed failing before the fix.
- The three tests from #268 still pass, so a pending tier stays `claimable` while the campaign is in progress.
- Verified against a real captured inventory (320 `gameEventDrops`, Hunt absent from `dropCampaignsInProgress`): `develop` yields the `locked,locked,locked,locked` line above; with this fix every tier is `claimed` and the campaign is `completed`.
- `pnpm check` green: 990 extension tests, 126 CLI, all typechecks, site build.

## Follow-up

The benefit-id heuristic is the wrong primitive on both sides of this. The `Inventory` response also exposes `earnedDropRewards`, which is campaign-scoped and has **one edge per claim**, so a benefit shared by N tiers yields N `CLAIMED` edges with distinct `earnedAt`:

```
9a0d24bc  Supply Crate  status=CLAIMED  earnedAt=2026-07-25T13:33:09.586Z
9a0d24bc  Supply Crate  status=CLAIMED  earnedAt=2026-07-25T12:33:11.274Z
9a0d24bc  Supply Crate  status=CLAIMED  earnedAt=2026-07-25T11:33:07.886Z
9a0d24bc  Supply Crate  status=CLAIMED  earnedAt=2026-07-25T11:03:10.765Z
```

That is the per-tier count `gameEventDrops` collapses, and it would remove the need for this heuristic entirely. The extension's `Inventory` query does not currently request the field, so adopting it is a capability change (`twitch-inventory-v2`) and is deliberately out of scope for this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch campaign progress handling when active progress data is unavailable.
  * Correctly reconciles shared rewards across tiers, preventing rewards from being incorrectly shown as claimable.
  * Ensures completed campaigns display the correct completion status and eligibility.

* **Tests**
  * Added coverage for campaigns without in-progress data and shared-benefit rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->