### PR TITLE
fix(diagnostics): stamp events when they are emitted

### DIFF
--- a/packages/core/src/core/activityDiagnostics.ts
+++ b/packages/core/src/core/activityDiagnostics.ts
@@ -69,7 +69,12 @@ export function activityDiagnostic(event: ActivityEvent): DiagnosticEvent {
 // the mirror when they filter by category, so this costs them no storage.
 export function withActivityDiagnostics(emit: EventEmitter): EventEmitter {
   return (event: EngineEvent) => {
-    emit(event);
-    if (event.category === "activity") emit(activityDiagnostic(event));
+    // Stamp the moment of emission here: a host collects a tick's events and
+    // writes them in one batch, so the write time can be many seconds later and
+    // identical for events that happened far apart. An event that already
+    // carries emittedAt (a replayed or host-synthesised one) keeps it.
+    const emittedAt = event.emittedAt ?? new Date().toISOString();
+    emit({ ...event, emittedAt });
+    if (event.category === "activity") emit({ ...activityDiagnostic(event), emittedAt });
   };
 }

--- a/packages/extension/src/core/activityStorage.ts
+++ b/packages/extension/src/core/activityStorage.ts
@@ -144,13 +144,21 @@ class IndexedDbActivityRepository implements ActivityRepository {
 
   async append(events: readonly EngineEvent[]): Promise<void> {
     if (events.length === 0) return;
-    const at = new Date().toISOString();
-    const stored: StoredEngineEvent[] = events.map((event, index) => ({
-      ...event,
-      id: `${at}-${String(index).padStart(6, "0")}-${crypto.randomUUID()}`,
-      at,
-      ...(event.data ? { data: { ...event.data } } : {}),
-    })) as StoredEngineEvent[];
+    const writtenAt = new Date().toISOString();
+    const stored: StoredEngineEvent[] = events.map((event, index) => {
+      // Prefer when the event was emitted; the batch write time is only a
+      // fallback for events that reach storage without one.
+      const { emittedAt, ...rest } = event;
+      const at = emittedAt ?? writtenAt;
+      return {
+        ...rest,
+        // The index keeps events that share a timestamp sorting by emission
+        // order, since load() falls back to comparing ids when `at` ties.
+        id: `${at}-${String(index).padStart(6, "0")}-${crypto.randomUUID()}`,
+        at,
+        ...(event.data ? { data: { ...event.data } } : {}),
+      };
+    }) as StoredEngineEvent[];
     await this.putAll(stored);
     await this.pruneIfDue();
   }

--- a/packages/extension/tests/activityDiagnostics.test.ts
+++ b/packages/extension/tests/activityDiagnostics.test.ts
@@ -168,11 +168,33 @@ describe("activity diagnostics", () => {
     emit(EVENTS.reward_claimed);
     emit({ category: "diagnostic", level: "debug", message: "Kick fetch kick.com 200" });
 
-    expect(events).toEqual([
+    expect(events.map(({ emittedAt, ...event }) => event)).toEqual([
       EVENTS.reward_claimed,
       activityDiagnostic(EVENTS.reward_claimed),
       { category: "diagnostic", level: "debug", message: "Kick fetch kick.com 200" },
     ]);
+  });
+
+  it("stamps every emitted event with the time it was emitted", () => {
+    const events: EngineEvent[] = [];
+    const emit = withActivityDiagnostics((event) => events.push(event));
+
+    emit(EVENTS.reward_claimed);
+
+    // An activity event and its mirror describe one moment, so they share it.
+    const [activity, mirror] = events;
+    expect(activity.emittedAt).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+    expect(mirror.emittedAt).toBe(activity.emittedAt);
+  });
+
+  it("keeps an emittedAt the caller already set", () => {
+    const events: EngineEvent[] = [];
+    const emit = withActivityDiagnostics((event) => events.push(event));
+
+    emit({ ...EVENTS.reward_claimed, emittedAt: "2020-01-01T00:00:00.000Z" });
+
+    expect(events.map((event) => event.emittedAt))
+      .toEqual(["2020-01-01T00:00:00.000Z", "2020-01-01T00:00:00.000Z"]);
   });
 
   it("emits the mirror right after its activity event so the log stays ordered", () => {

--- a/packages/extension/tests/activityStorage.test.ts
+++ b/packages/extension/tests/activityStorage.test.ts
@@ -47,6 +47,29 @@ describe("activity repository", () => {
     vi.useRealTimers();
   }, 30_000);
 
+  // A tick emits its events over real time (an integrity wait alone can take
+  // 12s) but persists them in one batch. Stamping the batch time onto all of
+  // them made every event in an exported log share one timestamp, so durations
+  // were unrecoverable exactly when they mattered.
+  it("keeps the time each event was emitted rather than the batch write time", async () => {
+    const first = new Date(NOW.getTime() - 24_000).toISOString();
+    const second = new Date(NOW.getTime() - 12_000).toISOString();
+
+    await repository.append([
+      { ...diagnosticEvent(1), emittedAt: first },
+      { ...diagnosticEvent(2), emittedAt: second },
+      diagnosticEvent(3),
+    ]);
+
+    const stored = (await repository.load({ category: "diagnostic" })).events;
+    const byMessage = new Map(stored.map((event) => [event.message, event.at]));
+    expect(byMessage.get("diagnostic-1")).toBe(first);
+    expect(byMessage.get("diagnostic-2")).toBe(second);
+    // No emittedAt: falls back to the write time, which is all we know.
+    expect(byMessage.get("diagnostic-3")).toBe(NOW.toISOString());
+    expect(new Set(stored.map((event) => event.at)).size).toBe(3);
+  }, 30_000);
+
   it("keeps activity when diagnostics exceed their independent cap", async () => {
     await repository.append([activityEvent("a")]);
     await repository.append(Array.from({ length: 2_001 }, (_, index) => diagnosticEvent(index)));

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -385,6 +385,7 @@ describe("background controller", () => {
         level: "info",
         platform: "twitch",
         data: { from: "healthy", to: "checking" },
+        emittedAt: expect.any(String),
       },
       {
         category: "diagnostic",
@@ -394,6 +395,7 @@ describe("background controller", () => {
         mirroredActivity: true,
         message: "twitch authentication health changed from healthy to checking",
         data: { from: "healthy", to: "checking" },
+        emittedAt: expect.any(String),
       },
     ]);
 
@@ -426,6 +428,7 @@ describe("background controller", () => {
         level: "error",
         platform: "kick",
         data: { from: "checking", to: "blocked", reason: "security_policy_blocked" },
+        emittedAt: expect.any(String),
       },
       {
         category: "diagnostic",
@@ -435,6 +438,7 @@ describe("background controller", () => {
         mirroredActivity: true,
         message: "kick authentication health changed from checking to blocked: reason=security_policy_blocked",
         data: { from: "checking", to: "blocked", reason: "security_policy_blocked" },
+        emittedAt: expect.any(String),
       },
     ]);
   });

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -75,7 +75,10 @@ export type DiagnosticEvent = {
 };
 
 export type EventCategory = EngineEvent["category"];
-export type EngineEvent = ActivityEvent | DiagnosticEvent;
+// emittedAt is stamped at the emit choke point (withActivityDiagnostics) because
+// a host persists a tick's events in one batch long after some of them happened.
+// Hosts that log immediately can ignore it; storage falls back to the write time.
+export type EngineEvent = (ActivityEvent | DiagnosticEvent) & { emittedAt?: string };
 export type EventEmitter = (event: EngineEvent) => void;
 export type EventReporter = (events: readonly EngineEvent[]) => void | Promise<void>;
 export type StoredEngineEvent = EngineEvent & { id: string; at: string };


### PR DESCRIPTION
## Problem

`activityStorage.append()` computed one timestamp per batch and applied it to every event in it:

```ts
const at = new Date().toISOString();
const stored = events.map((event, index) => ({ ...event, at, ... }));
```

A tick emits its events over real time but persists them together, so every event in an exported log shared one timestamp. From a real user report — 16 events, all at `10:22:43.138Z`, despite the sequence containing two 12-second integrity waits:

```
10:22:43.138Z [info] No valid Twitch integrity token; opening a twitch.tv tab to capture one
10:22:43.138Z [warn] Timed out waiting for a Twitch integrity token after 12000ms
10:22:43.138Z [warn] Claim for Supply Crate was rejected for integrity; refreshing and retrying once
10:22:43.138Z [info] No valid Twitch integrity token; opening a twitch.tv tab to capture one
10:22:43.138Z [warn] Timed out waiting for a Twitch integrity token after 12000ms
```

That log spans 24s+ of wall time. Ordering survived via the index in `id`, but every duration was unrecoverable — precisely what a timeout report needs.

## Fix

Stamp `emittedAt` at `withActivityDiagnostics`, the choke point every engine emitter funnels through, and prefer it over the write time when persisting.

- An activity event and its diagnostic mirror describe one moment, so they share the stamp.
- An event that already carries `emittedAt` keeps it (replayed or host-synthesised events).
- One that reaches storage without it falls back to the batch write time, which is all that is known.
- `EngineEvent` becomes `(ActivityEvent | DiagnosticEvent) & { emittedAt?: string }`, so it is optional and hosts that log immediately (the CLI) can ignore it.

## Testing

- New storage test: events appended in one batch with distinct `emittedAt` keep distinct `at`; one without falls back to the write time. Confirmed failing before the fix.
- New emitter tests: every emitted event is stamped, an activity event and its mirror share the stamp, and a caller-supplied `emittedAt` is preserved.
- Three existing exact-shape assertions (`activityDiagnostics`, `backgroundController` ×2) now assert `emittedAt: expect.any(String)` rather than being loosened to `objectContaining`, so they stay strict.
- `pnpm check` green: 992 extension tests, 126 CLI, all typechecks, site build.

Found while diagnosing #270 — the broken timestamps actively misled that investigation, which is why it is worth fixing rather than working around.