### PR TITLE
fix(auth): resolve platform health promptly

### DIFF
--- a/docs/superpowers/plans/2026-07-26-auth-health-prompt-resolution.md
+++ b/docs/superpowers/plans/2026-07-26-auth-health-prompt-resolution.md
@@ -1,0 +1,779 @@
+# Prompt Authentication Health Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every enabled platform's authentication health resolve and persist independently within a configurable 10-second default deadline after scheduler, startup, install/update, and credential-cookie triggers.
+
+**Architecture:** The controller owns one timeout and `AbortController` per platform probe. It starts requested probes concurrently, then each completed result acquires the existing state lock, reloads current state, applies only its platform transition, and persists before scheduler work begins. The adapter contract carries the abort signal into only the Twitch and Kick identity requests.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Vitest fake timers/deferred promises, WXT WebExtension APIs.
+
+## Global Constraints
+
+- `BackgroundControllerDeps.authProbeTimeoutMs` is internal host configuration and defaults to exactly `10_000` milliseconds.
+- Do not add a persisted or user-facing timeout setting.
+- Do not add or translate diagnostic messages; existing auth-health message keys are reused.
+- Do not apply this timeout to campaign, progress, claim, heartbeat, or other non-auth requests.
+- Disabled platforms are skipped.
+- Every auth result is persisted through the existing state lock using a freshly loaded state.
+- Follow strict test-first development: every production behavior change must first be observed failing in its focused test.
+
+---
+
+## File Map
+
+- `packages/core/src/platforms/adapter.ts`: optional abort-signal contract for auth probes.
+- `packages/core/src/platforms/twitch/index.ts`: thread the signal through the CurrentUser GQL request only.
+- `packages/core/src/platforms/kick/index.ts`: thread the signal through the `/api/v1/user` request only.
+- `packages/core/src/background/controller.ts`: timeout, concurrent refresh orchestration, early locked persistence, scheduler/startup integration.
+- `packages/extension/entrypoints/background.ts`: route credential-cookie rechecks to bounded auth refresh rather than a scheduler tick.
+- `packages/extension/tests/adapters.test.ts`: observable adapter signal forwarding tests.
+- `packages/extension/tests/backgroundController.test.ts`: concurrency, timeout, persistence, locking, scheduler ordering, and lifecycle tests.
+- `packages/extension/tests/credentialObserver.test.ts`: retain debounce behavior; no production observer changes are expected.
+
+### Task 1: Carry cancellation into platform identity requests
+
+**Files:**
+- Modify: `packages/core/src/platforms/adapter.ts`
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Modify: `packages/core/src/platforms/kick/index.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Consumes: existing `PageFetcher.fetchJson<T>(url, init?, emit?)`.
+- Produces: `PlatformAdapter.checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth>`.
+- Produces: a final optional `signal?: AbortSignal` argument on the internal `TwitchGqlTransport` call signature and `createTwitchGqlTransport` implementation.
+
+- [ ] **Step 1: Write failing adapter tests for auth-only signal forwarding**
+
+Add one Twitch and one Kick test beside the existing auth-health adapter tests. The production mutation each test catches is dropping the supplied signal before the identity fetch.
+
+```ts
+it("passes the auth probe signal to the Twitch CurrentUser request", async () => {
+  const abort = new AbortController();
+  const fetchJson = vi.fn(async () => ({ data: { currentUser: { id: "u" } } }));
+
+  await new TwitchAdapter({ fetchJson }).checkAuthHealth(abort.signal);
+
+  expect(fetchJson).toHaveBeenCalledWith(
+    "https://gql.twitch.tv/gql",
+    expect.objectContaining({ signal: abort.signal }),
+    expect.any(Function),
+  );
+});
+
+it("passes the auth probe signal to the Kick identity request", async () => {
+  const abort = new AbortController();
+  const fetchJson = vi.fn(async () => ({ id: 42 }));
+
+  await new KickAdapter({ fetchJson }).checkAuthHealth(abort.signal);
+
+  expect(fetchJson).toHaveBeenCalledWith(
+    "https://kick.com/api/v1/user",
+    { signal: abort.signal },
+    expect.any(Function),
+  );
+});
+```
+
+Construct both adapters with an explicit `emit = vi.fn()` and assert that same
+function as the third argument. This keeps the test focused on the real adapter
+boundary rather than an anonymous default.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts
+```
+
+Expected: both new tests fail because `checkAuthHealth` accepts no signal and neither request contains one.
+
+- [ ] **Step 3: Extend the adapter contract and Kick identity request**
+
+Change the shared interface and Kick implementation:
+
+```ts
+export interface PlatformAdapter {
+  platform: Platform;
+  readonly compatibility?: ResolvedCompatibility[Platform];
+  checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth>;
+  discoverCampaigns(): Promise<DropCampaign[]>;
+  readProgress(campaigns: DropCampaign[], session?: WatchSession): Promise<DropCampaign[]>;
+  // Retain the remaining existing PlatformAdapter methods verbatim.
+}
+```
+
+```ts
+async checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth> {
+  const checkedAt = new Date().toISOString();
+  try {
+    const response = await this.fetcher.fetchJson<KickIdentityResponse>(
+      "https://kick.com/api/v1/user",
+      signal ? { signal } : undefined,
+      this.emit,
+    );
+    if (hasKickIdentity(response)) return { status: "healthy", checkedAt };
+    return {
+      status: "unavailable",
+      checkedAt,
+      reasonCode: "platform_unavailable",
+      message: { key: "authPlatformUnavailable" },
+    };
+  }
+}
+```
+
+Keep `undefined` when no signal is supplied so existing request shapes and tests do not change.
+
+- [ ] **Step 4: Thread the signal through Twitch GQL without affecting other operations**
+
+Add an optional final signal parameter to `TwitchGqlTransport`, its factory implementation, and its request builder:
+
+```ts
+type TwitchGqlTransport = <T>(
+  operationName: string,
+  sha256Hash: string,
+  variables: Record<string, unknown>,
+  query?: string,
+  credentials?: RequestCredentials,
+  emit?: EventEmitter,
+  signal?: AbortSignal,
+) => Promise<TwitchGqlResponse<T>>;
+```
+
+```ts
+const buildRequest = (queryText?: string) => ({
+  method: "POST",
+  headers: {
+    "Accept": "*/*",
+    "Accept-Language": "en-US",
+    "Content-Type": "text/plain; charset=UTF-8",
+    "Client-ID": clientId,
+    ...(userAgent ? { "User-Agent": userAgent } : {}),
+  },
+  ...(credentials ? { credentials } : {}),
+  ...(signal ? { signal } : {}),
+  body: JSON.stringify(
+    queryText
+      ? { operationName, variables, query: queryText }
+      : {
+          operationName,
+          variables,
+          extensions: { persistedQuery: { version: 1, sha256Hash } },
+        },
+  ),
+} satisfies RequestInit);
+```
+
+Pass the signal only from `TwitchAdapter.checkAuthHealth`:
+
+```ts
+async checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth> {
+  const response = await this.gqlTransport(
+    "CurrentUser",
+    "",
+    {},
+    CURRENT_USER_QUERY,
+    undefined,
+    this.emit,
+    signal,
+  );
+  if (response.data?.currentUser) {
+    return { status: "healthy", checkedAt, message: { key: "authHealthy" } };
+  }
+  return {
+    status: "invalid_credentials",
+    checkedAt,
+    reasonCode: "credentials_rejected",
+    message: { key: "authInvalidCredentials" },
+  };
+}
+```
+
+- [ ] **Step 5: Run focused adapter tests and typechecks**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts
+pnpm typecheck
+```
+
+Expected: focused tests pass and every package typechecks. Existing mock adapters remain valid because the parameter is optional.
+
+- [ ] **Step 6: Commit the adapter contract**
+
+```bash
+git add packages/core/src/platforms/adapter.ts packages/core/src/platforms/twitch/index.ts packages/core/src/platforms/kick/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "feat(core): cancel timed out auth requests"
+```
+
+### Task 2: Resolve and persist platform probes concurrently
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: `PlatformAdapter.checkAuthHealth(signal?: AbortSignal)`.
+- Produces: `BackgroundControllerDeps.authProbeTimeoutMs?: number`.
+- Produces: controller method `checkAuthHealth(platform: Platform): Promise<void>` as the public bounded platform-local refresh entrypoint.
+- Internal helper: `refreshAuthHealth(platforms: Platform[], settings?: S): Promise<void>`.
+
+- [ ] **Step 1: Extend the controller test harness for deferred probes and timeout configuration**
+
+Add `authProbeTimeoutMs?: number` to the harness overrides and pass it into controller dependencies only when defined:
+
+```ts
+overrides: {
+  saveState?: (state: SchedulerState) => Promise<void>;
+  reportEvents?: (events: readonly EngineEvent[]) => Promise<void>;
+  stopPageContextTabs?: StopPageContextTabs;
+  wait?: (ms: number, signal: AbortSignal) => Promise<void>;
+  checkCredentialAvailability?: (platform: Platform) => Promise<CredentialAvailability>;
+  authProbeTimeoutMs?: number;
+} = {},
+```
+
+```ts
+...(overrides.authProbeTimeoutMs === undefined
+  ? {}
+  : { authProbeTimeoutMs: overrides.authProbeTimeoutMs }),
+```
+
+Use a local deferred helper in the test file:
+
+```ts
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+```
+
+- [ ] **Step 2: Write the failing concurrency and early-persistence test**
+
+The production mutation this catches is awaiting Twitch before starting or persisting Kick.
+
+```ts
+it("starts enabled auth probes concurrently and persists each before scheduler work", async () => {
+  const env = harness({ ...DEFAULT_SETTINGS, running: true });
+  const twitchHealth = deferred<PlatformAuthHealth>();
+  const kickHealth = deferred<PlatformAuthHealth>();
+  vi.mocked(env.twitch.checkAuthHealth).mockReturnValue(twitchHealth.promise);
+  vi.mocked(env.kick.checkAuthHealth).mockReturnValue(kickHealth.promise);
+
+  const ticking = env.controller.tick();
+  await vi.waitFor(() => {
+    expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+    expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce();
+  });
+
+  kickHealth.resolve({
+    status: "healthy",
+    checkedAt: "2026-07-26T12:00:00.000Z",
+  });
+  await vi.waitFor(() => expect(env.state.authHealth.kick.status).toBe("healthy"));
+
+  expect(env.state.authHealth.twitch.status).toBe("checking");
+  expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+  expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+
+  twitchHealth.resolve({
+    status: "healthy",
+    checkedAt: "2026-07-26T12:00:01.000Z",
+  });
+  await ticking;
+
+  expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+  expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+});
+```
+
+- [ ] **Step 3: Run the concurrency test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts -t "starts enabled auth probes concurrently"
+```
+
+Expected: Kick is not started or cannot persist while Twitch is pending.
+
+- [ ] **Step 4: Add configurable timeout and terminal timeout mapping**
+
+Add the dependency and default:
+
+```ts
+export interface BackgroundControllerDeps<S extends EngineSettings = EngineSettings> {
+  loadSettings(): Promise<S>;
+  saveSettings(settings: S): Promise<void>;
+  loadState(): Promise<SchedulerState>;
+  saveState(state: SchedulerState): Promise<void>;
+  authProbeTimeoutMs?: number;
+  // Retain the remaining existing host dependencies verbatim.
+}
+
+const DEFAULT_AUTH_PROBE_TIMEOUT_MS = 10_000;
+```
+
+Refactor `probeAuthHealth` to own an `AbortController`, start the full credential-plus-adapter operation, and race it against the deadline:
+
+```ts
+async function probeAuthHealth(
+  platform: Platform,
+  adapter: PlatformAdapter,
+): Promise<PlatformAuthHealth> {
+  const abort = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const terminalProbe = (async (): Promise<PlatformAuthHealth> => {
+    try {
+      const availability = await deps.checkCredentialAvailability?.(platform);
+      if (availability?.status === "missing") {
+        return {
+          status: "missing_credentials",
+          checkedAt: new Date().toISOString(),
+          reasonCode: "credentials_missing",
+          message: { key: "authMissingCredentials" },
+        };
+      }
+      if (availability?.status === "unavailable") {
+        return {
+          status: "unavailable",
+          checkedAt: new Date().toISOString(),
+          reasonCode: "credential_lookup_failed",
+          message: { key: "authCredentialLookupFailed" },
+        };
+      }
+      return await adapter.checkAuthHealth(abort.signal);
+    } catch {
+      return {
+        status: "unavailable",
+        checkedAt: new Date().toISOString(),
+        reasonCode: "credential_lookup_failed",
+        message: { key: "authCredentialLookupFailed" },
+      };
+    }
+  })();
+  const timedOut = new Promise<PlatformAuthHealth>((resolve) => {
+    timeout = setTimeout(() => {
+      abort.abort();
+      resolve({
+        status: "unavailable",
+        checkedAt: new Date().toISOString(),
+        reasonCode: "network_unavailable",
+        message: { key: "authNetworkUnavailable" },
+      });
+    }, deps.authProbeTimeoutMs ?? DEFAULT_AUTH_PROBE_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([terminalProbe, timedOut]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+```
+
+Keep the operation promise internally caught so a rejection arriving after timeout cannot become unhandled.
+
+- [ ] **Step 5: Add concurrent refresh with per-result locked persistence**
+
+Extract persistence from `checkAuthHealth`:
+
+```ts
+async function persistAuthHealth(
+  platform: Platform,
+  health: PlatformAuthHealth,
+): Promise<void> {
+  await withStateLock(() => withEventCollector(async (emit, events) => {
+    const state = await deps.loadState();
+    const transition = applyPlatformAuthHealth(state, platform, health);
+    if (transition.event) emit(transition.event);
+    await persistAndReport(transition.state, events);
+  }));
+}
+
+async function refreshAuthHealth(platforms: Platform[], loadedSettings?: S): Promise<void> {
+  const settings = loadedSettings ?? await deps.loadSettings();
+  const enabled = platforms.filter((platform) => settings.platform[platform].enabled);
+  await Promise.all(enabled.map(async (platform) => {
+    const collector = withEventCollector(async (emit, events) => {
+      const adapter = deps.createAdapters(emit, settings).adapters[platform];
+      const health = await probeAuthHealth(platform, adapter);
+      await reportBestEffort(events);
+      return health;
+    });
+    await persistAuthHealth(platform, await collector);
+  }));
+}
+
+async function checkAuthHealth(platform: Platform): Promise<void> {
+  await refreshAuthHealth([platform]);
+}
+```
+
+If compatibility diagnostics emitted during adapter creation must be reported atomically with the auth transition, fold adapter creation and probe events into `persistAuthHealth`'s event collector while keeping the network await outside `withStateLock`. Do not hold the state lock during credential or network work.
+
+- [ ] **Step 6: Move scheduler auth work before the scheduler state lock**
+
+At the beginning of `tick`, load settings and refresh only when farming is running:
+
+```ts
+async function tick(platforms?: Platform[]): Promise<ClaimedRewards> {
+  const claimedRewards: ClaimedRewards = {};
+  const settings = await deps.loadSettings();
+  if (settings.running) {
+    await refreshAuthHealth(platforms ?? PLATFORMS, settings);
+  }
+  await withStateLock(() => withEventCollector(async (emit, events) => {
+    const settings = await deps.loadSettings();
+    const state = await deps.loadState();
+    const adapters = createAdapters(settings, emit);
+    const result = await runSchedulerTick(state, settings, adapters, {
+      ...(platforms ? { platforms } : {}),
+      stopPageContextTabs: deps.stopPageContextTabs,
+      waitingClaimRewardIds: nextWaitingClaimRewardIds,
+      emit: claimObservingEmit,
+    });
+    // Retain notification, ad-focus, watcher reconciliation, rollback, and
+    // final persistence logic after this call.
+  }));
+  return claimedRewards;
+}
+```
+
+Delete `probedHealth` and its rollback reapplication. The locked scheduler phase now loads already persisted auth state, so its existing rollback baseline contains the terminal values.
+
+- [ ] **Step 7: Run the concurrency test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts -t "starts enabled auth probes concurrently"
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Write the failing timeout and cancellation tests**
+
+The mutations these catch are ignoring the configured deadline, sharing a timer between platforms, or failing to abort the request.
+
+```ts
+it("times out and aborts a stalled auth probe at the configured deadline", async () => {
+  vi.useFakeTimers();
+  try {
+    const env = harness(
+      { ...DEFAULT_SETTINGS, running: false },
+      { authProbeTimeoutMs: 25 },
+    );
+    let signal: AbortSignal | undefined;
+    vi.mocked(env.twitch.checkAuthHealth).mockImplementation((nextSignal) => {
+      signal = nextSignal;
+      return new Promise(() => undefined);
+    });
+
+    const checking = env.controller.checkAuthHealth("twitch");
+    await vi.advanceTimersByTimeAsync(24);
+    expect(env.state.authHealth.twitch.status).toBe("checking");
+    await vi.advanceTimersByTimeAsync(1);
+    await checking;
+
+    expect(signal?.aborted).toBe(true);
+    expect(env.state.authHealth.twitch).toMatchObject({
+      status: "unavailable",
+      reasonCode: "network_unavailable",
+      message: { key: "authNetworkUnavailable" },
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});
+```
+
+Add a second test where Kick resolves immediately and Twitch never resolves; assert Kick is persisted before advancing Twitch's deadline and that the overall refresh finishes after exactly the configured deadline.
+
+Add a late-settlement test whose deferred adapter rejects after the timeout; attach an `unhandledRejection` spy only if Vitest exposes a deterministic repository pattern. Otherwise prove single settlement by asserting `saveState` and auth transition event counts remain unchanged after rejecting and flushing promises.
+
+- [ ] **Step 9: Run timeout tests and verify RED, then GREEN**
+
+Run before implementing/refining:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts -t "times out and aborts|does not delay|settles once"
+```
+
+Expected RED: the old controller has no deadline or signal.
+
+After completing the minimal timeout code, rerun the same command.
+
+Expected GREEN: all new timeout tests pass without warnings or unhandled rejections.
+
+- [ ] **Step 10: Write and pass a lock-safe merge regression test**
+
+The mutation this catches is persisting auth from a stale state loaded before its network probe.
+
+```ts
+it("merges a completed auth probe into state written while the probe was pending", async () => {
+  const env = harness({ ...DEFAULT_SETTINGS, running: false });
+  const health = deferred<PlatformAuthHealth>();
+  vi.mocked(env.twitch.checkAuthHealth).mockReturnValue(health.promise);
+
+  const checking = env.controller.checkAuthHealth("twitch");
+  await vi.waitFor(() => expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce());
+
+  env.state.sessions.kick = {
+    platform: "kick",
+    status: "watching",
+    channel: channel("kick"),
+    offlineChecks: 0,
+    tabId: 20,
+    tabManagedByExtension: true,
+  };
+  await env.controller.handleMessage({
+    type: "playbackTelemetry",
+    platform: "kick",
+    telemetry: {
+      videoCount: 1,
+      mutedVideoCount: 1,
+      unmutedVideoCount: 0,
+      playingVideoCount: 1,
+      blockedPlaybackCount: 0,
+      documentHidden: true,
+      readyState: 4,
+      currentTime: 12,
+      duration: 1200,
+    },
+  }, { tab: { id: 20 } });
+  health.resolve({ status: "healthy", checkedAt: "2026-07-26T12:00:01.000Z" });
+  await checking;
+
+  expect(env.state.authHealth.twitch.status).toBe("healthy");
+  expect(env.state.sessions.kick.playback?.videoCount).toBe(1);
+});
+```
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts -t "merges a completed auth probe"
+```
+
+Expected: RED if auth uses a pre-probe snapshot, then GREEN with load-modify-save inside `withStateLock`.
+
+- [ ] **Step 11: Run the complete controller suite**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+```
+
+Expected: PASS, including existing rollback, telemetry, heartbeat, settings, and authentication tests.
+
+- [ ] **Step 12: Commit controller orchestration**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "fix(controller): persist auth health promptly"
+```
+
+### Task 3: Refresh auth on stopped-farming lifecycle triggers
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/extension/entrypoints/background.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/extension/tests/credentialObserver.test.ts` only if callback semantics need clarification; otherwise leave it unchanged.
+
+**Interfaces:**
+- Consumes: bounded `checkAuthHealth(platform)` and internal `refreshAuthHealth(platforms, settings?)`.
+- Produces: `ensureAlarm()` and `handleStartup()` refresh enabled auth while stopped.
+- Produces: credential observer `recheck` calls `controller.checkAuthHealth(platform)`.
+
+- [ ] **Step 1: Write failing stopped-farming lifecycle tests**
+
+The mutations these catch are retaining the old `running` guard or forgetting one lifecycle entrypoint.
+
+```ts
+it("refreshes enabled auth health from ensureAlarm while farming is stopped", async () => {
+  const env = harness({
+    ...DEFAULT_SETTINGS,
+    running: false,
+    platform: {
+      twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
+      kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
+    },
+  });
+
+  await env.controller.ensureAlarm();
+
+  expect(env.state.authHealth.twitch.status).toBe("healthy");
+  expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+  expect(env.kick.checkAuthHealth).not.toHaveBeenCalled();
+  expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+});
+
+it("refreshes enabled auth health on startup without starting farming", async () => {
+  const env = harness({ ...DEFAULT_SETTINGS, running: false });
+
+  await env.controller.handleStartup();
+
+  expect(env.state.authHealth.twitch.status).toBe("healthy");
+  expect(env.state.authHealth.kick.status).toBe("healthy");
+  expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+  expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+});
+```
+
+Add an auto-start assertion showing each adapter is probed exactly once when `ensureAlarm` or `handleStartup` delegates to `tick`.
+
+- [ ] **Step 2: Run lifecycle tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts -t "refreshes enabled auth health from ensureAlarm|refreshes enabled auth health on startup"
+```
+
+Expected: stopped-farming paths do not invoke adapter auth checks.
+
+- [ ] **Step 3: Integrate refresh into `ensureAlarm` without duplicate probes**
+
+Use these mutually exclusive branches:
+
+```ts
+async function ensureAlarm(): Promise<void> {
+  const settings = await deps.loadSettings();
+  await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
+  await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
+  if (settings.autoStartDropFarming && settings.running) {
+    await tick();
+  } else {
+    await refreshAuthHealth(PLATFORMS, settings);
+  }
+}
+```
+
+- [ ] **Step 4: Integrate refresh into every `handleStartup` exit path**
+
+Restructure `handleStartup` so startup cleanup and running-setting changes remain unchanged, but exactly one of these happens before returning:
+
+- auto-start path: `await tick()`, which owns auth refresh;
+- non-auto-start path: `await refreshAuthHealth(PLATFORMS, nextSettings)`.
+
+Do not add refresh calls before branches that later call `tick`, and do not start campaign discovery when `running` is false.
+
+- [ ] **Step 5: Run lifecycle tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts -t "ensureAlarm|startup|auto-start"
+```
+
+Expected: new and existing lifecycle tests pass, and auto-start performs one probe per enabled platform.
+
+- [ ] **Step 6: Change credential recheck wiring**
+
+In `packages/extension/entrypoints/background.ts`:
+
+```ts
+createCredentialObserver({
+  onChanged: {
+    addListener: (listener) => browser.cookies.onChanged.addListener(listener),
+    removeListener: (listener) => browser.cookies.onChanged.removeListener(listener),
+  },
+  invalidate: (platform) => controller.invalidateAuthHealth(platform),
+  recheck: (platform) => controller.checkAuthHealth(platform),
+});
+```
+
+Do not change `credentialObserver.ts`: it already invalidates immediately, debounces independently per platform, and contains rejected callbacks.
+This is a one-line host composition change rather than new branching logic; its
+behavior is covered by the observer's real debounce tests plus the controller's
+bounded platform-local refresh tests.
+
+- [ ] **Step 7: Run focused lifecycle and observer suites**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts credentialObserver.test.ts
+pnpm typecheck
+```
+
+Expected: PASS with no new warnings.
+
+- [ ] **Step 8: Commit lifecycle integration**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/entrypoints/background.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/credentialObserver.test.ts
+git commit -m "fix(extension): refresh auth health on lifecycle triggers"
+```
+
+### Task 4: Verify issue #275 end to end
+
+**Files:**
+- Modify only files needed to correct verification failures caused by Tasks 1–3.
+
+**Interfaces:**
+- Consumes: all prior task contracts.
+- Produces: a clean, release-ready branch satisfying issue #275.
+
+- [ ] **Step 1: Run formatting and diff checks**
+
+```bash
+git diff --check origin/develop...HEAD
+git status --short
+```
+
+Expected: no whitespace errors and only intended tracked changes.
+
+- [ ] **Step 2: Run all workspace tests and typechecks**
+
+```bash
+pnpm test
+pnpm typecheck
+```
+
+Expected: all CLI, extension, and site tests pass; all workspace packages typecheck.
+
+- [ ] **Step 3: Run the full repository check**
+
+```bash
+pnpm check
+```
+
+Expected: script tests, typechecks, extension tests, and Astro build all pass. The existing Astro chunk-size warning is acceptable; new warnings are not.
+
+- [ ] **Step 4: Review acceptance coverage**
+
+Confirm each behavior from issue #275 has a named passing test:
+
+- concurrent Twitch/Kick start;
+- per-platform early persistence;
+- configured timeout and terminal `network_unavailable`;
+- abort signal reaches each identity request;
+- one stalled platform does not delay the other platform's visible health;
+- scheduler discovery waits for terminal auth;
+- startup and `ensureAlarm` refresh while stopped;
+- cookie recheck uses bounded auth-only refresh;
+- fresh locked state preserves telemetry and scheduler rollback state;
+- late timeout settlement persists once.
+
+- [ ] **Step 5: Commit any verification-only corrections**
+
+If verification required source changes, first add a failing regression test, then make it pass and commit only those corrections:
+
+```bash
+git add packages/core/src/background/controller.ts packages/core/src/platforms/adapter.ts packages/core/src/platforms/twitch/index.ts packages/core/src/platforms/kick/index.ts packages/extension/entrypoints/background.ts packages/extension/tests/adapters.test.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "test(controller): cover auth refresh regressions"
+```
+
+If no corrections were required, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-26-auth-health-prompt-resolution-design.md
+++ b/docs/superpowers/specs/2026-07-26-auth-health-prompt-resolution-design.md
@@ -1,0 +1,179 @@
+# Prompt Authentication Health Resolution
+
+## Summary
+
+Resolve enabled-platform authentication health promptly after browser startup,
+extension installation/update/reload, scheduler ticks, and relevant credential
+cookie changes. Twitch and Kick probes run concurrently, each has a configurable
+controller-owned timeout with a 10-second default, and each result is persisted
+as soon as it settles.
+
+This work addresses GitHub issue #275. It does not add a user-facing timeout
+setting or change which cookies are observed.
+
+## Goals
+
+- Move every enabled platform from `checking` to a terminal authentication
+  health state within a bounded interval.
+- Prevent a slow Twitch probe from delaying Kick persistence, and vice versa.
+- Persist authentication health before campaign discovery or other scheduler
+  work.
+- Refresh authentication health when the UI can present it even if farming is
+  stopped.
+- Preserve all concurrent scheduler state mutations while applying a
+  platform-local authentication update.
+- Cancel the auth-specific network request after a timeout rather than leaving
+  it running in the background.
+
+## Non-goals
+
+- Exposing the timeout in extension or CLI settings.
+- Applying the auth timeout to campaign discovery, progress, claims, heartbeat,
+  or other non-authentication requests.
+- Changing authentication-health statuses or adding localized messages.
+- Changing platform enablement or automatically starting farming.
+
+## Configuration and contracts
+
+`BackgroundControllerDeps` gains an optional `authProbeTimeoutMs` number. The
+controller uses `10_000` milliseconds when the host does not provide a value.
+This is an internal host dependency, so tests and alternate hosts can choose a
+different timeout without adding persisted settings.
+
+`PlatformAdapter.checkAuthHealth` accepts an optional `AbortSignal`. Twitch and
+Kick adapters pass that signal in the `RequestInit` for authentication-specific
+fetches. Existing callers and adapters remain source-compatible because the
+argument is optional.
+
+The timeout covers the complete controller probe, including credential
+availability lookup and adapter work. When it expires, the result is:
+
+```ts
+{
+  status: "unavailable",
+  checkedAt: "<current ISO timestamp>",
+  reasonCode: "network_unavailable",
+  message: { key: "authNetworkUnavailable" },
+}
+```
+
+Existing mappings remain unchanged: missing cookies produce
+`missing_credentials`, unavailable cookie lookup produces
+`credential_lookup_failed`, rejected credentials remain adapter-defined, and
+other thrown probe failures retain the controller's existing terminal
+`unavailable` fallback.
+
+## Controller architecture
+
+The controller separates authentication refresh from the scheduler's long-held
+state mutation lock:
+
+1. Load settings and create the platform adapters needed for the refresh.
+2. Start one refresh task for every requested, enabled platform without awaiting
+   the previous platform.
+3. Give each task its own `AbortController` and timeout.
+4. When a task settles, clear its timer and acquire the existing state lock.
+5. Inside the lock, reload the latest stored state, apply only that platform's
+   health transition, then persist the state and report its events.
+6. Resolve the platform task only after its state and events are durable.
+
+Each persistence operation therefore performs a fresh load-modify-save while
+holding the same lock used by scheduler ticks, telemetry, heartbeat, and other
+controller state mutations. It cannot overwrite fields written by a concurrent
+operation. The refresh tasks compete for the lock only after their network work
+has completed; no network request holds the state lock.
+
+A multi-platform refresh returns after all requested tasks resolve. Because each
+task persists independently, a fast platform becomes visible while the other is
+still probing. A timeout bounds how long the scheduler waits before proceeding.
+
+## Scheduler flow
+
+At the beginning of `tick`, the controller loads settings, refreshes
+authentication for the requested enabled platforms concurrently, and waits for
+the bounded refresh group to finish. It then enters the existing serialized
+scheduler mutation, reloads settings and state, creates the scheduler adapters,
+and performs campaign discovery, progress reads, claims, tab work, notifications,
+ad focus, and tabless reconciliation.
+
+The scheduler no longer carries unpersisted probe results in `probedHealth` or
+reapplies them during rollback. Auth results are already durable before
+scheduler work begins. A later scheduler failure rolls back scheduler work only
+and cannot revert the separately persisted authentication fields because the
+locked scheduler phase began from the post-refresh state.
+
+Platform-scoped ticks refresh only their requested platform. Disabled platforms
+are skipped.
+
+## Startup, installation, and cookie lifecycle
+
+`handleStartup` schedules a bounded refresh for every enabled platform
+regardless of `running` or `autoStartDropFarming`. It retains the existing tab
+cleanup and farming restart behavior. The refresh does not start farming.
+When startup will immediately auto-start through `tick`, that tick supplies the
+refresh; otherwise `handleStartup` calls the refresh directly. Thus one startup
+path performs one probe per enabled platform.
+
+`ensureAlarm` also schedules the same refresh after creating alarms. Because
+`runtime.onInstalled` already calls `ensureAlarm`, fresh installs, updates, and
+extension reload/update lifecycle handling refresh authentication even when
+farming is stopped. When `ensureAlarm` will immediately auto-start through
+`tick`, it delegates the refresh to that tick instead of probing first. No
+long-lived auth cache is added.
+
+The credential observer continues to persist `checking` immediately and debounce
+rapid cookie changes. Its recheck callback calls the controller's platform-local
+bounded authentication refresh directly. It does not invoke a full farming tick,
+so a failed or stalled auth request cannot leave `checking` indefinitely and a
+cookie event cannot trigger unrelated scheduler work.
+
+## Timeout and cancellation behavior
+
+Each platform has an independent timer. On timeout, the controller aborts that
+platform's signal and resolves its task with the terminal network-unavailable
+health result. The other platform's timer, request, and persistence are
+unaffected.
+
+The timeout race must settle exactly once. A late adapter result or rejection
+after the timeout must not produce a second persistence operation or an unhandled
+rejection. Timers are cleared on every non-timeout completion. Aborting an auth
+fetch is an expected timeout path and must not emit raw exception text or add
+localized diagnostic keys.
+
+## Testing
+
+Controller tests use deferred promises to show that:
+
+- Twitch and Kick probes are both started before either resolves.
+- Resolving Kick persists Kick health while Twitch remains pending.
+- Campaign discovery has not begun before all requested auth tasks are terminal.
+- A scheduler failure after the refresh preserves both durable auth results.
+- A state mutation queued while a probe is pending is retained when auth health
+  is later applied.
+
+Fake-timer tests configure a short `authProbeTimeoutMs` and show that:
+
+- Advancing to the configured deadline resolves a stalled probe to
+  `unavailable` with `network_unavailable`.
+- The adapter receives an `AbortSignal` that becomes aborted at the deadline.
+- One platform timing out does not delay an already resolved platform.
+- Late probe settlement does not persist twice or cause an unhandled rejection.
+
+Startup tests show that `handleStartup` and `ensureAlarm` refresh every enabled
+platform while farming is stopped and skip disabled platforms. Background
+wiring tests or focused lifecycle assertions show that `runtime.onInstalled`
+continues through `ensureAlarm`.
+
+Credential observer tests show that the debounced callback invokes the
+platform-local refresh path and that its bounded controller behavior—not a full
+scheduler tick—owns terminal resolution.
+
+Adapter/transport tests assert that Twitch and Kick auth requests receive the
+controller signal while unrelated fetches remain unchanged.
+
+## Acceptance
+
+The implementation is complete when all issue #275 acceptance criteria are
+covered by deterministic tests, workspace typechecks pass, the extension test
+suite passes, and the scheduler's existing state-locking and rollback tests
+remain green.

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -43,6 +43,7 @@ export async function runLoop(options: RunOptions): Promise<void> {
     reportEvents: (events) => reportCliEvents(events, logger),
     // The CLI drives its own interval below, so alarm scheduling is a no-op.
     createAlarm: async () => {},
+    createAdapter: (platform, emit, currentSettings) => transport.createAdapter(platform, emit, currentSettings),
     createAdapters: (emit, currentSettings) => transport.createAdapters(emit, currentSettings),
     createNotification: async ({ title, message }) => logger.info(`${title}: ${message}`, "notify"),
     ...(options.checkCredentialAvailability ? { checkCredentialAvailability: options.checkCredentialAvailability } : {}),

--- a/packages/cli/src/transport/common.ts
+++ b/packages/cli/src/transport/common.ts
@@ -8,6 +8,9 @@ import type { CompatibilityResolution } from "@lurkloot/core";
 // this shape so the commands can dispose uniformly.
 export interface TransportHandle {
   adapters: Record<Platform, PlatformAdapter>;
+  createAdapter(platform: Platform, emit: EventEmitter, settings: EngineSettings): {
+    adapter: PlatformAdapter;
+  } & CompatibilityResolution;
   createAdapters(emit: EventEmitter, settings: EngineSettings): {
     adapters: Record<Platform, PlatformAdapter>;
   } & CompatibilityResolution;

--- a/packages/cli/src/transport/common.ts
+++ b/packages/cli/src/transport/common.ts
@@ -24,6 +24,21 @@ export interface EnabledPlatforms {
   kick: boolean;
 }
 
+export function createLazyAdapters(
+  createAdapter: (platform: Platform) => PlatformAdapter,
+): Record<Platform, PlatformAdapter> {
+  let twitch: PlatformAdapter | undefined;
+  let kick: PlatformAdapter | undefined;
+  return {
+    get twitch() {
+      return twitch ??= createAdapter("twitch");
+    },
+    get kick() {
+      return kick ??= createAdapter("kick");
+    },
+  };
+}
+
 export const HEARTBEAT_REQUEST_TIMEOUT_MS = 15_000;
 
 export async function withHeartbeatTimeout<T>(

--- a/packages/cli/src/transport/cycle.ts
+++ b/packages/cli/src/transport/cycle.ts
@@ -28,7 +28,11 @@ export function kickHeaders(url: string, init: RequestInit | undefined, creds: P
 
 // cycletls-backed Kick PageFetcher: carries a Chrome JA3/HTTP-2 fingerprint past
 // Cloudflare's WAF (pure-Node fetch 403s). Shared by the impersonate and browser
-// transports, which both reach Kick this way.
+// transports, which both reach Kick this way. CycleTLS 2.x has no per-request
+// cancellation primitive: its only interruption API is process-wide exit(),
+// which would terminate sibling requests and the shared transport. The
+// controller deadline therefore bounds the caller while an aborted host request
+// finishes in CycleTLS.
 export function createCycleKickFetcher(cycleTLS: CycleTLSClient, creds: PlatformCredentials): PageFetcher {
   return {
     async fetchJson<T>(url: string, init?: RequestInit): Promise<T> {

--- a/packages/cli/src/transport/http.ts
+++ b/packages/cli/src/transport/http.ts
@@ -8,7 +8,7 @@ import type { Platform } from "@lurkloot/shared/models";
 import type { PlatformCredentials } from "../authStore";
 import { twitchClientIdentity } from "../twitch";
 import { kickCookieApi, twitchCookieApi } from "./cookieApi";
-import { tablessWatchPort, withHeartbeatTimeout, type EnabledPlatforms, type TransportHandle } from "./common";
+import { createLazyAdapters, tablessWatchPort, withHeartbeatTimeout, type EnabledPlatforms, type TransportHandle } from "./common";
 
 // Plain Node fetch transport. Twitch GQL works (no WAF). Kick's Cloudflare WAF
 // fingerprints the TLS/HTTP-2 stack, so pure-Node requests get HTTP 403 — that
@@ -70,7 +70,7 @@ export function createHttpTransport(creds: PlatformCredentials, _enabled: Enable
     };
   };
   return {
-    adapters: createAdapters(undefined).adapters,
+    adapters: createLazyAdapters((platform) => createAdapter(platform, undefined).adapter),
     createAdapter,
     createAdapters,
     async dispose() {

--- a/packages/cli/src/transport/http.ts
+++ b/packages/cli/src/transport/http.ts
@@ -4,6 +4,7 @@ import { TwitchAdapter } from "@lurkloot/core/twitch";
 import { resolveCompatibility } from "@lurkloot/core";
 import type { EventEmitter } from "@lurkloot/shared/events";
 import { DEFAULT_ENGINE_SETTINGS } from "@lurkloot/shared/settings";
+import type { Platform } from "@lurkloot/shared/models";
 import type { PlatformCredentials } from "../authStore";
 import { twitchClientIdentity } from "../twitch";
 import { kickCookieApi, twitchCookieApi } from "./cookieApi";
@@ -17,50 +18,60 @@ export function createHttpTransport(creds: PlatformCredentials, _enabled: Enable
   const twitchApi = twitchCookieApi(creds);
   const kickApi = kickCookieApi(creds);
   const kickClaimState = new KickClaimState();
-  const createAdapters = (emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
+  const createAdapter = (platform: Platform, emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
     const identity = twitchClientIdentity(creds);
     const twitchIdentity = identity.userAgent ? "android" : "web";
     const resolution = resolveCompatibility(settings.compatibility, { host: "cli", twitchIdentity });
+    const adapter = platform === "twitch"
+      ? new TwitchAdapter(
+        { fetchJson: (url, init) => fetchTwitchInBackgroundWith(twitchApi, url, init) },
+        async () => false,
+        tablessWatchPort,
+        {
+          ...identity,
+          compatibility: resolution.compatibility.twitch,
+          heartbeatIdentity: twitchIdentity,
+          heartbeatFetchText: async (url, init) => {
+            const response = await withHeartbeatTimeout(
+              (signal) => fetch(url, { ...init, signal }),
+              init?.signal,
+            );
+            return response.text();
+          },
+          heartbeatPost: async (url, init) => {
+            const response = await withHeartbeatTimeout(
+              (signal) => fetch(url, { ...init, signal }),
+              init.signal,
+            );
+            return { status: response.status };
+          },
+        },
+        emit,
+      )
+      : new KickAdapter(
+        { fetchJson: (url, init) => fetchKickInBackgroundWith(kickApi, url, init) },
+        tablessWatchPort,
+        undefined,
+        emit,
+        { compatibility: resolution.compatibility.kick, claimState: kickClaimState },
+      );
+    return { adapter, ...resolution };
+  };
+  const createAdapters = (emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
+    const twitch = createAdapter("twitch", emit, settings);
+    const kick = createAdapter("kick", emit, settings);
     return {
       adapters: {
-        twitch: new TwitchAdapter(
-          { fetchJson: (url, init) => fetchTwitchInBackgroundWith(twitchApi, url, init) },
-          async () => false,
-          tablessWatchPort,
-          {
-            ...identity,
-            compatibility: resolution.compatibility.twitch,
-            heartbeatIdentity: twitchIdentity,
-            heartbeatFetchText: async (url, init) => {
-              const response = await withHeartbeatTimeout(
-                (signal) => fetch(url, { ...init, signal }),
-                init?.signal,
-              );
-              return response.text();
-            },
-            heartbeatPost: async (url, init) => {
-              const response = await withHeartbeatTimeout(
-                (signal) => fetch(url, { ...init, signal }),
-                init.signal,
-              );
-              return { status: response.status };
-            },
-          },
-          emit,
-        ),
-        kick: new KickAdapter(
-          { fetchJson: (url, init) => fetchKickInBackgroundWith(kickApi, url, init) },
-          tablessWatchPort,
-          undefined,
-          emit,
-          { compatibility: resolution.compatibility.kick, claimState: kickClaimState },
-        ),
+        twitch: twitch.adapter,
+        kick: kick.adapter,
       },
-      ...resolution,
+      compatibility: twitch.compatibility,
+      warnings: twitch.warnings,
     };
   };
   return {
     adapters: createAdapters(undefined).adapters,
+    createAdapter,
     createAdapters,
     async dispose() {
       // The http transport holds no long-lived resources.

--- a/packages/cli/src/transport/impersonate.ts
+++ b/packages/cli/src/transport/impersonate.ts
@@ -9,7 +9,7 @@ import type { PlatformCredentials } from "../authStore";
 import { twitchClientIdentity } from "../twitch";
 import { twitchCookieApi } from "./cookieApi";
 import { createCycleKickFetcher, createCycleKickWebSocketFactory, initCycle, type CycleTLSClient } from "./cycle";
-import { CHROME_HTTP2, CHROME_JA3, headersToObject, tablessWatchPort, withHeartbeatTimeout, type EnabledPlatforms, type TransportHandle } from "./common";
+import { CHROME_HTTP2, CHROME_JA3, createLazyAdapters, headersToObject, tablessWatchPort, withHeartbeatTimeout, type EnabledPlatforms, type TransportHandle } from "./common";
 
 export interface ImpersonateDeps {
   // Injectable for tests; defaults to spawning the real cycletls subprocess.
@@ -89,7 +89,7 @@ export async function createImpersonateTransport(
   };
 
   return {
-    adapters: createAdapters(undefined).adapters,
+    adapters: createLazyAdapters((platform) => createAdapter(platform, undefined).adapter),
     createAdapter,
     createAdapters,
     async dispose() {

--- a/packages/cli/src/transport/impersonate.ts
+++ b/packages/cli/src/transport/impersonate.ts
@@ -4,6 +4,7 @@ import { TwitchAdapter } from "@lurkloot/core/twitch";
 import { resolveCompatibility } from "@lurkloot/core";
 import type { EventEmitter } from "@lurkloot/shared/events";
 import { DEFAULT_ENGINE_SETTINGS } from "@lurkloot/shared/settings";
+import type { Platform } from "@lurkloot/shared/models";
 import type { PlatformCredentials } from "../authStore";
 import { twitchClientIdentity } from "../twitch";
 import { twitchCookieApi } from "./cookieApi";
@@ -27,59 +28,69 @@ export async function createImpersonateTransport(
 ): Promise<TransportHandle> {
   const cycleTLS = await (deps.initClient ?? initCycle)();
   const kickClaimState = new KickClaimState();
-  const createAdapters = (emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
+  const createAdapter = (platform: Platform, emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
     const identity = twitchClientIdentity(creds);
     const twitchIdentity = identity.userAgent ? "android" : "web";
     const resolution = resolveCompatibility(settings.compatibility, { host: "cli", twitchIdentity });
+    const adapter = platform === "twitch"
+      ? new TwitchAdapter(
+        { fetchJson: (url, init) => fetchTwitchInBackgroundWith(twitchCookieApi(creds), url, init) },
+        async () => false,
+        tablessWatchPort,
+        {
+          ...identity,
+          compatibility: resolution.compatibility.twitch,
+          heartbeatIdentity: twitchIdentity,
+          heartbeatFetchText: async (url, init) => {
+            const response = await withHeartbeatTimeout(() => cycleTLS(url, {
+              ja3: CHROME_JA3,
+              http2Fingerprint: CHROME_HTTP2,
+              userAgent: identity.userAgent,
+              headers: headersToObject(init?.headers),
+              body: typeof init?.body === "string" ? init.body : undefined,
+              disableRedirect: init?.redirect === "error" || init?.redirect === "manual",
+            }, (init?.method ?? "GET").toLowerCase() as "get" | "post"), init?.signal);
+            return typeof response.data === "string" ? response.data : JSON.stringify(response.data ?? "");
+          },
+          heartbeatPost: async (url, init) => {
+            const response = await withHeartbeatTimeout(() => cycleTLS(url, {
+              ja3: CHROME_JA3,
+              http2Fingerprint: CHROME_HTTP2,
+              userAgent: identity.userAgent,
+              headers: headersToObject(init.headers),
+              body: typeof init.body === "string" ? init.body : undefined,
+              disableRedirect: init.redirect === "error" || init.redirect === "manual",
+            }, "post"), init.signal);
+            return { status: response.status };
+          },
+        },
+        emit,
+      )
+      : new KickAdapter(
+        createCycleKickFetcher(cycleTLS, creds),
+        tablessWatchPort,
+        createCycleKickWebSocketFactory(cycleTLS, creds),
+        emit,
+        { compatibility: resolution.compatibility.kick, claimState: kickClaimState },
+      );
+    return { adapter, ...resolution };
+  };
+  const createAdapters = (emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
+    const twitch = createAdapter("twitch", emit, settings);
+    const kick = createAdapter("kick", emit, settings);
     return {
       adapters: {
-        twitch: new TwitchAdapter(
-          { fetchJson: (url, init) => fetchTwitchInBackgroundWith(twitchCookieApi(creds), url, init) },
-          async () => false,
-          tablessWatchPort,
-          {
-            ...identity,
-            compatibility: resolution.compatibility.twitch,
-            heartbeatIdentity: twitchIdentity,
-            heartbeatFetchText: async (url, init) => {
-              const response = await withHeartbeatTimeout(() => cycleTLS(url, {
-                ja3: CHROME_JA3,
-                http2Fingerprint: CHROME_HTTP2,
-                userAgent: identity.userAgent,
-                headers: headersToObject(init?.headers),
-                body: typeof init?.body === "string" ? init.body : undefined,
-                disableRedirect: init?.redirect === "error" || init?.redirect === "manual",
-              }, (init?.method ?? "GET").toLowerCase() as "get" | "post"), init?.signal);
-              return typeof response.data === "string" ? response.data : JSON.stringify(response.data ?? "");
-            },
-            heartbeatPost: async (url, init) => {
-              const response = await withHeartbeatTimeout(() => cycleTLS(url, {
-                ja3: CHROME_JA3,
-                http2Fingerprint: CHROME_HTTP2,
-                userAgent: identity.userAgent,
-                headers: headersToObject(init.headers),
-                body: typeof init.body === "string" ? init.body : undefined,
-                disableRedirect: init.redirect === "error" || init.redirect === "manual",
-              }, "post"), init.signal);
-              return { status: response.status };
-            },
-          },
-          emit,
-        ),
-        kick: new KickAdapter(
-          createCycleKickFetcher(cycleTLS, creds),
-          tablessWatchPort,
-          createCycleKickWebSocketFactory(cycleTLS, creds),
-          emit,
-          { compatibility: resolution.compatibility.kick, claimState: kickClaimState },
-        ),
+        twitch: twitch.adapter,
+        kick: kick.adapter,
       },
-      ...resolution,
+      compatibility: twitch.compatibility,
+      warnings: twitch.warnings,
     };
   };
 
   return {
     adapters: createAdapters(undefined).adapters,
+    createAdapter,
     createAdapters,
     async dispose() {
       await cycleTLS.exit();

--- a/packages/cli/tests/bootstrap.test.ts
+++ b/packages/cli/tests/bootstrap.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const adapterConstruction = vi.hoisted(() => ({
+  failKick: false,
+}));
+
+vi.mock("@lurkloot/core/kick", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lurkloot/core/kick")>();
+  const KickAdapter = new Proxy(actual.KickAdapter, {
+    construct(target, args) {
+      if (adapterConstruction.failKick) throw new Error("Kick adapter construction failed");
+      return Reflect.construct(target, args, target);
+    },
+  });
+  return { ...actual, KickAdapter };
+});
+
+vi.mock("@lurkloot/core/twitch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lurkloot/core/twitch")>();
+  const TwitchAdapter = new Proxy(actual.TwitchAdapter, {
+    construct(target, args) {
+      const adapter = Reflect.construct(target, args, target) as InstanceType<typeof actual.TwitchAdapter>;
+      adapter.checkAuthHealth = async () => ({
+        status: "healthy",
+        checkedAt: "2026-07-26T12:00:00.000Z",
+        message: { key: "authHealthy" },
+      });
+      return adapter;
+    },
+  });
+  return { ...actual, TwitchAdapter };
+});
+
+import type { SchedulerState } from "@lurkloot/shared/models";
+import { createHttpTransport } from "../src/transport/http";
+import { createImpersonateTransport } from "../src/transport/impersonate";
+import type { TransportHandle } from "../src/transport";
+import type { CycleTLSClient } from "../src/transport/cycle";
+import { DEFAULT_CLI_SETTINGS } from "../src/settings";
+import { runLoop } from "../src/runtime/run";
+import type { Logger } from "../src/logger";
+
+const logger: Logger = {
+  level: "error",
+  log() {},
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function fakeCycleClient(): CycleTLSClient {
+  const client = async () => ({ status: 200, data: {} });
+  return Object.assign(client, {
+    exit: async () => undefined,
+    ws: async () => ({
+      send() {},
+      close() {},
+      onMessage() {},
+      onClose() {},
+      onError() {},
+    }),
+  }) as unknown as CycleTLSClient;
+}
+
+const transports: Array<[string, () => Promise<TransportHandle>]> = [
+  [
+    "http",
+    async () => createHttpTransport({}, { twitch: true, kick: false }),
+  ],
+  [
+    "impersonate",
+    async () => createImpersonateTransport(
+      {},
+      { twitch: true, kick: false },
+      { initClient: async () => fakeCycleClient() },
+    ),
+  ],
+];
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "lurkloot-bootstrap-"));
+  adapterConstruction.failKick = true;
+});
+
+afterEach(async () => {
+  adapterConstruction.failKick = false;
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe.each(transports)("%s transport bootstrap", (_name, createTransport) => {
+  it("starts and persists Twitch auth health when disabled Kick cannot construct", async () => {
+    const statePath = join(dir, "state.json");
+    const transport = await createTransport();
+
+    expect(transport.adapters.twitch.platform).toBe("twitch");
+    await runLoop({
+      settings: {
+        ...DEFAULT_CLI_SETTINGS,
+        platform: {
+          ...DEFAULT_CLI_SETTINGS.platform,
+          twitch: { ...DEFAULT_CLI_SETTINGS.platform.twitch, enabled: true },
+          kick: { ...DEFAULT_CLI_SETTINGS.platform.kick, enabled: false },
+        },
+      },
+      statePath,
+      transport,
+      logger,
+      once: true,
+      checkCredentialAvailability: async () => ({ status: "available" }),
+    });
+
+    const state = JSON.parse(await readFile(statePath, "utf8")) as SchedulerState;
+    expect(state.authHealth.twitch).toMatchObject({
+      status: "healthy",
+      checkedAt: "2026-07-26T12:00:00.000Z",
+    });
+  });
+});

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -45,8 +45,17 @@ async function fakeTransport(health: Record<Platform, PlatformAuthHealth>): Prom
       warnings,
     };
   };
+  const buildOne = (platform: Platform, emit: EventEmitter, settings: EngineSettings) => {
+    const { adapters, ...resolution } = build(emit, settings);
+    return { adapter: adapters[platform], ...resolution };
+  };
   const initial = build(() => {}, DEFAULT_CLI_SETTINGS as unknown as EngineSettings);
-  return { adapters: initial.adapters, createAdapters: build, dispose: async () => { await real.dispose(); } };
+  return {
+    adapters: initial.adapters,
+    createAdapter: buildOne,
+    createAdapters: build,
+    dispose: async () => { await real.dispose(); },
+  };
 }
 
 const HEALTHY: PlatformAuthHealth = { status: "healthy", message: { key: "authHealthy" } };

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -271,6 +271,19 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     return construction.adapter;
   }
 
+  function createSelectedAdapters(
+    settings: S,
+    emit: EventEmitter,
+    platforms: readonly Platform[],
+  ): Record<Platform, PlatformAdapter> {
+    if (platforms.length === PLATFORMS.length) return createAdapters(settings, emit);
+    const adapters: Partial<Record<Platform, PlatformAdapter>> = {};
+    for (const platform of platforms) {
+      adapters[platform] = createAdapter(platform, settings, emit, true);
+    }
+    return adapters as Record<Platform, PlatformAdapter>;
+  }
+
   async function withEventCollector<T>(operation: (emit: EventEmitter, events: EngineEvent[]) => Promise<T>): Promise<T> {
     const events: EngineEvent[] = [];
     const emit = withActivityDiagnostics((event) => events.push(event));
@@ -658,12 +671,6 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           platform: failure.platform,
           data: { reason: "platform_error", detail: failure.message },
         });
-        emit({
-          category: "diagnostic",
-          platform: failure.platform,
-          level: "error",
-          message: failure.message,
-        });
       }
       await persistAndReport(state, events);
     }));
@@ -672,6 +679,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function tick(platforms?: Platform[]): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
     const settings = await deps.loadSettings();
+    const setupFailedPlatforms = new Set<Platform>();
     if (settings.running) {
       try {
         await refreshAuthHealth(platforms ?? PLATFORMS, settings);
@@ -680,6 +688,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         const setupFailures = failures.filter((failure): failure is AuthProbeSetupError =>
           failure instanceof AuthProbeSetupError);
         if (setupFailures.length === 0) throw error;
+        for (const failure of setupFailures) setupFailedPlatforms.add(failure.platform);
         let reportingFailure: unknown;
         try {
           await reportAuthSetupFailures(setupFailures);
@@ -697,9 +706,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           throw error;
         }
         if (reportingFailure !== undefined) throw reportingFailure;
-        return claimedRewards;
       }
     }
+    const schedulerPlatforms = (platforms ?? PLATFORMS).filter((platform) =>
+      !setupFailedPlatforms.has(platform));
+    if (schedulerPlatforms.length === 0) return claimedRewards;
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const settings = await deps.loadSettings();
       const state = await deps.loadState();
@@ -709,7 +720,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       };
       let nextState: SchedulerState;
       try {
-        const adapters = createAdapters(settings, emit);
+        const adapters = setupFailedPlatforms.size > 0
+          ? createSelectedAdapters(settings, emit, schedulerPlatforms)
+          : createAdapters(settings, emit);
         // Observed here rather than returned by the scheduler: the controller
         // already sees every emitted event, and the post-claim handoff only
         // needs to know which platforms claimed.
@@ -721,7 +734,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         };
         const eventsBeforeTick = events.length;
         const result = await runSchedulerTick(state, settings, adapters, {
-          ...(platforms ? { platforms } : {}),
+          platforms: schedulerPlatforms,
           stopPageContextTabs: deps.stopPageContextTabs,
           waitingClaimRewardIds: nextWaitingClaimRewardIds,
           emit: claimObservingEmit,
@@ -730,7 +743,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         for (const event of lifecycleEvents) emit(event);
         await emitNotifications(settings, state, result.state, result.events);
         await applyAdFocusForState(result.state, emit);
-        await reconcileTablessWatchers(result.state, settings, adapters, emit, platforms);
+        await reconcileTablessWatchers(result.state, settings, adapters, emit, schedulerPlatforms);
         nextState = result.state;
         if (settings.criticalFailurePromptEnabled) {
           // Page-context tabs are created deep inside tabs.ts, which has no access

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -41,7 +41,15 @@ function isNothingLeftToFarm(reasonCode: WatchReasonCode | undefined): boolean {
 const RECENT_HEARTBEAT_MS = 30_000;
 const PLATFORMS: Platform[] = ["twitch", "kick"];
 const DEFAULT_AUTH_PROBE_TIMEOUT_MS = 10_000;
-class AuthProbeSetupError extends Error {}
+class AuthProbeSetupError extends Error {
+  constructor(
+    readonly platform: Platform,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AuthProbeSetupError";
+  }
+}
 const FARMING_STOP_REASON_CODES: Record<FarmingStopReason, true> = {
   automation_disabled: true,
   platform_disabled: true,
@@ -117,6 +125,11 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
     compatibility: ResolvedCompatibility;
     warnings: CompatibilityResolution["warnings"];
   };
+  createAdapter(platform: Platform, emit: EventEmitter, settings: S): {
+    adapter: PlatformAdapter;
+    compatibility: ResolvedCompatibility;
+    warnings: CompatibilityResolution["warnings"];
+  };
   checkCredentialAvailability?(platform: Platform): Promise<CredentialAvailability>;
   createNotification?(notification: { title: string; message: string }): Promise<void>;
   translate?(key: string, substitutions?: string | string[]): string | Promise<string>;
@@ -146,6 +159,10 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
 export function createBackgroundController<S extends EngineSettings = EngineSettings>(deps: BackgroundControllerDeps<S>) {
   const reportedCompatibility = new Map<Platform, string>();
   const reportedCompatibilityWarnings = new Set<string>();
+  const authRefreshGeneration: Record<Platform, number> = {
+    twitch: 0,
+    kick: 0,
+  };
   // In-flight post-claim handoffs, one per platform. A claim arriving while a
   // handoff is already running for that platform is absorbed by the running
   // loop rather than starting a second one, which is what keeps the work
@@ -187,10 +204,17 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     return field === "profile" ? "Kick profile" : "Kick claim";
   };
 
-  function createAdapters(settings: S, emit: EventEmitter): Record<Platform, PlatformAdapter> {
-    const construction = deps.createAdapters(emit, settings);
+  function reportAdapterCompatibility(
+    construction: {
+      compatibility: ResolvedCompatibility;
+      warnings: CompatibilityResolution["warnings"];
+    },
+    settings: S,
+    emit: EventEmitter,
+    platforms: readonly Platform[],
+  ): void {
     for (const warning of construction.warnings) {
-      if (!settings.platform[warning.platform].enabled) continue;
+      if (!platforms.includes(warning.platform) || !settings.platform[warning.platform].enabled) continue;
       const key = `${warning.code}:${warning.platform}:${warning.field}:${warning.resolved}:${selectionFingerprint(warning.requested)}`;
       if (reportedCompatibilityWarnings.has(key)) continue;
       const reason = warning.code === "unknown_selection" ? "Unknown" : "Host-incompatible";
@@ -205,7 +229,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       });
       reportedCompatibilityWarnings.add(key);
     }
-    for (const platform of PLATFORMS) {
+    for (const platform of platforms) {
       if (!settings.platform[platform].enabled) continue;
       const profile = construction.compatibility[platform].profile;
       const capabilities = platform === "twitch"
@@ -226,7 +250,25 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       });
       reportedCompatibility.set(platform, key);
     }
+  }
+
+  function createAdapters(settings: S, emit: EventEmitter): Record<Platform, PlatformAdapter> {
+    const construction = deps.createAdapters(emit, settings);
+    reportAdapterCompatibility(construction, settings, emit, PLATFORMS);
     return construction.adapters;
+  }
+
+  function createAdapter(
+    platform: Platform,
+    settings: S,
+    emit: EventEmitter,
+    reportCompatibility = false,
+  ): PlatformAdapter {
+    const construction = deps.createAdapter(platform, emit, settings);
+    if (reportCompatibility) {
+      reportAdapterCompatibility(construction, settings, emit, [platform]);
+    }
+    return construction.adapter;
   }
 
   async function withEventCollector<T>(operation: (emit: EventEmitter, events: EngineEvent[]) => Promise<T>): Promise<T> {
@@ -357,33 +399,51 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
+  async function ensureInstalledAt(installedAt = new Date().toISOString()): Promise<void> {
+    await withStateLock(async () => {
+      const state = await deps.loadState();
+      if (state.installedAt) return;
+      await saveOperationalState({ ...state, installedAt });
+    });
+  }
+
+  async function normalizeStartupSettings(): Promise<S> {
+    return withSettingsLock(async () => {
+      const settings = await deps.loadSettings();
+      if (!settings.running || settings.autoStartDropFarming) return settings;
+      const nextSettings = { ...settings, running: false };
+      await deps.saveSettings(nextSettings);
+      return nextSettings;
+    });
+  }
+
   async function handleStartup(): Promise<void> {
     // A restart kills the watchers a handoff would transmit through, so leave
     // no loop running against them.
     abortClaimHandoffs();
-    const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+    const settings = await deps.loadSettings();
     await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
     await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
-    await withEventCollector(async (emit, events) => {
-      createAdapters(settings, emit);
-      await reportBestEffort(events);
-    });
     // A restart kills any in-memory watchers; start clean and let tick() rebuild.
     tablessWatchers.clear();
 
     const preservePageContexts = settings.running && settings.autoStartDropFarming;
-    registerManagedPageContextTabs(preservePageContexts ? state.managedPageContextTabs ?? {} : {});
-    const cleanup = staleStartupCleanup(state, preservePageContexts);
-    if (!cleanup.hasStaleSession) {
-      let nextSettings = settings;
-      if (settings.running && !settings.autoStartDropFarming) {
-        nextSettings = { ...settings, running: false };
-        await deps.saveSettings(nextSettings);
+    const { state, cleanup } = await withStateLock(async () => {
+      const state = await deps.loadState();
+      registerManagedPageContextTabs(preservePageContexts ? state.managedPageContextTabs ?? {} : {});
+      const cleanup = staleStartupCleanup(state, preservePageContexts);
+      if (cleanup.hasStaleSession) {
+        const restartEvents = farmingLifecycleEvents(state, cleanup.state);
+        await persistAndReport(cleanup.state, restartEvents);
       }
+      return { state, cleanup };
+    });
+    if (!cleanup.hasStaleSession) {
+      const nextSettings = await normalizeStartupSettings();
       if (nextSettings.autoStartDropFarming && nextSettings.running) {
         await tick();
       } else {
-        await refreshAuthHealth(PLATFORMS, nextSettings);
+        await refreshAuthHealth(PLATFORMS, nextSettings, true);
       }
       return;
     }
@@ -402,19 +462,12 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       });
     }
 
-    let nextSettings = settings;
-    if (settings.running && !settings.autoStartDropFarming) {
-      nextSettings = { ...settings, running: false };
-      await deps.saveSettings(nextSettings);
-    }
-
-    const restartEvents = farmingLifecycleEvents(state, cleanup.state);
-    await persistAndReport(cleanup.state, restartEvents);
+    const nextSettings = await normalizeStartupSettings();
 
     if (nextSettings.running && nextSettings.autoStartDropFarming) {
       await tick();
     } else {
-      await refreshAuthHealth(PLATFORMS, nextSettings);
+      await refreshAuthHealth(PLATFORMS, nextSettings, true);
     }
   }
 
@@ -501,34 +554,119 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     platform: Platform,
     health: PlatformAuthHealth,
     probeEvents: readonly EngineEvent[] = [],
-  ): Promise<void> {
-    await withStateLock(() => withEventCollector(async (emit, events) => {
+    generation: number,
+  ): Promise<boolean> {
+    return withStateLock(() => withEventCollector(async (emit, events) => {
+      if (authRefreshGeneration[platform] !== generation) return false;
       events.push(...probeEvents);
       const state = await deps.loadState();
       const transition = applyPlatformAuthHealth(state, platform, health);
       if (transition.event) emit(transition.event);
       await persistAndReport(transition.state, events);
+      return true;
     }));
   }
 
-  async function refreshAuthHealth(platforms: Platform[], loadedSettings?: S): Promise<void> {
+  async function beginAuthRefresh(platforms: readonly Platform[]): Promise<Partial<Record<Platform, number>>> {
+    return withStateLock(async () => {
+      const generations: Partial<Record<Platform, number>> = {};
+      for (const platform of platforms) {
+        authRefreshGeneration[platform] += 1;
+        generations[platform] = authRefreshGeneration[platform];
+      }
+      return generations;
+    });
+  }
+
+  function unavailableAfterAdapterSetup(): PlatformAuthHealth {
+    return {
+      status: "unavailable",
+      checkedAt: new Date().toISOString(),
+      reasonCode: "platform_unavailable",
+      message: { key: "authPlatformUnavailable" },
+    };
+  }
+
+  function flattenedRefreshFailures(error: unknown): unknown[] {
+    if (error instanceof AggregateError) {
+      return error.errors.flatMap((failure) => flattenedRefreshFailures(failure));
+    }
+    return [error];
+  }
+
+  function throwRefreshFailures(results: PromiseSettledResult<void>[]): void {
+    const failures = results.flatMap((result) =>
+      result.status === "rejected" ? flattenedRefreshFailures(result.reason) : []);
+    if (failures.length === 0) return;
+    if (failures.length === 1) throw failures[0];
+    throw new AggregateError(failures, "Authentication refresh failed");
+  }
+
+  async function refreshAuthHealth(
+    platforms: Platform[],
+    loadedSettings?: S,
+    reportCompatibility = false,
+  ): Promise<void> {
+    const generations = await beginAuthRefresh(platforms);
     const settings = loadedSettings ?? await deps.loadSettings();
     const enabled = platforms.filter((platform) => settings.platform[platform].enabled);
     const results = await Promise.allSettled(enabled.map(async (platform) => {
       const result = await withEventCollector(async (emit, events) => {
-        let adapter: PlatformAdapter;
+        let setupFailure: AuthProbeSetupError | undefined;
+        let health: PlatformAuthHealth;
+        let adapter: PlatformAdapter | undefined;
         try {
-          adapter = deps.createAdapters(emit, settings).adapters[platform];
+          adapter = createAdapter(platform, settings, emit, reportCompatibility);
         } catch (error) {
-          throw new AuthProbeSetupError(error instanceof Error ? error.message : "Adapter factory failed");
+          setupFailure = new AuthProbeSetupError(
+            platform,
+            error instanceof Error ? error.message : "Adapter factory failed",
+          );
         }
-        const health = await probeAuthHealth(platform, adapter);
-        return { health, events };
+        health = adapter
+          ? await probeAuthHealth(platform, adapter)
+          : unavailableAfterAdapterSetup();
+        return { health, events, setupFailure };
       });
-      await persistAuthHealth(platform, result.health, result.events);
+      const generation = generations[platform];
+      if (generation === undefined) return;
+      let accepted: boolean;
+      try {
+        accepted = await persistAuthHealth(platform, result.health, result.events, generation);
+      } catch (error) {
+        if (result.setupFailure) {
+          throw new AggregateError(
+            [result.setupFailure, error],
+            `${platform} authentication setup and persistence failed`,
+          );
+        }
+        throw error;
+      }
+      if (accepted && result.setupFailure) throw result.setupFailure;
     }));
-    const failure = results.find((result) => result.status === "rejected");
-    if (failure?.status === "rejected") throw failure.reason;
+    throwRefreshFailures(results);
+  }
+
+  async function reportAuthSetupFailures(failures: readonly AuthProbeSetupError[]): Promise<void> {
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      const state = await deps.loadState();
+      for (const failure of failures) {
+        emit({
+          category: "activity",
+          code: "interruption",
+          level: "error",
+          platform: failure.platform,
+          data: { reason: "platform_error", detail: failure.message },
+        });
+        emit({
+          category: "diagnostic",
+          platform: failure.platform,
+          level: "error",
+          message: failure.message,
+        });
+      }
+      await persistAndReport(state, events);
+    }));
   }
 
   async function tick(platforms?: Platform[]): Promise<ClaimedRewards> {
@@ -538,18 +676,27 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       try {
         await refreshAuthHealth(platforms ?? PLATFORMS, settings);
       } catch (error) {
-        if (!(error instanceof AuthProbeSetupError)) throw error;
-        await withStateLock(() => withEventCollector(async (emit, events) => {
-          const state = await deps.loadState();
-          emit({
-            category: "activity",
-            code: "interruption",
-            level: "error",
-            data: { reason: "platform_error", detail: error.message },
-          });
-          emit({ category: "diagnostic", level: "error", message: error.message });
-          await persistAndReport(state, events);
-        }));
+        const failures = flattenedRefreshFailures(error);
+        const setupFailures = failures.filter((failure): failure is AuthProbeSetupError =>
+          failure instanceof AuthProbeSetupError);
+        if (setupFailures.length === 0) throw error;
+        let reportingFailure: unknown;
+        try {
+          await reportAuthSetupFailures(setupFailures);
+        } catch (failure) {
+          reportingFailure = failure;
+        }
+        const nonSetupFailures = failures.filter((failure) => !(failure instanceof AuthProbeSetupError));
+        if (nonSetupFailures.length > 0) {
+          if (reportingFailure !== undefined) {
+            throw new AggregateError(
+              [...failures, reportingFailure],
+              "Authentication refresh and interruption persistence failed",
+            );
+          }
+          throw error;
+        }
+        if (reportingFailure !== undefined) throw reportingFailure;
         return claimedRewards;
       }
     }
@@ -629,7 +776,12 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function invalidateAuthHealth(platform: Platform): Promise<void> {
+    const generations = await beginAuthRefresh([platform]);
+    const generation = generations[platform];
+    const settings = await deps.loadSettings();
+    if (!settings.platform[platform].enabled) return;
     await withStateLock(() => withEventCollector(async (emit, events) => {
+      if (generation === undefined || authRefreshGeneration[platform] !== generation) return;
       const state = await deps.loadState();
       const transition = applyPlatformAuthHealth(state, platform, { status: "checking" });
       if (transition.event) emit(transition.event);
@@ -1460,6 +1612,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   return {
     ensureAlarm,
+    ensureInstalledAt,
     handleStartup,
     handleTabRemoved,
     handleMessage,

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -350,7 +350,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const settings = await deps.loadSettings();
     await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
     await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
-    if (settings.autoStartDropFarming && settings.running) await tick();
+    if (settings.autoStartDropFarming && settings.running) {
+      await tick();
+    } else {
+      await refreshAuthHealth(PLATFORMS, settings);
+    }
   }
 
   async function handleStartup(): Promise<void> {
@@ -371,9 +375,15 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     registerManagedPageContextTabs(preservePageContexts ? state.managedPageContextTabs ?? {} : {});
     const cleanup = staleStartupCleanup(state, preservePageContexts);
     if (!cleanup.hasStaleSession) {
-      if (settings.autoStartDropFarming && settings.running) await tick();
+      let nextSettings = settings;
       if (settings.running && !settings.autoStartDropFarming) {
-        await deps.saveSettings({ ...settings, running: false });
+        nextSettings = { ...settings, running: false };
+        await deps.saveSettings(nextSettings);
+      }
+      if (nextSettings.autoStartDropFarming && nextSettings.running) {
+        await tick();
+      } else {
+        await refreshAuthHealth(PLATFORMS, nextSettings);
       }
       return;
     }
@@ -403,6 +413,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
     if (nextSettings.running && nextSettings.autoStartDropFarming) {
       await tick();
+    } else {
+      await refreshAuthHealth(PLATFORMS, nextSettings);
     }
   }
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -502,7 +502,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function refreshAuthHealth(platforms: Platform[], loadedSettings?: S): Promise<void> {
     const settings = loadedSettings ?? await deps.loadSettings();
     const enabled = platforms.filter((platform) => settings.platform[platform].enabled);
-    await Promise.all(enabled.map(async (platform) => {
+    const results = await Promise.allSettled(enabled.map(async (platform) => {
       const result = await withEventCollector(async (emit, events) => {
         let adapter: PlatformAdapter;
         try {
@@ -515,6 +515,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       });
       await persistAuthHealth(platform, result.health, result.events);
     }));
+    const failure = results.find((result) => result.status === "rejected");
+    if (failure?.status === "rejected") throw failure.reason;
   }
 
   async function tick(platforms?: Platform[]): Promise<ClaimedRewards> {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -40,6 +40,8 @@ function isNothingLeftToFarm(reasonCode: WatchReasonCode | undefined): boolean {
 // still transmits.
 const RECENT_HEARTBEAT_MS = 30_000;
 const PLATFORMS: Platform[] = ["twitch", "kick"];
+const DEFAULT_AUTH_PROBE_TIMEOUT_MS = 10_000;
+class AuthProbeSetupError extends Error {}
 const FARMING_STOP_REASON_CODES: Record<FarmingStopReason, true> = {
   automation_disabled: true,
   platform_disabled: true,
@@ -107,6 +109,7 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
   saveSettings(settings: S): Promise<void>;
   loadState(): Promise<SchedulerState>;
   saveState(state: SchedulerState): Promise<void>;
+  authProbeTimeoutMs?: number;
   reportEvents?: EventReporter;
   createAlarm(name: string, options: { periodInMinutes: number }): Promise<void>;
   createAdapters(emit: EventEmitter, settings: S): {
@@ -433,17 +436,29 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     // cookies (or the adapter probe) throws, mapping it to "unavailable" here
     // keeps the failure from propagating into the tick, where a rollback would
     // strand the popup on "Checking your signed-in session…" indefinitely.
-    try {
-      const availability = await deps.checkCredentialAvailability?.(platform);
-      if (availability?.status === "missing") {
-        return {
-          status: "missing_credentials",
-          checkedAt: new Date().toISOString(),
-          reasonCode: "credentials_missing",
-          message: { key: "authMissingCredentials" },
-        };
-      }
-      if (availability?.status === "unavailable") {
+    const abort = new AbortController();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const terminalProbe = (async (): Promise<PlatformAuthHealth> => {
+      try {
+        const availability = await deps.checkCredentialAvailability?.(platform);
+        if (availability?.status === "missing") {
+          return {
+            status: "missing_credentials",
+            checkedAt: new Date().toISOString(),
+            reasonCode: "credentials_missing",
+            message: { key: "authMissingCredentials" },
+          };
+        }
+        if (availability?.status === "unavailable") {
+          return {
+            status: "unavailable",
+            checkedAt: new Date().toISOString(),
+            reasonCode: "credential_lookup_failed",
+            message: { key: "authCredentialLookupFailed" },
+          };
+        }
+        return await adapter.checkAuthHealth(abort.signal);
+      } catch {
         return {
           status: "unavailable",
           checkedAt: new Date().toISOString(),
@@ -451,19 +466,79 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           message: { key: "authCredentialLookupFailed" },
         };
       }
-      return await adapter.checkAuthHealth();
-    } catch {
-      return {
-        status: "unavailable",
-        checkedAt: new Date().toISOString(),
-        reasonCode: "credential_lookup_failed",
-        message: { key: "authCredentialLookupFailed" },
-      };
+    })();
+    const timedOut = new Promise<PlatformAuthHealth>((resolve) => {
+      timeout = setTimeout(() => {
+        abort.abort();
+        resolve({
+          status: "unavailable",
+          checkedAt: new Date().toISOString(),
+          reasonCode: "network_unavailable",
+          message: { key: "authNetworkUnavailable" },
+        });
+      }, deps.authProbeTimeoutMs ?? DEFAULT_AUTH_PROBE_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([terminalProbe, timedOut]);
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
     }
+  }
+
+  async function persistAuthHealth(
+    platform: Platform,
+    health: PlatformAuthHealth,
+    probeEvents: readonly EngineEvent[] = [],
+  ): Promise<void> {
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      events.push(...probeEvents);
+      const state = await deps.loadState();
+      const transition = applyPlatformAuthHealth(state, platform, health);
+      if (transition.event) emit(transition.event);
+      await persistAndReport(transition.state, events);
+    }));
+  }
+
+  async function refreshAuthHealth(platforms: Platform[], loadedSettings?: S): Promise<void> {
+    const settings = loadedSettings ?? await deps.loadSettings();
+    const enabled = platforms.filter((platform) => settings.platform[platform].enabled);
+    await Promise.all(enabled.map(async (platform) => {
+      const result = await withEventCollector(async (emit, events) => {
+        let adapter: PlatformAdapter;
+        try {
+          adapter = deps.createAdapters(emit, settings).adapters[platform];
+        } catch (error) {
+          throw new AuthProbeSetupError(error instanceof Error ? error.message : "Adapter factory failed");
+        }
+        const health = await probeAuthHealth(platform, adapter);
+        return { health, events };
+      });
+      await persistAuthHealth(platform, result.health, result.events);
+    }));
   }
 
   async function tick(platforms?: Platform[]): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
+    const settings = await deps.loadSettings();
+    if (settings.running) {
+      try {
+        await refreshAuthHealth(platforms ?? PLATFORMS, settings);
+      } catch (error) {
+        if (!(error instanceof AuthProbeSetupError)) throw error;
+        await withStateLock(() => withEventCollector(async (emit, events) => {
+          const state = await deps.loadState();
+          emit({
+            category: "activity",
+            code: "interruption",
+            level: "error",
+            data: { reason: "platform_error", detail: error.message },
+          });
+          emit({ category: "diagnostic", level: "error", message: error.message });
+          await persistAndReport(state, events);
+        }));
+        return claimedRewards;
+      }
+    }
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const settings = await deps.loadSettings();
       const state = await deps.loadState();
@@ -472,25 +547,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         kick: new Set(waitingClaimRewardIds.kick),
       };
       let nextState: SchedulerState;
-      // Auth health is account-level, not tick-scoped: once probed it must be
-      // persisted even if the scheduler body below throws. Remember each probe
-      // so the rollback path can re-apply it instead of reverting the popup to
-      // its prior "checking" value.
-      const probedHealth: Partial<Record<Platform, PlatformAuthHealth>> = {};
       try {
         const adapters = createAdapters(settings, emit);
-        let schedulerState = state;
-        const tickPlatforms = platforms ?? PLATFORMS;
-        if (settings.running) {
-          for (const platform of tickPlatforms) {
-            if (!settings.platform[platform].enabled) continue;
-            const health = await probeAuthHealth(platform, adapters[platform]);
-            probedHealth[platform] = health;
-            const transition = applyPlatformAuthHealth(schedulerState, platform, health);
-            schedulerState = transition.state;
-            if (transition.event) emit(transition.event);
-          }
-        }
         // Observed here rather than returned by the scheduler: the controller
         // already sees every emitted event, and the post-claim handoff only
         // needs to know which platforms claimed.
@@ -501,7 +559,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           emit(event);
         };
         const eventsBeforeTick = events.length;
-        const result = await runSchedulerTick(schedulerState, settings, adapters, {
+        const result = await runSchedulerTick(state, settings, adapters, {
           ...(platforms ? { platforms } : {}),
           stopPageContextTabs: deps.stopPageContextTabs,
           waitingClaimRewardIds: nextWaitingClaimRewardIds,
@@ -538,14 +596,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         const detail = error instanceof Error ? error.message : "Scheduler tick failed";
         emit({ category: "activity", code: "interruption", level: "error", data: { reason: "platform_error", detail } });
         emit({ category: "diagnostic", level: "error", message: detail });
-        // Roll back the scheduler work but keep the auth-health probe results:
-        // discarding them would leave the popup stuck on "checking".
-        let rolledBack = state;
-        for (const platform of Object.keys(probedHealth) as Platform[]) {
-          const health = probedHealth[platform];
-          if (health) rolledBack = applyPlatformAuthHealth(rolledBack, platform, health).state;
-        }
-        await persistAndReport(rolledBack, events);
+        await persistAndReport(state, events);
         return;
       }
       await persistAndReport(nextState, events);
@@ -560,13 +611,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function checkAuthHealth(platform: Platform): Promise<void> {
-    await withStateLock(() => withEventCollector(async (emit, events) => {
-      const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
-      const health = await probeAuthHealth(platform, deps.createAdapters(emit, settings).adapters[platform]);
-      const transition = applyPlatformAuthHealth(state, platform, health);
-      if (transition.event) emit(transition.event);
-      await persistAndReport(transition.state, events);
-    }));
+    await refreshAuthHealth([platform]);
   }
 
   async function invalidateAuthHealth(platform: Platform): Promise<void> {

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -42,11 +42,13 @@ interface PageContextTab {
   tabId: number;
   createdByExtension: boolean;
   retainedContext?: ManagedPageContextTab;
+  openedForRequest?: boolean;
 }
 
 interface PageContextEntry {
   promise: Promise<PageContextTab>;
   refs: number;
+  abort: AbortController;
 }
 
 const pageContextTabs = new Map<string, PageContextEntry>();
@@ -737,24 +739,29 @@ export async function fetchJsonInPageWithBrowser<T>(
   init?: RequestInit,
   options?: PageFetchOptions,
 ): Promise<T> {
+  const signal = init?.signal;
+  signal?.throwIfAborted();
   const origin = new URL(originUrl).origin;
-  const pageContext = await acquirePageContextTab(browserApi, originUrl, origin, options);
+  const pageContext = await acquirePageContextTab(browserApi, originUrl, origin, options, signal);
 
   try {
+    signal?.throwIfAborted();
+    const initJson = pageFetchInitJson(init);
     const runtimeBrowser = browserApi;
 
     if (runtimeBrowser.scripting?.executeScript) {
-      const [result] = await runtimeBrowser.scripting.executeScript({
+      const execution = runtimeBrowser.scripting.executeScript({
         target: { tabId: pageContext.tabId },
         // args must be JSON-serializable; `undefined` is rejected ("unserializable"),
         // so pass `null` when there is no init (e.g. Kick GET requests).
-        args: [url, init ? JSON.stringify(init) : null],
+        args: [url, initJson],
         // Kick needs the page MAIN world for Cloudflare/session context.
         // Twitch GQL also runs in MAIN, but uses XHR below to avoid Twitch's
         // page fetch wrappers.
         world: "MAIN",
         func: pageFetchJson,
       });
+      const [result] = await withAbortSignal(execution, signal);
       // executeScript resolves one entry per injected frame; an empty array
       // means the context tab was closed or navigated away before injection.
       // Surface that clearly instead of dereferencing undefined.
@@ -763,15 +770,43 @@ export async function fetchJsonInPageWithBrowser<T>(
     }
 
     if (runtimeBrowser.tabs.executeScript) {
-      const code = `(${pageFetchJson.toString()})(${JSON.stringify(url)}, ${JSON.stringify(init ? JSON.stringify(init) : undefined)})`;
-      const results = await runtimeBrowser.tabs.executeScript(pageContext.tabId, { code });
+      const code = `(${pageFetchJson.toString()})(${JSON.stringify(url)}, ${JSON.stringify(initJson ?? undefined)})`;
+      const execution = runtimeBrowser.tabs.executeScript(pageContext.tabId, { code });
+      const results = await withAbortSignal(execution, signal);
       const result = results?.[0];
       return unwrapPageFetchResult<T>(result);
     }
 
     throw new Error("No supported page script execution API is available");
   } finally {
-    await releasePageContextTab(browserApi, origin, pageContext, options?.emit);
+    await releasePageContextTab(
+      browserApi,
+      origin,
+      pageContext,
+      options?.emit,
+      signal?.aborted === true && pageContext.openedForRequest === true,
+    );
+  }
+}
+
+function pageFetchInitJson(init?: RequestInit): string | null {
+  if (!init) return null;
+  const { signal: _signal, ...serializableInit } = init;
+  return JSON.stringify(serializableInit);
+}
+
+async function withAbortSignal<T>(operation: Promise<T>, signal?: AbortSignal | null): Promise<T> {
+  if (!signal) return operation;
+  signal.throwIfAborted();
+  let onAbort!: () => void;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([operation, aborted]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
   }
 }
 
@@ -788,29 +823,39 @@ async function acquirePageContextTab(
   originUrl: string,
   origin: string,
   options?: PageFetchOptions,
+  signal?: AbortSignal | null,
 ): Promise<PageContextTab> {
-  const existing = pageContextTabs.get(origin);
-  if (existing) {
-    existing.refs += 1;
-    return existing.promise;
+  signal?.throwIfAborted();
+  let entry = pageContextTabs.get(origin);
+  if (!entry) {
+    const abort = new AbortController();
+    entry = {
+      promise: findOrCreatePageContextTab(browserApi, originUrl, origin, options, abort.signal),
+      refs: 0,
+      abort,
+    };
+    pageContextTabs.set(origin, entry);
   }
-
-  const entry: PageContextEntry = {
-    promise: findOrCreatePageContextTab(browserApi, originUrl, origin, options),
-    refs: 1,
-  };
-  pageContextTabs.set(origin, entry);
+  entry.refs += 1;
   try {
-    return await entry.promise;
+    return await withAbortSignal(entry.promise, signal);
   } catch (error) {
-    if (pageContextTabs.get(origin) === entry) {
+    entry.refs -= 1;
+    if (entry.refs === 0 && pageContextTabs.get(origin) === entry) {
       pageContextTabs.delete(origin);
+      entry.abort.abort(signal?.aborted ? signal.reason : error);
     }
     throw error;
   }
 }
 
-async function releasePageContextTab(browserApi: BrowserTabApi, origin: string, pageContext: PageContextTab, emit: EventEmitter = ignoreEvent): Promise<void> {
+async function releasePageContextTab(
+  browserApi: BrowserTabApi,
+  origin: string,
+  pageContext: PageContextTab,
+  emit: EventEmitter = ignoreEvent,
+  discardRetainedContext = false,
+): Promise<void> {
   const entry = pageContextTabs.get(origin);
   if (!entry) return;
 
@@ -818,12 +863,19 @@ async function releasePageContextTab(browserApi: BrowserTabApi, origin: string, 
   if (entry.refs > 0) return;
 
   pageContextTabs.delete(origin);
-  if (!pageContext.createdByExtension || !browserApi.tabs.remove) return;
-  if (pageContext.retainedContext) {
+  if (!pageContext.createdByExtension) return;
+  if (pageContext.retainedContext && !discardRetainedContext) {
     retainedPageContextTabs.set(pageContext.retainedContext.platform, pageContext.retainedContext);
     diagnostic(emit, "debug", `Retained managed page context on ${new URL(pageContext.retainedContext.origin).host} because it may still be required`, pageContext.retainedContext.platform);
     return;
   }
+  if (pageContext.retainedContext) {
+    const retained = retainedPageContextTabs.get(pageContext.retainedContext.platform);
+    if (retained?.tabId === pageContext.tabId) {
+      retainedPageContextTabs.delete(pageContext.retainedContext.platform);
+    }
+  }
+  if (!browserApi.tabs.remove) return;
 
   try {
     await browserApi.tabs.remove(pageContext.tabId);
@@ -837,11 +889,13 @@ async function findOrCreatePageContextTab(
   originUrl: string,
   origin: string,
   options?: PageFetchOptions,
+  signal?: AbortSignal,
 ): Promise<PageContextTab> {
+  signal?.throwIfAborted();
   const retain = options?.retainPageContext;
   let openReason = options?.openReason ?? "background_rejected";
   const retained = retain?.managedContext ?? (retain ? retainedPageContextTabs.get(retain.platform) : undefined);
-  const tabs = await browserApi.tabs.query({ url: `${origin}/*` });
+  const tabs = await withAbortSignal(browserApi.tabs.query({ url: `${origin}/*` }), signal);
   const retainedIds = new Set(
     [...retainedPageContextTabs.values(), retained]
       .filter((tab): tab is ManagedPageContextTab => tab != null && tab.origin === origin)
@@ -850,7 +904,7 @@ async function findOrCreatePageContextTab(
   let tabId: number | undefined;
   for (const tab of tabs) {
     if (tab.id == null || retainedIds.has(tab.id)) continue;
-    if (await isUsablePageContext(browserApi, tab.id, origin)) {
+    if (await isUsablePageContext(browserApi, tab.id, origin, signal)) {
       tabId = tab.id;
       break;
     }
@@ -863,7 +917,7 @@ async function findOrCreatePageContextTab(
         diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(retained.origin).host} because tab removal is unavailable`, retained.platform);
       } else {
         try {
-          await remove(retained.tabId);
+          await withAbortSignal(remove(retained.tabId), signal);
           options?.emit?.({
             category: "activity",
             code: "page_context_closed",
@@ -877,14 +931,15 @@ async function findOrCreatePageContextTab(
         }
       }
     }
+    signal?.throwIfAborted();
     diagnostic(options?.emit ?? ignoreEvent, "debug", `Reused user page context on ${new URL(origin).host}`, retain?.platform);
     return { tabId, createdByExtension: false };
   }
 
   if (retained?.origin === origin) {
     try {
-      const tab = await browserApi.tabs.get(retained.tabId);
-      if (tab?.id && tab.url?.startsWith(origin) && await isUsablePageContext(browserApi, tab.id, origin)) {
+      const tab = await withAbortSignal(browserApi.tabs.get(retained.tabId), signal);
+      if (tab?.id && tab.url?.startsWith(origin) && await isUsablePageContext(browserApi, tab.id, origin, signal)) {
         retainedPageContextTabs.set(retained.platform, retained);
         diagnostic(options?.emit ?? ignoreEvent, "debug", `Reused managed page context on ${new URL(origin).host}`, retained.platform);
         return { tabId: tab.id, createdByExtension: true, retainedContext: retained };
@@ -897,7 +952,7 @@ async function findOrCreatePageContextTab(
           diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(origin).host} because tab removal is unavailable`, retained.platform);
         } else {
           try {
-            await remove(retained.tabId);
+            await withAbortSignal(remove(retained.tabId), signal);
             options?.emit?.({
               category: "activity",
               code: "page_context_closed",
@@ -910,7 +965,8 @@ async function findOrCreatePageContextTab(
           }
         }
       }
-    } catch {
+    } catch (error) {
+      signal?.throwIfAborted();
       retainedPageContextTabs.delete(retained.platform);
       openReason = "managed_context_unusable";
       diagnostic(options?.emit ?? ignoreEvent, "debug", `Forgot managed page context on ${new URL(origin).host} because it is unusable`, retained.platform);
@@ -928,22 +984,30 @@ async function findOrCreatePageContextTab(
     });
   }
 
+  signal?.throwIfAborted();
   const tab = await browserApi.tabs.create({ url: originUrl, pinned: false, active: false }) as { id?: number };
   if (tab.id == null) {
+    signal?.throwIfAborted();
     throw new Error(`Could not open page context for ${originUrl}`);
   }
-  await browserApi.tabs.update(tab.id, { muted: true, active: false });
-  await waitForPageContextReady(browserApi, tab.id, origin);
-  if (!await isUsablePageContext(browserApi, tab.id, origin)) {
+  try {
+    signal?.throwIfAborted();
+    await withAbortSignal(browserApi.tabs.update(tab.id, { muted: true, active: false }), signal);
+    await waitForPageContextReady(browserApi, tab.id, origin, signal);
+    if (!await isUsablePageContext(browserApi, tab.id, origin, signal)) {
+      throw new SafeFetchError({
+        kind: "security_policy_blocked",
+        reason: "Kick page context is blocked or unusable",
+      });
+    }
+    signal?.throwIfAborted();
+  } catch (error) {
     try {
       await browserApi.tabs.remove?.(tab.id);
     } catch {
       // The unusable page may already have been closed.
     }
-    throw new SafeFetchError({
-      kind: "security_policy_blocked",
-      reason: "Kick page context is blocked or unusable",
-    });
+    throw error;
   }
   if (retain) {
     const retainedContext: ManagedPageContextTab = {
@@ -961,29 +1025,39 @@ async function findOrCreatePageContextTab(
       platform: retain.platform,
       data: { host: new URL(origin).host, reason: openReason },
     });
-    return { tabId: tab.id, createdByExtension: true, retainedContext };
+    return { tabId: tab.id, createdByExtension: true, retainedContext, openedForRequest: true };
   }
-  return { tabId: tab.id, createdByExtension: true };
+  return { tabId: tab.id, createdByExtension: true, openedForRequest: true };
 }
 
-async function isUsablePageContext(browserApi: BrowserTabApi, tabId: number, origin: string): Promise<boolean> {
+async function isUsablePageContext(
+  browserApi: BrowserTabApi,
+  tabId: number,
+  origin: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  signal?.throwIfAborted();
   if (origin !== "https://kick.com") return true;
   try {
     if (browserApi.scripting?.executeScript) {
-      const [result] = await browserApi.scripting.executeScript({
+      const [result] = await withAbortSignal(browserApi.scripting.executeScript({
         target: { tabId },
         world: "MAIN",
         func: validateKickPageContext,
-      });
+      }), signal);
       const value = result?.result as { usable?: unknown } | undefined;
       return value?.usable === true || (value as { ok?: unknown } | undefined)?.ok === true;
     }
     if (browserApi.tabs.executeScript) {
-      const results = await browserApi.tabs.executeScript(tabId, { code: `(${validateKickPageContext.toString()})()` });
+      const results = await withAbortSignal(
+        browserApi.tabs.executeScript(tabId, { code: `(${validateKickPageContext.toString()})()` }),
+        signal,
+      );
       const value = results?.[0] as { usable?: unknown; ok?: unknown } | undefined;
       return value?.usable === true || value?.ok === true;
     }
-  } catch {
+  } catch (error) {
+    signal?.throwIfAborted();
     return false;
   }
   return false;
@@ -1026,18 +1100,25 @@ function validateKickPageContext(): { usable: boolean; failure?: SafeFetchFailur
   return { usable: contentType.includes("html") || document.documentElement?.tagName === "HTML" };
 }
 
-async function waitForPageContextReady(browserApi: BrowserTabApi, tabId: number, origin: string): Promise<void> {
+async function waitForPageContextReady(
+  browserApi: BrowserTabApi,
+  tabId: number,
+  origin: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
   if (typeof process !== "undefined" && process.env.NODE_ENV === "test") return;
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
     try {
-      const tab = await browserApi.tabs.get(tabId);
+      const tab = await withAbortSignal(browserApi.tabs.get(tabId), signal);
       const url = tab?.url;
       if (tab && url?.startsWith(origin) && (tab.status == null || tab.status === "complete")) return;
-    } catch {
+    } catch (error) {
+      signal?.throwIfAborted();
       // Keep polling until the page either becomes ready or times out.
     }
-    await wait(100);
+    await withAbortSignal(wait(100), signal);
   }
 }
 

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -44,7 +44,7 @@ export interface ClaimedChallenge {
 export interface PlatformAdapter {
   platform: Platform;
   readonly compatibility?: ResolvedCompatibility[Platform];
-  checkAuthHealth(): Promise<PlatformAuthHealth>;
+  checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth>;
   discoverCampaigns(): Promise<DropCampaign[]>;
   readProgress(campaigns: DropCampaign[], session?: WatchSession): Promise<DropCampaign[]>;
   listCandidateChannels(campaign: DropCampaign): Promise<ChannelCandidate[]>;

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -127,15 +127,18 @@ export function createKickFetcher(deps: {
   };
   return {
     fetchJson: async <T,>(url: string, init?: RequestInit, emit: EventEmitter = ignoreEvent): Promise<T> => {
+      init?.signal?.throwIfAborted();
       const host = safeHost(url);
       let result: unknown;
       try {
         result = await background(url, init);
       } catch (error) {
+        init?.signal?.throwIfAborted();
         report(emit, host, "fallback", error instanceof KickWafBlockedError
           ? "→ WAF-blocked from service worker, using page tab"
           : "→ service worker error, using page tab");
         await notifyLifecycle(onPageFallback, host, emit);
+        init?.signal?.throwIfAborted();
         result = await pageFetch(url, init);
         return result as T;
       }

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -186,7 +186,7 @@ export class KickAdapter implements PlatformAdapter {
   readonly compatibility?: ResolvedCompatibility["kick"];
   private readonly claimCapability: KickClaimCapability;
 
-  async checkAuthHealth(): Promise<PlatformAuthHealth> {
+  async checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth> {
     const checkedAt = new Date().toISOString();
     try {
       // Kick serves this endpoint anonymously as `200 {}` instead of rejecting it, so the
@@ -194,7 +194,11 @@ export class KickAdapter implements PlatformAdapter {
       // It only works because kick.com is in KICK_AUTH_HOSTS (core/tabs.ts) and therefore
       // gets session_token replayed as a Bearer; without that header Kick returns the
       // empty object and a signed-in account looks signed out.
-      const response = await this.fetcher.fetchJson<KickIdentityResponse>("https://kick.com/api/v1/user", undefined, this.emit);
+      const response = await this.fetcher.fetchJson<KickIdentityResponse>(
+        "https://kick.com/api/v1/user",
+        signal ? { signal } : undefined,
+        this.emit,
+      );
       if (hasKickIdentity(response)) return { status: "healthy", checkedAt };
       // An empty/unrecognized body means the request went out without credentials, which
       // is a transport fault rather than proof of a signed-out session. Only an explicit

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -294,6 +294,7 @@ export type TwitchGqlTransport = <T>(
   query?: string,
   credentials?: RequestCredentials,
   emit?: EventEmitter,
+  signal?: AbortSignal,
 ) => Promise<TwitchGqlResponse<T>>;
 
 // Reporter-neutral transport: it captures only the request transport and
@@ -312,6 +313,7 @@ export function createTwitchGqlTransport(
     query?: string,
     credentials?: RequestCredentials,
     emit: EventEmitter = ignoreEvent,
+    signal?: AbortSignal,
   ): Promise<TwitchGqlResponse<T>> => {
     const buildRequest = (queryText?: string) => ({
       method: "POST",
@@ -323,6 +325,7 @@ export function createTwitchGqlTransport(
         ...(userAgent ? { "User-Agent": userAgent } : {}),
       },
       ...(credentials ? { credentials } : {}),
+      ...(signal ? { signal } : {}),
       body: JSON.stringify(
         queryText
           ? { operationName, variables, query: queryText }
@@ -398,7 +401,7 @@ export class TwitchAdapter implements PlatformAdapter {
   platform = "twitch" as const;
   readonly compatibility?: ResolvedCompatibility["twitch"];
 
-  async checkAuthHealth(): Promise<PlatformAuthHealth> {
+  async checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth> {
     const checkedAt = new Date().toISOString();
     try {
       const response = await this.gqlTransport<{ currentUser?: { id?: string } | null }>(
@@ -408,6 +411,7 @@ export class TwitchAdapter implements PlatformAdapter {
         CURRENT_USER_QUERY,
         undefined,
         this.emit,
+        signal,
       );
       if (response.data?.currentUser) {
         return { status: "healthy", checkedAt, message: { key: "authHealthy" } };

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -213,7 +213,7 @@ export default defineBackground(() => {
       removeListener: (listener) => browser.cookies.onChanged.removeListener(listener),
     },
     invalidate: (platform) => controller.invalidateAuthHealth(platform),
-    recheck: (platform) => controller.tickAndHandOff([platform]),
+    recheck: (platform) => controller.checkAuthHealth(platform),
   });
 
   browser.runtime.onInstalled.addListener(async (details) => {

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -32,7 +32,7 @@ import {
 } from "../src/core/activityMessages";
 import { twitchHeartbeatFetchText, twitchHeartbeatPost } from "../src/core/twitchHeartbeatTransport";
 import { createCredentialAvailabilityProvider } from "../src/core/credentialAvailability";
-import { createCredentialObserver } from "../src/core/credentialObserver";
+import { createCredentialHealthObserver } from "../src/core/credentialObserver";
 
 const localeCatalogs = new Map<string, MessageCatalog | undefined>();
 const getMessage = browser.i18n.getMessage as (key: string, substitutions?: string | string[]) => string;
@@ -207,14 +207,13 @@ const dispatchRuntimeMessage = createRuntimeMessageDispatcher({
 });
 
 export default defineBackground(() => {
-  createCredentialObserver({
-    onChanged: {
+  createCredentialHealthObserver(
+    {
       addListener: (listener) => browser.cookies.onChanged.addListener(listener),
       removeListener: (listener) => browser.cookies.onChanged.removeListener(listener),
     },
-    invalidate: (platform) => controller.invalidateAuthHealth(platform),
-    recheck: (platform) => controller.checkAuthHealth(platform),
-  });
+    controller,
+  );
 
   browser.runtime.onInstalled.addListener(async (details) => {
     await controller.ensureAlarm();

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -18,7 +18,8 @@ import { resolveCompatibility } from "@lurkloot/core";
 import { applySettingsPatch } from "@lurkloot/shared/settings";
 import { effectiveLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
 import { loadCatalog } from "@lurkloot/locales";
-import type { ExtensionSettings, SupportedLocale } from "@lurkloot/shared/models";
+import type { ExtensionSettings, Platform, SupportedLocale } from "@lurkloot/shared/models";
+import type { EventEmitter } from "@lurkloot/shared/events";
 import type { WatchTabPort } from "@lurkloot/core/adapter";
 import { createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/kick";
 import { TwitchAdapter } from "@lurkloot/core/twitch";
@@ -70,6 +71,57 @@ async function translate(key: string, substitutions?: string | string[]): Promis
   return translateFromCatalogs(key, substitutions, active, fallback ?? {});
 }
 
+function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings: ExtensionSettings) {
+  const resolution = resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" });
+  // The watch-tab port is operation-scoped so every browser diagnostic joins
+  // the same controller event batch as the adapter and scheduler events.
+  const watchTabPort: WatchTabPort = {
+    openPinnedMutedTab: async (channel, session, options) => {
+      const settings = await loadSettings();
+      return openPinnedMutedTab(channel, session, {
+        muted: settings.muteFarmingTabs,
+        keepVideosUnmuted: settings.keepFarmingVideosUnmuted,
+        closeManagedTabs: settings.autoCloseFinishedDrops,
+        ...options,
+      }, emit);
+    },
+    stopWatchTab: async (session, options) => {
+      const settings = await loadSettings();
+      return stopWatchTab(session, { closeManagedTabs: settings.autoCloseFinishedDrops, ...options }, emit);
+    },
+  };
+  const adapter = platform === "twitch"
+    ? new TwitchAdapter(
+      { fetchJson: (url, init) => fetchTwitchInBackground(url, init) },
+      () => ensureTwitchIntegrity(emit),
+      watchTabPort,
+      {
+        compatibility: resolution.compatibility.twitch,
+        heartbeatIdentity: "web",
+        heartbeatFetchText: twitchHeartbeatFetchText,
+        heartbeatPost: twitchHeartbeatPost,
+      },
+      emit,
+    )
+    : new KickAdapter(
+      createKickFetcher({
+        background: (url, init) => fetchKickInBackground<unknown>(url, init),
+        pageFetch: (url, init) => fetchJsonInPage<unknown>(KICK_PAGE_CONTEXT_URL, url, init, {
+          retainPageContext: { platform: "kick" },
+          emit,
+          openReason: "background_rejected",
+        }),
+        onBackgroundSuccess: (host, operationEmit) => recordManagedPageContextBackgroundSuccess(host, operationEmit),
+        onPageFallback: (host, operationEmit) => recordManagedPageContextFallback(host, operationEmit),
+      }),
+      watchTabPort,
+      undefined,
+      emit,
+      { compatibility: resolution.compatibility.kick, claimState: kickClaimState },
+    );
+  return { adapter, ...resolution };
+}
+
 const controller = createBackgroundController<ExtensionSettings>({
   loadSettings,
   saveSettings,
@@ -106,57 +158,17 @@ const controller = createBackgroundController<ExtensionSettings>({
   loadTwitchIntegrity,
   saveTwitchIntegrity,
   stopPageContextTabs: (contexts, options) => stopManagedPageContextTabs(contexts, options),
+  createAdapter: createExtensionAdapter,
   createAdapters: (emit, settings) => {
-    const resolution = resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" });
-    // The watch-tab port is operation-scoped so every browser diagnostic joins
-    // the same controller event batch as the adapter and scheduler events.
-    const watchTabPort: WatchTabPort = {
-      openPinnedMutedTab: async (channel, session, options) => {
-        const settings = await loadSettings();
-        return openPinnedMutedTab(channel, session, {
-          muted: settings.muteFarmingTabs,
-          keepVideosUnmuted: settings.keepFarmingVideosUnmuted,
-          closeManagedTabs: settings.autoCloseFinishedDrops,
-          ...options,
-        }, emit);
-      },
-      stopWatchTab: async (session, options) => {
-        const settings = await loadSettings();
-        return stopWatchTab(session, { closeManagedTabs: settings.autoCloseFinishedDrops, ...options }, emit);
-      },
-    };
+    const twitch = createExtensionAdapter("twitch", emit, settings);
+    const kick = createExtensionAdapter("kick", emit, settings);
     return {
       adapters: {
-        twitch: new TwitchAdapter(
-          { fetchJson: (url, init) => fetchTwitchInBackground(url, init) },
-          () => ensureTwitchIntegrity(emit),
-          watchTabPort,
-          {
-            compatibility: resolution.compatibility.twitch,
-            heartbeatIdentity: "web",
-            heartbeatFetchText: twitchHeartbeatFetchText,
-            heartbeatPost: twitchHeartbeatPost,
-          },
-          emit,
-        ),
-        kick: new KickAdapter(
-          createKickFetcher({
-            background: (url, init) => fetchKickInBackground<unknown>(url, init),
-            pageFetch: (url, init) => fetchJsonInPage<unknown>(KICK_PAGE_CONTEXT_URL, url, init, {
-              retainPageContext: { platform: "kick" },
-              emit,
-              openReason: "background_rejected",
-            }),
-            onBackgroundSuccess: (host, operationEmit) => recordManagedPageContextBackgroundSuccess(host, operationEmit),
-            onPageFallback: (host, operationEmit) => recordManagedPageContextFallback(host, operationEmit),
-          }),
-          watchTabPort,
-          undefined,
-          emit,
-          { compatibility: resolution.compatibility.kick, claimState: kickClaimState },
-        ),
+        twitch: twitch.adapter,
+        kick: kick.adapter,
       },
-      ...resolution,
+      compatibility: twitch.compatibility,
+      warnings: twitch.warnings,
     };
   },
 });
@@ -220,10 +232,7 @@ export default defineBackground(() => {
     // Stamp the install date once so the popup can time the rate/review nudge.
     // Set-if-missing (rather than gating on reason === "install") also backfills
     // a sane date for users upgrading from a pre-nudge version.
-    const state = await loadState();
-    if (!state.installedAt) {
-      await saveState({ ...state, installedAt: new Date().toISOString() });
-    }
+    await controller.ensureInstalledAt();
 
     // On a meaningful update (major/minor — not a patch bugfix, not a fresh
     // install), queue a popup notice so returning users can choose to see

--- a/packages/extension/src/core/credentialObserver.ts
+++ b/packages/extension/src/core/credentialObserver.ts
@@ -24,6 +24,14 @@ export interface CredentialObserverDeps {
   clearTimer?: (timer: TimerHandle) => void;
 }
 
+// The background owns the concrete controller, but credential changes must
+// remain auth-only: they invalidate immediately, then run the controller's
+// bounded platform-local health refresh after the observer debounce.
+export interface CredentialHealthController {
+  invalidateAuthHealth(platform: Platform): Promise<void>;
+  checkAuthHealth(platform: Platform): Promise<void>;
+}
+
 function normalizedDomain(domain: string): string {
   return domain.replace(/^\./, "").toLowerCase();
 }
@@ -64,4 +72,15 @@ export function createCredentialObserver(deps: CredentialObserverDeps): () => vo
     for (const timer of timers.values()) clearTimer(timer);
     timers.clear();
   };
+}
+
+export function createCredentialHealthObserver(
+  onChanged: CredentialCookieChangeEvent,
+  controller: CredentialHealthController,
+): () => void {
+  return createCredentialObserver({
+    onChanged,
+    invalidate: (platform) => controller.invalidateAuthHealth(platform),
+    recheck: (platform) => controller.checkAuthHealth(platform),
+  });
 }

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -79,6 +79,21 @@ function twitchCampaignDetails(dropID: string): unknown {
 }
 
 describe("KickAdapter", () => {
+  it("passes the auth probe signal to the Kick identity request", async () => {
+    const abort = new AbortController();
+    const emit = vi.fn();
+    const fetchJson = vi.fn(async () => ({ id: 42 }));
+    const fetcher = { fetchJson: fetchJson as PageFetcher["fetchJson"] };
+
+    await new KickAdapter(fetcher, undefined, undefined, emit).checkAuthHealth(abort.signal);
+
+    expect(fetchJson).toHaveBeenCalledWith(
+      "https://kick.com/api/v1/user",
+      { signal: abort.signal },
+      emit,
+    );
+  });
+
   it("does not swallow authentication failures while reading progress", async () => {
     const failure = new SafeFetchError({ kind: "authentication_rejected", status: 401 });
     const adapter = new KickAdapter(jsonFetcher(() => { throw failure; }));
@@ -853,6 +868,21 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
 });
 
 describe("TwitchAdapter", () => {
+  it("passes the auth probe signal to the Twitch CurrentUser request", async () => {
+    const abort = new AbortController();
+    const emit = vi.fn();
+    const fetchJson = vi.fn(async () => ({ data: { currentUser: { id: "u" } } }));
+    const fetcher = { fetchJson: fetchJson as PageFetcher["fetchJson"] };
+
+    await new TwitchAdapter(fetcher, undefined, undefined, undefined, emit).checkAuthHealth(abort.signal);
+
+    expect(fetchJson).toHaveBeenCalledWith(
+      "https://gql.twitch.tv/gql",
+      expect.objectContaining({ signal: abort.signal }),
+      emit,
+    );
+  });
+
   it("reports healthy only when the authenticated CurrentUser probe returns a user", async () => {
     const ensureIntegrity = vi.fn(async () => true);
     const fetcher = jsonFetcher((_url, init) => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -800,6 +800,56 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
     expect(onPageFallback).toHaveBeenCalledWith("web.kick.com", expect.any(Function));
   });
 
+  it("does not enter page fallback for an already-aborted request", async () => {
+    const reason = new Error("auth deadline elapsed");
+    const abort = new AbortController();
+    abort.abort(reason);
+    const background = vi.fn(async () => {
+      throw new KickWafBlockedError("background rejected after deadline");
+    });
+    const pageFetch = vi.fn(async () => ({ id: 42 }));
+    const onPageFallback = vi.fn(async () => undefined);
+    const fetcher = createKickFetcher({ background, pageFetch, onPageFallback });
+
+    await expect(fetcher.fetchJson(
+      "https://kick.com/api/v1/user",
+      { signal: abort.signal },
+    )).rejects.toBe(reason);
+
+    expect(pageFetch).not.toHaveBeenCalled();
+    expect(onPageFallback).not.toHaveBeenCalled();
+  });
+
+  it("does not enter page fallback when an in-flight background request is aborted", async () => {
+    const reason = new Error("auth deadline elapsed");
+    const abort = new AbortController();
+    let backgroundStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      backgroundStarted = resolve;
+    });
+    const background = vi.fn(async (_url: string, init?: RequestInit) => {
+      backgroundStarted();
+      await new Promise<void>((resolve) => {
+        init?.signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      throw new KickWafBlockedError("background rejected after deadline");
+    });
+    const pageFetch = vi.fn(async () => ({ id: 42 }));
+    const onPageFallback = vi.fn(async () => undefined);
+    const fetcher = createKickFetcher({ background, pageFetch, onPageFallback });
+
+    const request = fetcher.fetchJson(
+      "https://kick.com/api/v1/user",
+      { signal: abort.signal },
+    );
+    await started;
+    abort.abort(reason);
+
+    await expect(request).rejects.toBe(reason);
+    expect(pageFetch).not.toHaveBeenCalled();
+    expect(onPageFallback).not.toHaveBeenCalled();
+  });
+
   it("records fallback before page execution even when the page request fails", async () => {
     const order: string[] = [];
     const fetcher = createKickFetcher({

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -165,6 +165,58 @@ describe("background controller", () => {
     expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
   });
 
+  it("waits for started auth probes before reporting a sibling setup failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const env = harness(
+        { ...DEFAULT_SETTINGS, running: true },
+        { authProbeTimeoutMs: 25 },
+      );
+      const oldTwitchHealth = deferred<PlatformAuthHealth>();
+      vi.mocked(env.twitch.checkAuthHealth)
+        .mockReturnValueOnce(oldTwitchHealth.promise)
+        .mockResolvedValueOnce({
+          status: "healthy",
+          checkedAt: "2026-07-26T12:00:01.000Z",
+        });
+      let adapterCreations = 0;
+      vi.mocked(env.deps.createAdapters).mockImplementation((emit, settings) => {
+        adapterCreations += 1;
+        if (adapterCreations === 2) {
+          throw new Error("kick adapter setup failed");
+        }
+        return {
+          adapters: { twitch: env.twitch, kick: env.kick },
+          ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
+        };
+      });
+
+      let tickSettled = false;
+      const ticking = env.controller.tick().then(() => {
+        tickSettled = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      const settledBeforeDeadline = tickSettled;
+      const refreshing = ticking.then(() => env.controller.checkAuthHealth("twitch"));
+
+      await vi.advanceTimersByTimeAsync(25);
+      await refreshing;
+
+      expect(env.state.authHealth.twitch).toMatchObject({
+        status: "healthy",
+        checkedAt: "2026-07-26T12:00:01.000Z",
+      });
+      expect(settledBeforeDeadline).toBe(false);
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(expect.objectContaining({
+        category: "activity",
+        code: "interruption",
+        data: expect.objectContaining({ detail: "kick adapter setup failed" }),
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("times out and aborts a stalled auth probe at the configured deadline", async () => {
     vi.useFakeTimers();
     try {
@@ -869,14 +921,27 @@ describe("background controller", () => {
   });
 
   it("does not publish tick events when the corresponding state save fails", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true }, {
-      saveState: vi.fn().mockRejectedValueOnce(new Error("storage unavailable")),
+    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    let saveCalls = 0;
+    env.deps.saveState.mockImplementation(async (next: SchedulerState) => {
+      saveCalls += 1;
+      if (saveCalls === 2) throw new Error("storage unavailable");
+      Object.assign(env.state, next);
     });
 
     await expect(env.controller.tick(["twitch"])).rejects.toThrow("storage unavailable");
 
-    expect(env.deps.saveState).toHaveBeenCalledTimes(1);
-    expect(env.reportEvents).not.toHaveBeenCalled();
+    expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.deps.saveState).toHaveBeenCalledTimes(2);
+    expect(env.reportEvents).toHaveBeenCalledTimes(1);
+    expect(env.reportEvents.mock.calls[0]?.[0]).toContainEqual(expect.objectContaining({
+      category: "activity",
+      code: "auth_health_changed",
+      platform: "twitch",
+    }));
+    expect(env.reportEvents.mock.calls.flatMap(([events]) => events).some((event) =>
+      event.category === "diagnostic" && event.message.startsWith("Campaign inventory changed")
+    )).toBe(false);
   });
 
   it("never persists an event outbox in scheduler state", async () => {
@@ -899,9 +964,12 @@ describe("background controller", () => {
 
     await env.controller.tick();
 
-    const published = env.reportEvents.mock.calls.flatMap(([events]) => events);
-    const adapterIndex = published.findIndex((event) => event.category === "diagnostic" && event.message === "adapter-created");
-    const schedulerIndex = published.findIndex((event) => event.category === "diagnostic" && event.message.startsWith("Campaign inventory changed"));
+    const schedulerBatch = env.reportEvents.mock.calls.map(([events]) => events).find((events) =>
+      events.some((event) => event.category === "diagnostic" && event.message.startsWith("Campaign inventory changed"))
+    );
+    expect(schedulerBatch).toBeDefined();
+    const adapterIndex = schedulerBatch!.findIndex((event) => event.category === "diagnostic" && event.message === "adapter-created");
+    const schedulerIndex = schedulerBatch!.findIndex((event) => event.category === "diagnostic" && event.message.startsWith("Campaign inventory changed"));
     expect(adapterIndex).toBeGreaterThanOrEqual(0);
     expect(schedulerIndex).toBeGreaterThan(adapterIndex);
   });

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ALARM_NAME, createBackgroundController, type CredentialAvailability } from "@lurkloot/core/controller";
 import { resolveCompatibility } from "@lurkloot/core";
-import type { ChannelCandidate, DropCampaign, DropReward, ExtensionSettings, Platform, SchedulerState } from "@lurkloot/shared/models";
+import type { ChannelCandidate, DropCampaign, DropReward, ExtensionSettings, Platform, PlatformAuthHealth, SchedulerState } from "@lurkloot/shared/models";
 import type { DiagnosticEvent, EngineEvent, EventEmitter } from "@lurkloot/shared/events";
 import type { RuntimeSnapshot } from "@lurkloot/shared/messages";
 import { applySettingsPatch, DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
@@ -39,6 +39,16 @@ function asSnapshot(value: unknown): RuntimeSnapshot {
   return value as RuntimeSnapshot;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
 function adapter(platform: Platform): PlatformAdapter {
   return {
     platform,
@@ -61,6 +71,7 @@ function harness(
     stopPageContextTabs?: StopPageContextTabs;
     wait?: (ms: number, signal: AbortSignal) => Promise<void>;
     checkCredentialAvailability?: (platform: Platform) => Promise<CredentialAvailability>;
+    authProbeTimeoutMs?: number;
   } = {},
 ) {
   let currentSettings = settings;
@@ -100,6 +111,9 @@ function harness(
     ...(overrides.checkCredentialAvailability
       ? { checkCredentialAvailability: vi.fn(overrides.checkCredentialAvailability) }
       : {}),
+    ...(overrides.authProbeTimeoutMs === undefined
+      ? {}
+      : { authProbeTimeoutMs: overrides.authProbeTimeoutMs }),
   };
 
   return {
@@ -118,6 +132,176 @@ function harness(
 }
 
 describe("background controller", () => {
+  it("starts enabled auth probes concurrently and persists each before scheduler work", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const twitchHealth = deferred<PlatformAuthHealth>();
+    const kickHealth = deferred<PlatformAuthHealth>();
+    vi.mocked(env.twitch.checkAuthHealth).mockReturnValue(twitchHealth.promise);
+    vi.mocked(env.kick.checkAuthHealth).mockReturnValue(kickHealth.promise);
+
+    const ticking = env.controller.tick();
+    await vi.waitFor(() => {
+      expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+      expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce();
+    });
+
+    kickHealth.resolve({
+      status: "healthy",
+      checkedAt: "2026-07-26T12:00:00.000Z",
+    });
+    await vi.waitFor(() => expect(env.state.authHealth.kick.status).toBe("healthy"));
+
+    expect(env.state.authHealth.twitch.status).toBe("checking");
+    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+
+    twitchHealth.resolve({
+      status: "healthy",
+      checkedAt: "2026-07-26T12:00:01.000Z",
+    });
+    await ticking;
+
+    expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+  });
+
+  it("times out and aborts a stalled auth probe at the configured deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const env = harness(
+        { ...DEFAULT_SETTINGS, running: false },
+        { authProbeTimeoutMs: 25 },
+      );
+      let signal: AbortSignal | undefined;
+      vi.mocked(env.twitch.checkAuthHealth).mockImplementation((nextSignal) => {
+        signal = nextSignal;
+        return new Promise(() => undefined);
+      });
+
+      const checking = env.controller.checkAuthHealth("twitch");
+      await vi.advanceTimersByTimeAsync(24);
+      expect(env.state.authHealth.twitch.status).toBe("checking");
+      await vi.advanceTimersByTimeAsync(1);
+      await checking;
+
+      expect(signal?.aborted).toBe(true);
+      expect(env.state.authHealth.twitch).toMatchObject({
+        status: "unavailable",
+        reasonCode: "network_unavailable",
+        message: { key: "authNetworkUnavailable" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not delay a resolved platform while another probe awaits its own deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const env = harness(
+        { ...DEFAULT_SETTINGS, running: true },
+        { authProbeTimeoutMs: 25 },
+      );
+      vi.mocked(env.twitch.checkAuthHealth).mockImplementation(() => new Promise(() => undefined));
+      vi.mocked(env.kick.checkAuthHealth).mockResolvedValue({
+        status: "healthy",
+        checkedAt: "2026-07-26T12:00:00.000Z",
+      });
+
+      let settled = false;
+      const ticking = env.controller.tick().then(() => {
+        settled = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(env.state.authHealth.kick.status).toBe("healthy");
+      expect(env.state.authHealth.twitch.status).toBe("checking");
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(24);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await ticking;
+
+      expect(settled).toBe(true);
+      expect(env.state.authHealth.twitch).toMatchObject({
+        status: "unavailable",
+        reasonCode: "network_unavailable",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("settles once when a timed out auth adapter rejects later", async () => {
+    vi.useFakeTimers();
+    try {
+      const env = harness(
+        { ...DEFAULT_SETTINGS, running: false },
+        { authProbeTimeoutMs: 25 },
+      );
+      const health = deferred<PlatformAuthHealth>();
+      vi.mocked(env.twitch.checkAuthHealth).mockReturnValue(health.promise);
+
+      const checking = env.controller.checkAuthHealth("twitch");
+      await vi.advanceTimersByTimeAsync(25);
+      await checking;
+      const saveCount = env.deps.saveState.mock.calls.length;
+      const transitionCount = env.reportEvents.mock.calls.flatMap(([events]) => events).filter((event) =>
+        event.category === "activity" && event.code === "auth_health_changed"
+      ).length;
+
+      health.reject(new Error("late adapter failure"));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(env.deps.saveState).toHaveBeenCalledTimes(saveCount);
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events).filter((event) =>
+        event.category === "activity" && event.code === "auth_health_changed"
+      )).toHaveLength(transitionCount);
+      expect(env.state.authHealth.twitch.reasonCode).toBe("network_unavailable");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("merges a completed auth probe into state written while the probe was pending", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const health = deferred<PlatformAuthHealth>();
+    vi.mocked(env.twitch.checkAuthHealth).mockReturnValue(health.promise);
+
+    const checking = env.controller.checkAuthHealth("twitch");
+    await vi.waitFor(() => expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce());
+
+    env.state.sessions.kick = {
+      platform: "kick",
+      status: "watching",
+      channel: channel("kick"),
+      offlineChecks: 0,
+      tabId: 20,
+      tabManagedByExtension: true,
+    };
+    await env.controller.handleMessage({
+      type: "playbackTelemetry",
+      platform: "kick",
+      telemetry: {
+        videoCount: 1,
+        mutedVideoCount: 1,
+        unmutedVideoCount: 0,
+        playingVideoCount: 1,
+        blockedPlaybackCount: 0,
+        documentHidden: true,
+        readyState: 4,
+        currentTime: 12,
+        duration: 1200,
+      },
+    }, { tab: { id: 20 } });
+    health.resolve({ status: "healthy", checkedAt: "2026-07-26T12:00:01.000Z" });
+    await checking;
+
+    expect(env.state.authHealth.twitch.status).toBe("healthy");
+    expect(env.state.sessions.kick.playback?.videoCount).toBe(1);
+  });
+
   it("reports missing credentials without calling the platform probe", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
       checkCredentialAvailability: async () => ({ status: "missing" }),
@@ -668,7 +852,7 @@ describe("background controller", () => {
     }));
   });
 
-  it("saves operational state before publishing the ordered batch", async () => {
+  it("saves each operational state before publishing its ordered batch", async () => {
     const calls: string[] = [];
     const env = harness({ ...DEFAULT_SETTINGS, running: true }, {
       saveState: async () => { calls.push("state"); },
@@ -677,7 +861,11 @@ describe("background controller", () => {
 
     await env.controller.tick();
 
-    expect(calls).toEqual(["state", "events"]);
+    expect(calls).toEqual([
+      "state", "events",
+      "state", "events",
+      "state", "events",
+    ]);
   });
 
   it("does not publish tick events when the corresponding state save fails", async () => {
@@ -685,7 +873,7 @@ describe("background controller", () => {
       saveState: vi.fn().mockRejectedValueOnce(new Error("storage unavailable")),
     });
 
-    await expect(env.controller.tick()).rejects.toThrow("storage unavailable");
+    await expect(env.controller.tick(["twitch"])).rejects.toThrow("storage unavailable");
 
     expect(env.deps.saveState).toHaveBeenCalledTimes(1);
     expect(env.reportEvents).not.toHaveBeenCalled();

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1168,12 +1168,43 @@ describe("background controller", () => {
     expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: 11 });
   });
 
+  it("refreshes enabled auth health from ensureAlarm while farming is stopped", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: false,
+      platform: {
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
+      },
+    });
+
+    await env.controller.ensureAlarm();
+
+    expect(env.state.authHealth.twitch.status).toBe("healthy");
+    expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+    expect(env.kick.checkAuthHealth).not.toHaveBeenCalled();
+    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+  });
+
+  it("refreshes enabled auth health on startup without starting farming", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+
+    await env.controller.handleStartup();
+
+    expect(env.state.authHealth.twitch.status).toBe("healthy");
+    expect(env.state.authHealth.kick.status).toBe("healthy");
+    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+  });
+
   it("auto-starts on launch only when the persisted running state is enabled", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true, autoStartDropFarming: true });
 
     await env.controller.ensureAlarm();
 
     expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
+    expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+    expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce();
   });
 
   it("clears stale restart tabs and auto-resumes with fresh tabs when auto-start is enabled", async () => {
@@ -1222,6 +1253,8 @@ describe("background controller", () => {
       expect.objectContaining({ tabId: 44, channelUrl: "https://www.twitch.tv/twitch-creator", ownedByExtension: true }),
     ]);
     expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
+    expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+    expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce();
     expect(env.state.sessions.twitch.status).toBe("watching");
     expect(env.state.sessions.twitch.tabId).toBe(10);
     expect(env.reportEvents).toHaveBeenCalledWith(expect.arrayContaining([
@@ -1366,7 +1399,6 @@ describe("background controller", () => {
 
     expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
     expect(env.deps.closeManagedTabs).not.toHaveBeenCalled();
-    expect(env.deps.saveState).not.toHaveBeenCalled();
     expect(env.reportEvents.mock.calls.flatMap(([events]) => events).some((event) =>
       event.category === "diagnostic" && event.message.includes("Browser restarted")
     )).toBe(false);
@@ -1380,7 +1412,8 @@ describe("background controller", () => {
     expect(env.settings.running).toBe(false);
     expect(env.deps.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ running: false }));
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-    expect(env.deps.saveState).not.toHaveBeenCalled();
+    expect(env.state.authHealth.twitch.status).toBe("healthy");
+    expect(env.state.authHealth.kick.status).toBe("healthy");
   });
 
   it("starts automation, persists settings, creates alarm, and runs an immediate tick", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -7,10 +7,10 @@ import type { RuntimeSnapshot } from "@lurkloot/shared/messages";
 import { applySettingsPatch, DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
 import { DEFAULT_STATE } from "../src/core/storage";
 import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
-import { KickAdapter, KickClaimState } from "@lurkloot/core/kick";
+import { createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/kick";
 import type { TablessWatchController } from "@lurkloot/core/tablessWatch";
 import type { StopPageContextTabs } from "@lurkloot/core/scheduler";
-import { forgetManagedPageContextTabs, managedTabBreakerOpen, recordManagedPageContextFallback, registerManagedPageContextTabs, syncManagedTabBreakers } from "@lurkloot/core/tabs";
+import { forgetManagedPageContextTabs, KickWafBlockedError, managedTabBreakerOpen, recordManagedPageContextFallback, registerManagedPageContextTabs, syncManagedTabBreakers } from "@lurkloot/core/tabs";
 import { TAB_CHURN_LIMIT } from "@lurkloot/core/criticalHealth";
 
 const reward = (status: DropReward["status"] = "in_progress"): DropReward => ({
@@ -105,6 +105,10 @@ function harness(
       adapters: { twitch, kick },
       ...resolveCompatibility(nextSettings.compatibility, { host: "extension", twitchIdentity: "web" }),
     })),
+    createAdapter: vi.fn((platform: Platform, _emit: EventEmitter, nextSettings: ExtensionSettings) => ({
+      adapter: platform === "twitch" ? twitch : kick,
+      ...resolveCompatibility(nextSettings.compatibility, { host: "extension", twitchIdentity: "web" }),
+    })),
     reportEvents: vi.fn(overrides.reportEvents ?? reportEvents),
     stopPageContextTabs: vi.fn(overrides.stopPageContextTabs ?? forgetManagedPageContextTabs),
     wait: overrides.wait,
@@ -179,14 +183,12 @@ describe("background controller", () => {
           status: "healthy",
           checkedAt: "2026-07-26T12:00:01.000Z",
         });
-      let adapterCreations = 0;
-      vi.mocked(env.deps.createAdapters).mockImplementation((emit, settings) => {
-        adapterCreations += 1;
-        if (adapterCreations === 2) {
+      vi.mocked(env.deps.createAdapter).mockImplementation((platform, emit, settings) => {
+        if (platform === "kick") {
           throw new Error("kick adapter setup failed");
         }
         return {
-          adapters: { twitch: env.twitch, kick: env.kick },
+          adapter: env.twitch,
           ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
         };
       });
@@ -241,6 +243,46 @@ describe("background controller", () => {
         status: "unavailable",
         reasonCode: "network_unavailable",
         message: { key: "authNetworkUnavailable" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not start a Kick page fallback after the auth deadline aborts background fetch", async () => {
+    vi.useFakeTimers();
+    try {
+      const env = harness(
+        { ...DEFAULT_SETTINGS, running: false },
+        { authProbeTimeoutMs: 25 },
+      );
+      let backgroundStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        backgroundStarted = resolve;
+      });
+      const pageFetch = vi.fn(async () => ({ id: 42 }));
+      const kick = new KickAdapter(createKickFetcher({
+        background: async (_url, init) => {
+          backgroundStarted();
+          await new Promise<void>((resolve) => {
+            init?.signal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+          throw new KickWafBlockedError("background rejected after deadline");
+        },
+        pageFetch,
+      }));
+      vi.mocked(env.kick.checkAuthHealth).mockImplementation((signal) => kick.checkAuthHealth(signal));
+
+      const checking = env.controller.checkAuthHealth("kick");
+      await started;
+      await vi.advanceTimersByTimeAsync(25);
+      await checking;
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(pageFetch).not.toHaveBeenCalled();
+      expect(env.state.authHealth.kick).toMatchObject({
+        status: "unavailable",
+        reasonCode: "network_unavailable",
       });
     } finally {
       vi.useRealTimers();
@@ -352,6 +394,234 @@ describe("background controller", () => {
 
     expect(env.state.authHealth.twitch.status).toBe("healthy");
     expect(env.state.sessions.kick.playback?.videoCount).toBe(1);
+  });
+
+  it("keeps a newer same-platform refresh when an older tick probe settles last", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
+      },
+    });
+    const older = deferred<PlatformAuthHealth>();
+    const newer = deferred<PlatformAuthHealth>();
+    vi.mocked(env.twitch.checkAuthHealth)
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const ticking = env.controller.tick(["twitch"]);
+    await vi.waitFor(() => expect(env.twitch.checkAuthHealth).toHaveBeenCalledTimes(1));
+    const cookieRefresh = env.controller.checkAuthHealth("twitch");
+    await vi.waitFor(() => expect(env.twitch.checkAuthHealth).toHaveBeenCalledTimes(2));
+
+    newer.resolve({
+      status: "healthy",
+      checkedAt: "2026-07-26T12:05:00.000Z",
+      message: { key: "authHealthy" },
+    });
+    await cookieRefresh;
+    older.resolve({
+      status: "invalid_credentials",
+      checkedAt: "2026-07-26T12:00:00.000Z",
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    });
+    await ticking;
+
+    expect(env.state.authHealth.twitch).toEqual({
+      status: "healthy",
+      checkedAt: "2026-07-26T12:05:00.000Z",
+      message: { key: "authHealthy" },
+    });
+  });
+
+  it("keeps invalidation checking when it supersedes an in-flight probe", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const older = deferred<PlatformAuthHealth>();
+    vi.mocked(env.twitch.checkAuthHealth).mockReturnValueOnce(older.promise);
+
+    const checking = env.controller.checkAuthHealth("twitch");
+    await vi.waitFor(() => expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce());
+    await env.controller.invalidateAuthHealth("twitch");
+
+    older.resolve({
+      status: "healthy",
+      checkedAt: "2026-07-26T12:00:00.000Z",
+      message: { key: "authHealthy" },
+    });
+    await checking;
+
+    expect(env.state.authHealth.twitch).toEqual({ status: "checking" });
+  });
+
+  it("supersedes an in-flight probe without putting a newly disabled platform in checking", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    env.state.authHealth = {
+      ...env.state.authHealth,
+      twitch: {
+        status: "healthy",
+        checkedAt: "2026-07-26T12:00:00.000Z",
+        message: { key: "authHealthy" },
+      },
+    };
+    const older = deferred<PlatformAuthHealth>();
+    vi.mocked(env.twitch.checkAuthHealth).mockReturnValueOnce(older.promise);
+
+    const checking = env.controller.checkAuthHealth("twitch");
+    await vi.waitFor(() => expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce());
+    await env.deps.saveSettings({
+      ...env.settings,
+      platform: {
+        ...env.settings.platform,
+        twitch: { ...env.settings.platform.twitch, enabled: false },
+      },
+    });
+    await env.controller.invalidateAuthHealth("twitch");
+
+    older.resolve({
+      status: "invalid_credentials",
+      checkedAt: "2026-07-26T12:01:00.000Z",
+      reasonCode: "credentials_rejected",
+      message: { key: "authInvalidCredentials" },
+    });
+    await checking;
+
+    expect(env.state.authHealth.twitch).toEqual({
+      status: "healthy",
+      checkedAt: "2026-07-26T12:00:00.000Z",
+      message: { key: "authHealthy" },
+    });
+  });
+
+  it("terminalizes direct adapter setup failures with platform context", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    vi.mocked(env.deps.createAdapter).mockImplementation(() => {
+      throw new Error("twitch adapter setup failed");
+    });
+
+    const error = await env.controller.checkAuthHealth("twitch").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({
+      platform: "twitch",
+      message: "twitch adapter setup failed",
+    });
+    expect(env.state.authHealth.twitch).toMatchObject({
+      status: "unavailable",
+      reasonCode: "platform_unavailable",
+      message: { key: "authPlatformUnavailable" },
+    });
+    expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(expect.objectContaining({
+      category: "activity",
+      code: "auth_health_changed",
+      platform: "twitch",
+      data: expect.objectContaining({ to: "unavailable" }),
+    }));
+  });
+
+  it("surfaces sibling auth persistence failure alongside adapter setup failure", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const kickHealth = deferred<PlatformAuthHealth>();
+    vi.mocked(env.kick.checkAuthHealth).mockReturnValue(kickHealth.promise);
+    vi.mocked(env.deps.createAdapter).mockImplementation((platform, emit, settings) => {
+      if (platform === "twitch") {
+        throw new Error("twitch adapter setup failed");
+      }
+      return {
+        adapter: env.kick,
+        ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
+      };
+    });
+    const persist = env.deps.saveState.getMockImplementation();
+    if (!persist) throw new Error("Expected harness state persistence");
+    env.deps.saveState.mockImplementation(async (state) => {
+      if (state.authHealth.kick.status === "healthy") {
+        throw new Error("kick auth persistence failed");
+      }
+      await persist(state);
+    });
+
+    const ticking = env.controller.tick();
+    await vi.waitFor(() => expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce());
+    kickHealth.resolve({
+      status: "healthy",
+      checkedAt: "2026-07-26T12:00:00.000Z",
+    });
+    const error = await ticking.catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ platform: "twitch", message: "twitch adapter setup failed" }),
+      expect.objectContaining({ message: "kick auth persistence failed" }),
+    ]));
+    expect(env.state.authHealth.twitch).toMatchObject({
+      status: "unavailable",
+      reasonCode: "platform_unavailable",
+    });
+    expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(expect.objectContaining({
+      category: "activity",
+      code: "interruption",
+      platform: "twitch",
+      data: expect.objectContaining({ detail: "twitch adapter setup failed" }),
+    }));
+  });
+
+  it("isolates a consistently failing Kick constructor from Twitch auth health", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    vi.mocked(env.deps.createAdapters).mockImplementation(() => {
+      throw new Error("combined construction reached failing Kick adapter");
+    });
+    vi.mocked(env.deps.createAdapter).mockImplementation((platform, emit, settings) => {
+      if (platform === "kick") throw new Error("kick adapter setup failed");
+      return {
+        adapter: env.twitch,
+        ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
+      };
+    });
+
+    await env.controller.tick();
+
+    expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+    expect(env.state.authHealth.twitch.status).toBe("healthy");
+    expect(env.state.authHealth.kick).toMatchObject({
+      status: "unavailable",
+      reasonCode: "platform_unavailable",
+    });
+    const interruptions = env.reportEvents.mock.calls.flatMap(([events]) => events).filter((event) =>
+      event.category === "activity" && event.code === "interruption");
+    expect(interruptions).toEqual([
+      expect.objectContaining({ platform: "kick" }),
+    ]);
+  });
+
+  it("terminalizes startup adapter setup failure instead of leaving checking", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: false,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
+      },
+    });
+    vi.mocked(env.deps.createAdapters).mockImplementation(() => {
+      throw new Error("combined startup construction failed");
+    });
+    vi.mocked(env.deps.createAdapter).mockImplementation(() => {
+      throw new Error("twitch startup adapter failed");
+    });
+
+    const error = await env.controller.handleStartup().catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      platform: "twitch",
+      message: "twitch startup adapter failed",
+    });
+    expect(env.state.authHealth.twitch).toMatchObject({
+      status: "unavailable",
+      reasonCode: "platform_unavailable",
+    });
   });
 
   it("reports missing credentials without calling the platform probe", async () => {
@@ -1166,6 +1436,63 @@ describe("background controller", () => {
     await env.controller.ensureAlarm();
 
     expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: 11 });
+  });
+
+  it("stamps the install time once through the serialized controller lifecycle", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+
+    await env.controller.ensureInstalledAt("2026-07-26T12:00:00.000Z");
+    await env.controller.ensureInstalledAt("2026-07-26T13:00:00.000Z");
+
+    expect(env.state.installedAt).toBe("2026-07-26T12:00:00.000Z");
+  });
+
+  it("preserves a state write that lands while startup setup reporting is pending", async () => {
+    const setupReported = deferred<void>();
+    const env = harness(
+      { ...DEFAULT_SETTINGS, running: false },
+      { reportEvents: async () => setupReported.promise },
+    );
+    env.state.sessions.twitch = {
+      platform: "twitch",
+      status: "watching",
+      channel: channel("twitch"),
+      offlineChecks: 0,
+      tabId: 44,
+      tabManagedByExtension: true,
+    };
+
+    const startup = env.controller.handleStartup();
+    await vi.waitFor(() => expect(env.reportEvents).toHaveBeenCalled());
+    await env.deps.saveState({
+      ...env.state,
+      installedAt: "2026-07-26T12:00:00.000Z",
+    });
+    setupReported.resolve();
+    await startup;
+
+    expect(env.state.installedAt).toBe("2026-07-26T12:00:00.000Z");
+  });
+
+  it("preserves a settings patch that lands while startup setup reporting is pending", async () => {
+    const setupReported = deferred<void>();
+    const env = harness(
+      { ...DEFAULT_SETTINGS, running: true, autoStartDropFarming: false },
+      { reportEvents: async () => setupReported.promise },
+    );
+
+    const startup = env.controller.handleStartup();
+    await vi.waitFor(() => expect(env.reportEvents).toHaveBeenCalled());
+    await env.controller.handleMessage({
+      type: "saveSettings",
+      settingsPatch: { diagnosticLogging: false },
+      tickAfterSave: false,
+    });
+    setupReported.resolve();
+    await startup;
+
+    expect(env.settings.running).toBe(false);
+    expect(env.settings.diagnosticLogging).toBe(false);
   });
 
   it("refreshes enabled auth health from ensureAlarm while farming is stopped", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -589,11 +589,25 @@ describe("background controller", () => {
       status: "unavailable",
       reasonCode: "platform_unavailable",
     });
-    const interruptions = env.reportEvents.mock.calls.flatMap(([events]) => events).filter((event) =>
+    const published = env.reportEvents.mock.calls.flatMap(([events]) => events);
+    const interruptions = published.filter((event) =>
       event.category === "activity" && event.code === "interruption");
     expect(interruptions).toEqual([
       expect.objectContaining({ platform: "kick" }),
     ]);
+    expect(published.filter((event) =>
+      event.category === "diagnostic"
+      && event.platform === "kick"
+      && event.message.includes("kick adapter setup failed")
+    )).toEqual([
+      expect.objectContaining({
+        code: "interruption",
+        mirroredActivity: true,
+        message: "Farming interrupted: reason=platform_error (kick adapter setup failed)",
+      }),
+    ]);
+    expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
   });
 
   it("terminalizes startup adapter setup failure instead of leaving checking", async () => {

--- a/packages/extension/tests/credentialObserver.test.ts
+++ b/packages/extension/tests/credentialObserver.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createCredentialObserver, type CredentialCookieChange } from "../src/core/credentialObserver";
+import {
+  createCredentialHealthObserver,
+  createCredentialObserver,
+  type CredentialCookieChange,
+  type CredentialCookieChangeEvent,
+} from "../src/core/credentialObserver";
+import type { Platform } from "@lurkloot/shared/models";
 
 function harness() {
   let listener: ((change: CredentialCookieChange) => void) | undefined;
@@ -95,6 +101,45 @@ describe("credential cookie observer", () => {
     expect(env.recheck).toHaveBeenCalledTimes(2);
     expect(env.recheck).toHaveBeenCalledWith("twitch");
     expect(env.recheck).toHaveBeenCalledWith("kick");
+  });
+
+  it("uses bounded auth-only refreshes after independently debounced credential changes", async () => {
+    let listener: ((event: CredentialCookieChange) => void) | undefined;
+    const states = new Map<Platform, "checking" | "healthy" | "scheduler-ran">();
+    const events: CredentialCookieChangeEvent = {
+      addListener(next) {
+        listener = next;
+      },
+      removeListener() {},
+    };
+    const controller = {
+      async invalidateAuthHealth(platform: Platform) {
+        states.set(platform, "checking");
+      },
+      async checkAuthHealth(platform: Platform) {
+        states.set(platform, "healthy");
+      },
+      async tickAndHandOff(platforms: Platform[]) {
+        for (const platform of platforms) states.set(platform, "scheduler-ran");
+      },
+    };
+
+    const dispose = createCredentialHealthObserver(events, controller);
+    listener?.(change("auth-token", "twitch.tv"));
+    listener?.(change("session_token", "kick.com"));
+
+    expect(states).toEqual(new Map<Platform, "checking" | "healthy" | "scheduler-ran">([
+      ["twitch", "checking"],
+      ["kick", "checking"],
+    ]));
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(states).toEqual(new Map<Platform, "checking" | "healthy" | "scheduler-ran">([
+      ["twitch", "healthy"],
+      ["kick", "healthy"],
+    ]));
+    dispose();
   });
 
   it("clears a valid zero-valued timer handle when coalescing", () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -43,6 +43,16 @@ function browserMock() {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
 // Foreground activations issued by playback priming (`tabs.update(id, { active: true })`).
 function activationCalls(browser: ReturnType<typeof browserMock>): unknown[][] {
   return (browser.tabs.update.mock.calls as unknown as unknown[][])
@@ -625,6 +635,121 @@ describe("tab manager", () => {
       args: ["https://web.kick.com/api/v1/drops/progress", null],
     }));
     expect(browser.tabs.remove).not.toHaveBeenCalled();
+  });
+
+  it("omits AbortSignal from page-world RequestInit while preserving request fields", async () => {
+    const browser = {
+      ...browserMock(),
+      scripting: {
+        executeScript: vi.fn(async () => [{ result: { ok: true } }]),
+      },
+    };
+    browser.tabs.query.mockResolvedValue([{ id: 3 }]);
+    const abort = new AbortController();
+
+    await fetchJsonInPageWithBrowser(
+      browser,
+      "https://kick.com",
+      "https://web.kick.com/api/v1/drops/progress",
+      { method: "POST", body: "{\"campaign\":\"drop\"}", signal: abort.signal },
+    );
+
+    expect(browser.scripting.executeScript).toHaveBeenCalledWith(expect.objectContaining({
+      args: [
+        "https://web.kick.com/api/v1/drops/progress",
+        JSON.stringify({ method: "POST", body: "{\"campaign\":\"drop\"}" }),
+      ],
+    }));
+  });
+
+  it("aborts an active page fallback without retaining its newly opened context", async () => {
+    const pageExecution = deferred<Array<{ result?: unknown }>>();
+    const executeScript = vi.fn()
+      .mockResolvedValueOnce([{ result: { usable: true } }])
+      .mockReturnValueOnce(pageExecution.promise);
+    const browser = {
+      ...browserMock(),
+      scripting: { executeScript },
+    };
+    browser.tabs.create.mockResolvedValue({ id: 14 });
+    const abort = new AbortController();
+    const reason = new Error("auth deadline elapsed");
+
+    const request = fetchJsonInPageWithBrowser(
+      browser,
+      "https://kick.com/drops/inventory",
+      "https://kick.com/api/v1/user",
+      { signal: abort.signal },
+      { retainPageContext: { platform: "kick" } },
+    );
+    await vi.waitFor(() => expect(executeScript).toHaveBeenCalledTimes(2));
+
+    abort.abort(reason);
+    pageExecution.reject(new Error("page execution closed after abort"));
+
+    await expect(request).rejects.toBe(reason);
+    expect(browser.tabs.remove).toHaveBeenCalledWith(14);
+    expect(currentManagedPageContextTabs().kick).toBeUndefined();
+  });
+
+  it("does not create a page-context tab when abort lands during tab discovery", async () => {
+    const query = deferred<Array<{ id?: number; url?: string; status?: string }>>();
+    const browser = {
+      ...browserMock(),
+      scripting: { executeScript: vi.fn(async () => [{ result: { usable: true } }]) },
+    };
+    browser.tabs.query.mockReturnValue(query.promise);
+    const abort = new AbortController();
+    const reason = new Error("auth deadline elapsed during tab discovery");
+
+    const request = fetchJsonInPageWithBrowser(
+      browser,
+      "https://kick.com/drops/inventory",
+      "https://kick.com/api/v1/user",
+      { signal: abort.signal },
+      { retainPageContext: { platform: "kick" } },
+    );
+    abort.abort(reason);
+    query.resolve([]);
+
+    await expect(request).rejects.toBe(reason);
+    expect(browser.tabs.create).not.toHaveBeenCalled();
+  });
+
+  it("removes a newly created page-context tab immediately when readiness aborts", async () => {
+    const validation = deferred<Array<{ result?: unknown }>>();
+    const browser = {
+      ...browserMock(),
+      scripting: { executeScript: vi.fn(() => validation.promise) },
+    };
+    browser.tabs.create.mockResolvedValue({ id: 14 });
+    const abort = new AbortController();
+    const reason = new Error("auth deadline elapsed during page readiness");
+
+    const request = fetchJsonInPageWithBrowser(
+      browser,
+      "https://kick.com/drops/inventory",
+      "https://kick.com/api/v1/user",
+      { signal: abort.signal },
+      { retainPageContext: { platform: "kick" } },
+    );
+    const outcome = request.catch((error: unknown) => error);
+    await vi.waitFor(() => expect(browser.scripting.executeScript).toHaveBeenCalledOnce());
+    abort.abort(reason);
+    let cleanupFailure: unknown;
+    try {
+      await vi.waitFor(() => expect(browser.tabs.remove).toHaveBeenCalledWith(14), {
+        timeout: 50,
+        interval: 5,
+      });
+    } catch (error) {
+      cleanupFailure = error;
+    }
+    validation.resolve([{ result: { usable: true } }]);
+
+    expect(await outcome).toBe(reason);
+    expect(cleanupFailure).toBeUndefined();
+    expect(currentManagedPageContextTabs().kick).toBeUndefined();
   });
 
   it("reconstructs sanitized page-context failures", async () => {


### PR DESCRIPTION
## Summary

- run enabled Twitch and Kick authentication probes concurrently with an internal, configurable 10-second default deadline
- persist each platform result immediately through the controller state lock before scheduler work
- refresh authentication after startup, install/update, and credential-cookie changes even while farming is stopped
- make Kick page fallback abort-safe and prevent stale overlapping probes from overwriting newer health
- isolate platform adapter setup failures across the extension and CLI bootstrap paths

## Root cause

Authentication results were held until the full scheduler tick completed, probes ran sequentially, and native requests had no bounded deadline. Lifecycle and cookie-change paths could also leave newly invalidated state at `checking`. During review, additional ordering and transport issues were found: stale probes could overwrite newer results, Kick page fallback could not serialize an `AbortSignal`, adapter setup failures were not terminalized per platform, and CLI handles eagerly constructed disabled-platform adapters.

## Impact

Each enabled platform now independently reaches a terminal authentication state within the configured bound. A slow, unavailable, or misconfigured platform no longer delays the other platform or strands the popup on `checking`, and scheduler/telemetry state remains protected by the existing mutation locks.

## Testing

- `pnpm check`
- 17 Chrome Web Store script tests
- 70 release script tests
- 128 CLI tests
- 1,017 extension tests
- workspace typechecks
- Astro site tests and production build
- focused deferred-promise, fake-timer, abort/fallback, startup, cookie-observer, state-locking, and CLI bootstrap regressions

Closes #275