### PR TITLE
fix(twitch): report which page context an integrity wait used

### DIFF
--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -38,10 +38,17 @@ interface BrowserTab {
   mutedInfo?: { muted?: boolean };
 }
 
+// Where a page-context tab came from. Only used for diagnostics: a freshly
+// created tab boots the SPA and issues authenticated GQL, while an inherited one
+// may be idle and issue nothing, which decides whether waiting for a token can
+// succeed at all.
+type PageContextSource = "created" | "user_tab" | "managed_tab" | "shared_entry";
+
 interface PageContextTab {
   tabId: number;
   createdByExtension: boolean;
   retainedContext?: ManagedPageContextTab;
+  source?: PageContextSource;
 }
 
 interface PageContextEntry {
@@ -519,18 +526,26 @@ export async function ensureTwitchIntegrityWithBrowser(
 ): Promise<boolean> {
   if (hasValidTwitchIntegrity()) return true;
 
-  diagnostic(emit, "info", "No valid Twitch integrity token; opening a twitch.tv tab to capture one", "twitch");
+  diagnostic(emit, "info", "No valid Twitch integrity token; using a twitch.tv page context to capture one", "twitch");
   const origin = new URL(originUrl).origin;
   let pageContext: PageContextTab | undefined;
   try {
     pageContext = await acquirePageContextTab(browserApi, originUrl, origin, {
       retainPageContext: { platform: "twitch" },
+      emit,
     });
+    // Which context we got decides whether waiting can work at all: only a
+    // freshly created tab is guaranteed to boot the SPA and issue authenticated
+    // GQL for the listener to read a token from. An inherited or already-idle tab
+    // may issue nothing, and the wait can only ever time out.
+    const source = pageContext.source ?? "unknown";
+    diagnostic(emit, "debug", `Waiting up to ${timeoutMs}ms for a Twitch integrity token from a ${source} page context (tab ${pageContext.tabId})`, "twitch");
     // On success the capture itself is logged once by setTwitchIntegrity (info);
     // here we only surface the failure case so the log isn't doubled up.
+    const startedAt = Date.now();
     const captured = await waitForIntegrityCapture(timeoutMs);
     if (!captured) {
-      diagnostic(emit, "warn", `Timed out waiting for a Twitch integrity token after ${timeoutMs}ms (is twitch.tv logged in?)`, "twitch");
+      diagnostic(emit, "warn", `Timed out waiting for a Twitch integrity token after ${Date.now() - startedAt}ms from a ${source} page context (is twitch.tv logged in?)`, "twitch");
     }
     return captured;
   } catch (error) {
@@ -792,7 +807,10 @@ async function acquirePageContextTab(
   const existing = pageContextTabs.get(origin);
   if (existing) {
     existing.refs += 1;
-    return existing.promise;
+    // Inherited from a concurrent caller: this tab has already served its own
+    // request and may now be idle, which matters to anyone waiting for the page
+    // to issue a fresh request (see ensureTwitchIntegrityWithBrowser).
+    return existing.promise.then((tab) => ({ ...tab, source: "shared_entry" as const }));
   }
 
   const entry: PageContextEntry = {
@@ -878,7 +896,7 @@ async function findOrCreatePageContextTab(
       }
     }
     diagnostic(options?.emit ?? ignoreEvent, "debug", `Reused user page context on ${new URL(origin).host}`, retain?.platform);
-    return { tabId, createdByExtension: false };
+    return { tabId, createdByExtension: false, source: "user_tab" };
   }
 
   if (retained?.origin === origin) {
@@ -887,7 +905,7 @@ async function findOrCreatePageContextTab(
       if (tab?.id && tab.url?.startsWith(origin) && await isUsablePageContext(browserApi, tab.id, origin)) {
         retainedPageContextTabs.set(retained.platform, retained);
         diagnostic(options?.emit ?? ignoreEvent, "debug", `Reused managed page context on ${new URL(origin).host}`, retained.platform);
-        return { tabId: tab.id, createdByExtension: true, retainedContext: retained };
+        return { tabId: tab.id, createdByExtension: true, retainedContext: retained, source: "managed_tab" };
       }
       retainedPageContextTabs.delete(retained.platform);
       openReason = "managed_context_unusable";
@@ -961,9 +979,9 @@ async function findOrCreatePageContextTab(
       platform: retain.platform,
       data: { host: new URL(origin).host, reason: openReason },
     });
-    return { tabId: tab.id, createdByExtension: true, retainedContext };
+    return { tabId: tab.id, createdByExtension: true, retainedContext, source: "created" };
   }
-  return { tabId: tab.id, createdByExtension: true };
+  return { tabId: tab.id, createdByExtension: true, source: "created" };
 }
 
 async function isUsablePageContext(browserApi: BrowserTabApi, tabId: number, origin: string): Promise<boolean> {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1074,6 +1074,42 @@ describe("twitch integrity refresh", () => {
         message: expect.stringContaining("Timed out waiting for a Twitch integrity token"),
       }));
     });
+
+    // Which page context answered decides whether the wait could ever succeed:
+    // only a freshly created tab is guaranteed to boot the SPA and issue the
+    // authenticated GQL the listener reads the token from. Reporting it turns a
+    // bare timeout into something a diagnostics log can be read against.
+    it("names a reused user tab as the page context it waited on", async () => {
+      const browser = browserMock();
+      browser.tabs.query.mockResolvedValue([{ id: 3 }]);
+      const events: EngineEvent[] = [];
+
+      await ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 50, (event) => events.push(event));
+
+      expect(browser.tabs.create).not.toHaveBeenCalled();
+      expect(events).toContainEqual(expect.objectContaining({
+        level: "debug",
+        message: expect.stringContaining("from a user_tab page context (tab 3)"),
+      }));
+      expect(events).toContainEqual(expect.objectContaining({
+        level: "warn",
+        message: expect.stringContaining("from a user_tab page context"),
+      }));
+    });
+
+    it("names a freshly created tab as the page context it waited on", async () => {
+      const browser = browserMock();
+      browser.tabs.query.mockResolvedValue([]);
+      browser.tabs.create.mockResolvedValue({ id: 21 });
+      const events: EngineEvent[] = [];
+
+      await ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 50, (event) => events.push(event));
+
+      expect(events).toContainEqual(expect.objectContaining({
+        level: "debug",
+        message: expect.stringContaining("from a created page context (tab 21)"),
+      }));
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

A drop claim needs a `Client-Integrity` token, captured by the background `webRequest` listener from the twitch.tv page's own GQL requests. When none is held, `ensureTwitchIntegrityWithBrowser` acquires a page context and waits.

It logs this unconditionally:

```
[info] No valid Twitch integrity token; opening a twitch.tv tab to capture one
```

But `acquirePageContextTab` has four outcomes, only one of which is "opening a tab":

| Source | Boots the SPA / issues GQL? |
|---|---|
| `created` | yes |
| `user_tab` (reuses any twitch.tv tab; `isUsablePageContext` returns `true` unconditionally for Twitch) | only if it happens to be active |
| `managed_tab` | maybe |
| `shared_entry` (inherited from a concurrent caller via the refcounted cache) | it has already served its request and may be idle |

That distinction decides whether the wait can succeed **at all**: an idle tab issues no authenticated GQL, so there is nothing to intercept and the wait can only time out.

From a user report — two consecutive timeouts, a rejected claim, and no way to tell which path ran:

```
[info] No valid Twitch integrity token; opening a twitch.tv tab to capture one
[warn] Timed out waiting for a Twitch integrity token after 12000ms (is twitch.tv logged in?)
[warn] Claim for Supply Crate was rejected for integrity; refreshing the token and retrying once
[info] No valid Twitch integrity token; opening a twitch.tv tab to capture one
[warn] Timed out waiting for a Twitch integrity token after 12000ms (is twitch.tv logged in?)
[error] Twitch rejected the claim for Supply Crate (failed integrity check)
```

Neither the `Reused user page context` debug line nor a `page_context_opened` activity event appears, so the report cannot distinguish "opened a tab that booted too slowly" from "silently inherited an idle tab".

## Change

- Tag `PageContextTab` with its `source` (`created` / `user_tab` / `managed_tab` / `shared_entry`).
- Name it in the wait diagnostic, with the tab id, and again in the timeout.
- Report the **measured** wait rather than restating the configured timeout, so a wait cut short by something else is visible.
- Correct the opening message to say "using a twitch.tv page context", which is what actually happens.

## Deliberately not fixed here

The underlying capture failure. The plausible causes are a silently inherited idle tab, a cold SPA boot exceeding the 12s budget, or a background tab being throttled — and they need different fixes (tab selection, timeout, or scheduling). The available logs cannot separate them, partly because every event in them shared one timestamp (fixed in #272).

Guessing between three causes is how the earlier regression (#270) happened, so this PR only makes the next report conclusive. Once a log arrives naming the source and a real elapsed time, the fix follows directly.

## Testing

- New tests assert the reused-user-tab path names `user_tab` (and creates no tab) and the created path names `created`, in both the wait and timeout diagnostics.
- `pnpm check` green: 991 extension tests, 126 CLI, all typechecks, site build.