### PR TITLE
test(popup): wait for the catalog in every popup mount helper

### DIFF
--- a/packages/extension/tests/criticalFailurePopup.test.tsx
+++ b/packages/extension/tests/criticalFailurePopup.test.tsx
@@ -6,31 +6,17 @@ import type { RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages"
 import type { Platform } from "@lurkloot/shared/models";
 import { DEFAULT_CRITICAL_HEALTH } from "@lurkloot/shared/criticalHealth";
 import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
+import { catalogDelay, resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
 
-// Reproduces the cold module cache deterministically: the real loadCatalog is a
-// dynamic import(), so its resolution can take several macrotasks the first time
-// a worker loads the catalog. Tests set this to emulate that first load.
-const catalogDelay = { ticks: 0 };
-
-vi.mock("@lurkloot/locales", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@lurkloot/locales")>();
-  return {
-    ...actual,
-    loadCatalog: async (locale: Parameters<typeof actual.loadCatalog>[0]) => {
-      for (let tick = 0; tick < catalogDelay.ticks; tick += 1) {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      }
-      return actual.loadCatalog(locale);
-    },
-  };
-});
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
 
 let root: Root | undefined;
 
 afterEach(() => {
   if (root) act(() => root?.unmount());
   root = undefined;
-  catalogDelay.ticks = 0;
+  resetCatalogTracking();
   vi.unstubAllGlobals();
 });
 
@@ -89,33 +75,9 @@ async function mountPopup(options: { flagged: Platform | null; promptEnabled?: b
     root.render(<Popup adapter={adapter} />);
     await Promise.resolve();
   });
-  await waitForCatalog(container);
+  await waitForCatalog();
 
   return { container, sent, adapter };
-}
-
-// The popup fills its labels from loadCatalog(), a dynamic import() of a JSON
-// catalog. That needs real module resolution rather than a fixed number of
-// microtask flushes, so whether the labels are translated by the time the
-// assertions run depends on which test file warmed the module cache first. Until
-// it resolves the header status line renders its raw key ("automationRunning ·
-// Twitch" instead of "Running · Twitch") and every copy assertion fails.
-//
-// Yield to the macrotask queue until the status line is translated. Match on the
-// untranslated form: a raw "automationRunning" also appears elsewhere in the
-// header regardless of the catalog, and "Running · Twitch" is a substring of the
-// untranslated "automationRunning · Twitch", so neither works as a positive
-// signal.
-async function waitForCatalog(container: Element): Promise<void> {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
-    if (!container.textContent?.includes("automationRunning · Twitch")) return;
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-  }
-  throw new Error(
-    `Popup message catalog never loaded; rendered text was: ${container.textContent?.slice(0, 200)}`,
-  );
 }
 
 describe("critical failure prompt in the popup", () => {

--- a/packages/extension/tests/helpers/popupCatalog.ts
+++ b/packages/extension/tests/helpers/popupCatalog.ts
@@ -1,0 +1,83 @@
+import { act } from "react";
+
+// The popup fills its labels from loadCatalog(), a dynamic import() of a JSON
+// catalog. That needs real module resolution rather than a fixed number of
+// microtask flushes, so whether labels are translated by assertion time depends
+// on which test file warmed the module cache in that worker. Until it resolves,
+// every label renders as its raw message key and copy assertions fail
+// intermittently.
+//
+// Mount helpers should await waitForCatalog() instead of flushing a set number
+// of microtasks. Install the loader wrapper it depends on with:
+//
+//   vi.mock("@lurkloot/locales", async (importOriginal) =>
+//     (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
+//
+// The factory imports this module dynamically because vi.mock is hoisted above
+// the file's own imports.
+
+// Set from a test to emulate a cold module cache: the number of macrotasks the
+// catalog import takes to resolve. 0 keeps the real (already warm) timing.
+export const catalogDelay = { ticks: 0 };
+
+const loads = { started: 0, settled: 0 };
+
+export function resetCatalogTracking(): void {
+  catalogDelay.ticks = 0;
+  loads.started = 0;
+  loads.settled = 0;
+}
+
+type LocalesModule = typeof import("@lurkloot/locales");
+
+export async function delayedLocales(
+  importOriginal: <T = LocalesModule>() => Promise<T>,
+): Promise<LocalesModule> {
+  const actual = await importOriginal<LocalesModule>();
+  return {
+    ...actual,
+    loadCatalog: async (locale: Parameters<LocalesModule["loadCatalog"]>[0]) => {
+      loads.started += 1;
+      try {
+        for (let tick = 0; tick < catalogDelay.ticks; tick += 1) await yieldMacrotask();
+        return await actual.loadCatalog(locale);
+      } finally {
+        loads.settled += 1;
+      }
+    },
+  };
+}
+
+// Captured at module load, before any test installs fake timers. Files that fake
+// timers (popupAuthHealth) would otherwise deadlock here: a faked setTimeout
+// never fires on its own, and driving the faked clock from inside the loader
+// wrapper while the wait loop drives it too leaves the load pending forever.
+// Yielding on the real event loop keeps this independent of the clock under test.
+const realSetTimeout = setTimeout;
+
+function yieldMacrotask(): Promise<void> {
+  return new Promise((resolve) => realSetTimeout(resolve, 0));
+}
+
+// Resolves once every catalog load the popup started has settled and React has
+// flushed the resulting render. Tracking the loader rather than matching on
+// rendered copy keeps this independent of which strings a given test asserts —
+// and avoids the trap that "Running · Twitch" is a substring of the
+// untranslated "automationRunning · Twitch".
+export async function waitForCatalog(): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (loads.started > 0 && loads.settled >= loads.started) {
+      // One more flush so the state set by the last resolved load renders.
+      await act(async () => {
+        await yieldMacrotask();
+      });
+      return;
+    }
+    await act(async () => {
+      await yieldMacrotask();
+    });
+  }
+  throw new Error(
+    `Popup catalog never finished loading (started ${loads.started}, settled ${loads.settled})`,
+  );
+}

--- a/packages/extension/tests/popupAuthHealth.test.tsx
+++ b/packages/extension/tests/popupAuthHealth.test.tsx
@@ -4,10 +4,15 @@ import { parseHTML } from "linkedom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
+import { catalogDelay, resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
+
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
 
 let root: Root | undefined;
 
 afterEach(() => {
+  resetCatalogTracking();
   if (root) act(() => root?.unmount());
   root = undefined;
   vi.useRealTimers();
@@ -72,13 +77,28 @@ async function mountWithSnapshots(authStatuses: Array<RuntimeSnapshot["state"]["
   await act(async () => {
     root = createRoot(container);
     root.render(<Popup adapter={adapter} />);
-    await Promise.resolve();
-    await Promise.resolve();
   });
+  await waitForCatalog();
   return { container, sent };
 }
 
 describe("popup authentication health", () => {
+  // Guards the race these mount helpers used to lose: the copy below is only
+  // present once the catalog import resolves. This file installs fake timers, so
+  // it also covers waitForCatalog advancing them instead of waiting on a
+  // setTimeout that would never fire.
+  it("renders translated copy even when the catalog import resolves late", async () => {
+    catalogDelay.ticks = 5;
+
+    const { container } = await mountWithSnapshots([{
+      status: "missing_credentials",
+      reasonCode: "credentials_missing",
+    }]);
+
+    expect(container.textContent).toContain("Needs sign-in · Twitch");
+    expect(container.textContent).not.toContain("authNeedsSignIn");
+  });
+
   it("keeps the header, switcher, and hero consistent in a degraded state", async () => {
     const { container } = await mountWithSnapshots([{
       status: "missing_credentials",

--- a/packages/extension/tests/settingsCredentialExport.test.tsx
+++ b/packages/extension/tests/settingsCredentialExport.test.tsx
@@ -4,6 +4,10 @@ import { createRoot, type Root } from "react-dom/client";
 import { parseHTML } from "linkedom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Popup, createDemoPopupAdapter, screenshotVariant, type PopupAdapter } from "@lurkloot/popup-ui";
+import { resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
+
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
 
 const labels: Record<string, string> = {
   openSettings: "Open settings",
@@ -20,6 +24,7 @@ const labels: Record<string, string> = {
 let root: Root | undefined;
 
 afterEach(() => {
+  resetCatalogTracking();
   if (root) act(() => root?.unmount());
   root = undefined;
   vi.unstubAllGlobals();
@@ -46,8 +51,8 @@ async function mount() {
   await act(async () => {
     root = createRoot(container);
     root.render(<Popup adapter={adapter} initialState={{ preview: true, variant: screenshotVariant("settings") }} />);
-    await Promise.resolve();
   });
+  await waitForCatalog();
   return { confirm, container, exportCredentials };
 }
 

--- a/packages/extension/tests/settingsFactoryReset.test.tsx
+++ b/packages/extension/tests/settingsFactoryReset.test.tsx
@@ -4,6 +4,10 @@ import { createRoot, type Root } from "react-dom/client";
 import { parseHTML } from "linkedom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Popup, createDemoPopupAdapter, screenshotVariant, type PopupAdapter } from "@lurkloot/popup-ui";
+import { resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
+
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
 import type { RuntimeSnapshot } from "@lurkloot/shared/messages";
 import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
 
@@ -26,6 +30,7 @@ const labels: Record<string, string> = {
 let root: Root | undefined;
 
 afterEach(() => {
+  resetCatalogTracking();
   if (root) act(() => root?.unmount());
   root = undefined;
   vi.unstubAllGlobals();
@@ -49,8 +54,8 @@ async function mount(resetExtension?: () => Promise<RuntimeSnapshot>) {
   await act(async () => {
     root = createRoot(container);
     root.render(<Popup adapter={adapter} initialState={{ preview: true, variant: screenshotVariant("settings") }} />);
-    await Promise.resolve();
   });
+  await waitForCatalog();
   return { container };
 }
 


### PR DESCRIPTION
## Summary

Closes #269. The popup mount helpers waited for React by draining a fixed number of microtasks:

```ts
await act(async () => {
  root.render(<Popup adapter={adapter} />);
  await Promise.resolve();
  await Promise.resolve();
});
```

`loadCatalog` is a dynamic `import()` of a JSON catalog, so its first resolution needs real module resolution rather than microtask draining. Whichever test file warmed the module cache decided whether labels were still raw message keys — every copy assertion carried an ordering-dependent race. `criticalFailurePopup` was simply the file where it surfaced, producing:

```
AssertionError: expected 'LurklootautomationRunning · TwitchTTw…' to contain 'Copy logs & open issue'
```

## Change

Extract the wait into `tests/helpers/popupCatalog.ts` and adopt it in the three remaining files that assert on translated copy: `popupAuthHealth`, `settingsCredentialExport`, `settingsFactoryReset`. (`popupSettingsLifecycle` shares the pattern but asserts no copy, so it is left alone.)

The helper **tracks the loader** rather than matching rendered text — it resolves once every catalog load the popup started has settled and React has flushed. That keeps it independent of which strings a given test asserts, and sidesteps the trap that cost time in #268: `"Running · Twitch"` is a substring of the untranslated `"automationRunning · Twitch"`, so polling for it passes on a false positive while the copy is still untranslated.

It also carries the deterministic delay wrapper, so any file can set `catalogDelay.ticks` to emulate a cold module cache and turn this race into a reproducible failure.

## Two traps worth recording

Both were hit while writing this, and both are documented in the helper:

1. **`vi.mock` is hoisted** above the file's own imports, so the factory dynamically imports the helper instead of referencing an imported binding:
   ```ts
   vi.mock("@lurkloot/locales", async (importOriginal) =>
     (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
   ```
2. **Fake timers deadlock the wait.** `popupAuthHealth` fakes timers for the whole file. A faked `setTimeout` never fires on its own, and driving the faked clock from both the loader wrapper and the wait loop left the load pending forever (`Popup catalog never finished loading (started 1, settled 0)`). The helper yields on a `setTimeout` captured at module load, before any test installs fake timers, so it is independent of the clock under test.

## Testing

- New test in `popupAuthHealth` (the fake-timers file) sets `catalogDelay.ticks = 5` and asserts translated copy renders and the raw `authNeedsSignIn` key does not — covering both the race and the fake-timers path.
- The `criticalFailurePopup` delayed-catalog test now runs against the shared helper, and was re-confirmed failing when the wait is swapped back for a fixed microtask flush, so the helper is not vacuous.
- `pnpm check` green: 990 extension tests, 126 CLI, all typechecks, site build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup localization reliability during delayed catalog loading.
  * Ensured translated sign-in and settings content renders correctly before UI checks run.

* **Tests**
  * Added coverage for late-loading localization catalogs.
  * Stabilized popup authentication, credential export, and factory reset test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->