### PR TITLE
feat(twitch): read per-tier claim state from earnedDropRewards

### DIFF
--- a/packages/core/src/compatibility/registry.ts
+++ b/packages/core/src/compatibility/registry.ts
@@ -19,7 +19,7 @@ const twitchProfiles = frozen({
       web: "twitch-heartbeat-spade-v1",
       android: "twitch-heartbeat-trowel-v1",
     }),
-    inventory: "twitch-inventory-v1",
+    inventory: "twitch-inventory-v2",
   }),
 });
 
@@ -55,7 +55,16 @@ const twitchInventory = frozen({
   "twitch-inventory-v1": frozen({
     id: "twitch-inventory-v1",
     title: "Inventory query v1",
-    description: "Current verified Twitch inventory query and parser contract.",
+    description: "Inventory query without earned-reward counts; infers shared-benefit claims.",
+    lifecycle: "legacy",
+    replacement: "twitch-inventory-v2",
+    hosts: ALL_HOSTS,
+    identities: ALL_IDENTITIES,
+  }),
+  "twitch-inventory-v2": frozen({
+    id: "twitch-inventory-v2",
+    title: "Inventory query v2",
+    description: "Adds earnedDropRewards, giving per-tier claim counts for a shared benefit.",
     lifecycle: "recommended",
     hosts: ALL_HOSTS,
     identities: ALL_IDENTITIES,

--- a/packages/core/src/platforms/twitch/inventory/factory.ts
+++ b/packages/core/src/platforms/twitch/inventory/factory.ts
@@ -1,11 +1,14 @@
 import type { TwitchInventoryId } from "../../../compatibility/types";
 import type { TwitchInventoryCapability } from "./types";
 import { twitchInventoryV1 } from "./v1";
+import { twitchInventoryV2 } from "./v2";
 
 export function createTwitchInventory(capabilityId: TwitchInventoryId): TwitchInventoryCapability {
   switch (capabilityId) {
     case "twitch-inventory-v1":
       return twitchInventoryV1;
+    case "twitch-inventory-v2":
+      return twitchInventoryV2;
     default: {
       const exhaustive: never = capabilityId;
       throw new Error(`Unsupported Twitch inventory capability: ${String(exhaustive)}`);

--- a/packages/core/src/platforms/twitch/inventory/types.ts
+++ b/packages/core/src/platforms/twitch/inventory/types.ts
@@ -1,7 +1,7 @@
 import type { DropCampaign } from "@lurkloot/shared/models";
 
 export interface TwitchInventoryCapability {
-  readonly id: "twitch-inventory-v1";
+  readonly id: "twitch-inventory-v1" | "twitch-inventory-v2";
   readonly hash: string;
   readonly variables: Readonly<Record<string, unknown>>;
   readonly inlineQuery: string;

--- a/packages/core/src/platforms/twitch/inventory/v2.ts
+++ b/packages/core/src/platforms/twitch/inventory/v2.ts
@@ -1,0 +1,125 @@
+import { mergeTwitchCampaignProgress, parseTwitchInventory } from "../parser";
+import type { TwitchInventoryCapability } from "./types";
+
+const TWITCH_CAMPAIGN_FIELDS = `{
+  id
+  name
+  imageURL
+  startAt
+  endAt
+  status
+  accountLinkURL
+  detailsURL
+  self { isAccountConnected }
+  game { id name displayName slug boxArtURL }
+  allow { channels { name login } }
+  timeBasedDrops {
+    id
+    name
+    startAt
+    endAt
+    requiredMinutesWatched
+    requiredSubs
+    preconditionDrops { id }
+    benefitEdges { benefit { id name imageAssetURL distributionType } }
+    self { currentMinutesWatched isClaimed dropInstanceID }
+  }
+}`;
+
+// earnedDropRewards returns one edge per claim, campaign-scoped and keyed by item
+// (benefit) id. It is the only field that reports how many tiers of a benefit
+// shared across several watch tiers were claimed — gameEventDrops deduplicates
+// them into a single entry, and the per-tier self edge disappears once the
+// campaign leaves dropCampaignsInProgress.
+const INLINE_QUERY = `query Inventory($fetchRewardCampaigns: Boolean!) {
+  currentUser {
+    id
+    inventory {
+      gameEventDrops { id benefit { id } lastAwardedAt }
+      earnedDropRewards { edges { node { id item { id } campaign { id } status earnedAt } } }
+      dropCampaignsInProgress ${TWITCH_CAMPAIGN_FIELDS}
+      dropCampaigns @include(if: $fetchRewardCampaigns) ${TWITCH_CAMPAIGN_FIELDS}
+    }
+  }
+}`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isV2Reward(value: unknown): boolean {
+  return isRecord(value) && typeof value.id === "string";
+}
+
+function isV2Campaign(value: unknown): boolean {
+  if (!isRecord(value) || typeof value.id !== "string") return false;
+  const rewards = value.timeBasedDrops;
+  return rewards == null || (Array.isArray(rewards) && rewards.every(isV2Reward));
+}
+
+// An edge whose node lacks the ids we count by would silently undercount claims,
+// so treat a malformed connection as a schema mismatch rather than parsing it.
+function hasValidEarnedDropRewards(value: unknown): boolean {
+  if (value == null) return true;
+  if (!isRecord(value)) return false;
+  const edges = value.edges;
+  if (edges == null) return true;
+  if (!Array.isArray(edges)) return false;
+  return edges.every((edge) => {
+    if (!isRecord(edge)) return false;
+    const node = edge.node;
+    if (node == null) return true;
+    if (!isRecord(node)) return false;
+    const item = node.item;
+    const campaign = node.campaign;
+    return (typeof node.id === "string" || (isRecord(item) && typeof item.id === "string"))
+      && (campaign == null || isRecord(campaign));
+  });
+}
+
+function hasValidEntries(field: string, value: unknown): boolean {
+  if (field === "earnedDropRewards") return hasValidEarnedDropRewards(value);
+  if (value === null) return true;
+  if (!Array.isArray(value)) return false;
+  return field === "gameEventDrops"
+    ? value.every((entry) => isRecord(entry) && typeof entry.id === "string")
+    : value.every(isV2Campaign);
+}
+
+function hasV2Schema(response: unknown): boolean {
+  if (!isRecord(response) || !isRecord(response.data)) return false;
+  const currentUser = response.data.currentUser;
+  if (currentUser === null) return true;
+  if (!isRecord(currentUser) || !isRecord(currentUser.inventory)) return false;
+  const inventory = currentUser.inventory;
+  const fields = ["dropCampaignsInProgress", "dropCampaigns", "gameEventDrops", "earnedDropRewards"];
+  const presentFields = fields.filter((field) => Object.prototype.hasOwnProperty.call(inventory, field));
+  return presentFields.length > 0
+    && presentFields.every((field) => hasValidEntries(field, inventory[field]));
+}
+
+export const twitchInventoryV2: TwitchInventoryCapability = {
+  id: "twitch-inventory-v2",
+  // The hash Twitch's own web client uses for Inventory; its stored query already
+  // returns earnedDropRewards alongside the fields v1 relies on. The inline query
+  // above is the fallback when the persisted query is not found, and additionally
+  // requests dropCampaigns, which the stored query omits.
+  hash: "8337eb8541b314040b0edde0c09c5c7a2783ba1960aa9edfbf3bac16d0fec404",
+  variables: Object.freeze({ fetchRewardCampaigns: false }),
+  inlineQuery: INLINE_QUERY,
+  parse(response) {
+    if (!hasV2Schema(response)) {
+      throw new Error("twitch-inventory-v2 inventory response schema mismatch");
+    }
+    return parseTwitchInventory(response as Parameters<typeof parseTwitchInventory>[0]);
+  },
+  reconcileProgress(campaigns, response) {
+    if (!hasV2Schema(response)) {
+      throw new Error("twitch-inventory-v2 inventory response schema mismatch");
+    }
+    return mergeTwitchCampaignProgress(
+      campaigns,
+      response as Parameters<typeof mergeTwitchCampaignProgress>[1],
+    );
+  },
+};

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -9,6 +9,8 @@ interface TwitchInventory {
         dropCampaignsInProgress?: TwitchCampaign[];
         dropCampaigns?: TwitchCampaign[];
         gameEventDrops?: TwitchGameEventDrop[];
+        // twitch-inventory-v2 only; absent on v1 responses.
+        earnedDropRewards?: { edges?: Array<{ node?: TwitchEarnedDropReward }> };
       };
       dropCampaigns?: TwitchCampaign[];
     };
@@ -61,6 +63,72 @@ interface TwitchGameEventDrop {
   lastAwardedAt?: string;
 }
 
+// One edge per claim, campaign-scoped, keyed by benefit (item) id rather than by
+// drop id. Counting edges is therefore the only way to learn how many tiers of a
+// shared benefit were claimed — gameEventDrops deduplicates them away.
+export interface TwitchEarnedDropReward {
+  id?: string;
+  item?: { id?: string };
+  campaign?: { id?: string };
+  status?: string;
+  earnedAt?: string;
+}
+
+// claimedCount[campaignId][benefitId] = number of claimed rewards of that benefit.
+export type EarnedRewardCounts = ReadonlyMap<string, ReadonlyMap<string, number>>;
+
+export function earnedRewardCounts(
+  edges: ReadonlyArray<{ node?: TwitchEarnedDropReward } | TwitchEarnedDropReward>,
+): EarnedRewardCounts {
+  const counts = new Map<string, Map<string, number>>();
+  for (const edge of edges) {
+    const node = ("node" in edge ? edge.node : edge) as TwitchEarnedDropReward | undefined;
+    if (node?.status !== "CLAIMED") continue;
+    const campaignId = node.campaign?.id;
+    const benefitId = node.item?.id ?? node.id;
+    if (!campaignId || !benefitId) continue;
+    const byBenefit = counts.get(campaignId) ?? new Map<string, number>();
+    byBenefit.set(benefitId, (byBenefit.get(benefitId) ?? 0) + 1);
+    counts.set(campaignId, byBenefit);
+  }
+  return counts;
+}
+
+// Resolves which reward ids a campaign's earned counts account for. A benefit
+// claimed N times covers the N cheapest tiers that award it: Twitch releases a
+// tier's claim only once its watch requirement is met, so claims accrue in
+// ascending requiredMinutesWatched order.
+function rewardIdsClaimedByEarnedCounts(
+  rewards: ReadonlyArray<{ id: string; requiredMinutes: number; benefitIds?: readonly (string | undefined)[] }>,
+  countsForCampaign: ReadonlyMap<string, number> | undefined,
+): ReadonlySet<string> {
+  const claimed = new Set<string>();
+  if (!countsForCampaign || countsForCampaign.size === 0) return claimed;
+  const byBenefit = new Map<string, Array<{ id: string; requiredMinutes: number }>>();
+  for (const reward of rewards) {
+    for (const benefitId of new Set(reward.benefitIds ?? [])) {
+      if (!benefitId) continue;
+      const tiers = byBenefit.get(benefitId) ?? [];
+      tiers.push({ id: reward.id, requiredMinutes: reward.requiredMinutes });
+      byBenefit.set(benefitId, tiers);
+    }
+  }
+  for (const [benefitId, tiers] of byBenefit) {
+    const count = countsForCampaign.get(benefitId) ?? 0;
+    if (count === 0) continue;
+    tiers
+      .sort((left, right) => left.requiredMinutes - right.requiredMinutes)
+      .slice(0, count)
+      .forEach((tier) => claimed.add(tier.id));
+  }
+  return claimed;
+}
+
+function earnedRewardCountsFromInventory(input: TwitchInventory): EarnedRewardCounts | undefined {
+  const edges = input.data?.currentUser?.inventory?.earnedDropRewards?.edges;
+  return edges ? earnedRewardCounts(edges) : undefined;
+}
+
 export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]): DropCampaign[] {
   const inProgress = Array.isArray(input)
     ? undefined
@@ -76,6 +144,11 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
   // shared-benefit tiers there must keep using the owned-benefit fallback.
   const hasPerTierProgress = campaigns === inProgress;
   const gameEventDrops = Array.isArray(input) ? [] : input.data?.currentUser?.inventory?.gameEventDrops ?? [];
+  // v2 responses carry one edge per claim, which answers per tier what
+  // gameEventDrops can only answer per benefit. Empty on v1.
+  const earnedCounts = Array.isArray(input)
+    ? undefined
+    : earnedRewardCountsFromInventory(input);
   const userId = Array.isArray(input) ? undefined : input.data?.currentUser?.id;
   const now = Date.now();
 
@@ -112,8 +185,17 @@ export function parseTwitchInventory(input: TwitchInventory | TwitchCampaign[]):
           (drop.benefitEdges ?? []).map((edge) => edge.benefit?.id)),
       )
       : new Set<string>();
+    const claimedByEarned = rewardIdsClaimedByEarnedCounts(
+      (campaign.timeBasedDrops ?? []).map((drop) => ({
+        id: drop.id,
+        requiredMinutes: drop.requiredMinutesWatched ?? 0,
+        benefitIds: (drop.benefitEdges ?? []).map((edge) => edge.benefit?.id),
+      })),
+      earnedCounts?.get(campaign.id),
+    );
+    const earnedBenefitIds = new Set(earnedCounts?.get(campaign.id)?.keys() ?? []);
     const parsedRewards = (campaign.timeBasedDrops ?? [])
-      .map((drop) => parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops, sharedBenefitIds));
+      .map((drop) => parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops, sharedBenefitIds, claimedByEarned, earnedBenefitIds));
     const rewards = parsedRewards.map((reward) => ({
       ...reward,
       preconditionsMet: (reward.preconditionRewardIds ?? []).every((id) =>
@@ -170,6 +252,8 @@ function parseTwitchReward(
   campaignEndsAt?: string,
   gameEventDrops: TwitchGameEventDrop[] = [],
   sharedBenefitIds: ReadonlySet<string> = new Set(),
+  claimedByEarnedRewardIds: ReadonlySet<string> = new Set(),
+  earnedBenefitIds: ReadonlySet<string> = new Set(),
 ): DropReward {
   const watchedMinutes = reward.self?.currentMinutesWatched ?? 0;
   const requiredMinutes = reward.requiredMinutesWatched ?? 0;
@@ -194,11 +278,21 @@ function parseTwitchReward(
   // and gameEventDrops carries no per-tier count. Claiming the earliest tier
   // would otherwise mark every later tier claimed and strand a real pending
   // claim, so those tiers defer to their own self edge.
+  // A benefit the earned-reward counts mention is fully accounted for by them, so
+  // the owned-benefit fallback must not add claims on top — otherwise a count of 3
+  // over 4 tiers would still mark the fourth claimed. Benefits absent from the
+  // counts keep the fallback: Twitch only surfaces recently earned rewards, so an
+  // old campaign may have no edges at all.
   const benefitIdsForOwnership = benefits
     .map((benefit) => benefit.id)
-    .filter((id) => id != null && !sharedBenefitIds.has(id));
+    .filter((id) => id != null && !sharedBenefitIds.has(id) && !earnedBenefitIds.has(id));
   const ownsBenefit = isWatchBased && ownsRewardBenefit(benefitIdsForOwnership, gameEventDrops);
-  const isClaimed = reward.self?.isClaimed === true || ownsBenefit;
+  // An earned-reward count is per claim and campaign-scoped, so it outranks both
+  // the self edge (absent once a campaign leaves the progress payload) and the
+  // owned-benefit fallback (blind to how many tiers of a shared benefit paid out).
+  const isClaimed = claimedByEarnedRewardIds.has(reward.id)
+    || reward.self?.isClaimed === true
+    || ownsBenefit;
   // Twitch's real dropInstanceID has the form `userID#campaignID#dropID` (see
   // TwitchDropsMiner inventory.py generate_claim and its inventory dump, which
   // strips user ids out of these). Prefer the value Twitch returns on the self
@@ -261,6 +355,7 @@ export function mergeTwitchCampaignProgress(
 ): DropCampaign[] {
   const progressCampaigns = parseTwitchInventory(inventory);
   const gameEventDrops = Array.isArray(inventory) ? [] : inventory.data?.currentUser?.inventory?.gameEventDrops ?? [];
+  const earnedCounts = Array.isArray(inventory) ? undefined : earnedRewardCountsFromInventory(inventory);
   return campaigns.map((campaign) => {
     const progress = progressCampaigns.find((item) => item.id === campaign.id);
     // Withholding the owned-benefit fallback from shared benefits is only safe
@@ -271,9 +366,24 @@ export function mergeTwitchCampaignProgress(
     const sharedBenefitIds = progress
       ? benefitIdsSharedAcrossRewards(campaign.rewards.map((reward) => reward.benefitIds ?? []))
       : new Set<string>();
+    // Per-claim truth for this campaign, when the response carries it (v2). It
+    // answers the shared-benefit question outright, so it applies whether or not
+    // the campaign is still in the progress payload.
+    const claimedByEarned = rewardIdsClaimedByEarnedCounts(
+      campaign.rewards.map((reward) => ({
+        id: reward.id,
+        requiredMinutes: reward.requiredMinutes,
+        benefitIds: reward.benefitIds,
+      })),
+      earnedCounts?.get(campaign.id),
+    );
+    const earnedBenefitIds = new Set(earnedCounts?.get(campaign.id)?.keys() ?? []);
     const rewards = campaign.rewards.map((reward) => {
       const progressReward = progress?.rewards.find((item) => item.id === reward.id);
       const merged = progressReward ? { ...reward, ...progressReward } : reward;
+      if (merged.status !== "claimed" && claimedByEarned.has(merged.id)) {
+        return { ...merged, status: "claimed" as const, watchedMinutes: merged.requiredMinutes };
+      }
       // A claimed watch campaign falls out of dropCampaignsInProgress, so the
       // merge above can't update it. gameEventDrops is always returned, so
       // cross-check watch ownership without applying its campaign-agnostic
@@ -283,7 +393,7 @@ export function mergeTwitchCampaignProgress(
         merged.status !== "claimed"
         && isWatchReward(merged)
         && ownsRewardBenefit(
-          (merged.benefitIds ?? []).filter((id) => !sharedBenefitIds.has(id)),
+          (merged.benefitIds ?? []).filter((id) => !sharedBenefitIds.has(id) && !earnedBenefitIds.has(id)),
           gameEventDrops,
         )
       ) {

--- a/packages/extension/tests/compatibility.test.ts
+++ b/packages/extension/tests/compatibility.test.ts
@@ -17,7 +17,9 @@ function settings(overrides: {
 describe("compatibility registry", () => {
   it("publishes frozen lifecycle metadata for bundled profiles and capabilities", () => {
     expect(COMPATIBILITY_REGISTRY.twitch.profiles["twitch-2026-07"].lifecycle).toBe("recommended");
-    expect(Object.keys(COMPATIBILITY_REGISTRY.twitch.inventory)).toEqual(["twitch-inventory-v1"]);
+    expect(Object.keys(COMPATIBILITY_REGISTRY.twitch.inventory)).toEqual(["twitch-inventory-v1", "twitch-inventory-v2"]);
+    expect(COMPATIBILITY_REGISTRY.twitch.inventory["twitch-inventory-v1"].lifecycle).toBe("legacy");
+    expect(COMPATIBILITY_REGISTRY.twitch.inventory["twitch-inventory-v2"].lifecycle).toBe("recommended");
     expect(COMPATIBILITY_REGISTRY.kick.claim["kick-claim-v1"].lifecycle).toBe("legacy");
     expect(Object.isFrozen(COMPATIBILITY_REGISTRY)).toBe(true);
     expect(Object.isFrozen(COMPATIBILITY_REGISTRY.twitch.heartbeat)).toBe(true);
@@ -49,7 +51,7 @@ describe("resolveCompatibility", () => {
         twitch: {
           profile: "twitch-2026-07",
           heartbeat: "twitch-heartbeat-spade-v1",
-          inventory: "twitch-inventory-v1",
+          inventory: "twitch-inventory-v2",
         },
         kick: { profile: "kick-2026-07", claim: "kick-claim-v2" },
       },
@@ -88,12 +90,12 @@ describe("resolveCompatibility", () => {
       twitch: {
         profile: "twitch-2026-07",
         heartbeat: "twitch-heartbeat-gql-v1",
-        inventory: "twitch-inventory-v1",
+        inventory: "twitch-inventory-v2",
       },
       kick: { profile: "kick-2026-07", claim: "kick-claim-v1" },
     });
     expect(result.warnings).toEqual([
-      expect.objectContaining({ code: "unknown_selection", field: "inventoryQueryVersion", requested: "unverified-inventory-version", resolved: "twitch-inventory-v1" }),
+      expect.objectContaining({ code: "unknown_selection", field: "inventoryQueryVersion", requested: "unverified-inventory-version", resolved: "twitch-inventory-v2" }),
     ]);
   });
 
@@ -107,7 +109,7 @@ describe("resolveCompatibility", () => {
       twitch: {
         profile: "twitch-2026-07",
         heartbeat: "twitch-heartbeat-spade-v1",
-        inventory: "twitch-inventory-v1",
+        inventory: "twitch-inventory-v2",
       },
       kick: { profile: "kick-2026-07", claim: "kick-claim-v2" },
     });

--- a/packages/extension/tests/compatibilitySettingsView.test.tsx
+++ b/packages/extension/tests/compatibilitySettingsView.test.tsx
@@ -40,6 +40,7 @@ const labels: Record<string, string> = {
   compatibilityOptionTwitchHeartbeatSpadeV1: "Spade heartbeat v1",
   compatibilityOptionTwitchHeartbeatTrowelV1: "Trowel heartbeat v1",
   compatibilityOptionTwitchInventoryV1: "Inventory query v1",
+  compatibilityOptionTwitchInventoryV2: "Inventory query v2",
   compatibilityOptionKickProfile202607: "Kick July 2026",
   compatibilityOptionKickClaimV1: "Claim handling v1",
   compatibilityOptionKickClaimV2: "Claim handling v2",
@@ -116,7 +117,7 @@ describe("extension compatibility settings", () => {
     expect(container.textContent).not.toContain("Claim handling");
     // The resolved id sits on the row itself rather than in a separate summary
     // block, so "Automatic" always states what it actually picked.
-    for (const id of ["twitch-2026-07", "twitch-heartbeat-spade-v1", "twitch-inventory-v1"]) {
+    for (const id of ["twitch-2026-07", "twitch-heartbeat-spade-v1", "twitch-inventory-v2"]) {
       expect(container.textContent).toContain(id);
     }
     // Full capability names stay as accessible names for the controls.
@@ -168,7 +169,7 @@ describe("extension compatibility settings", () => {
     const { container, onChange } = mount(undefined, "twitch");
     expect(container.querySelectorAll('input[type="text"]')).toHaveLength(0);
 
-    expect([...select(container, "Twitch inventory query").options].map((option) => option.value)).toEqual(["auto", "twitch-inventory-v1"]);
+    expect([...select(container, "Twitch inventory query").options].map((option) => option.value)).toEqual(["auto", "twitch-inventory-v1", "twitch-inventory-v2"]);
 
     const heartbeat = select(container, "Twitch heartbeat transport");
     expect(heartbeat.textContent).not.toContain("Trowel");

--- a/packages/extension/tests/fixtures/twitch-inventory-v2-earned.json
+++ b/packages/extension/tests/fixtures/twitch-inventory-v2-earned.json
@@ -1,0 +1,95 @@
+{
+  "data": {
+    "currentUser": {
+      "id": "sanitized-user",
+      "inventory": {
+        "gameEventDrops": [
+          {
+            "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02",
+            "benefit": {
+              "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02"
+            },
+            "lastAwardedAt": "2026-07-25T13:33:09.586Z"
+          },
+          {
+            "id": "8152c851-2605-11f1-b46f-0a58a9feac02",
+            "benefit": {
+              "id": "8152c851-2605-11f1-b46f-0a58a9feac02"
+            },
+            "lastAwardedAt": "2026-07-25T14:33:08.131Z"
+          }
+        ],
+        "earnedDropRewards": {
+          "edges": [
+            {
+              "node": {
+                "id": "8152c851-2605-11f1-b46f-0a58a9feac02",
+                "item": {
+                  "id": "8152c851-2605-11f1-b46f-0a58a9feac02"
+                },
+                "campaign": {
+                  "id": "26935687-0a71-4e48-a978-71f63abd8e1f"
+                },
+                "status": "CLAIMED",
+                "earnedAt": "2026-07-25T14:33:08.131Z"
+              }
+            },
+            {
+              "node": {
+                "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02",
+                "item": {
+                  "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02"
+                },
+                "campaign": {
+                  "id": "26935687-0a71-4e48-a978-71f63abd8e1f"
+                },
+                "status": "CLAIMED",
+                "earnedAt": "2026-07-25T13:33:09.586Z"
+              }
+            },
+            {
+              "node": {
+                "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02",
+                "item": {
+                  "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02"
+                },
+                "campaign": {
+                  "id": "26935687-0a71-4e48-a978-71f63abd8e1f"
+                },
+                "status": "CLAIMED",
+                "earnedAt": "2026-07-25T12:33:11.274Z"
+              }
+            },
+            {
+              "node": {
+                "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02",
+                "item": {
+                  "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02"
+                },
+                "campaign": {
+                  "id": "26935687-0a71-4e48-a978-71f63abd8e1f"
+                },
+                "status": "CLAIMED",
+                "earnedAt": "2026-07-25T11:33:07.886Z"
+              }
+            },
+            {
+              "node": {
+                "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02",
+                "item": {
+                  "id": "9a0d24bc-2604-11f1-9ba4-0a58a9feac02"
+                },
+                "campaign": {
+                  "id": "26935687-0a71-4e48-a978-71f63abd8e1f"
+                },
+                "status": "CLAIMED",
+                "earnedAt": "2026-07-25T11:03:10.765Z"
+              }
+            }
+          ]
+        },
+        "dropCampaignsInProgress": []
+      }
+    }
+  }
+}

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -925,6 +925,95 @@ describe("Twitch parsers", () => {
     expect(campaignHasClaimableReward(merged[0])).toBe(false);
   });
 
+  // earnedDropRewards is per claim and campaign-scoped, so it settles the
+  // shared-benefit question outright instead of inferring it from benefit ids.
+  describe("twitch-inventory-v2 earned rewards", () => {
+    const HUNT = "26935687-0a71-4e48-a978-71f63abd8e1f";
+    const CRATE = "9a0d24bc-2604-11f1-9ba4-0a58a9feac02";
+
+    const huntDetails = () => parseTwitchInventory([{
+      id: HUNT,
+      name: "Hunt 1896 (Week 1, Pt. 2)",
+      timeBasedDrops: [30, 60, 120, 180].map((minutes) => ({
+        id: `tier-${minutes}`,
+        name: "Supply Crate",
+        requiredMinutesWatched: minutes,
+        benefitEdges: [{ benefit: { id: CRATE, name: "Supply Crate" } }],
+      })),
+    }]);
+
+    const inventoryWithCrateClaims = (claims: number) => ({
+      data: {
+        currentUser: {
+          id: "sanitized-user",
+          inventory: {
+            gameEventDrops: [{ id: CRATE, lastAwardedAt: "2026-07-25T13:33:09.586Z" }],
+            earnedDropRewards: {
+              edges: Array.from({ length: claims }, (_, index) => ({
+                node: {
+                  id: CRATE,
+                  item: { id: CRATE },
+                  campaign: { id: HUNT },
+                  status: "CLAIMED",
+                  earnedAt: `2026-07-25T1${index}:00:00.000Z`,
+                },
+              })),
+            },
+            dropCampaignsInProgress: [],
+          },
+        },
+      },
+    });
+
+    it("claims exactly as many tiers as the campaign has earned edges", () => {
+      const merged = mergeTwitchCampaignProgress(huntDetails(), inventoryWithCrateClaims(3));
+
+      // Three claims cover the three cheapest tiers; the 180 tier is still owed.
+      expect(merged[0].rewards.map((reward) => reward.status))
+        .toEqual(["claimed", "claimed", "claimed", "locked"]);
+      expect(merged[0].status).not.toBe("completed");
+    });
+
+    it("completes the campaign once every tier has an earned edge", () => {
+      const merged = mergeTwitchCampaignProgress(huntDetails(), inventoryWithCrateClaims(4));
+
+      expect(merged[0].rewards.every((reward) => reward.status === "claimed")).toBe(true);
+      expect(merged[0].status).toBe("completed");
+      expect(campaignHasClaimableReward(merged[0])).toBe(false);
+    });
+
+    it("ignores edges that are not CLAIMED", () => {
+      const inventory = inventoryWithCrateClaims(4);
+      inventory.data.currentUser.inventory.earnedDropRewards.edges
+        .forEach((edge) => { (edge.node as { status: string }).status = "PENDING"; });
+
+      const merged = mergeTwitchCampaignProgress(huntDetails(), inventory);
+
+      // Falls back to the owned-benefit behaviour rather than trusting a count.
+      expect(merged[0].rewards.map((reward) => reward.status))
+        .toEqual(["claimed", "claimed", "claimed", "claimed"]);
+    });
+
+    it("does not let one campaign's claims settle another's tiers", () => {
+      const inventory = inventoryWithCrateClaims(4);
+      inventory.data.currentUser.inventory.earnedDropRewards.edges
+        .forEach((edge) => { (edge.node.campaign as { id: string }).id = "another-campaign"; });
+      inventory.data.currentUser.inventory.gameEventDrops = [];
+
+      const merged = mergeTwitchCampaignProgress(huntDetails(), inventory);
+
+      expect(merged[0].rewards.every((reward) => reward.status === "locked")).toBe(true);
+    });
+
+    it("resolves the captured Hunt inventory through the v2 capability", () => {
+      const fixture = JSON.parse(readFileSync(new URL("./fixtures/twitch-inventory-v2-earned.json", import.meta.url), "utf8"));
+      const merged = createTwitchInventory("twitch-inventory-v2").reconcileProgress(huntDetails(), fixture);
+
+      expect(merged[0].rewards.every((reward) => reward.status === "claimed")).toBe(true);
+      expect(merged[0].status).toBe("completed");
+    });
+  });
+
   it("keeps a shared-benefit tier claimable when merging progress into campaign details", () => {
     const details = parseTwitchInventory([{
       id: "hunt",

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "المشاهدة متوقفة مؤقتًا. فعّل المفتاح لاستئناف فارم Drops."
   },
-  "hideTipsTitle": { "message": "إخفاء النصائح" },
-  "hideTipsDescription": { "message": "يخفي النصائح المفيدة من النافذة الرئيسية." },
-  "tipCampaignPriority": { "message": "تأخذ Drops الأولوية على قائمة المشاهدة الخاملة. اسحب الحملات من المقبض لترتيب الفارم." },
-  "tipMissingCampaigns": { "message": "هل هناك حملة مفقودة؟ تحقق من مخزون Drops في المنصة ثم من عوامل التصفية في الإعدادات." },
-  "tipCategorySelection": { "message": "تريد ألعابًا محددة فقط؟ عطّل «فارم كل الفئات» واختر فئاتك." },
-  "tipIdleWatchlist": { "message": "تفارم قائمة المشاهدة الخاملة القنوات المختارة عند عدم توفر Drops مؤهلة." },
-  "tipTablessMode": { "message": "يستهلك الوضع بلا تبويبات موارد أقل ويفتح تبويبًا مكتومًا عند الحاجة." },
-  "tipCli": { "message": "تفضّل العمل بلا إضافة؟ يتوفر Lurkloot أيضًا كواجهة CLI عبر Docker." },
-  "tipCliAction": { "message": "اقرأ دليل CLI" },
-  "tipFeedback": { "message": "وجدت خطأ أو لديك فكرة؟" },
-  "tipFeedbackAction": { "message": "افتح issue على GitHub" },
-  "tipExcludedCampaigns": { "message": "استبعدت حملة بالخطأ؟ استعدها من إعدادات Drops." },
+  "hideTipsTitle": {
+    "message": "إخفاء النصائح"
+  },
+  "hideTipsDescription": {
+    "message": "يخفي النصائح المفيدة من النافذة الرئيسية."
+  },
+  "tipCampaignPriority": {
+    "message": "تأخذ Drops الأولوية على قائمة المشاهدة الخاملة. اسحب الحملات من المقبض لترتيب الفارم."
+  },
+  "tipMissingCampaigns": {
+    "message": "هل هناك حملة مفقودة؟ تحقق من مخزون Drops في المنصة ثم من عوامل التصفية في الإعدادات."
+  },
+  "tipCategorySelection": {
+    "message": "تريد ألعابًا محددة فقط؟ عطّل «فارم كل الفئات» واختر فئاتك."
+  },
+  "tipIdleWatchlist": {
+    "message": "تفارم قائمة المشاهدة الخاملة القنوات المختارة عند عدم توفر Drops مؤهلة."
+  },
+  "tipTablessMode": {
+    "message": "يستهلك الوضع بلا تبويبات موارد أقل ويفتح تبويبًا مكتومًا عند الحاجة."
+  },
+  "tipCli": {
+    "message": "تفضّل العمل بلا إضافة؟ يتوفر Lurkloot أيضًا كواجهة CLI عبر Docker."
+  },
+  "tipCliAction": {
+    "message": "اقرأ دليل CLI"
+  },
+  "tipFeedback": {
+    "message": "وجدت خطأ أو لديك فكرة؟"
+  },
+  "tipFeedbackAction": {
+    "message": "افتح issue على GitHub"
+  },
+  "tipExcludedCampaigns": {
+    "message": "استبعدت حملة بالخطأ؟ استعدها من إعدادات Drops."
+  },
   "noCampaigns": {
     "message": "لم يتم اكتشاف أي حملات بعد."
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "فارم عبر إشارات مشاهدة خفيفة بدل تبويب فيديو. يستخدم Twitch نبضات مشاهدة؛ ويستخدم Kick اتصال مشاهد. يعود تلقائيًا إلى تبويب إذا توقف عن الاحتساب."
   },
-  "tablessFallbackFailureLimitTitle": { "message": "حد الرجوع عن وضع بلا علامات تبويب" },
-  "tablessFallbackFailureLimitDescription": { "message": "يفتح علامة تبويب فيديو بعد هذا العدد من حالات فشل إشارات المشاهدة المتتالية بلا علامة تبويب." },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "فعّل وضع الموارد المنخفضة بلا علامات تبويب لتغيير هذا الإعداد." },
-  "failuresSuffix": { "message": "حالات فشل" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "حد الرجوع عن وضع بلا علامات تبويب"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "يفتح علامة تبويب فيديو بعد هذا العدد من حالات فشل إشارات المشاهدة المتتالية بلا علامة تبويب."
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "فعّل وضع الموارد المنخفضة بلا علامات تبويب لتغيير هذا الإعداد."
+  },
+  "failuresSuffix": {
+    "message": "حالات فشل"
+  },
   "autoCloseTabsTitle": {
     "message": "إغلاق تبويبات الفارم تلقائيًا"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "ث"
   },
-  "deadlineSafetyMarginTitle": { "message": "هامش أمان الموعد النهائي" },
-  "deadlineSafetyMarginDescription": { "message": "دقائق إضافية مطلوبة قبل جمع المكافأة." },
-  "deadlineSafetyMarginDisabledReason": { "message": "فعّل تصفية الموعد النهائي لتغيير هامش الأمان." },
-  "skipUnfinishableRewardsTitle": { "message": "تخطي المكافآت التي لا يمكن إكمالها" },
-  "skipUnfinishableRewardsDescription": { "message": "لا تجمع المكافآت عندما يتجاوز وقت المشاهدة المتبقي الوقت المتاح قبل الموعد النهائي." },
-  "minutesSuffix": { "message": "د" },
-  "insufficientTimeRemaining": { "message": "الوقت المتبقي غير كافٍ" },
+  "deadlineSafetyMarginTitle": {
+    "message": "هامش أمان الموعد النهائي"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "دقائق إضافية مطلوبة قبل جمع المكافأة."
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "فعّل تصفية الموعد النهائي لتغيير هامش الأمان."
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "تخطي المكافآت التي لا يمكن إكمالها"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "لا تجمع المكافآت عندما يتجاوز وقت المشاهدة المتبقي الوقت المتاح قبل الموعد النهائي."
+  },
+  "minutesSuffix": {
+    "message": "د"
+  },
+  "insufficientTimeRemaining": {
+    "message": "الوقت المتبقي غير كافٍ"
+  },
   "automationSectionTitle": {
     "message": "الأتمتة"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "الموقع"
   },
-  "updateNoticeTitle": { "message": "تم تحديث Lurkloot إلى الإصدار $1" },
-  "updateNoticeBody": { "message": "تعرّف على الميزات الجديدة والتغييرات." },
-  "updateNoticeAction": { "message": "عرض التغييرات" },
-  "updateNoticeDismiss": { "message": "تجاهل إشعار التحديث" },
+  "updateNoticeTitle": {
+    "message": "تم تحديث Lurkloot إلى الإصدار $1"
+  },
+  "updateNoticeBody": {
+    "message": "تعرّف على الميزات الجديدة والتغييرات."
+  },
+  "updateNoticeAction": {
+    "message": "عرض التغييرات"
+  },
+  "updateNoticeDismiss": {
+    "message": "تجاهل إشعار التحديث"
+  },
   "rateNudgeTitle": {
     "message": "هل يعجبك Lurkloot؟"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "تصدير بيانات الاعتماد"
   },
-  "factoryResetTitle": { "message": "إعادة ضبط Lurkloot" },
-  "factoryResetHint": { "message": "يمسح جميع إعدادات Lurkloot وتقدم التجميع وسجل النشاط. ستبقى مسجّلًا في Twitch وKick." },
-  "factoryResetButton": { "message": "إعادة ضبط Lurkloot" },
-  "factoryResetConfirm": { "message": "يؤدي هذا إلى إيقاف التجميع وإغلاق علامات التبويب التي فتحها Lurkloot ومسح جميع بياناته نهائيًا. ستبقى مسجّلًا في Twitch وKick." },
-  "factoryResetCancel": { "message": "إلغاء" },
-  "factoryResetConfirmButton": { "message": "إعادة ضبط الكل" },
-  "factoryResetProgress": { "message": "جارٍ إعادة الضبط…" },
-  "factoryResetFailed": { "message": "تعذّرت إعادة ضبط Lurkloot بالكامل. حاول مرة أخرى." },
-  "factoryResetRetry": { "message": "حاول إعادة الضبط مجددًا" },
+  "factoryResetTitle": {
+    "message": "إعادة ضبط Lurkloot"
+  },
+  "factoryResetHint": {
+    "message": "يمسح جميع إعدادات Lurkloot وتقدم التجميع وسجل النشاط. ستبقى مسجّلًا في Twitch وKick."
+  },
+  "factoryResetButton": {
+    "message": "إعادة ضبط Lurkloot"
+  },
+  "factoryResetConfirm": {
+    "message": "يؤدي هذا إلى إيقاف التجميع وإغلاق علامات التبويب التي فتحها Lurkloot ومسح جميع بياناته نهائيًا. ستبقى مسجّلًا في Twitch وKick."
+  },
+  "factoryResetCancel": {
+    "message": "إلغاء"
+  },
+  "factoryResetConfirmButton": {
+    "message": "إعادة ضبط الكل"
+  },
+  "factoryResetProgress": {
+    "message": "جارٍ إعادة الضبط…"
+  },
+  "factoryResetFailed": {
+    "message": "تعذّرت إعادة ضبط Lurkloot بالكامل. حاول مرة أخرى."
+  },
+  "factoryResetRetry": {
+    "message": "حاول إعادة الضبط مجددًا"
+  },
   "diagnosticLoggingTitle": {
     "message": "تضمين سجلات التشخيص"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "تم استلام بطاقة $1 من تحدي $2"
   },
-  "activityAuthHealthChanged": { "message": "تغيّرت مصادقة $1 من $2 إلى $3." },
-  "activityCriticalFailureDetected": { "message": "$1 لا يعمل: $2." },
-  "activityCriticalFailureCleared": { "message": "تم تجاهل العطل الحرج في $1؛ جارٍ إعادة المحاولة." },
-  "criticalFailureReasonNoProgress": { "message": "لا تقدّم رغم تكرار الأخطاء" },
-  "criticalFailureReasonPageContextChurn": { "message": "ظلّت علامة تبويب تُعاد فتحها باستمرار" },
-  "criticalFailureTitle": { "message": "توقف Lurkloot عن العمل" },
-  "criticalFailureBodyNoProgress": { "message": "أخطاء متكررة ولا يوجد أي تقدم في الدروبس منذ وقت طويل. على الأرجح تغيّر شيء في هذه المنصة ولم يعد بإمكان الإضافة كسب الدروبس." },
-  "criticalFailureBodyTabChurn": { "message": "ظلت إحدى علامات التبويب تُفتح من جديد مرارًا. تم إيقاف إعادة الفتح لتتمكن من استخدام المتصفح بشكل طبيعي، وتم إيقاف الفارم مؤقتًا لهذه المنصة." },
-  "criticalFailureCopyAndReport": { "message": "نسخ السجلات وفتح بلاغ" },
-  "criticalFailureDismiss": { "message": "تجاهل وإعادة المحاولة" },
-  "criticalFailureClipboardFallback": { "message": "تعذّر النسخ تلقائيًا. حدّد هذا النص وانسخه ثم افتح بلاغًا." },
-  "activityPageContextOpened": { "message": "تم فتح سياق في الخلفية على $1 لأن $2." },
-  "activityPageContextClosed": { "message": "تم إغلاق سياق الخلفية على $1 لأن $2." },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick رفض الطلب دون علامة تبويب" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "سياق الخلفية السابق لم يكن صالحًا للاستخدام" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "طلبات العمل دون علامة تبويب عادت للعمل" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "أصبحت علامة تبويب Kick موجودة متاحة" },
+  "activityAuthHealthChanged": {
+    "message": "تغيّرت مصادقة $1 من $2 إلى $3."
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 لا يعمل: $2."
+  },
+  "activityCriticalFailureCleared": {
+    "message": "تم تجاهل العطل الحرج في $1؛ جارٍ إعادة المحاولة."
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "لا تقدّم رغم تكرار الأخطاء"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "ظلّت علامة تبويب تُعاد فتحها باستمرار"
+  },
+  "criticalFailureTitle": {
+    "message": "توقف Lurkloot عن العمل"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "أخطاء متكررة ولا يوجد أي تقدم في الدروبس منذ وقت طويل. على الأرجح تغيّر شيء في هذه المنصة ولم يعد بإمكان الإضافة كسب الدروبس."
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "ظلت إحدى علامات التبويب تُفتح من جديد مرارًا. تم إيقاف إعادة الفتح لتتمكن من استخدام المتصفح بشكل طبيعي، وتم إيقاف الفارم مؤقتًا لهذه المنصة."
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "نسخ السجلات وفتح بلاغ"
+  },
+  "criticalFailureDismiss": {
+    "message": "تجاهل وإعادة المحاولة"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "تعذّر النسخ تلقائيًا. حدّد هذا النص وانسخه ثم افتح بلاغًا."
+  },
+  "activityPageContextOpened": {
+    "message": "تم فتح سياق في الخلفية على $1 لأن $2."
+  },
+  "activityPageContextClosed": {
+    "message": "تم إغلاق سياق الخلفية على $1 لأن $2."
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick رفض الطلب دون علامة تبويب"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "سياق الخلفية السابق لم يكن صالحًا للاستخدام"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "طلبات العمل دون علامة تبويب عادت للعمل"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "أصبحت علامة تبويب Kick موجودة متاحة"
+  },
   "activityInterruption": {
     "message": "توقف الجمع: $1."
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "تم تعطيل المنصة"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "المصادقة غير متاحة" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "المصادقة غير متاحة"
+  },
   "activityReasonPlatformBackoff": {
     "message": "المنصة في انتظار مؤقت"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "استعلام المخزون الإصدار 1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "استعلام المخزون الإصدار 2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick يوليو 2026"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "معالجة الروابط الإصدار 2"
   },
-  "automationChecking": { "message": "جارٍ التحقق" },
-  "automationNeedsSignIn": { "message": "يلزم تسجيل الدخول" },
-  "automationBlocked": { "message": "محظور" },
-  "automationUnavailable": { "message": "غير متاح" },
-  "authCheckingDetail": { "message": "جارٍ التحقق من جلسة تسجيل دخولك…" },
-  "authSignInMissing": { "message": "سجّل الدخول لمواصلة جمع المكافآت." },
-  "authSignInRejected": { "message": "لم تعد جلستك صالحة. سجّل الدخول مجددًا للمتابعة." },
-  "signInToTwitch": { "message": "تسجيل الدخول إلى Twitch" },
-  "signInToKick": { "message": "تسجيل الدخول إلى Kick" },
-  "authBrowserProfileBlocked": { "message": "رفض Kick ملف تعريف المتصفح هذا. قد لا يكفي تسجيل الدخول وحده لحل المشكلة." },
-  "authCredentialCheckUnavailable": { "message": "تعذر التحقق من جلسة المتصفح. سيعيد Lurkloot المحاولة تلقائيًا." },
-  "authNetworkTemporarilyUnavailable": { "message": "الشبكة غير متاحة مؤقتًا. سيعيد Lurkloot المحاولة تلقائيًا." },
-  "authPlatformTemporarilyUnavailable": { "message": "المنصة غير متاحة مؤقتًا. سيعيد Lurkloot المحاولة تلقائيًا." },
-  "automationPausedTabClosed": { "message": "متوقّف مؤقتًا — أُغلقت علامة التبويب" },
-  "watchTabClosedPauseDetail": { "message": "لقد أغلقت علامة تبويب الزراعة، لذا أوقف Lurkloot الزراعة هنا." },
-  "resumeFarming": { "message": "استئناف الزراعة" },
-  "activityReasonManualTabClose": { "message": "أُغلقت علامة تبويب الزراعة" }
+  "automationChecking": {
+    "message": "جارٍ التحقق"
+  },
+  "automationNeedsSignIn": {
+    "message": "يلزم تسجيل الدخول"
+  },
+  "automationBlocked": {
+    "message": "محظور"
+  },
+  "automationUnavailable": {
+    "message": "غير متاح"
+  },
+  "authCheckingDetail": {
+    "message": "جارٍ التحقق من جلسة تسجيل دخولك…"
+  },
+  "authSignInMissing": {
+    "message": "سجّل الدخول لمواصلة جمع المكافآت."
+  },
+  "authSignInRejected": {
+    "message": "لم تعد جلستك صالحة. سجّل الدخول مجددًا للمتابعة."
+  },
+  "signInToTwitch": {
+    "message": "تسجيل الدخول إلى Twitch"
+  },
+  "signInToKick": {
+    "message": "تسجيل الدخول إلى Kick"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "رفض Kick ملف تعريف المتصفح هذا. قد لا يكفي تسجيل الدخول وحده لحل المشكلة."
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "تعذر التحقق من جلسة المتصفح. سيعيد Lurkloot المحاولة تلقائيًا."
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "الشبكة غير متاحة مؤقتًا. سيعيد Lurkloot المحاولة تلقائيًا."
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "المنصة غير متاحة مؤقتًا. سيعيد Lurkloot المحاولة تلقائيًا."
+  },
+  "automationPausedTabClosed": {
+    "message": "متوقّف مؤقتًا — أُغلقت علامة التبويب"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "لقد أغلقت علامة تبويب الزراعة، لذا أوقف Lurkloot الزراعة هنا."
+  },
+  "resumeFarming": {
+    "message": "استئناف الزراعة"
+  },
+  "activityReasonManualTabClose": {
+    "message": "أُغلقت علامة تبويب الزراعة"
+  }
 }

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "Schauen pausiert. Schalter aktivieren, um Drop-Farming fortzusetzen."
   },
-  "hideTipsTitle": { "message": "Tipps ausblenden" },
-  "hideTipsDescription": { "message": "Blendet hilfreiche Tipps im Hauptfenster aus." },
-  "tipCampaignPriority": { "message": "Drops haben Vorrang vor der Leerlauf-Watchlist. Ziehe Kampagnen am Griff, um sie zu ordnen." },
-  "tipMissingCampaigns": { "message": "Fehlt eine Kampagne? Prüfe das Drops-Inventar der Plattform und die Filter in den Einstellungen." },
-  "tipCategorySelection": { "message": "Nur bestimmte Spiele? Deaktiviere „Alle Kategorien farmen“ und wähle deine Kategorien." },
-  "tipIdleWatchlist": { "message": "Die Leerlauf-Watchlist farmt ausgewählte Kanäle, wenn keine geeigneten Drops verfügbar sind." },
-  "tipTablessMode": { "message": "Der tablose Modus spart Ressourcen und öffnet bei Bedarf einen stummgeschalteten Tab." },
-  "tipCli": { "message": "Lieber ohne Erweiterung? Lurkloot ist auch als Docker-CLI verfügbar." },
-  "tipCliAction": { "message": "CLI-Anleitung lesen" },
-  "tipFeedback": { "message": "Fehler gefunden oder eine Idee?" },
-  "tipFeedbackAction": { "message": "GitHub-Issue öffnen" },
-  "tipExcludedCampaigns": { "message": "Kampagne versehentlich ausgeschlossen? Stelle sie in den Drops-Einstellungen wieder her." },
+  "hideTipsTitle": {
+    "message": "Tipps ausblenden"
+  },
+  "hideTipsDescription": {
+    "message": "Blendet hilfreiche Tipps im Hauptfenster aus."
+  },
+  "tipCampaignPriority": {
+    "message": "Drops haben Vorrang vor der Leerlauf-Watchlist. Ziehe Kampagnen am Griff, um sie zu ordnen."
+  },
+  "tipMissingCampaigns": {
+    "message": "Fehlt eine Kampagne? Prüfe das Drops-Inventar der Plattform und die Filter in den Einstellungen."
+  },
+  "tipCategorySelection": {
+    "message": "Nur bestimmte Spiele? Deaktiviere „Alle Kategorien farmen“ und wähle deine Kategorien."
+  },
+  "tipIdleWatchlist": {
+    "message": "Die Leerlauf-Watchlist farmt ausgewählte Kanäle, wenn keine geeigneten Drops verfügbar sind."
+  },
+  "tipTablessMode": {
+    "message": "Der tablose Modus spart Ressourcen und öffnet bei Bedarf einen stummgeschalteten Tab."
+  },
+  "tipCli": {
+    "message": "Lieber ohne Erweiterung? Lurkloot ist auch als Docker-CLI verfügbar."
+  },
+  "tipCliAction": {
+    "message": "CLI-Anleitung lesen"
+  },
+  "tipFeedback": {
+    "message": "Fehler gefunden oder eine Idee?"
+  },
+  "tipFeedbackAction": {
+    "message": "GitHub-Issue öffnen"
+  },
+  "tipExcludedCampaigns": {
+    "message": "Kampagne versehentlich ausgeschlossen? Stelle sie in den Drops-Einstellungen wieder her."
+  },
   "noCampaigns": {
     "message": "Noch keine Kampagnen gefunden."
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "Farmt über leichte Watch-Signale statt Video-Tab. Twitch nutzt Watch-Heartbeats; Kick nutzt eine Zuschauerverbindung. Fällt automatisch auf einen Tab zurück, wenn es nicht mehr zählt."
   },
-  "tablessFallbackFailureLimitTitle": { "message": "Schwellenwert für den Tabless-Rückfall" },
-  "tablessFallbackFailureLimitDescription": { "message": "Öffnet nach dieser Anzahl aufeinanderfolgender fehlgeschlagener Tabless-Wiedergabesignale einen Video-Tab." },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "Aktiviere den ressourcenschonenden Tabless-Modus, um diese Einstellung zu ändern." },
-  "failuresSuffix": { "message": "Fehler" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "Schwellenwert für den Tabless-Rückfall"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "Öffnet nach dieser Anzahl aufeinanderfolgender fehlgeschlagener Tabless-Wiedergabesignale einen Video-Tab."
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "Aktiviere den ressourcenschonenden Tabless-Modus, um diese Einstellung zu ändern."
+  },
+  "failuresSuffix": {
+    "message": "Fehler"
+  },
   "autoCloseTabsTitle": {
     "message": "Farming-Tabs automatisch schließen"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "Sek."
   },
-  "deadlineSafetyMarginTitle": { "message": "Sicherheitsmarge bis zum Ablauf" },
-  "deadlineSafetyMarginDescription": { "message": "Zusätzliche Minuten vor dem Farmen einer Belohnung." },
-  "deadlineSafetyMarginDisabledReason": { "message": "Aktiviere den Fristfilter, um die Sicherheitsmarge zu ändern." },
-  "skipUnfinishableRewardsTitle": { "message": "Nicht abschließbare Belohnungen überspringen" },
-  "skipUnfinishableRewardsDescription": { "message": "Belohnungen nicht farmen, wenn die verbleibende Wiedergabezeit die Frist überschreitet." },
-  "minutesSuffix": { "message": "Min." },
-  "insufficientTimeRemaining": { "message": "Nicht genügend Zeit verbleibend" },
+  "deadlineSafetyMarginTitle": {
+    "message": "Sicherheitsmarge bis zum Ablauf"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "Zusätzliche Minuten vor dem Farmen einer Belohnung."
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "Aktiviere den Fristfilter, um die Sicherheitsmarge zu ändern."
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "Nicht abschließbare Belohnungen überspringen"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "Belohnungen nicht farmen, wenn die verbleibende Wiedergabezeit die Frist überschreitet."
+  },
+  "minutesSuffix": {
+    "message": "Min."
+  },
+  "insufficientTimeRemaining": {
+    "message": "Nicht genügend Zeit verbleibend"
+  },
   "automationSectionTitle": {
     "message": "Automatisierung"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "Website"
   },
-  "updateNoticeTitle": { "message": "Lurkloot wurde auf $1 aktualisiert" },
-  "updateNoticeBody": { "message": "Sieh dir die Neuerungen und Änderungen an." },
-  "updateNoticeAction": { "message": "Änderungen ansehen" },
-  "updateNoticeDismiss": { "message": "Update-Hinweis schließen" },
+  "updateNoticeTitle": {
+    "message": "Lurkloot wurde auf $1 aktualisiert"
+  },
+  "updateNoticeBody": {
+    "message": "Sieh dir die Neuerungen und Änderungen an."
+  },
+  "updateNoticeAction": {
+    "message": "Änderungen ansehen"
+  },
+  "updateNoticeDismiss": {
+    "message": "Update-Hinweis schließen"
+  },
   "rateNudgeTitle": {
     "message": "Gefällt dir Lurkloot?"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "Anmeldedaten exportieren"
   },
-  "factoryResetTitle": { "message": "Lurkloot zurücksetzen" },
-  "factoryResetHint": { "message": "Löscht alle Lurkloot-Einstellungen, den Farming-Fortschritt und den Aktivitätsverlauf. Deine Twitch- und Kick-Konten bleiben angemeldet." },
-  "factoryResetButton": { "message": "Lurkloot zurücksetzen" },
-  "factoryResetConfirm": { "message": "Dadurch wird das Farming beendet, von Lurkloot geöffnete Tabs werden geschlossen und alle Lurkloot-Daten dauerhaft gelöscht. Twitch und Kick bleiben angemeldet." },
-  "factoryResetCancel": { "message": "Abbrechen" },
-  "factoryResetConfirmButton": { "message": "Alles zurücksetzen" },
-  "factoryResetProgress": { "message": "Wird zurückgesetzt…" },
-  "factoryResetFailed": { "message": "Lurkloot konnte nicht vollständig zurückgesetzt werden. Versuche es erneut." },
-  "factoryResetRetry": { "message": "Erneut versuchen" },
+  "factoryResetTitle": {
+    "message": "Lurkloot zurücksetzen"
+  },
+  "factoryResetHint": {
+    "message": "Löscht alle Lurkloot-Einstellungen, den Farming-Fortschritt und den Aktivitätsverlauf. Deine Twitch- und Kick-Konten bleiben angemeldet."
+  },
+  "factoryResetButton": {
+    "message": "Lurkloot zurücksetzen"
+  },
+  "factoryResetConfirm": {
+    "message": "Dadurch wird das Farming beendet, von Lurkloot geöffnete Tabs werden geschlossen und alle Lurkloot-Daten dauerhaft gelöscht. Twitch und Kick bleiben angemeldet."
+  },
+  "factoryResetCancel": {
+    "message": "Abbrechen"
+  },
+  "factoryResetConfirmButton": {
+    "message": "Alles zurücksetzen"
+  },
+  "factoryResetProgress": {
+    "message": "Wird zurückgesetzt…"
+  },
+  "factoryResetFailed": {
+    "message": "Lurkloot konnte nicht vollständig zurückgesetzt werden. Versuche es erneut."
+  },
+  "factoryResetRetry": {
+    "message": "Erneut versuchen"
+  },
   "diagnosticLoggingTitle": {
     "message": "Diagnoseprotokolle einschließen"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "$1-Karte aus der $2-Challenge erhalten"
   },
-  "activityAuthHealthChanged": { "message": "Die Authentifizierung von $1 wechselte von $2 zu $3." },
-  "activityCriticalFailureDetected": { "message": "$1 funktioniert nicht: $2." },
-  "activityCriticalFailureCleared": { "message": "Kritischer Fehler von $1 verworfen; erneuter Versuch läuft." },
-  "criticalFailureReasonNoProgress": { "message": "trotz wiederholter Fehler kein Fortschritt" },
-  "criticalFailureReasonPageContextChurn": { "message": "ein Tab öffnete sich immer wieder neu" },
-  "criticalFailureTitle": { "message": "Lurkloot funktioniert nicht mehr" },
-  "criticalFailureBodyNoProgress": { "message": "Wiederholte Fehler und seit Langem kein Drop-Fortschritt. Auf dieser Plattform hat sich vermutlich etwas geändert und die Erweiterung kann keine Drops mehr sammeln." },
-  "criticalFailureBodyTabChurn": { "message": "Ein Tab wurde immer wieder neu geöffnet. Das Neuöffnen wurde gestoppt, damit du den Browser normal nutzen kannst; das Farmen ist für diese Plattform pausiert." },
-  "criticalFailureCopyAndReport": { "message": "Logs kopieren & Issue öffnen" },
-  "criticalFailureDismiss": { "message": "Verwerfen und erneut versuchen" },
-  "criticalFailureClipboardFallback": { "message": "Automatisches Kopieren fehlgeschlagen. Markiere und kopiere diesen Text und öffne dann ein Issue." },
-  "activityPageContextOpened": { "message": "Ein Hintergrundkontext auf $1 wurde geöffnet, weil $2." },
-  "activityPageContextClosed": { "message": "Der Hintergrundkontext auf $1 wurde geschlossen, weil $2." },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick die Anfrage ohne Tab abgelehnt hat" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "der vorherige Hintergrundkontext unbrauchbar war" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "Anfragen ohne Tab wieder funktionieren" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "ein vorhandener Kick-Tab verfügbar wurde" },
+  "activityAuthHealthChanged": {
+    "message": "Die Authentifizierung von $1 wechselte von $2 zu $3."
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 funktioniert nicht: $2."
+  },
+  "activityCriticalFailureCleared": {
+    "message": "Kritischer Fehler von $1 verworfen; erneuter Versuch läuft."
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "trotz wiederholter Fehler kein Fortschritt"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "ein Tab öffnete sich immer wieder neu"
+  },
+  "criticalFailureTitle": {
+    "message": "Lurkloot funktioniert nicht mehr"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "Wiederholte Fehler und seit Langem kein Drop-Fortschritt. Auf dieser Plattform hat sich vermutlich etwas geändert und die Erweiterung kann keine Drops mehr sammeln."
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "Ein Tab wurde immer wieder neu geöffnet. Das Neuöffnen wurde gestoppt, damit du den Browser normal nutzen kannst; das Farmen ist für diese Plattform pausiert."
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "Logs kopieren & Issue öffnen"
+  },
+  "criticalFailureDismiss": {
+    "message": "Verwerfen und erneut versuchen"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "Automatisches Kopieren fehlgeschlagen. Markiere und kopiere diesen Text und öffne dann ein Issue."
+  },
+  "activityPageContextOpened": {
+    "message": "Ein Hintergrundkontext auf $1 wurde geöffnet, weil $2."
+  },
+  "activityPageContextClosed": {
+    "message": "Der Hintergrundkontext auf $1 wurde geschlossen, weil $2."
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick die Anfrage ohne Tab abgelehnt hat"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "der vorherige Hintergrundkontext unbrauchbar war"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "Anfragen ohne Tab wieder funktionieren"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "ein vorhandener Kick-Tab verfügbar wurde"
+  },
   "activityInterruption": {
     "message": "Sammeln unterbrochen: $1."
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "die Plattform wurde deaktiviert"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "die Authentifizierung ist nicht verfügbar" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "die Authentifizierung ist nicht verfügbar"
+  },
   "activityReasonPlatformBackoff": {
     "message": "die Plattform wartet vorübergehend"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "Inventarabfrage v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "Inventarabfrage v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick Juli 2026"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "Verknüpfungsverarbeitung v2"
   },
-  "automationChecking": { "message": "Wird geprüft" },
-  "automationNeedsSignIn": { "message": "Anmeldung erforderlich" },
-  "automationBlocked": { "message": "Blockiert" },
-  "automationUnavailable": { "message": "Nicht verfügbar" },
-  "authCheckingDetail": { "message": "Deine angemeldete Sitzung wird geprüft…" },
-  "authSignInMissing": { "message": "Melde dich an, um weiter Drops zu farmen." },
-  "authSignInRejected": { "message": "Deine Sitzung ist nicht mehr gültig. Melde dich erneut an, um fortzufahren." },
-  "signInToTwitch": { "message": "Bei Twitch anmelden" },
-  "signInToKick": { "message": "Bei Kick anmelden" },
-  "authBrowserProfileBlocked": { "message": "Kick hat dieses Browserprofil abgelehnt. Eine Anmeldung allein behebt das Problem möglicherweise nicht." },
-  "authCredentialCheckUnavailable": { "message": "Deine Browsersitzung konnte nicht geprüft werden. Lurkloot versucht es automatisch erneut." },
-  "authNetworkTemporarilyUnavailable": { "message": "Das Netzwerk ist vorübergehend nicht verfügbar. Lurkloot versucht es automatisch erneut." },
-  "authPlatformTemporarilyUnavailable": { "message": "Die Plattform ist vorübergehend nicht verfügbar. Lurkloot versucht es automatisch erneut." },
-  "automationPausedTabClosed": { "message": "Pausiert — Tab geschlossen" },
-  "watchTabClosedPauseDetail": { "message": "Du hast den Farming-Tab geschlossen, daher hat Lurkloot das Farmen hier gestoppt." },
-  "resumeFarming": { "message": "Farmen fortsetzen" },
-  "activityReasonManualTabClose": { "message": "Farming-Tab geschlossen" }
+  "automationChecking": {
+    "message": "Wird geprüft"
+  },
+  "automationNeedsSignIn": {
+    "message": "Anmeldung erforderlich"
+  },
+  "automationBlocked": {
+    "message": "Blockiert"
+  },
+  "automationUnavailable": {
+    "message": "Nicht verfügbar"
+  },
+  "authCheckingDetail": {
+    "message": "Deine angemeldete Sitzung wird geprüft…"
+  },
+  "authSignInMissing": {
+    "message": "Melde dich an, um weiter Drops zu farmen."
+  },
+  "authSignInRejected": {
+    "message": "Deine Sitzung ist nicht mehr gültig. Melde dich erneut an, um fortzufahren."
+  },
+  "signInToTwitch": {
+    "message": "Bei Twitch anmelden"
+  },
+  "signInToKick": {
+    "message": "Bei Kick anmelden"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "Kick hat dieses Browserprofil abgelehnt. Eine Anmeldung allein behebt das Problem möglicherweise nicht."
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "Deine Browsersitzung konnte nicht geprüft werden. Lurkloot versucht es automatisch erneut."
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "Das Netzwerk ist vorübergehend nicht verfügbar. Lurkloot versucht es automatisch erneut."
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "Die Plattform ist vorübergehend nicht verfügbar. Lurkloot versucht es automatisch erneut."
+  },
+  "automationPausedTabClosed": {
+    "message": "Pausiert — Tab geschlossen"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "Du hast den Farming-Tab geschlossen, daher hat Lurkloot das Farmen hier gestoppt."
+  },
+  "resumeFarming": {
+    "message": "Farmen fortsetzen"
+  },
+  "activityReasonManualTabClose": {
+    "message": "Farming-Tab geschlossen"
+  }
 }

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "Watching paused. Toggle to resume drop farming."
   },
-  "hideTipsTitle": { "message": "Hide tips" },
-  "hideTipsDescription": { "message": "Remove helpful tips from the main popup." },
-  "tipCampaignPriority": { "message": "Drops take priority over the Idle Watchlist. Drag campaigns by the grip to set their farming order." },
-  "tipMissingCampaigns": { "message": "Missing a campaign? Check your platform's Drops inventory, then review campaign filters in Settings." },
-  "tipCategorySelection": { "message": "Only farming certain games? Turn off ‘Farm all categories’ in platform settings and choose your categories." },
-  "tipIdleWatchlist": { "message": "Drops stay first priority. The Idle Watchlist watches selected channels when no eligible drops are available." },
-  "tipTablessMode": { "message": "Tabless mode uses fewer resources and falls back to a muted tab when needed." },
-  "tipCli": { "message": "Prefer running without an extension? Lurkloot is also available as a Docker-based CLI." },
-  "tipCliAction": { "message": "Read the CLI guide" },
-  "tipFeedback": { "message": "Found a bug or have an idea?" },
-  "tipFeedbackAction": { "message": "Open a GitHub issue" },
-  "tipExcludedCampaigns": { "message": "Excluded a campaign by mistake? Restore excluded campaigns from Drops settings." },
+  "hideTipsTitle": {
+    "message": "Hide tips"
+  },
+  "hideTipsDescription": {
+    "message": "Remove helpful tips from the main popup."
+  },
+  "tipCampaignPriority": {
+    "message": "Drops take priority over the Idle Watchlist. Drag campaigns by the grip to set their farming order."
+  },
+  "tipMissingCampaigns": {
+    "message": "Missing a campaign? Check your platform's Drops inventory, then review campaign filters in Settings."
+  },
+  "tipCategorySelection": {
+    "message": "Only farming certain games? Turn off ‘Farm all categories’ in platform settings and choose your categories."
+  },
+  "tipIdleWatchlist": {
+    "message": "Drops stay first priority. The Idle Watchlist watches selected channels when no eligible drops are available."
+  },
+  "tipTablessMode": {
+    "message": "Tabless mode uses fewer resources and falls back to a muted tab when needed."
+  },
+  "tipCli": {
+    "message": "Prefer running without an extension? Lurkloot is also available as a Docker-based CLI."
+  },
+  "tipCliAction": {
+    "message": "Read the CLI guide"
+  },
+  "tipFeedback": {
+    "message": "Found a bug or have an idea?"
+  },
+  "tipFeedbackAction": {
+    "message": "Open a GitHub issue"
+  },
+  "tipExcludedCampaigns": {
+    "message": "Excluded a campaign by mistake? Restore excluded campaigns from Drops settings."
+  },
   "noCampaigns": {
     "message": "No campaigns discovered yet."
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "Farm via lightweight watch signals instead of a video tab. Twitch uses watch heartbeats; Kick uses a viewer connection. Falls back to a tab automatically if it stops earning."
   },
-  "tablessFallbackFailureLimitTitle": { "message": "Tabless fallback threshold" },
-  "tablessFallbackFailureLimitDescription": { "message": "Open a video tab after this many consecutive failed tabless watch signals." },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "Enable tabless low-resource mode to change this setting." },
-  "failuresSuffix": { "message": "failures" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "Tabless fallback threshold"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "Open a video tab after this many consecutive failed tabless watch signals."
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "Enable tabless low-resource mode to change this setting."
+  },
+  "failuresSuffix": {
+    "message": "failures"
+  },
   "autoCloseTabsTitle": {
     "message": "Auto-close farming tabs"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "sec"
   },
-  "deadlineSafetyMarginTitle": { "message": "Deadline safety margin" },
-  "deadlineSafetyMarginDescription": { "message": "Extra minutes required before farming a reward." },
-  "deadlineSafetyMarginDisabledReason": { "message": "Enable deadline filtering to change the safety margin." },
-  "skipUnfinishableRewardsTitle": { "message": "Skip rewards that cannot be completed" },
-  "skipUnfinishableRewardsDescription": { "message": "Do not farm rewards when their remaining watch time exceeds the time before their deadline." },
-  "minutesSuffix": { "message": "min" },
-  "insufficientTimeRemaining": { "message": "Insufficient time remaining" },
+  "deadlineSafetyMarginTitle": {
+    "message": "Deadline safety margin"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "Extra minutes required before farming a reward."
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "Enable deadline filtering to change the safety margin."
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "Skip rewards that cannot be completed"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "Do not farm rewards when their remaining watch time exceeds the time before their deadline."
+  },
+  "minutesSuffix": {
+    "message": "min"
+  },
+  "insufficientTimeRemaining": {
+    "message": "Insufficient time remaining"
+  },
   "automationSectionTitle": {
     "message": "Automation"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "Website"
   },
-  "updateNoticeTitle": { "message": "Lurkloot was updated to $1" },
-  "updateNoticeBody": { "message": "See what's new and what changed." },
-  "updateNoticeAction": { "message": "View changes" },
-  "updateNoticeDismiss": { "message": "Dismiss update notice" },
+  "updateNoticeTitle": {
+    "message": "Lurkloot was updated to $1"
+  },
+  "updateNoticeBody": {
+    "message": "See what's new and what changed."
+  },
+  "updateNoticeAction": {
+    "message": "View changes"
+  },
+  "updateNoticeDismiss": {
+    "message": "Dismiss update notice"
+  },
   "rateNudgeTitle": {
     "message": "Enjoying Lurkloot?"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "Export credentials"
   },
-  "factoryResetTitle": { "message": "Reset Lurkloot" },
-  "factoryResetHint": { "message": "Erase all Lurkloot settings, farming progress, and activity history. Your Twitch and Kick accounts stay signed in." },
-  "factoryResetButton": { "message": "Reset Lurkloot" },
-  "factoryResetConfirm": { "message": "This stops farming, closes tabs opened by Lurkloot, and permanently erases all Lurkloot data. Twitch and Kick stay signed in." },
-  "factoryResetCancel": { "message": "Cancel" },
-  "factoryResetConfirmButton": { "message": "Reset everything" },
-  "factoryResetProgress": { "message": "Resetting…" },
-  "factoryResetFailed": { "message": "Lurkloot couldn't reset completely. Try again." },
-  "factoryResetRetry": { "message": "Try reset again" },
+  "factoryResetTitle": {
+    "message": "Reset Lurkloot"
+  },
+  "factoryResetHint": {
+    "message": "Erase all Lurkloot settings, farming progress, and activity history. Your Twitch and Kick accounts stay signed in."
+  },
+  "factoryResetButton": {
+    "message": "Reset Lurkloot"
+  },
+  "factoryResetConfirm": {
+    "message": "This stops farming, closes tabs opened by Lurkloot, and permanently erases all Lurkloot data. Twitch and Kick stay signed in."
+  },
+  "factoryResetCancel": {
+    "message": "Cancel"
+  },
+  "factoryResetConfirmButton": {
+    "message": "Reset everything"
+  },
+  "factoryResetProgress": {
+    "message": "Resetting…"
+  },
+  "factoryResetFailed": {
+    "message": "Lurkloot couldn't reset completely. Try again."
+  },
+  "factoryResetRetry": {
+    "message": "Try reset again"
+  },
   "diagnosticLoggingTitle": {
     "message": "Include diagnostic logs"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "Claimed a $1 card from the $2 challenge"
   },
-  "activityAuthHealthChanged": { "message": "$1 authentication changed from $2 to $3." },
-  "activityCriticalFailureDetected": { "message": "$1 is not working: $2." },
-  "activityCriticalFailureCleared": { "message": "$1 critical failure dismissed; retrying." },
-  "criticalFailureReasonNoProgress": { "message": "no progress despite repeated errors" },
-  "criticalFailureReasonPageContextChurn": { "message": "a tab kept reopening" },
-  "criticalFailureTitle": { "message": "Lurkloot has stopped working" },
-  "criticalFailureBodyNoProgress": { "message": "Repeated errors and no drop progress for a long time. Something on this platform likely changed and the extension can no longer earn drops." },
-  "criticalFailureBodyTabChurn": { "message": "A tab kept reopening over and over. Reopening has been stopped so you can use your browser normally, and farming is paused for this platform." },
-  "criticalFailureCopyAndReport": { "message": "Copy logs & open issue" },
-  "criticalFailureDismiss": { "message": "Dismiss and try again" },
-  "criticalFailureClipboardFallback": { "message": "Could not copy automatically. Select and copy this, then open an issue." },
-  "activityPageContextOpened": { "message": "Opened a background context on $1 because $2." },
-  "activityPageContextClosed": { "message": "Closed the background context on $1 because $2." },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick rejected the tabless request" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "the previous background context was unusable" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "tabless requests recovered" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "an existing Kick tab became available" },
+  "activityAuthHealthChanged": {
+    "message": "$1 authentication changed from $2 to $3."
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 is not working: $2."
+  },
+  "activityCriticalFailureCleared": {
+    "message": "$1 critical failure dismissed; retrying."
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "no progress despite repeated errors"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "a tab kept reopening"
+  },
+  "criticalFailureTitle": {
+    "message": "Lurkloot has stopped working"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "Repeated errors and no drop progress for a long time. Something on this platform likely changed and the extension can no longer earn drops."
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "A tab kept reopening over and over. Reopening has been stopped so you can use your browser normally, and farming is paused for this platform."
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "Copy logs & open issue"
+  },
+  "criticalFailureDismiss": {
+    "message": "Dismiss and try again"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "Could not copy automatically. Select and copy this, then open an issue."
+  },
+  "activityPageContextOpened": {
+    "message": "Opened a background context on $1 because $2."
+  },
+  "activityPageContextClosed": {
+    "message": "Closed the background context on $1 because $2."
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick rejected the tabless request"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "the previous background context was unusable"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "tabless requests recovered"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "an existing Kick tab became available"
+  },
   "activityInterruption": {
     "message": "Farming interrupted: $1."
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "the platform was disabled"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "authentication is unavailable" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "authentication is unavailable"
+  },
   "activityReasonPlatformBackoff": {
     "message": "the platform is temporarily backing off"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "Inventory query v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "Inventory query v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick July 2026"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "Claim handling v2"
   },
-  "automationChecking": { "message": "Checking" },
-  "automationNeedsSignIn": { "message": "Needs sign-in" },
-  "automationBlocked": { "message": "Blocked" },
-  "automationUnavailable": { "message": "Unavailable" },
-  "authCheckingDetail": { "message": "Checking your signed-in session…" },
-  "authSignInMissing": { "message": "Sign in to continue farming drops." },
-  "authSignInRejected": { "message": "Your session is no longer valid. Sign in again to continue." },
-  "signInToTwitch": { "message": "Sign in to Twitch" },
-  "signInToKick": { "message": "Sign in to Kick" },
-  "authBrowserProfileBlocked": { "message": "Kick rejected this browser profile. Signing in alone may not resolve it." },
-  "authCredentialCheckUnavailable": { "message": "Your browser session could not be checked. Lurkloot will retry automatically." },
-  "authNetworkTemporarilyUnavailable": { "message": "The network is temporarily unavailable. Lurkloot will retry automatically." },
-  "authPlatformTemporarilyUnavailable": { "message": "The platform is temporarily unavailable. Lurkloot will retry automatically." },
-  "automationPausedTabClosed": { "message": "Paused — tab closed" },
-  "watchTabClosedPauseDetail": { "message": "You closed the farming tab, so Lurkloot stopped farming here." },
-  "resumeFarming": { "message": "Resume farming" },
-  "activityReasonManualTabClose": { "message": "farming tab closed" }
+  "automationChecking": {
+    "message": "Checking"
+  },
+  "automationNeedsSignIn": {
+    "message": "Needs sign-in"
+  },
+  "automationBlocked": {
+    "message": "Blocked"
+  },
+  "automationUnavailable": {
+    "message": "Unavailable"
+  },
+  "authCheckingDetail": {
+    "message": "Checking your signed-in session…"
+  },
+  "authSignInMissing": {
+    "message": "Sign in to continue farming drops."
+  },
+  "authSignInRejected": {
+    "message": "Your session is no longer valid. Sign in again to continue."
+  },
+  "signInToTwitch": {
+    "message": "Sign in to Twitch"
+  },
+  "signInToKick": {
+    "message": "Sign in to Kick"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "Kick rejected this browser profile. Signing in alone may not resolve it."
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "Your browser session could not be checked. Lurkloot will retry automatically."
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "The network is temporarily unavailable. Lurkloot will retry automatically."
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "The platform is temporarily unavailable. Lurkloot will retry automatically."
+  },
+  "automationPausedTabClosed": {
+    "message": "Paused — tab closed"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "You closed the farming tab, so Lurkloot stopped farming here."
+  },
+  "resumeFarming": {
+    "message": "Resume farming"
+  },
+  "activityReasonManualTabClose": {
+    "message": "farming tab closed"
+  }
 }

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "Visualización pausada. Activa el interruptor para reanudar el farmeo de drops."
   },
-  "hideTipsTitle": { "message": "Ocultar consejos" },
-  "hideTipsDescription": { "message": "Oculta los consejos de la ventana principal." },
-  "tipCampaignPriority": { "message": "Los drops tienen prioridad sobre la lista. Arrastra las campañas por el agarre para ordenar el farmeo." },
-  "tipMissingCampaigns": { "message": "¿Falta una campaña? Comprueba el inventario de drops de la plataforma y los filtros en Ajustes." },
-  "tipCategorySelection": { "message": "¿Solo quieres ciertos juegos? Desactiva «Farmear todas las categorías» y elige las categorías." },
-  "tipIdleWatchlist": { "message": "La lista farmea los canales elegidos cuando no hay drops disponibles." },
-  "tipTablessMode": { "message": "El modo sin pestañas usa menos recursos y recurre a una pestaña silenciada cuando hace falta." },
-  "tipCli": { "message": "¿Prefieres no usar una extensión? Lurkloot también ofrece una CLI para Docker." },
-  "tipCliAction": { "message": "Ver guía de la CLI" },
-  "tipFeedback": { "message": "¿Encontraste un error o tienes una idea?" },
-  "tipFeedbackAction": { "message": "Abrir un issue en GitHub" },
-  "tipExcludedCampaigns": { "message": "¿Excluiste una campaña por error? Restáurala desde los ajustes de Drops." },
+  "hideTipsTitle": {
+    "message": "Ocultar consejos"
+  },
+  "hideTipsDescription": {
+    "message": "Oculta los consejos de la ventana principal."
+  },
+  "tipCampaignPriority": {
+    "message": "Los drops tienen prioridad sobre la lista. Arrastra las campañas por el agarre para ordenar el farmeo."
+  },
+  "tipMissingCampaigns": {
+    "message": "¿Falta una campaña? Comprueba el inventario de drops de la plataforma y los filtros en Ajustes."
+  },
+  "tipCategorySelection": {
+    "message": "¿Solo quieres ciertos juegos? Desactiva «Farmear todas las categorías» y elige las categorías."
+  },
+  "tipIdleWatchlist": {
+    "message": "La lista farmea los canales elegidos cuando no hay drops disponibles."
+  },
+  "tipTablessMode": {
+    "message": "El modo sin pestañas usa menos recursos y recurre a una pestaña silenciada cuando hace falta."
+  },
+  "tipCli": {
+    "message": "¿Prefieres no usar una extensión? Lurkloot también ofrece una CLI para Docker."
+  },
+  "tipCliAction": {
+    "message": "Ver guía de la CLI"
+  },
+  "tipFeedback": {
+    "message": "¿Encontraste un error o tienes una idea?"
+  },
+  "tipFeedbackAction": {
+    "message": "Abrir un issue en GitHub"
+  },
+  "tipExcludedCampaigns": {
+    "message": "¿Excluiste una campaña por error? Restáurala desde los ajustes de Drops."
+  },
   "noCampaigns": {
     "message": "Aún no se han descubierto campañas."
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "Farmea con señales ligeras de visualización en lugar de una pestaña de vídeo. Twitch usa heartbeats de visualización; Kick usa una conexión de espectador. Vuelve automáticamente a una pestaña si deja de contar."
   },
-  "tablessFallbackFailureLimitTitle": { "message": "Umbral de cambio desde el modo sin pestañas" },
-  "tablessFallbackFailureLimitDescription": { "message": "Abre una pestaña de vídeo después de esta cantidad de señales de visualización sin pestañas fallidas consecutivas." },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "Activa el modo de bajo consumo sin pestañas para cambiar este ajuste." },
-  "failuresSuffix": { "message": "fallos" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "Umbral de cambio desde el modo sin pestañas"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "Abre una pestaña de vídeo después de esta cantidad de señales de visualización sin pestañas fallidas consecutivas."
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "Activa el modo de bajo consumo sin pestañas para cambiar este ajuste."
+  },
+  "failuresSuffix": {
+    "message": "fallos"
+  },
   "autoCloseTabsTitle": {
     "message": "Cerrar pestañas de farmeo automáticamente"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "s"
   },
-  "deadlineSafetyMarginTitle": { "message": "Margen de seguridad del plazo" },
-  "deadlineSafetyMarginDescription": { "message": "Minutos adicionales requeridos antes de farmear una recompensa." },
-  "deadlineSafetyMarginDisabledReason": { "message": "Activa el filtro de plazos para cambiar el margen de seguridad." },
-  "skipUnfinishableRewardsTitle": { "message": "Omitir recompensas que no se pueden completar" },
-  "skipUnfinishableRewardsDescription": { "message": "No farmear recompensas cuyo tiempo de visionado restante supere el plazo disponible." },
-  "minutesSuffix": { "message": "min." },
-  "insufficientTimeRemaining": { "message": "No queda tiempo suficiente" },
+  "deadlineSafetyMarginTitle": {
+    "message": "Margen de seguridad del plazo"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "Minutos adicionales requeridos antes de farmear una recompensa."
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "Activa el filtro de plazos para cambiar el margen de seguridad."
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "Omitir recompensas que no se pueden completar"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "No farmear recompensas cuyo tiempo de visionado restante supere el plazo disponible."
+  },
+  "minutesSuffix": {
+    "message": "min."
+  },
+  "insufficientTimeRemaining": {
+    "message": "No queda tiempo suficiente"
+  },
   "automationSectionTitle": {
     "message": "Automatización"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "Sitio web"
   },
-  "updateNoticeTitle": { "message": "Lurkloot se ha actualizado a la versión $1" },
-  "updateNoticeBody": { "message": "Descubre las novedades y los cambios." },
-  "updateNoticeAction": { "message": "Ver cambios" },
-  "updateNoticeDismiss": { "message": "Descartar aviso de actualización" },
+  "updateNoticeTitle": {
+    "message": "Lurkloot se ha actualizado a la versión $1"
+  },
+  "updateNoticeBody": {
+    "message": "Descubre las novedades y los cambios."
+  },
+  "updateNoticeAction": {
+    "message": "Ver cambios"
+  },
+  "updateNoticeDismiss": {
+    "message": "Descartar aviso de actualización"
+  },
   "rateNudgeTitle": {
     "message": "¿Te gusta Lurkloot?"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "Exportar credenciales"
   },
-  "factoryResetTitle": { "message": "Restablecer Lurkloot" },
-  "factoryResetHint": { "message": "Borra todos los ajustes, el progreso de farmeo y el historial de actividad de Lurkloot. Tus cuentas de Twitch y Kick seguirán conectadas." },
-  "factoryResetButton": { "message": "Restablecer Lurkloot" },
-  "factoryResetConfirm": { "message": "Esto detiene el farmeo, cierra las pestañas abiertas por Lurkloot y borra permanentemente todos sus datos. Twitch y Kick seguirán conectados." },
-  "factoryResetCancel": { "message": "Cancelar" },
-  "factoryResetConfirmButton": { "message": "Borrar todo" },
-  "factoryResetProgress": { "message": "Restableciendo…" },
-  "factoryResetFailed": { "message": "Lurkloot no se pudo restablecer por completo. Inténtalo de nuevo." },
-  "factoryResetRetry": { "message": "Reintentar" },
+  "factoryResetTitle": {
+    "message": "Restablecer Lurkloot"
+  },
+  "factoryResetHint": {
+    "message": "Borra todos los ajustes, el progreso de farmeo y el historial de actividad de Lurkloot. Tus cuentas de Twitch y Kick seguirán conectadas."
+  },
+  "factoryResetButton": {
+    "message": "Restablecer Lurkloot"
+  },
+  "factoryResetConfirm": {
+    "message": "Esto detiene el farmeo, cierra las pestañas abiertas por Lurkloot y borra permanentemente todos sus datos. Twitch y Kick seguirán conectados."
+  },
+  "factoryResetCancel": {
+    "message": "Cancelar"
+  },
+  "factoryResetConfirmButton": {
+    "message": "Borrar todo"
+  },
+  "factoryResetProgress": {
+    "message": "Restableciendo…"
+  },
+  "factoryResetFailed": {
+    "message": "Lurkloot no se pudo restablecer por completo. Inténtalo de nuevo."
+  },
+  "factoryResetRetry": {
+    "message": "Reintentar"
+  },
   "diagnosticLoggingTitle": {
     "message": "Incluir registros de diagnóstico"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "Reclamó una carta $1 del desafío $2"
   },
-  "activityAuthHealthChanged": { "message": "La autenticación de $1 cambió de $2 a $3." },
-  "activityCriticalFailureDetected": { "message": "$1 no está funcionando: $2." },
-  "activityCriticalFailureCleared": { "message": "Se descartó el fallo crítico de $1; reintentando." },
-  "criticalFailureReasonNoProgress": { "message": "sin progreso pese a errores repetidos" },
-  "criticalFailureReasonPageContextChurn": { "message": "una pestaña seguía reabriéndose" },
-  "criticalFailureTitle": { "message": "Lurkloot ha dejado de funcionar" },
-  "criticalFailureBodyNoProgress": { "message": "Errores repetidos y ningún progreso en los drops durante mucho tiempo. Es probable que algo haya cambiado en esta plataforma y la extensión ya no pueda conseguir drops." },
-  "criticalFailureBodyTabChurn": { "message": "Una pestaña se reabría una y otra vez. Se ha detenido la reapertura para que puedas usar el navegador con normalidad, y el farmeo está pausado en esta plataforma." },
-  "criticalFailureCopyAndReport": { "message": "Copiar registros y abrir incidencia" },
-  "criticalFailureDismiss": { "message": "Descartar y reintentar" },
-  "criticalFailureClipboardFallback": { "message": "No se pudo copiar automáticamente. Selecciona y copia esto y luego abre una incidencia." },
-  "activityPageContextOpened": { "message": "Se abrió un contexto en segundo plano en $1 porque $2." },
-  "activityPageContextClosed": { "message": "Se cerró el contexto en segundo plano en $1 porque $2." },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick rechazó la solicitud sin pestaña" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "el contexto anterior no se podía usar" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "las solicitudes sin pestaña se recuperaron" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "había disponible una pestaña de Kick existente" },
+  "activityAuthHealthChanged": {
+    "message": "La autenticación de $1 cambió de $2 a $3."
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 no está funcionando: $2."
+  },
+  "activityCriticalFailureCleared": {
+    "message": "Se descartó el fallo crítico de $1; reintentando."
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "sin progreso pese a errores repetidos"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "una pestaña seguía reabriéndose"
+  },
+  "criticalFailureTitle": {
+    "message": "Lurkloot ha dejado de funcionar"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "Errores repetidos y ningún progreso en los drops durante mucho tiempo. Es probable que algo haya cambiado en esta plataforma y la extensión ya no pueda conseguir drops."
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "Una pestaña se reabría una y otra vez. Se ha detenido la reapertura para que puedas usar el navegador con normalidad, y el farmeo está pausado en esta plataforma."
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "Copiar registros y abrir incidencia"
+  },
+  "criticalFailureDismiss": {
+    "message": "Descartar y reintentar"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "No se pudo copiar automáticamente. Selecciona y copia esto y luego abre una incidencia."
+  },
+  "activityPageContextOpened": {
+    "message": "Se abrió un contexto en segundo plano en $1 porque $2."
+  },
+  "activityPageContextClosed": {
+    "message": "Se cerró el contexto en segundo plano en $1 porque $2."
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick rechazó la solicitud sin pestaña"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "el contexto anterior no se podía usar"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "las solicitudes sin pestaña se recuperaron"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "había disponible una pestaña de Kick existente"
+  },
   "activityInterruption": {
     "message": "Obtención interrumpida: $1."
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "se desactivó la plataforma"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "la autenticación no está disponible" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "la autenticación no está disponible"
+  },
   "activityReasonPlatformBackoff": {
     "message": "la plataforma está esperando temporalmente"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "Consulta de inventario v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "Consulta de inventario v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick julio de 2026"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "Gestión de enlaces v2"
   },
-  "automationChecking": { "message": "Comprobando" },
-  "automationNeedsSignIn": { "message": "Necesita iniciar sesión" },
-  "automationBlocked": { "message": "Bloqueado" },
-  "automationUnavailable": { "message": "No disponible" },
-  "authCheckingDetail": { "message": "Comprobando tu sesión iniciada…" },
-  "authSignInMissing": { "message": "Inicia sesión para seguir consiguiendo drops." },
-  "authSignInRejected": { "message": "Tu sesión ya no es válida. Vuelve a iniciar sesión para continuar." },
-  "signInToTwitch": { "message": "Iniciar sesión en Twitch" },
-  "signInToKick": { "message": "Iniciar sesión en Kick" },
-  "authBrowserProfileBlocked": { "message": "Kick rechazó este perfil del navegador. Puede que iniciar sesión no sea suficiente para resolverlo." },
-  "authCredentialCheckUnavailable": { "message": "No se pudo comprobar la sesión del navegador. Lurkloot volverá a intentarlo automáticamente." },
-  "authNetworkTemporarilyUnavailable": { "message": "La red no está disponible temporalmente. Lurkloot volverá a intentarlo automáticamente." },
-  "authPlatformTemporarilyUnavailable": { "message": "La plataforma no está disponible temporalmente. Lurkloot volverá a intentarlo automáticamente." },
-  "automationPausedTabClosed": { "message": "En pausa — pestaña cerrada" },
-  "watchTabClosedPauseDetail": { "message": "Cerraste la pestaña de farmeo, así que Lurkloot dejó de farmear aquí." },
-  "resumeFarming": { "message": "Reanudar farmeo" },
-  "activityReasonManualTabClose": { "message": "pestaña de farmeo cerrada" }
+  "automationChecking": {
+    "message": "Comprobando"
+  },
+  "automationNeedsSignIn": {
+    "message": "Necesita iniciar sesión"
+  },
+  "automationBlocked": {
+    "message": "Bloqueado"
+  },
+  "automationUnavailable": {
+    "message": "No disponible"
+  },
+  "authCheckingDetail": {
+    "message": "Comprobando tu sesión iniciada…"
+  },
+  "authSignInMissing": {
+    "message": "Inicia sesión para seguir consiguiendo drops."
+  },
+  "authSignInRejected": {
+    "message": "Tu sesión ya no es válida. Vuelve a iniciar sesión para continuar."
+  },
+  "signInToTwitch": {
+    "message": "Iniciar sesión en Twitch"
+  },
+  "signInToKick": {
+    "message": "Iniciar sesión en Kick"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "Kick rechazó este perfil del navegador. Puede que iniciar sesión no sea suficiente para resolverlo."
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "No se pudo comprobar la sesión del navegador. Lurkloot volverá a intentarlo automáticamente."
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "La red no está disponible temporalmente. Lurkloot volverá a intentarlo automáticamente."
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "La plataforma no está disponible temporalmente. Lurkloot volverá a intentarlo automáticamente."
+  },
+  "automationPausedTabClosed": {
+    "message": "En pausa — pestaña cerrada"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "Cerraste la pestaña de farmeo, así que Lurkloot dejó de farmear aquí."
+  },
+  "resumeFarming": {
+    "message": "Reanudar farmeo"
+  },
+  "activityReasonManualTabClose": {
+    "message": "pestaña de farmeo cerrada"
+  }
 }

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "Visionnage en pause. Activez le bouton pour reprendre le farm de drops."
   },
-  "hideTipsTitle": { "message": "Masquer les astuces" },
-  "hideTipsDescription": { "message": "Masque les astuces de la fenêtre principale." },
-  "tipCampaignPriority": { "message": "Les drops ont priorité sur la liste de veille inactive. Faites glisser les campagnes par la poignée pour les ordonner." },
-  "tipMissingCampaigns": { "message": "Une campagne manque ? Vérifiez l’inventaire Drops de la plateforme puis les filtres dans les paramètres." },
-  "tipCategorySelection": { "message": "Seulement certains jeux ? Désactivez « Farmer toutes les catégories » et choisissez vos catégories." },
-  "tipIdleWatchlist": { "message": "La liste de veille inactive farme les chaînes choisies lorsqu’aucun drop éligible n’est disponible." },
-  "tipTablessMode": { "message": "Le mode sans onglet utilise moins de ressources et ouvre un onglet muet si nécessaire." },
-  "tipCli": { "message": "Vous préférez éviter l’extension ? Lurkloot existe aussi en CLI Docker." },
-  "tipCliAction": { "message": "Lire le guide CLI" },
-  "tipFeedback": { "message": "Un bug ou une idée ?" },
-  "tipFeedbackAction": { "message": "Ouvrir une issue GitHub" },
-  "tipExcludedCampaigns": { "message": "Campagne exclue par erreur ? Restaurez-la dans les paramètres des Drops." },
+  "hideTipsTitle": {
+    "message": "Masquer les astuces"
+  },
+  "hideTipsDescription": {
+    "message": "Masque les astuces de la fenêtre principale."
+  },
+  "tipCampaignPriority": {
+    "message": "Les drops ont priorité sur la liste de veille inactive. Faites glisser les campagnes par la poignée pour les ordonner."
+  },
+  "tipMissingCampaigns": {
+    "message": "Une campagne manque ? Vérifiez l’inventaire Drops de la plateforme puis les filtres dans les paramètres."
+  },
+  "tipCategorySelection": {
+    "message": "Seulement certains jeux ? Désactivez « Farmer toutes les catégories » et choisissez vos catégories."
+  },
+  "tipIdleWatchlist": {
+    "message": "La liste de veille inactive farme les chaînes choisies lorsqu’aucun drop éligible n’est disponible."
+  },
+  "tipTablessMode": {
+    "message": "Le mode sans onglet utilise moins de ressources et ouvre un onglet muet si nécessaire."
+  },
+  "tipCli": {
+    "message": "Vous préférez éviter l’extension ? Lurkloot existe aussi en CLI Docker."
+  },
+  "tipCliAction": {
+    "message": "Lire le guide CLI"
+  },
+  "tipFeedback": {
+    "message": "Un bug ou une idée ?"
+  },
+  "tipFeedbackAction": {
+    "message": "Ouvrir une issue GitHub"
+  },
+  "tipExcludedCampaigns": {
+    "message": "Campagne exclue par erreur ? Restaurez-la dans les paramètres des Drops."
+  },
   "noCampaigns": {
     "message": "Aucune campagne découverte pour le moment."
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "Farme via des signaux légers au lieu d’un onglet vidéo. Twitch utilise des heartbeats de visionnage ; Kick utilise une connexion spectateur. Revient automatiquement à un onglet si cela ne progresse plus."
   },
-  "tablessFallbackFailureLimitTitle": { "message": "Seuil de repli du mode sans onglet" },
-  "tablessFallbackFailureLimitDescription": { "message": "Ouvre un onglet vidéo après ce nombre d’échecs consécutifs des signaux de visionnage sans onglet." },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "Activez le mode basse consommation sans onglet pour modifier ce réglage." },
-  "failuresSuffix": { "message": "échecs" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "Seuil de repli du mode sans onglet"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "Ouvre un onglet vidéo après ce nombre d’échecs consécutifs des signaux de visionnage sans onglet."
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "Activez le mode basse consommation sans onglet pour modifier ce réglage."
+  },
+  "failuresSuffix": {
+    "message": "échecs"
+  },
   "autoCloseTabsTitle": {
     "message": "Fermer automatiquement les onglets de farm"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "s"
   },
-  "deadlineSafetyMarginTitle": { "message": "Marge de sécurité avant échéance" },
-  "deadlineSafetyMarginDescription": { "message": "Minutes supplémentaires requises avant de farmer une récompense." },
-  "deadlineSafetyMarginDisabledReason": { "message": "Activez le filtre des échéances pour modifier la marge." },
-  "skipUnfinishableRewardsTitle": { "message": "Ignorer les récompenses impossibles à terminer" },
-  "skipUnfinishableRewardsDescription": { "message": "Ne pas farmer une récompense si le temps de visionnage restant dépasse son échéance." },
-  "minutesSuffix": { "message": "min." },
-  "insufficientTimeRemaining": { "message": "Temps restant insuffisant" },
+  "deadlineSafetyMarginTitle": {
+    "message": "Marge de sécurité avant échéance"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "Minutes supplémentaires requises avant de farmer une récompense."
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "Activez le filtre des échéances pour modifier la marge."
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "Ignorer les récompenses impossibles à terminer"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "Ne pas farmer une récompense si le temps de visionnage restant dépasse son échéance."
+  },
+  "minutesSuffix": {
+    "message": "min."
+  },
+  "insufficientTimeRemaining": {
+    "message": "Temps restant insuffisant"
+  },
   "automationSectionTitle": {
     "message": "Automatisation"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "Site web"
   },
-  "updateNoticeTitle": { "message": "Lurkloot a été mis à jour vers la version $1" },
-  "updateNoticeBody": { "message": "Découvrez les nouveautés et les changements." },
-  "updateNoticeAction": { "message": "Voir les changements" },
-  "updateNoticeDismiss": { "message": "Fermer l’avis de mise à jour" },
+  "updateNoticeTitle": {
+    "message": "Lurkloot a été mis à jour vers la version $1"
+  },
+  "updateNoticeBody": {
+    "message": "Découvrez les nouveautés et les changements."
+  },
+  "updateNoticeAction": {
+    "message": "Voir les changements"
+  },
+  "updateNoticeDismiss": {
+    "message": "Fermer l’avis de mise à jour"
+  },
   "rateNudgeTitle": {
     "message": "Lurkloot vous plaît ?"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "Exporter les identifiants"
   },
-  "factoryResetTitle": { "message": "Réinitialiser Lurkloot" },
-  "factoryResetHint": { "message": "Efface tous les réglages, la progression de farming et l’historique d’activité de Lurkloot. Vos comptes Twitch et Kick restent connectés." },
-  "factoryResetButton": { "message": "Réinitialiser Lurkloot" },
-  "factoryResetConfirm": { "message": "Cela arrête le farming, ferme les onglets ouverts par Lurkloot et efface définitivement toutes ses données. Twitch et Kick restent connectés." },
-  "factoryResetCancel": { "message": "Annuler" },
-  "factoryResetConfirmButton": { "message": "Tout réinitialiser" },
-  "factoryResetProgress": { "message": "Réinitialisation…" },
-  "factoryResetFailed": { "message": "Lurkloot n’a pas pu être entièrement réinitialisé. Réessayez." },
-  "factoryResetRetry": { "message": "Réessayer" },
+  "factoryResetTitle": {
+    "message": "Réinitialiser Lurkloot"
+  },
+  "factoryResetHint": {
+    "message": "Efface tous les réglages, la progression de farming et l’historique d’activité de Lurkloot. Vos comptes Twitch et Kick restent connectés."
+  },
+  "factoryResetButton": {
+    "message": "Réinitialiser Lurkloot"
+  },
+  "factoryResetConfirm": {
+    "message": "Cela arrête le farming, ferme les onglets ouverts par Lurkloot et efface définitivement toutes ses données. Twitch et Kick restent connectés."
+  },
+  "factoryResetCancel": {
+    "message": "Annuler"
+  },
+  "factoryResetConfirmButton": {
+    "message": "Tout réinitialiser"
+  },
+  "factoryResetProgress": {
+    "message": "Réinitialisation…"
+  },
+  "factoryResetFailed": {
+    "message": "Lurkloot n’a pas pu être entièrement réinitialisé. Réessayez."
+  },
+  "factoryResetRetry": {
+    "message": "Réessayer"
+  },
   "diagnosticLoggingTitle": {
     "message": "Inclure les journaux de diagnostic"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "Carte $1 réclamée depuis le défi $2"
   },
-  "activityAuthHealthChanged": { "message": "L’authentification de $1 est passée de $2 à $3." },
-  "activityCriticalFailureDetected": { "message": "$1 ne fonctionne pas : $2." },
-  "activityCriticalFailureCleared": { "message": "Échec critique de $1 ignoré ; nouvelle tentative en cours." },
-  "criticalFailureReasonNoProgress": { "message": "aucune progression malgré des erreurs répétées" },
-  "criticalFailureReasonPageContextChurn": { "message": "un onglet n’arrêtait pas de se rouvrir" },
-  "criticalFailureTitle": { "message": "Lurkloot a cessé de fonctionner" },
-  "criticalFailureBodyNoProgress": { "message": "Des erreurs répétées et aucune progression des drops depuis longtemps. Quelque chose a probablement changé sur cette plateforme et l'extension ne peut plus obtenir de drops." },
-  "criticalFailureBodyTabChurn": { "message": "Un onglet se rouvrait sans cesse. La réouverture a été stoppée pour que vous puissiez utiliser votre navigateur normalement, et le farming est en pause sur cette plateforme." },
-  "criticalFailureCopyAndReport": { "message": "Copier les journaux et ouvrir un ticket" },
-  "criticalFailureDismiss": { "message": "Ignorer et réessayer" },
-  "criticalFailureClipboardFallback": { "message": "Copie automatique impossible. Sélectionnez et copiez ceci, puis ouvrez un ticket." },
-  "activityPageContextOpened": { "message": "Un contexte en arrière-plan a été ouvert sur $1 car $2." },
-  "activityPageContextClosed": { "message": "Le contexte en arrière-plan sur $1 a été fermé car $2." },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick a refusé la requête sans onglet" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "le contexte précédent était inutilisable" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "les requêtes sans onglet ont été rétablies" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "un onglet Kick existant est devenu disponible" },
+  "activityAuthHealthChanged": {
+    "message": "L’authentification de $1 est passée de $2 à $3."
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 ne fonctionne pas : $2."
+  },
+  "activityCriticalFailureCleared": {
+    "message": "Échec critique de $1 ignoré ; nouvelle tentative en cours."
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "aucune progression malgré des erreurs répétées"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "un onglet n’arrêtait pas de se rouvrir"
+  },
+  "criticalFailureTitle": {
+    "message": "Lurkloot a cessé de fonctionner"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "Des erreurs répétées et aucune progression des drops depuis longtemps. Quelque chose a probablement changé sur cette plateforme et l'extension ne peut plus obtenir de drops."
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "Un onglet se rouvrait sans cesse. La réouverture a été stoppée pour que vous puissiez utiliser votre navigateur normalement, et le farming est en pause sur cette plateforme."
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "Copier les journaux et ouvrir un ticket"
+  },
+  "criticalFailureDismiss": {
+    "message": "Ignorer et réessayer"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "Copie automatique impossible. Sélectionnez et copiez ceci, puis ouvrez un ticket."
+  },
+  "activityPageContextOpened": {
+    "message": "Un contexte en arrière-plan a été ouvert sur $1 car $2."
+  },
+  "activityPageContextClosed": {
+    "message": "Le contexte en arrière-plan sur $1 a été fermé car $2."
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick a refusé la requête sans onglet"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "le contexte précédent était inutilisable"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "les requêtes sans onglet ont été rétablies"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "un onglet Kick existant est devenu disponible"
+  },
   "activityInterruption": {
     "message": "Collecte interrompue : $1."
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "la plateforme a été désactivée"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "l’authentification est indisponible" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "l’authentification est indisponible"
+  },
   "activityReasonPlatformBackoff": {
     "message": "la plateforme est temporairement en attente"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "Requête d’inventaire v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "Requête d’inventaire v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick juillet 2026"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "Gestion des liens v2"
   },
-  "automationChecking": { "message": "Vérification" },
-  "automationNeedsSignIn": { "message": "Connexion requise" },
-  "automationBlocked": { "message": "Bloqué" },
-  "automationUnavailable": { "message": "Indisponible" },
-  "authCheckingDetail": { "message": "Vérification de votre session connectée…" },
-  "authSignInMissing": { "message": "Connectez-vous pour continuer à récupérer des drops." },
-  "authSignInRejected": { "message": "Votre session n’est plus valide. Reconnectez-vous pour continuer." },
-  "signInToTwitch": { "message": "Se connecter à Twitch" },
-  "signInToKick": { "message": "Se connecter à Kick" },
-  "authBrowserProfileBlocked": { "message": "Kick a rejeté ce profil de navigateur. Se reconnecter uniquement ne suffira peut-être pas." },
-  "authCredentialCheckUnavailable": { "message": "Votre session de navigateur n’a pas pu être vérifiée. Lurkloot réessaiera automatiquement." },
-  "authNetworkTemporarilyUnavailable": { "message": "Le réseau est temporairement indisponible. Lurkloot réessaiera automatiquement." },
-  "authPlatformTemporarilyUnavailable": { "message": "La plateforme est temporairement indisponible. Lurkloot réessaiera automatiquement." },
-  "automationPausedTabClosed": { "message": "En pause — onglet fermé" },
-  "watchTabClosedPauseDetail": { "message": "Vous avez fermé l'onglet de farming, Lurkloot a donc arrêté de farmer ici." },
-  "resumeFarming": { "message": "Reprendre le farming" },
-  "activityReasonManualTabClose": { "message": "onglet de farming fermé" }
+  "automationChecking": {
+    "message": "Vérification"
+  },
+  "automationNeedsSignIn": {
+    "message": "Connexion requise"
+  },
+  "automationBlocked": {
+    "message": "Bloqué"
+  },
+  "automationUnavailable": {
+    "message": "Indisponible"
+  },
+  "authCheckingDetail": {
+    "message": "Vérification de votre session connectée…"
+  },
+  "authSignInMissing": {
+    "message": "Connectez-vous pour continuer à récupérer des drops."
+  },
+  "authSignInRejected": {
+    "message": "Votre session n’est plus valide. Reconnectez-vous pour continuer."
+  },
+  "signInToTwitch": {
+    "message": "Se connecter à Twitch"
+  },
+  "signInToKick": {
+    "message": "Se connecter à Kick"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "Kick a rejeté ce profil de navigateur. Se reconnecter uniquement ne suffira peut-être pas."
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "Votre session de navigateur n’a pas pu être vérifiée. Lurkloot réessaiera automatiquement."
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "Le réseau est temporairement indisponible. Lurkloot réessaiera automatiquement."
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "La plateforme est temporairement indisponible. Lurkloot réessaiera automatiquement."
+  },
+  "automationPausedTabClosed": {
+    "message": "En pause — onglet fermé"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "Vous avez fermé l'onglet de farming, Lurkloot a donc arrêté de farmer ici."
+  },
+  "resumeFarming": {
+    "message": "Reprendre le farming"
+  },
+  "activityReasonManualTabClose": {
+    "message": "onglet de farming fermé"
+  }
 }

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "देखना रुका है। Drops फ़ार्मिंग फिर शुरू करने के लिए टॉगल करें।"
   },
-  "hideTipsTitle": { "message": "सुझाव छिपाएँ" },
-  "hideTipsDescription": { "message": "मुख्य पॉपअप से उपयोगी सुझाव हटाएँ।" },
-  "tipCampaignPriority": { "message": "Drops को निष्क्रिय वॉचलिस्ट पर प्राथमिकता मिलती है। क्रम तय करने के लिए कैंपेन को ग्रिप से खींचें।" },
-  "tipMissingCampaigns": { "message": "कैंपेन नहीं दिख रहा? प्लेटफ़ॉर्म की Drops इन्वेंट्री और सेटिंग्स के फ़िल्टर जाँचें।" },
-  "tipCategorySelection": { "message": "सिर्फ़ कुछ गेम चाहिए? ‘सभी श्रेणियाँ फ़ार्म करें’ बंद करके श्रेणियाँ चुनें।" },
-  "tipIdleWatchlist": { "message": "योग्य Drops न होने पर निष्क्रिय वॉचलिस्ट चुने हुए चैनल फ़ार्म करती है।" },
-  "tipTablessMode": { "message": "टैबलेस मोड कम संसाधन इस्तेमाल करता है और ज़रूरत पर म्यूट टैब खोलता है।" },
-  "tipCli": { "message": "एक्सटेंशन नहीं चाहिए? Lurkloot Docker-आधारित CLI के रूप में भी उपलब्ध है।" },
-  "tipCliAction": { "message": "CLI गाइड पढ़ें" },
-  "tipFeedback": { "message": "बग मिला या कोई सुझाव है?" },
-  "tipFeedbackAction": { "message": "GitHub issue खोलें" },
-  "tipExcludedCampaigns": { "message": "गलती से कैंपेन हटाया? उसे Drops सेटिंग्स से वापस लाएँ।" },
+  "hideTipsTitle": {
+    "message": "सुझाव छिपाएँ"
+  },
+  "hideTipsDescription": {
+    "message": "मुख्य पॉपअप से उपयोगी सुझाव हटाएँ।"
+  },
+  "tipCampaignPriority": {
+    "message": "Drops को निष्क्रिय वॉचलिस्ट पर प्राथमिकता मिलती है। क्रम तय करने के लिए कैंपेन को ग्रिप से खींचें।"
+  },
+  "tipMissingCampaigns": {
+    "message": "कैंपेन नहीं दिख रहा? प्लेटफ़ॉर्म की Drops इन्वेंट्री और सेटिंग्स के फ़िल्टर जाँचें।"
+  },
+  "tipCategorySelection": {
+    "message": "सिर्फ़ कुछ गेम चाहिए? ‘सभी श्रेणियाँ फ़ार्म करें’ बंद करके श्रेणियाँ चुनें।"
+  },
+  "tipIdleWatchlist": {
+    "message": "योग्य Drops न होने पर निष्क्रिय वॉचलिस्ट चुने हुए चैनल फ़ार्म करती है।"
+  },
+  "tipTablessMode": {
+    "message": "टैबलेस मोड कम संसाधन इस्तेमाल करता है और ज़रूरत पर म्यूट टैब खोलता है।"
+  },
+  "tipCli": {
+    "message": "एक्सटेंशन नहीं चाहिए? Lurkloot Docker-आधारित CLI के रूप में भी उपलब्ध है।"
+  },
+  "tipCliAction": {
+    "message": "CLI गाइड पढ़ें"
+  },
+  "tipFeedback": {
+    "message": "बग मिला या कोई सुझाव है?"
+  },
+  "tipFeedbackAction": {
+    "message": "GitHub issue खोलें"
+  },
+  "tipExcludedCampaigns": {
+    "message": "गलती से कैंपेन हटाया? उसे Drops सेटिंग्स से वापस लाएँ।"
+  },
   "noCampaigns": {
     "message": "अभी कोई अभियान नहीं मिला।"
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "वीडियो टैब के बजाय हल्के watch signals से फ़ार्म करें। Twitch watch heartbeats उपयोग करता है; Kick viewer connection उपयोग करता है। कमाई रुकने पर अपने आप टैब पर लौटता है।"
   },
-  "tablessFallbackFailureLimitTitle": { "message": "टैबलेस फ़ॉलबैक सीमा" },
-  "tablessFallbackFailureLimitDescription": { "message": "लगातार इतनी टैबलेस वॉच सिग्नल विफलताओं के बाद वीडियो टैब खोलें।" },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "यह सेटिंग बदलने के लिए कम-संसाधन टैबलेस मोड चालू करें।" },
-  "failuresSuffix": { "message": "विफलताएँ" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "टैबलेस फ़ॉलबैक सीमा"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "लगातार इतनी टैबलेस वॉच सिग्नल विफलताओं के बाद वीडियो टैब खोलें।"
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "यह सेटिंग बदलने के लिए कम-संसाधन टैबलेस मोड चालू करें।"
+  },
+  "failuresSuffix": {
+    "message": "विफलताएँ"
+  },
   "autoCloseTabsTitle": {
     "message": "फ़ार्मिंग टैब अपने आप बंद करें"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "सेक"
   },
-  "deadlineSafetyMarginTitle": { "message": "समय-सीमा सुरक्षा मार्जिन" },
-  "deadlineSafetyMarginDescription": { "message": "इनाम फ़ार्म करने से पहले आवश्यक अतिरिक्त मिनट।" },
-  "deadlineSafetyMarginDisabledReason": { "message": "सुरक्षा मार्जिन बदलने के लिए समय-सीमा फ़िल्टर सक्षम करें।" },
-  "skipUnfinishableRewardsTitle": { "message": "पूरा न हो सकने वाले इनाम छोड़ें" },
-  "skipUnfinishableRewardsDescription": { "message": "जब बचा हुआ देखने का समय समय-सीमा से अधिक हो तो इनाम फ़ार्म न करें।" },
-  "minutesSuffix": { "message": "मिनट" },
-  "insufficientTimeRemaining": { "message": "पर्याप्त समय शेष नहीं" },
+  "deadlineSafetyMarginTitle": {
+    "message": "समय-सीमा सुरक्षा मार्जिन"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "इनाम फ़ार्म करने से पहले आवश्यक अतिरिक्त मिनट।"
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "सुरक्षा मार्जिन बदलने के लिए समय-सीमा फ़िल्टर सक्षम करें।"
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "पूरा न हो सकने वाले इनाम छोड़ें"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "जब बचा हुआ देखने का समय समय-सीमा से अधिक हो तो इनाम फ़ार्म न करें।"
+  },
+  "minutesSuffix": {
+    "message": "मिनट"
+  },
+  "insufficientTimeRemaining": {
+    "message": "पर्याप्त समय शेष नहीं"
+  },
   "automationSectionTitle": {
     "message": "ऑटोमेशन"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "वेबसाइट"
   },
-  "updateNoticeTitle": { "message": "Lurkloot को $1 में अपडेट किया गया" },
-  "updateNoticeBody": { "message": "नई सुविधाएँ और बदलाव देखें।" },
-  "updateNoticeAction": { "message": "बदलाव देखें" },
-  "updateNoticeDismiss": { "message": "अपडेट सूचना हटाएँ" },
+  "updateNoticeTitle": {
+    "message": "Lurkloot को $1 में अपडेट किया गया"
+  },
+  "updateNoticeBody": {
+    "message": "नई सुविधाएँ और बदलाव देखें।"
+  },
+  "updateNoticeAction": {
+    "message": "बदलाव देखें"
+  },
+  "updateNoticeDismiss": {
+    "message": "अपडेट सूचना हटाएँ"
+  },
   "rateNudgeTitle": {
     "message": "Lurkloot पसंद आया?"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "क्रेडेंशियल निर्यात करें"
   },
-  "factoryResetTitle": { "message": "Lurkloot रीसेट करें" },
-  "factoryResetHint": { "message": "Lurkloot की सभी सेटिंग, फ़ार्मिंग प्रगति और गतिविधि इतिहास मिटाता है। आपके Twitch और Kick खाते साइन इन रहेंगे।" },
-  "factoryResetButton": { "message": "Lurkloot रीसेट करें" },
-  "factoryResetConfirm": { "message": "यह फ़ार्मिंग रोकता है, Lurkloot द्वारा खोले गए टैब बंद करता है और Lurkloot का सारा डेटा स्थायी रूप से मिटाता है। Twitch और Kick साइन इन रहेंगे।" },
-  "factoryResetCancel": { "message": "रद्द करें" },
-  "factoryResetConfirmButton": { "message": "सब कुछ रीसेट करें" },
-  "factoryResetProgress": { "message": "रीसेट किया जा रहा है…" },
-  "factoryResetFailed": { "message": "Lurkloot पूरी तरह रीसेट नहीं हो सका। फिर से कोशिश करें।" },
-  "factoryResetRetry": { "message": "फिर से रीसेट करें" },
+  "factoryResetTitle": {
+    "message": "Lurkloot रीसेट करें"
+  },
+  "factoryResetHint": {
+    "message": "Lurkloot की सभी सेटिंग, फ़ार्मिंग प्रगति और गतिविधि इतिहास मिटाता है। आपके Twitch और Kick खाते साइन इन रहेंगे।"
+  },
+  "factoryResetButton": {
+    "message": "Lurkloot रीसेट करें"
+  },
+  "factoryResetConfirm": {
+    "message": "यह फ़ार्मिंग रोकता है, Lurkloot द्वारा खोले गए टैब बंद करता है और Lurkloot का सारा डेटा स्थायी रूप से मिटाता है। Twitch और Kick साइन इन रहेंगे।"
+  },
+  "factoryResetCancel": {
+    "message": "रद्द करें"
+  },
+  "factoryResetConfirmButton": {
+    "message": "सब कुछ रीसेट करें"
+  },
+  "factoryResetProgress": {
+    "message": "रीसेट किया जा रहा है…"
+  },
+  "factoryResetFailed": {
+    "message": "Lurkloot पूरी तरह रीसेट नहीं हो सका। फिर से कोशिश करें।"
+  },
+  "factoryResetRetry": {
+    "message": "फिर से रीसेट करें"
+  },
   "diagnosticLoggingTitle": {
     "message": "डायग्नोस्टिक लॉग शामिल करें"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "$2 चैलेंज से $1 कार्ड प्राप्त किया"
   },
-  "activityAuthHealthChanged": { "message": "$1 प्रमाणीकरण $2 से $3 में बदल गया।" },
-  "activityCriticalFailureDetected": { "message": "$1 काम नहीं कर रहा है: $2।" },
-  "activityCriticalFailureCleared": { "message": "$1 की गंभीर विफलता खारिज की गई; दोबारा प्रयास किया जा रहा है।" },
-  "criticalFailureReasonNoProgress": { "message": "बार-बार त्रुटियों के बावजूद कोई प्रगति नहीं हुई" },
-  "criticalFailureReasonPageContextChurn": { "message": "एक टैब बार-बार फिर से खुल रहा था" },
-  "criticalFailureTitle": { "message": "Lurkloot ने काम करना बंद कर दिया है" },
-  "criticalFailureBodyNoProgress": { "message": "लंबे समय से बार-बार त्रुटियाँ और ड्रॉप्स में कोई प्रगति नहीं। संभवतः इस प्लेटफ़ॉर्म पर कुछ बदल गया है और एक्सटेंशन अब ड्रॉप्स नहीं कमा पा रहा है।" },
-  "criticalFailureBodyTabChurn": { "message": "एक टैब बार-बार फिर से खुल रहा था। इसे रोक दिया गया है ताकि आप ब्राउज़र सामान्य रूप से उपयोग कर सकें, और इस प्लेटफ़ॉर्म पर फ़ार्मिंग रोक दी गई है।" },
-  "criticalFailureCopyAndReport": { "message": "लॉग कॉपी करें और issue खोलें" },
-  "criticalFailureDismiss": { "message": "खारिज करें और फिर कोशिश करें" },
-  "criticalFailureClipboardFallback": { "message": "अपने आप कॉपी नहीं हो सका। इसे चुनकर कॉपी करें, फिर issue खोलें।" },
-  "activityPageContextOpened": { "message": "$1 पर बैकग्राउंड कॉन्टेक्स्ट खोला गया क्योंकि $2।" },
-  "activityPageContextClosed": { "message": "$1 का बैकग्राउंड कॉन्टेक्स्ट बंद किया गया क्योंकि $2।" },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick ने बिना टैब वाला अनुरोध अस्वीकार किया" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "पिछला बैकग्राउंड कॉन्टेक्स्ट उपयोग योग्य नहीं था" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "बिना टैब वाले अनुरोध फिर से काम करने लगे" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "एक मौजूदा Kick टैब उपलब्ध हो गया" },
+  "activityAuthHealthChanged": {
+    "message": "$1 प्रमाणीकरण $2 से $3 में बदल गया।"
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 काम नहीं कर रहा है: $2।"
+  },
+  "activityCriticalFailureCleared": {
+    "message": "$1 की गंभीर विफलता खारिज की गई; दोबारा प्रयास किया जा रहा है।"
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "बार-बार त्रुटियों के बावजूद कोई प्रगति नहीं हुई"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "एक टैब बार-बार फिर से खुल रहा था"
+  },
+  "criticalFailureTitle": {
+    "message": "Lurkloot ने काम करना बंद कर दिया है"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "लंबे समय से बार-बार त्रुटियाँ और ड्रॉप्स में कोई प्रगति नहीं। संभवतः इस प्लेटफ़ॉर्म पर कुछ बदल गया है और एक्सटेंशन अब ड्रॉप्स नहीं कमा पा रहा है।"
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "एक टैब बार-बार फिर से खुल रहा था। इसे रोक दिया गया है ताकि आप ब्राउज़र सामान्य रूप से उपयोग कर सकें, और इस प्लेटफ़ॉर्म पर फ़ार्मिंग रोक दी गई है।"
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "लॉग कॉपी करें और issue खोलें"
+  },
+  "criticalFailureDismiss": {
+    "message": "खारिज करें और फिर कोशिश करें"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "अपने आप कॉपी नहीं हो सका। इसे चुनकर कॉपी करें, फिर issue खोलें।"
+  },
+  "activityPageContextOpened": {
+    "message": "$1 पर बैकग्राउंड कॉन्टेक्स्ट खोला गया क्योंकि $2।"
+  },
+  "activityPageContextClosed": {
+    "message": "$1 का बैकग्राउंड कॉन्टेक्स्ट बंद किया गया क्योंकि $2।"
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick ने बिना टैब वाला अनुरोध अस्वीकार किया"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "पिछला बैकग्राउंड कॉन्टेक्स्ट उपयोग योग्य नहीं था"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "बिना टैब वाले अनुरोध फिर से काम करने लगे"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "एक मौजूदा Kick टैब उपलब्ध हो गया"
+  },
   "activityInterruption": {
     "message": "ड्रॉप जुटाना रुका: $1।"
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "प्लेटफ़ॉर्म बंद किया गया"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "प्रमाणीकरण उपलब्ध नहीं है" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "प्रमाणीकरण उपलब्ध नहीं है"
+  },
   "activityReasonPlatformBackoff": {
     "message": "प्लेटफ़ॉर्म कुछ समय के लिए प्रतीक्षा कर रहा है"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "इन्वेंट्री क्वेरी v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "इन्वेंट्री क्वेरी v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick जुलाई 2026"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "लिंक प्रबंधन v2"
   },
-  "automationChecking": { "message": "जाँच जारी है" },
-  "automationNeedsSignIn": { "message": "साइन इन आवश्यक" },
-  "automationBlocked": { "message": "अवरुद्ध" },
-  "automationUnavailable": { "message": "अनुपलब्ध" },
-  "authCheckingDetail": { "message": "आपके साइन-इन सत्र की जाँच हो रही है…" },
-  "authSignInMissing": { "message": "ड्रॉप पाना जारी रखने के लिए साइन इन करें।" },
-  "authSignInRejected": { "message": "आपका सत्र अब मान्य नहीं है। जारी रखने के लिए फिर से साइन इन करें।" },
-  "signInToTwitch": { "message": "Twitch में साइन इन करें" },
-  "signInToKick": { "message": "Kick में साइन इन करें" },
-  "authBrowserProfileBlocked": { "message": "Kick ने इस ब्राउज़र प्रोफ़ाइल को अस्वीकार कर दिया। केवल साइन इन करने से समस्या शायद हल न हो।" },
-  "authCredentialCheckUnavailable": { "message": "आपके ब्राउज़र सत्र की जाँच नहीं हो सकी। Lurkloot अपने आप फिर प्रयास करेगा।" },
-  "authNetworkTemporarilyUnavailable": { "message": "नेटवर्क अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।" },
-  "authPlatformTemporarilyUnavailable": { "message": "प्लेटफ़ॉर्म अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।" },
-  "automationPausedTabClosed": { "message": "रुका हुआ — टैब बंद" },
-  "watchTabClosedPauseDetail": { "message": "आपने फ़ार्मिंग टैब बंद कर दिया, इसलिए Lurkloot ने यहाँ फ़ार्मिंग रोक दी।" },
-  "resumeFarming": { "message": "फ़ार्मिंग फिर से शुरू करें" },
-  "activityReasonManualTabClose": { "message": "फ़ार्मिंग टैब बंद" }
+  "automationChecking": {
+    "message": "जाँच जारी है"
+  },
+  "automationNeedsSignIn": {
+    "message": "साइन इन आवश्यक"
+  },
+  "automationBlocked": {
+    "message": "अवरुद्ध"
+  },
+  "automationUnavailable": {
+    "message": "अनुपलब्ध"
+  },
+  "authCheckingDetail": {
+    "message": "आपके साइन-इन सत्र की जाँच हो रही है…"
+  },
+  "authSignInMissing": {
+    "message": "ड्रॉप पाना जारी रखने के लिए साइन इन करें।"
+  },
+  "authSignInRejected": {
+    "message": "आपका सत्र अब मान्य नहीं है। जारी रखने के लिए फिर से साइन इन करें।"
+  },
+  "signInToTwitch": {
+    "message": "Twitch में साइन इन करें"
+  },
+  "signInToKick": {
+    "message": "Kick में साइन इन करें"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "Kick ने इस ब्राउज़र प्रोफ़ाइल को अस्वीकार कर दिया। केवल साइन इन करने से समस्या शायद हल न हो।"
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "आपके ब्राउज़र सत्र की जाँच नहीं हो सकी। Lurkloot अपने आप फिर प्रयास करेगा।"
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "नेटवर्क अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।"
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "प्लेटफ़ॉर्म अस्थायी रूप से अनुपलब्ध है। Lurkloot अपने आप फिर प्रयास करेगा।"
+  },
+  "automationPausedTabClosed": {
+    "message": "रुका हुआ — टैब बंद"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "आपने फ़ार्मिंग टैब बंद कर दिया, इसलिए Lurkloot ने यहाँ फ़ार्मिंग रोक दी।"
+  },
+  "resumeFarming": {
+    "message": "फ़ार्मिंग फिर से शुरू करें"
+  },
+  "activityReasonManualTabClose": {
+    "message": "फ़ार्मिंग टैब बंद"
+  }
 }

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "Visione in pausa. Attiva l’interruttore per riprendere il farming dei drop."
   },
-  "hideTipsTitle": { "message": "Nascondi suggerimenti" },
-  "hideTipsDescription": { "message": "Nasconde i suggerimenti dalla finestra principale." },
-  "tipCampaignPriority": { "message": "I drop hanno priorità sulla lista. Trascina le campagne dalla maniglia per ordinarle." },
-  "tipMissingCampaigns": { "message": "Manca una campagna? Controlla l’inventario Drop della piattaforma e i filtri nelle impostazioni." },
-  "tipCategorySelection": { "message": "Vuoi solo alcuni giochi? Disattiva «Farma tutte le categorie» e scegli le categorie." },
-  "tipIdleWatchlist": { "message": "La lista farma i canali scelti quando non ci sono drop idonei." },
-  "tipTablessMode": { "message": "La modalità senza schede usa meno risorse e apre una scheda silenziata quando serve." },
-  "tipCli": { "message": "Preferisci non usare un’estensione? Lurkloot è disponibile anche come CLI Docker." },
-  "tipCliAction": { "message": "Leggi la guida CLI" },
-  "tipFeedback": { "message": "Hai trovato un bug o hai un’idea?" },
-  "tipFeedbackAction": { "message": "Apri una issue GitHub" },
-  "tipExcludedCampaigns": { "message": "Hai escluso una campagna per errore? Ripristinala dalle impostazioni Drop." },
+  "hideTipsTitle": {
+    "message": "Nascondi suggerimenti"
+  },
+  "hideTipsDescription": {
+    "message": "Nasconde i suggerimenti dalla finestra principale."
+  },
+  "tipCampaignPriority": {
+    "message": "I drop hanno priorità sulla lista. Trascina le campagne dalla maniglia per ordinarle."
+  },
+  "tipMissingCampaigns": {
+    "message": "Manca una campagna? Controlla l’inventario Drop della piattaforma e i filtri nelle impostazioni."
+  },
+  "tipCategorySelection": {
+    "message": "Vuoi solo alcuni giochi? Disattiva «Farma tutte le categorie» e scegli le categorie."
+  },
+  "tipIdleWatchlist": {
+    "message": "La lista farma i canali scelti quando non ci sono drop idonei."
+  },
+  "tipTablessMode": {
+    "message": "La modalità senza schede usa meno risorse e apre una scheda silenziata quando serve."
+  },
+  "tipCli": {
+    "message": "Preferisci non usare un’estensione? Lurkloot è disponibile anche come CLI Docker."
+  },
+  "tipCliAction": {
+    "message": "Leggi la guida CLI"
+  },
+  "tipFeedback": {
+    "message": "Hai trovato un bug o hai un’idea?"
+  },
+  "tipFeedbackAction": {
+    "message": "Apri una issue GitHub"
+  },
+  "tipExcludedCampaigns": {
+    "message": "Hai escluso una campagna per errore? Ripristinala dalle impostazioni Drop."
+  },
   "noCampaigns": {
     "message": "Nessuna campagna scoperta finora."
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "Farma tramite segnali leggeri invece di una scheda video. Twitch usa heartbeat di visione; Kick usa una connessione viewer. Torna automaticamente a una scheda se smette di funzionare."
   },
-  "tablessFallbackFailureLimitTitle": { "message": "Soglia di fallback della modalità senza schede" },
-  "tablessFallbackFailureLimitDescription": { "message": "Apre una scheda video dopo questo numero di segnali di visione senza schede falliti consecutivamente." },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "Attiva la modalità a basso consumo senza schede per modificare questa impostazione." },
-  "failuresSuffix": { "message": "errori" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "Soglia di fallback della modalità senza schede"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "Apre una scheda video dopo questo numero di segnali di visione senza schede falliti consecutivamente."
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "Attiva la modalità a basso consumo senza schede per modificare questa impostazione."
+  },
+  "failuresSuffix": {
+    "message": "errori"
+  },
   "autoCloseTabsTitle": {
     "message": "Chiudi automaticamente le schede di farming"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "sec"
   },
-  "deadlineSafetyMarginTitle": { "message": "Margine di sicurezza della scadenza" },
-  "deadlineSafetyMarginDescription": { "message": "Minuti aggiuntivi richiesti prima di farmare una ricompensa." },
-  "deadlineSafetyMarginDisabledReason": { "message": "Attiva il filtro delle scadenze per modificare il margine." },
-  "skipUnfinishableRewardsTitle": { "message": "Salta le ricompense impossibili da completare" },
-  "skipUnfinishableRewardsDescription": { "message": "Non farmare ricompense se il tempo di visione restante supera la scadenza." },
-  "minutesSuffix": { "message": "min." },
-  "insufficientTimeRemaining": { "message": "Tempo rimanente insufficiente" },
+  "deadlineSafetyMarginTitle": {
+    "message": "Margine di sicurezza della scadenza"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "Minuti aggiuntivi richiesti prima di farmare una ricompensa."
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "Attiva il filtro delle scadenze per modificare il margine."
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "Salta le ricompense impossibili da completare"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "Non farmare ricompense se il tempo di visione restante supera la scadenza."
+  },
+  "minutesSuffix": {
+    "message": "min."
+  },
+  "insufficientTimeRemaining": {
+    "message": "Tempo rimanente insufficiente"
+  },
   "automationSectionTitle": {
     "message": "Automazione"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "Sito web"
   },
-  "updateNoticeTitle": { "message": "Lurkloot è stato aggiornato alla versione $1" },
-  "updateNoticeBody": { "message": "Scopri le novità e le modifiche." },
-  "updateNoticeAction": { "message": "Vedi modifiche" },
-  "updateNoticeDismiss": { "message": "Chiudi l’avviso di aggiornamento" },
+  "updateNoticeTitle": {
+    "message": "Lurkloot è stato aggiornato alla versione $1"
+  },
+  "updateNoticeBody": {
+    "message": "Scopri le novità e le modifiche."
+  },
+  "updateNoticeAction": {
+    "message": "Vedi modifiche"
+  },
+  "updateNoticeDismiss": {
+    "message": "Chiudi l’avviso di aggiornamento"
+  },
   "rateNudgeTitle": {
     "message": "Ti piace Lurkloot?"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "Esporta credenziali"
   },
-  "factoryResetTitle": { "message": "Reimposta Lurkloot" },
-  "factoryResetHint": { "message": "Cancella tutte le impostazioni, i progressi di farming e la cronologia attività di Lurkloot. Gli account Twitch e Kick rimarranno connessi." },
-  "factoryResetButton": { "message": "Reimposta Lurkloot" },
-  "factoryResetConfirm": { "message": "Interrompe il farming, chiude le schede aperte da Lurkloot e cancella definitivamente tutti i dati di Lurkloot. Twitch e Kick rimarranno connessi." },
-  "factoryResetCancel": { "message": "Annulla" },
-  "factoryResetConfirmButton": { "message": "Reimposta tutto" },
-  "factoryResetProgress": { "message": "Reimpostazione…" },
-  "factoryResetFailed": { "message": "Non è stato possibile reimpostare completamente Lurkloot. Riprova." },
-  "factoryResetRetry": { "message": "Riprova" },
+  "factoryResetTitle": {
+    "message": "Reimposta Lurkloot"
+  },
+  "factoryResetHint": {
+    "message": "Cancella tutte le impostazioni, i progressi di farming e la cronologia attività di Lurkloot. Gli account Twitch e Kick rimarranno connessi."
+  },
+  "factoryResetButton": {
+    "message": "Reimposta Lurkloot"
+  },
+  "factoryResetConfirm": {
+    "message": "Interrompe il farming, chiude le schede aperte da Lurkloot e cancella definitivamente tutti i dati di Lurkloot. Twitch e Kick rimarranno connessi."
+  },
+  "factoryResetCancel": {
+    "message": "Annulla"
+  },
+  "factoryResetConfirmButton": {
+    "message": "Reimposta tutto"
+  },
+  "factoryResetProgress": {
+    "message": "Reimpostazione…"
+  },
+  "factoryResetFailed": {
+    "message": "Non è stato possibile reimpostare completamente Lurkloot. Riprova."
+  },
+  "factoryResetRetry": {
+    "message": "Riprova"
+  },
   "diagnosticLoggingTitle": {
     "message": "Includi registri diagnostici"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "Riscattata una carta $1 dalla sfida $2"
   },
-  "activityAuthHealthChanged": { "message": "L’autenticazione di $1 è passata da $2 a $3." },
-  "activityCriticalFailureDetected": { "message": "$1 non funziona: $2." },
-  "activityCriticalFailureCleared": { "message": "Errore critico di $1 ignorato; nuovo tentativo in corso." },
-  "criticalFailureReasonNoProgress": { "message": "nessun progresso nonostante errori ripetuti" },
-  "criticalFailureReasonPageContextChurn": { "message": "una scheda continuava a riaprirsi" },
-  "criticalFailureTitle": { "message": "Lurkloot ha smesso di funzionare" },
-  "criticalFailureBodyNoProgress": { "message": "Errori ripetuti e nessun progresso nei drop per molto tempo. Probabilmente qualcosa è cambiato su questa piattaforma e l'estensione non riesce più a ottenere drop." },
-  "criticalFailureBodyTabChurn": { "message": "Una scheda continuava a riaprirsi. La riapertura è stata interrotta così puoi usare il browser normalmente e il farming è in pausa su questa piattaforma." },
-  "criticalFailureCopyAndReport": { "message": "Copia i log e apri una segnalazione" },
-  "criticalFailureDismiss": { "message": "Ignora e riprova" },
-  "criticalFailureClipboardFallback": { "message": "Copia automatica non riuscita. Seleziona e copia questo testo, poi apri una segnalazione." },
-  "activityPageContextOpened": { "message": "È stato aperto un contesto in background su $1 perché $2." },
-  "activityPageContextClosed": { "message": "Il contesto in background su $1 è stato chiuso perché $2." },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick ha rifiutato la richiesta senza scheda" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "il contesto precedente non era utilizzabile" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "le richieste senza scheda sono state ripristinate" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "è diventata disponibile una scheda Kick esistente" },
+  "activityAuthHealthChanged": {
+    "message": "L’autenticazione di $1 è passata da $2 a $3."
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 non funziona: $2."
+  },
+  "activityCriticalFailureCleared": {
+    "message": "Errore critico di $1 ignorato; nuovo tentativo in corso."
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "nessun progresso nonostante errori ripetuti"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "una scheda continuava a riaprirsi"
+  },
+  "criticalFailureTitle": {
+    "message": "Lurkloot ha smesso di funzionare"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "Errori ripetuti e nessun progresso nei drop per molto tempo. Probabilmente qualcosa è cambiato su questa piattaforma e l'estensione non riesce più a ottenere drop."
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "Una scheda continuava a riaprirsi. La riapertura è stata interrotta così puoi usare il browser normalmente e il farming è in pausa su questa piattaforma."
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "Copia i log e apri una segnalazione"
+  },
+  "criticalFailureDismiss": {
+    "message": "Ignora e riprova"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "Copia automatica non riuscita. Seleziona e copia questo testo, poi apri una segnalazione."
+  },
+  "activityPageContextOpened": {
+    "message": "È stato aperto un contesto in background su $1 perché $2."
+  },
+  "activityPageContextClosed": {
+    "message": "Il contesto in background su $1 è stato chiuso perché $2."
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick ha rifiutato la richiesta senza scheda"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "il contesto precedente non era utilizzabile"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "le richieste senza scheda sono state ripristinate"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "è diventata disponibile una scheda Kick esistente"
+  },
   "activityInterruption": {
     "message": "Raccolta interrotta: $1."
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "la piattaforma è stata disattivata"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "l’autenticazione non è disponibile" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "l’autenticazione non è disponibile"
+  },
   "activityReasonPlatformBackoff": {
     "message": "la piattaforma è temporaneamente in attesa"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "Query inventario v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "Query inventario v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick luglio 2026"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "Gestione link v2"
   },
-  "automationChecking": { "message": "Verifica" },
-  "automationNeedsSignIn": { "message": "Accesso necessario" },
-  "automationBlocked": { "message": "Bloccato" },
-  "automationUnavailable": { "message": "Non disponibile" },
-  "authCheckingDetail": { "message": "Verifica della sessione connessa…" },
-  "authSignInMissing": { "message": "Accedi per continuare a ottenere drop." },
-  "authSignInRejected": { "message": "La sessione non è più valida. Accedi di nuovo per continuare." },
-  "signInToTwitch": { "message": "Accedi a Twitch" },
-  "signInToKick": { "message": "Accedi a Kick" },
-  "authBrowserProfileBlocked": { "message": "Kick ha rifiutato questo profilo del browser. Il solo accesso potrebbe non risolvere il problema." },
-  "authCredentialCheckUnavailable": { "message": "Non è stato possibile verificare la sessione del browser. Lurkloot riproverà automaticamente." },
-  "authNetworkTemporarilyUnavailable": { "message": "La rete è temporaneamente non disponibile. Lurkloot riproverà automaticamente." },
-  "authPlatformTemporarilyUnavailable": { "message": "La piattaforma è temporaneamente non disponibile. Lurkloot riproverà automaticamente." },
-  "automationPausedTabClosed": { "message": "In pausa — scheda chiusa" },
-  "watchTabClosedPauseDetail": { "message": "Hai chiuso la scheda di farming, quindi Lurkloot ha smesso di farmare qui." },
-  "resumeFarming": { "message": "Riprendi il farming" },
-  "activityReasonManualTabClose": { "message": "scheda di farming chiusa" }
+  "automationChecking": {
+    "message": "Verifica"
+  },
+  "automationNeedsSignIn": {
+    "message": "Accesso necessario"
+  },
+  "automationBlocked": {
+    "message": "Bloccato"
+  },
+  "automationUnavailable": {
+    "message": "Non disponibile"
+  },
+  "authCheckingDetail": {
+    "message": "Verifica della sessione connessa…"
+  },
+  "authSignInMissing": {
+    "message": "Accedi per continuare a ottenere drop."
+  },
+  "authSignInRejected": {
+    "message": "La sessione non è più valida. Accedi di nuovo per continuare."
+  },
+  "signInToTwitch": {
+    "message": "Accedi a Twitch"
+  },
+  "signInToKick": {
+    "message": "Accedi a Kick"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "Kick ha rifiutato questo profilo del browser. Il solo accesso potrebbe non risolvere il problema."
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "Non è stato possibile verificare la sessione del browser. Lurkloot riproverà automaticamente."
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "La rete è temporaneamente non disponibile. Lurkloot riproverà automaticamente."
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "La piattaforma è temporaneamente non disponibile. Lurkloot riproverà automaticamente."
+  },
+  "automationPausedTabClosed": {
+    "message": "In pausa — scheda chiusa"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "Hai chiuso la scheda di farming, quindi Lurkloot ha smesso di farmare qui."
+  },
+  "resumeFarming": {
+    "message": "Riprendi il farming"
+  },
+  "activityReasonManualTabClose": {
+    "message": "scheda di farming chiusa"
+  }
 }

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "Visualização pausada. Ative para retomar o farming de drops."
   },
-  "hideTipsTitle": { "message": "Ocultar dicas" },
-  "hideTipsDescription": { "message": "Oculta as dicas úteis da janela principal." },
-  "tipCampaignPriority": { "message": "Drops têm prioridade sobre a lista. Arraste as campanhas pela alça para definir a ordem." },
-  "tipMissingCampaigns": { "message": "Não encontrou uma campanha? Confira o inventário de Drops da plataforma e os filtros nas configurações." },
-  "tipCategorySelection": { "message": "Quer apenas certos jogos? Desative “Farmar todas as categorias” e escolha as categorias." },
-  "tipIdleWatchlist": { "message": "A lista farma os canais escolhidos quando não há Drops elegíveis." },
-  "tipTablessMode": { "message": "O modo sem abas usa menos recursos e abre uma aba silenciada quando necessário." },
-  "tipCli": { "message": "Prefere não usar uma extensão? O Lurkloot também oferece uma CLI para Docker." },
-  "tipCliAction": { "message": "Ler o guia da CLI" },
-  "tipFeedback": { "message": "Encontrou um bug ou tem uma ideia?" },
-  "tipFeedbackAction": { "message": "Abrir uma issue no GitHub" },
-  "tipExcludedCampaigns": { "message": "Excluiu uma campanha por engano? Restaure-a nas configurações de Drops." },
+  "hideTipsTitle": {
+    "message": "Ocultar dicas"
+  },
+  "hideTipsDescription": {
+    "message": "Oculta as dicas úteis da janela principal."
+  },
+  "tipCampaignPriority": {
+    "message": "Drops têm prioridade sobre a lista. Arraste as campanhas pela alça para definir a ordem."
+  },
+  "tipMissingCampaigns": {
+    "message": "Não encontrou uma campanha? Confira o inventário de Drops da plataforma e os filtros nas configurações."
+  },
+  "tipCategorySelection": {
+    "message": "Quer apenas certos jogos? Desative “Farmar todas as categorias” e escolha as categorias."
+  },
+  "tipIdleWatchlist": {
+    "message": "A lista farma os canais escolhidos quando não há Drops elegíveis."
+  },
+  "tipTablessMode": {
+    "message": "O modo sem abas usa menos recursos e abre uma aba silenciada quando necessário."
+  },
+  "tipCli": {
+    "message": "Prefere não usar uma extensão? O Lurkloot também oferece uma CLI para Docker."
+  },
+  "tipCliAction": {
+    "message": "Ler o guia da CLI"
+  },
+  "tipFeedback": {
+    "message": "Encontrou um bug ou tem uma ideia?"
+  },
+  "tipFeedbackAction": {
+    "message": "Abrir uma issue no GitHub"
+  },
+  "tipExcludedCampaigns": {
+    "message": "Excluiu uma campanha por engano? Restaure-a nas configurações de Drops."
+  },
   "noCampaigns": {
     "message": "Nenhuma campanha descoberta ainda."
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "Farma por sinais leves de visualização em vez de uma aba de vídeo. Twitch usa heartbeats; Kick usa uma conexão de espectador. Volta para uma aba automaticamente se parar de contar."
   },
-  "tablessFallbackFailureLimitTitle": { "message": "Limite de fallback do modo sem abas" },
-  "tablessFallbackFailureLimitDescription": { "message": "Abre uma aba de vídeo após esta quantidade de falhas consecutivas nos sinais de visualização sem abas." },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "Ative o modo de baixo consumo sem abas para alterar esta configuração." },
-  "failuresSuffix": { "message": "falhas" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "Limite de fallback do modo sem abas"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "Abre uma aba de vídeo após esta quantidade de falhas consecutivas nos sinais de visualização sem abas."
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "Ative o modo de baixo consumo sem abas para alterar esta configuração."
+  },
+  "failuresSuffix": {
+    "message": "falhas"
+  },
   "autoCloseTabsTitle": {
     "message": "Fechar abas de farming automaticamente"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "s"
   },
-  "deadlineSafetyMarginTitle": { "message": "Margem de segurança do prazo" },
-  "deadlineSafetyMarginDescription": { "message": "Minutos extras antes de farmar uma recompensa." },
-  "deadlineSafetyMarginDisabledReason": { "message": "Ative o filtro de prazo para alterar a margem de segurança." },
-  "skipUnfinishableRewardsTitle": { "message": "Pular recompensas que não podem ser concluídas" },
-  "skipUnfinishableRewardsDescription": { "message": "Não farmar recompensas quando o tempo restante de exibição ultrapassar o prazo." },
-  "minutesSuffix": { "message": "min." },
-  "insufficientTimeRemaining": { "message": "Tempo restante insuficiente" },
+  "deadlineSafetyMarginTitle": {
+    "message": "Margem de segurança do prazo"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "Minutos extras antes de farmar uma recompensa."
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "Ative o filtro de prazo para alterar a margem de segurança."
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "Pular recompensas que não podem ser concluídas"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "Não farmar recompensas quando o tempo restante de exibição ultrapassar o prazo."
+  },
+  "minutesSuffix": {
+    "message": "min."
+  },
+  "insufficientTimeRemaining": {
+    "message": "Tempo restante insuficiente"
+  },
   "automationSectionTitle": {
     "message": "Automação"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "Site"
   },
-  "updateNoticeTitle": { "message": "O Lurkloot foi atualizado para a versão $1" },
-  "updateNoticeBody": { "message": "Veja as novidades e o que mudou." },
-  "updateNoticeAction": { "message": "Ver alterações" },
-  "updateNoticeDismiss": { "message": "Dispensar aviso de atualização" },
+  "updateNoticeTitle": {
+    "message": "O Lurkloot foi atualizado para a versão $1"
+  },
+  "updateNoticeBody": {
+    "message": "Veja as novidades e o que mudou."
+  },
+  "updateNoticeAction": {
+    "message": "Ver alterações"
+  },
+  "updateNoticeDismiss": {
+    "message": "Dispensar aviso de atualização"
+  },
   "rateNudgeTitle": {
     "message": "Curtindo o Lurkloot?"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "Exportar credenciais"
   },
-  "factoryResetTitle": { "message": "Redefinir o Lurkloot" },
-  "factoryResetHint": { "message": "Apaga todas as configurações, o progresso de farming e o histórico de atividades do Lurkloot. Suas contas da Twitch e Kick continuarão conectadas." },
-  "factoryResetButton": { "message": "Redefinir o Lurkloot" },
-  "factoryResetConfirm": { "message": "Isso interrompe o farming, fecha as abas abertas pelo Lurkloot e apaga permanentemente todos os dados. Twitch e Kick continuarão conectados." },
-  "factoryResetCancel": { "message": "Cancelar" },
-  "factoryResetConfirmButton": { "message": "Redefinir tudo" },
-  "factoryResetProgress": { "message": "Redefinindo…" },
-  "factoryResetFailed": { "message": "Não foi possível redefinir o Lurkloot por completo. Tente novamente." },
-  "factoryResetRetry": { "message": "Tentar novamente" },
+  "factoryResetTitle": {
+    "message": "Redefinir o Lurkloot"
+  },
+  "factoryResetHint": {
+    "message": "Apaga todas as configurações, o progresso de farming e o histórico de atividades do Lurkloot. Suas contas da Twitch e Kick continuarão conectadas."
+  },
+  "factoryResetButton": {
+    "message": "Redefinir o Lurkloot"
+  },
+  "factoryResetConfirm": {
+    "message": "Isso interrompe o farming, fecha as abas abertas pelo Lurkloot e apaga permanentemente todos os dados. Twitch e Kick continuarão conectados."
+  },
+  "factoryResetCancel": {
+    "message": "Cancelar"
+  },
+  "factoryResetConfirmButton": {
+    "message": "Redefinir tudo"
+  },
+  "factoryResetProgress": {
+    "message": "Redefinindo…"
+  },
+  "factoryResetFailed": {
+    "message": "Não foi possível redefinir o Lurkloot por completo. Tente novamente."
+  },
+  "factoryResetRetry": {
+    "message": "Tentar novamente"
+  },
   "diagnosticLoggingTitle": {
     "message": "Incluir registros de diagnóstico"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "Carta $1 resgatada do desafio $2"
   },
-  "activityAuthHealthChanged": { "message": "A autenticação da $1 mudou de $2 para $3." },
-  "activityCriticalFailureDetected": { "message": "$1 não está funcionando: $2." },
-  "activityCriticalFailureCleared": { "message": "Falha crítica da $1 dispensada; tentando novamente." },
-  "criticalFailureReasonNoProgress": { "message": "sem progresso apesar de erros repetidos" },
-  "criticalFailureReasonPageContextChurn": { "message": "uma aba ficava reabrindo" },
-  "criticalFailureTitle": { "message": "O Lurkloot parou de funcionar" },
-  "criticalFailureBodyNoProgress": { "message": "Erros repetidos e nenhum progresso nos drops por muito tempo. Provavelmente algo mudou nesta plataforma e a extensão não consegue mais ganhar drops." },
-  "criticalFailureBodyTabChurn": { "message": "Uma aba ficava reabrindo sem parar. A reabertura foi interrompida para você usar o navegador normalmente, e o farm está pausado nesta plataforma." },
-  "criticalFailureCopyAndReport": { "message": "Copiar logs e abrir issue" },
-  "criticalFailureDismiss": { "message": "Dispensar e tentar de novo" },
-  "criticalFailureClipboardFallback": { "message": "Não foi possível copiar automaticamente. Selecione e copie este texto e abra uma issue." },
-  "activityPageContextOpened": { "message": "Um contexto em segundo plano foi aberto em $1 porque $2." },
-  "activityPageContextClosed": { "message": "O contexto em segundo plano em $1 foi fechado porque $2." },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "a Kick rejeitou a solicitação sem aba" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "o contexto anterior não podia ser usado" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "as solicitações sem aba voltaram a funcionar" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "uma aba existente da Kick ficou disponível" },
+  "activityAuthHealthChanged": {
+    "message": "A autenticação da $1 mudou de $2 para $3."
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 não está funcionando: $2."
+  },
+  "activityCriticalFailureCleared": {
+    "message": "Falha crítica da $1 dispensada; tentando novamente."
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "sem progresso apesar de erros repetidos"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "uma aba ficava reabrindo"
+  },
+  "criticalFailureTitle": {
+    "message": "O Lurkloot parou de funcionar"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "Erros repetidos e nenhum progresso nos drops por muito tempo. Provavelmente algo mudou nesta plataforma e a extensão não consegue mais ganhar drops."
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "Uma aba ficava reabrindo sem parar. A reabertura foi interrompida para você usar o navegador normalmente, e o farm está pausado nesta plataforma."
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "Copiar logs e abrir issue"
+  },
+  "criticalFailureDismiss": {
+    "message": "Dispensar e tentar de novo"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "Não foi possível copiar automaticamente. Selecione e copie este texto e abra uma issue."
+  },
+  "activityPageContextOpened": {
+    "message": "Um contexto em segundo plano foi aberto em $1 porque $2."
+  },
+  "activityPageContextClosed": {
+    "message": "O contexto em segundo plano em $1 foi fechado porque $2."
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "a Kick rejeitou a solicitação sem aba"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "o contexto anterior não podia ser usado"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "as solicitações sem aba voltaram a funcionar"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "uma aba existente da Kick ficou disponível"
+  },
   "activityInterruption": {
     "message": "Coleta interrompida: $1."
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "a plataforma foi desativada"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "a autenticação não está disponível" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "a autenticação não está disponível"
+  },
   "activityReasonPlatformBackoff": {
     "message": "a plataforma está aguardando temporariamente"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "Consulta de inventário v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "Consulta de inventário v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick julho de 2026"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "Tratamento de links v2"
   },
-  "automationChecking": { "message": "Verificando" },
-  "automationNeedsSignIn": { "message": "Login necessário" },
-  "automationBlocked": { "message": "Bloqueado" },
-  "automationUnavailable": { "message": "Indisponível" },
-  "authCheckingDetail": { "message": "Verificando sua sessão conectada…" },
-  "authSignInMissing": { "message": "Entre na sua conta para continuar coletando drops." },
-  "authSignInRejected": { "message": "Sua sessão não é mais válida. Entre novamente para continuar." },
-  "signInToTwitch": { "message": "Entrar na Twitch" },
-  "signInToKick": { "message": "Entrar na Kick" },
-  "authBrowserProfileBlocked": { "message": "A Kick rejeitou este perfil do navegador. Apenas entrar na conta pode não resolver o problema." },
-  "authCredentialCheckUnavailable": { "message": "Não foi possível verificar a sessão do navegador. O Lurkloot tentará novamente automaticamente." },
-  "authNetworkTemporarilyUnavailable": { "message": "A rede está temporariamente indisponível. O Lurkloot tentará novamente automaticamente." },
-  "authPlatformTemporarilyUnavailable": { "message": "A plataforma está temporariamente indisponível. O Lurkloot tentará novamente automaticamente." },
-  "automationPausedTabClosed": { "message": "Pausado — aba fechada" },
-  "watchTabClosedPauseDetail": { "message": "Você fechou a aba de farm, então o Lurkloot parou de farmar aqui." },
-  "resumeFarming": { "message": "Retomar farm" },
-  "activityReasonManualTabClose": { "message": "aba de farm fechada" }
+  "automationChecking": {
+    "message": "Verificando"
+  },
+  "automationNeedsSignIn": {
+    "message": "Login necessário"
+  },
+  "automationBlocked": {
+    "message": "Bloqueado"
+  },
+  "automationUnavailable": {
+    "message": "Indisponível"
+  },
+  "authCheckingDetail": {
+    "message": "Verificando sua sessão conectada…"
+  },
+  "authSignInMissing": {
+    "message": "Entre na sua conta para continuar coletando drops."
+  },
+  "authSignInRejected": {
+    "message": "Sua sessão não é mais válida. Entre novamente para continuar."
+  },
+  "signInToTwitch": {
+    "message": "Entrar na Twitch"
+  },
+  "signInToKick": {
+    "message": "Entrar na Kick"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "A Kick rejeitou este perfil do navegador. Apenas entrar na conta pode não resolver o problema."
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "Não foi possível verificar a sessão do navegador. O Lurkloot tentará novamente automaticamente."
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "A rede está temporariamente indisponível. O Lurkloot tentará novamente automaticamente."
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "A plataforma está temporariamente indisponível. O Lurkloot tentará novamente automaticamente."
+  },
+  "automationPausedTabClosed": {
+    "message": "Pausado — aba fechada"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "Você fechou a aba de farm, então o Lurkloot parou de farmar aqui."
+  },
+  "resumeFarming": {
+    "message": "Retomar farm"
+  },
+  "activityReasonManualTabClose": {
+    "message": "aba de farm fechada"
+  }
 }

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "Просмотр приостановлен. Включите переключатель, чтобы продолжить фарм drops."
   },
-  "hideTipsTitle": { "message": "Скрыть советы" },
-  "hideTipsDescription": { "message": "Скрывает полезные советы в главном окне." },
-  "tipCampaignPriority": { "message": "Drops имеют приоритет над списком. Перетаскивайте кампании за ручку, чтобы задать порядок." },
-  "tipMissingCampaigns": { "message": "Нет кампании? Проверьте инвентарь Drops платформы и фильтры в настройках." },
-  "tipCategorySelection": { "message": "Нужны только отдельные игры? Отключите «Фармить все категории» и выберите категории." },
-  "tipIdleWatchlist": { "message": "Список фармит выбранные каналы, когда нет доступных Drops." },
-  "tipTablessMode": { "message": "Режим без вкладок экономит ресурсы и при необходимости открывает вкладку без звука." },
-  "tipCli": { "message": "Не хотите расширение? Lurkloot также доступен как CLI для Docker." },
-  "tipCliAction": { "message": "Открыть руководство CLI" },
-  "tipFeedback": { "message": "Нашли ошибку или есть идея?" },
-  "tipFeedbackAction": { "message": "Создать issue на GitHub" },
-  "tipExcludedCampaigns": { "message": "Исключили кампанию случайно? Восстановите её в настройках Drops." },
+  "hideTipsTitle": {
+    "message": "Скрыть советы"
+  },
+  "hideTipsDescription": {
+    "message": "Скрывает полезные советы в главном окне."
+  },
+  "tipCampaignPriority": {
+    "message": "Drops имеют приоритет над списком. Перетаскивайте кампании за ручку, чтобы задать порядок."
+  },
+  "tipMissingCampaigns": {
+    "message": "Нет кампании? Проверьте инвентарь Drops платформы и фильтры в настройках."
+  },
+  "tipCategorySelection": {
+    "message": "Нужны только отдельные игры? Отключите «Фармить все категории» и выберите категории."
+  },
+  "tipIdleWatchlist": {
+    "message": "Список фармит выбранные каналы, когда нет доступных Drops."
+  },
+  "tipTablessMode": {
+    "message": "Режим без вкладок экономит ресурсы и при необходимости открывает вкладку без звука."
+  },
+  "tipCli": {
+    "message": "Не хотите расширение? Lurkloot также доступен как CLI для Docker."
+  },
+  "tipCliAction": {
+    "message": "Открыть руководство CLI"
+  },
+  "tipFeedback": {
+    "message": "Нашли ошибку или есть идея?"
+  },
+  "tipFeedbackAction": {
+    "message": "Создать issue на GitHub"
+  },
+  "tipExcludedCampaigns": {
+    "message": "Исключили кампанию случайно? Восстановите её в настройках Drops."
+  },
   "noCampaigns": {
     "message": "Кампании пока не обнаружены."
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "Фармит лёгкими сигналами просмотра вместо видеовкладки. Twitch использует heartbeats просмотра; Kick — соединение зрителя. Автоматически возвращается к вкладке, если прогресс останавливается."
   },
-  "tablessFallbackFailureLimitTitle": { "message": "Порог перехода из режима без вкладок" },
-  "tablessFallbackFailureLimitDescription": { "message": "Открывает вкладку с видео после указанного числа последовательных сбоев сигналов просмотра без вкладки." },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "Включите ресурсосберегающий режим без вкладок, чтобы изменить эту настройку." },
-  "failuresSuffix": { "message": "сбоев" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "Порог перехода из режима без вкладок"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "Открывает вкладку с видео после указанного числа последовательных сбоев сигналов просмотра без вкладки."
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "Включите ресурсосберегающий режим без вкладок, чтобы изменить эту настройку."
+  },
+  "failuresSuffix": {
+    "message": "сбоев"
+  },
   "autoCloseTabsTitle": {
     "message": "Автозакрытие вкладок фарма"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "с"
   },
-  "deadlineSafetyMarginTitle": { "message": "Запас времени до окончания" },
-  "deadlineSafetyMarginDescription": { "message": "Дополнительные минуты перед фармом награды." },
-  "deadlineSafetyMarginDisabledReason": { "message": "Включите фильтр сроков, чтобы изменить запас времени." },
-  "skipUnfinishableRewardsTitle": { "message": "Пропускать награды, которые нельзя завершить" },
-  "skipUnfinishableRewardsDescription": { "message": "Не фармить награды, если оставшееся время просмотра превышает доступный срок." },
-  "minutesSuffix": { "message": "мин" },
-  "insufficientTimeRemaining": { "message": "Недостаточно оставшегося времени" },
+  "deadlineSafetyMarginTitle": {
+    "message": "Запас времени до окончания"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "Дополнительные минуты перед фармом награды."
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "Включите фильтр сроков, чтобы изменить запас времени."
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "Пропускать награды, которые нельзя завершить"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "Не фармить награды, если оставшееся время просмотра превышает доступный срок."
+  },
+  "minutesSuffix": {
+    "message": "мин"
+  },
+  "insufficientTimeRemaining": {
+    "message": "Недостаточно оставшегося времени"
+  },
   "automationSectionTitle": {
     "message": "Автоматизация"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "Сайт"
   },
-  "updateNoticeTitle": { "message": "Lurkloot обновлён до версии $1" },
-  "updateNoticeBody": { "message": "Узнайте о новых функциях и изменениях." },
-  "updateNoticeAction": { "message": "Посмотреть изменения" },
-  "updateNoticeDismiss": { "message": "Закрыть уведомление об обновлении" },
+  "updateNoticeTitle": {
+    "message": "Lurkloot обновлён до версии $1"
+  },
+  "updateNoticeBody": {
+    "message": "Узнайте о новых функциях и изменениях."
+  },
+  "updateNoticeAction": {
+    "message": "Посмотреть изменения"
+  },
+  "updateNoticeDismiss": {
+    "message": "Закрыть уведомление об обновлении"
+  },
   "rateNudgeTitle": {
     "message": "Нравится Lurkloot?"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "Экспортировать учётные данные"
   },
-  "factoryResetTitle": { "message": "Сбросить Lurkloot" },
-  "factoryResetHint": { "message": "Удаляет все настройки Lurkloot, прогресс фарма и историю действий. Вы останетесь в своих аккаунтах Twitch и Kick." },
-  "factoryResetButton": { "message": "Сбросить Lurkloot" },
-  "factoryResetConfirm": { "message": "Фарм будет остановлен, открытые Lurkloot вкладки закрыты, а все данные Lurkloot удалены навсегда. Вход в Twitch и Kick сохранится." },
-  "factoryResetCancel": { "message": "Отмена" },
-  "factoryResetConfirmButton": { "message": "Сбросить всё" },
-  "factoryResetProgress": { "message": "Сброс…" },
-  "factoryResetFailed": { "message": "Не удалось полностью сбросить Lurkloot. Попробуйте ещё раз." },
-  "factoryResetRetry": { "message": "Повторить сброс" },
+  "factoryResetTitle": {
+    "message": "Сбросить Lurkloot"
+  },
+  "factoryResetHint": {
+    "message": "Удаляет все настройки Lurkloot, прогресс фарма и историю действий. Вы останетесь в своих аккаунтах Twitch и Kick."
+  },
+  "factoryResetButton": {
+    "message": "Сбросить Lurkloot"
+  },
+  "factoryResetConfirm": {
+    "message": "Фарм будет остановлен, открытые Lurkloot вкладки закрыты, а все данные Lurkloot удалены навсегда. Вход в Twitch и Kick сохранится."
+  },
+  "factoryResetCancel": {
+    "message": "Отмена"
+  },
+  "factoryResetConfirmButton": {
+    "message": "Сбросить всё"
+  },
+  "factoryResetProgress": {
+    "message": "Сброс…"
+  },
+  "factoryResetFailed": {
+    "message": "Не удалось полностью сбросить Lurkloot. Попробуйте ещё раз."
+  },
+  "factoryResetRetry": {
+    "message": "Повторить сброс"
+  },
   "diagnosticLoggingTitle": {
     "message": "Включить диагностические журналы"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "Получена карта $1 за испытание $2"
   },
-  "activityAuthHealthChanged": { "message": "Состояние аутентификации $1 изменилось с $2 на $3." },
-  "activityCriticalFailureDetected": { "message": "$1 не работает: $2." },
-  "activityCriticalFailureCleared": { "message": "Критический сбой $1 сброшен; повтор попытки." },
-  "criticalFailureReasonNoProgress": { "message": "нет прогресса, несмотря на повторяющиеся ошибки" },
-  "criticalFailureReasonPageContextChurn": { "message": "вкладка постоянно открывалась заново" },
-  "criticalFailureTitle": { "message": "Lurkloot перестал работать" },
-  "criticalFailureBodyNoProgress": { "message": "Повторяющиеся ошибки и отсутствие прогресса дропов в течение долгого времени. Вероятно, на этой платформе что-то изменилось, и расширение больше не может получать дропы." },
-  "criticalFailureBodyTabChurn": { "message": "Вкладка постоянно открывалась заново. Повторное открытие остановлено, чтобы вы могли нормально пользоваться браузером; фарм на этой платформе приостановлен." },
-  "criticalFailureCopyAndReport": { "message": "Скопировать логи и открыть issue" },
-  "criticalFailureDismiss": { "message": "Закрыть и попробовать снова" },
-  "criticalFailureClipboardFallback": { "message": "Не удалось скопировать автоматически. Выделите и скопируйте этот текст, затем откройте issue." },
-  "activityPageContextOpened": { "message": "Фоновый контекст на $1 открыт, потому что $2." },
-  "activityPageContextClosed": { "message": "Фоновый контекст на $1 закрыт, потому что $2." },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick отклонил запрос без вкладки" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "предыдущий фоновый контекст был непригоден" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "запросы без вкладки снова работают" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "стала доступна существующая вкладка Kick" },
+  "activityAuthHealthChanged": {
+    "message": "Состояние аутентификации $1 изменилось с $2 на $3."
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 не работает: $2."
+  },
+  "activityCriticalFailureCleared": {
+    "message": "Критический сбой $1 сброшен; повтор попытки."
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "нет прогресса, несмотря на повторяющиеся ошибки"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "вкладка постоянно открывалась заново"
+  },
+  "criticalFailureTitle": {
+    "message": "Lurkloot перестал работать"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "Повторяющиеся ошибки и отсутствие прогресса дропов в течение долгого времени. Вероятно, на этой платформе что-то изменилось, и расширение больше не может получать дропы."
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "Вкладка постоянно открывалась заново. Повторное открытие остановлено, чтобы вы могли нормально пользоваться браузером; фарм на этой платформе приостановлен."
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "Скопировать логи и открыть issue"
+  },
+  "criticalFailureDismiss": {
+    "message": "Закрыть и попробовать снова"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "Не удалось скопировать автоматически. Выделите и скопируйте этот текст, затем откройте issue."
+  },
+  "activityPageContextOpened": {
+    "message": "Фоновый контекст на $1 открыт, потому что $2."
+  },
+  "activityPageContextClosed": {
+    "message": "Фоновый контекст на $1 закрыт, потому что $2."
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick отклонил запрос без вкладки"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "предыдущий фоновый контекст был непригоден"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "запросы без вкладки снова работают"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "стала доступна существующая вкладка Kick"
+  },
   "activityInterruption": {
     "message": "Сбор прерван: $1."
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "платформа отключена"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "аутентификация недоступна" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "аутентификация недоступна"
+  },
   "activityReasonPlatformBackoff": {
     "message": "платформа временно ожидает"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "Запрос инвентаря v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "Запрос инвентаря v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick, июль 2026"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "Обработка ссылок v2"
   },
-  "automationChecking": { "message": "Проверка" },
-  "automationNeedsSignIn": { "message": "Требуется вход" },
-  "automationBlocked": { "message": "Заблокировано" },
-  "automationUnavailable": { "message": "Недоступно" },
-  "authCheckingDetail": { "message": "Проверяем активный сеанс…" },
-  "authSignInMissing": { "message": "Войдите, чтобы продолжить получать награды." },
-  "authSignInRejected": { "message": "Сеанс больше недействителен. Войдите снова, чтобы продолжить." },
-  "signInToTwitch": { "message": "Войти в Twitch" },
-  "signInToKick": { "message": "Войти в Kick" },
-  "authBrowserProfileBlocked": { "message": "Kick отклонил этот профиль браузера. Одного входа может быть недостаточно для решения проблемы." },
-  "authCredentialCheckUnavailable": { "message": "Не удалось проверить сеанс браузера. Lurkloot повторит попытку автоматически." },
-  "authNetworkTemporarilyUnavailable": { "message": "Сеть временно недоступна. Lurkloot повторит попытку автоматически." },
-  "authPlatformTemporarilyUnavailable": { "message": "Платформа временно недоступна. Lurkloot повторит попытку автоматически." },
-  "automationPausedTabClosed": { "message": "Пауза — вкладка закрыта" },
-  "watchTabClosedPauseDetail": { "message": "Вы закрыли вкладку фарма, поэтому Lurkloot остановил фарм здесь." },
-  "resumeFarming": { "message": "Возобновить фарм" },
-  "activityReasonManualTabClose": { "message": "вкладка фарма закрыта" }
+  "automationChecking": {
+    "message": "Проверка"
+  },
+  "automationNeedsSignIn": {
+    "message": "Требуется вход"
+  },
+  "automationBlocked": {
+    "message": "Заблокировано"
+  },
+  "automationUnavailable": {
+    "message": "Недоступно"
+  },
+  "authCheckingDetail": {
+    "message": "Проверяем активный сеанс…"
+  },
+  "authSignInMissing": {
+    "message": "Войдите, чтобы продолжить получать награды."
+  },
+  "authSignInRejected": {
+    "message": "Сеанс больше недействителен. Войдите снова, чтобы продолжить."
+  },
+  "signInToTwitch": {
+    "message": "Войти в Twitch"
+  },
+  "signInToKick": {
+    "message": "Войти в Kick"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "Kick отклонил этот профиль браузера. Одного входа может быть недостаточно для решения проблемы."
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "Не удалось проверить сеанс браузера. Lurkloot повторит попытку автоматически."
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "Сеть временно недоступна. Lurkloot повторит попытку автоматически."
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "Платформа временно недоступна. Lurkloot повторит попытку автоматически."
+  },
+  "automationPausedTabClosed": {
+    "message": "Пауза — вкладка закрыта"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "Вы закрыли вкладку фарма, поэтому Lurkloot остановил фарм здесь."
+  },
+  "resumeFarming": {
+    "message": "Возобновить фарм"
+  },
+  "activityReasonManualTabClose": {
+    "message": "вкладка фарма закрыта"
+  }
 }

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -437,10 +437,18 @@
   "tablessDescription": {
     "message": "Sekme açmadan sessizce arka planda toplar. (İşlem takılırsa otomatik sekme açar.)"
   },
-  "tablessFallbackFailureLimitTitle": { "message": "Sekmesiz moddan geri dönüş eşiği" },
-  "tablessFallbackFailureLimitDescription": { "message": "Art arda bu sayıda sekmesiz izleme sinyali başarısız olduğunda bir video sekmesi açar." },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "Bu ayarı değiştirmek için düşük kaynak kullanan sekmesiz modu etkinleştirin." },
-  "failuresSuffix": { "message": "hata" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "Sekmesiz moddan geri dönüş eşiği"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "Art arda bu sayıda sekmesiz izleme sinyali başarısız olduğunda bir video sekmesi açar."
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "Bu ayarı değiştirmek için düşük kaynak kullanan sekmesiz modu etkinleştirin."
+  },
+  "failuresSuffix": {
+    "message": "hata"
+  },
   "autoCloseTabsTitle": {
     "message": "Gereksiz sekmeleri kapat"
   },
@@ -1050,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "Envanter sorgusu v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "Envanter sorgusu v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick Temmuz 2026"
   },
@@ -1098,8 +1109,16 @@
   "authPlatformTemporarilyUnavailable": {
     "message": "Platforma ulaşılamıyor. Otomatik tekrar denenecek."
   },
-  "automationPausedTabClosed": { "message": "Duraklatıldı — sekme kapatıldı" },
-  "watchTabClosedPauseDetail": { "message": "Farm sekmesini kapattınız, bu yüzden Lurkloot burada farmı durdurdu." },
-  "resumeFarming": { "message": "Farmı sürdür" },
-  "activityReasonManualTabClose": { "message": "farm sekmesi kapatıldı" }
+  "automationPausedTabClosed": {
+    "message": "Duraklatıldı — sekme kapatıldı"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "Farm sekmesini kapattınız, bu yüzden Lurkloot burada farmı durdurdu."
+  },
+  "resumeFarming": {
+    "message": "Farmı sürdür"
+  },
+  "activityReasonManualTabClose": {
+    "message": "farm sekmesi kapatıldı"
+  }
 }

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -140,18 +140,42 @@
   "watchingPausedHint": {
     "message": "观看已暂停。切换开关以继续刷掉宝。"
   },
-  "hideTipsTitle": { "message": "隐藏提示" },
-  "hideTipsDescription": { "message": "在主弹窗中隐藏实用提示。" },
-  "tipCampaignPriority": { "message": "Drops 优先于空闲观看列表。拖动活动把手即可设置刷取顺序。" },
-  "tipMissingCampaigns": { "message": "找不到活动？请检查平台的 Drops 库存，然后查看设置中的活动筛选器。" },
-  "tipCategorySelection": { "message": "只刷特定游戏？关闭平台设置中的“刷取所有类别”，然后选择类别。" },
-  "tipIdleWatchlist": { "message": "没有符合条件的 Drops 时，空闲观看列表会刷取所选频道。" },
-  "tipTablessMode": { "message": "无标签页模式占用更少资源，并在需要时回退到静音标签页。" },
-  "tipCli": { "message": "不想使用扩展？Lurkloot 也提供基于 Docker 的 CLI。" },
-  "tipCliAction": { "message": "阅读 CLI 指南" },
-  "tipFeedback": { "message": "发现错误或有建议？" },
-  "tipFeedbackAction": { "message": "提交 GitHub issue" },
-  "tipExcludedCampaigns": { "message": "误排除了活动？可在 Drops 设置中恢复。" },
+  "hideTipsTitle": {
+    "message": "隐藏提示"
+  },
+  "hideTipsDescription": {
+    "message": "在主弹窗中隐藏实用提示。"
+  },
+  "tipCampaignPriority": {
+    "message": "Drops 优先于空闲观看列表。拖动活动把手即可设置刷取顺序。"
+  },
+  "tipMissingCampaigns": {
+    "message": "找不到活动？请检查平台的 Drops 库存，然后查看设置中的活动筛选器。"
+  },
+  "tipCategorySelection": {
+    "message": "只刷特定游戏？关闭平台设置中的“刷取所有类别”，然后选择类别。"
+  },
+  "tipIdleWatchlist": {
+    "message": "没有符合条件的 Drops 时，空闲观看列表会刷取所选频道。"
+  },
+  "tipTablessMode": {
+    "message": "无标签页模式占用更少资源，并在需要时回退到静音标签页。"
+  },
+  "tipCli": {
+    "message": "不想使用扩展？Lurkloot 也提供基于 Docker 的 CLI。"
+  },
+  "tipCliAction": {
+    "message": "阅读 CLI 指南"
+  },
+  "tipFeedback": {
+    "message": "发现错误或有建议？"
+  },
+  "tipFeedbackAction": {
+    "message": "提交 GitHub issue"
+  },
+  "tipExcludedCampaigns": {
+    "message": "误排除了活动？可在 Drops 设置中恢复。"
+  },
   "noCampaigns": {
     "message": "尚未发现活动。"
   },
@@ -413,10 +437,18 @@
   "tablessDescription": {
     "message": "通过轻量观看信号而不是视频标签页刷取。Twitch 使用观看心跳；Kick 使用观众连接。如果停止计数，会自动退回标签页。"
   },
-  "tablessFallbackFailureLimitTitle": { "message": "无标签页回退阈值" },
-  "tablessFallbackFailureLimitDescription": { "message": "连续发生这么多次无标签页观看信号失败后打开视频标签页。" },
-  "tablessFallbackFailureLimitDisabledReason": { "message": "启用无标签页低资源模式以更改此设置。" },
-  "failuresSuffix": { "message": "次失败" },
+  "tablessFallbackFailureLimitTitle": {
+    "message": "无标签页回退阈值"
+  },
+  "tablessFallbackFailureLimitDescription": {
+    "message": "连续发生这么多次无标签页观看信号失败后打开视频标签页。"
+  },
+  "tablessFallbackFailureLimitDisabledReason": {
+    "message": "启用无标签页低资源模式以更改此设置。"
+  },
+  "failuresSuffix": {
+    "message": "次失败"
+  },
   "autoCloseTabsTitle": {
     "message": "自动关闭刷取标签页"
   },
@@ -489,13 +521,27 @@
   "secondsSuffix": {
     "message": "秒"
   },
-  "deadlineSafetyMarginTitle": { "message": "截止时间安全余量" },
-  "deadlineSafetyMarginDescription": { "message": "开始获取奖励前需额外预留的分钟数。" },
-  "deadlineSafetyMarginDisabledReason": { "message": "启用截止时间筛选后才能修改安全余量。" },
-  "skipUnfinishableRewardsTitle": { "message": "跳过无法完成的奖励" },
-  "skipUnfinishableRewardsDescription": { "message": "当剩余观看时间超过截止前可用时间时，不再获取该奖励。" },
-  "minutesSuffix": { "message": "分钟" },
-  "insufficientTimeRemaining": { "message": "剩余时间不足" },
+  "deadlineSafetyMarginTitle": {
+    "message": "截止时间安全余量"
+  },
+  "deadlineSafetyMarginDescription": {
+    "message": "开始获取奖励前需额外预留的分钟数。"
+  },
+  "deadlineSafetyMarginDisabledReason": {
+    "message": "启用截止时间筛选后才能修改安全余量。"
+  },
+  "skipUnfinishableRewardsTitle": {
+    "message": "跳过无法完成的奖励"
+  },
+  "skipUnfinishableRewardsDescription": {
+    "message": "当剩余观看时间超过截止前可用时间时，不再获取该奖励。"
+  },
+  "minutesSuffix": {
+    "message": "分钟"
+  },
+  "insufficientTimeRemaining": {
+    "message": "剩余时间不足"
+  },
   "automationSectionTitle": {
     "message": "自动化"
   },
@@ -691,10 +737,18 @@
   "siteAttributionShort": {
     "message": "网站"
   },
-  "updateNoticeTitle": { "message": "Lurkloot 已更新至 $1" },
-  "updateNoticeBody": { "message": "查看新增内容和改动。" },
-  "updateNoticeAction": { "message": "查看改动" },
-  "updateNoticeDismiss": { "message": "关闭更新通知" },
+  "updateNoticeTitle": {
+    "message": "Lurkloot 已更新至 $1"
+  },
+  "updateNoticeBody": {
+    "message": "查看新增内容和改动。"
+  },
+  "updateNoticeAction": {
+    "message": "查看改动"
+  },
+  "updateNoticeDismiss": {
+    "message": "关闭更新通知"
+  },
   "rateNudgeTitle": {
     "message": "喜欢 Lurkloot 吗？"
   },
@@ -731,15 +785,33 @@
   "cliExportButton": {
     "message": "导出凭据"
   },
-  "factoryResetTitle": { "message": "重置 Lurkloot" },
-  "factoryResetHint": { "message": "清除所有 Lurkloot 设置、挂机进度和活动记录。你的 Twitch 和 Kick 账号仍会保持登录。" },
-  "factoryResetButton": { "message": "重置 Lurkloot" },
-  "factoryResetConfirm": { "message": "此操作会停止挂机、关闭 Lurkloot 打开的标签页，并永久清除所有 Lurkloot 数据。Twitch 和 Kick 仍会保持登录。" },
-  "factoryResetCancel": { "message": "取消" },
-  "factoryResetConfirmButton": { "message": "全部重置" },
-  "factoryResetProgress": { "message": "正在重置…" },
-  "factoryResetFailed": { "message": "Lurkloot 未能完全重置，请重试。" },
-  "factoryResetRetry": { "message": "重新尝试重置" },
+  "factoryResetTitle": {
+    "message": "重置 Lurkloot"
+  },
+  "factoryResetHint": {
+    "message": "清除所有 Lurkloot 设置、挂机进度和活动记录。你的 Twitch 和 Kick 账号仍会保持登录。"
+  },
+  "factoryResetButton": {
+    "message": "重置 Lurkloot"
+  },
+  "factoryResetConfirm": {
+    "message": "此操作会停止挂机、关闭 Lurkloot 打开的标签页，并永久清除所有 Lurkloot 数据。Twitch 和 Kick 仍会保持登录。"
+  },
+  "factoryResetCancel": {
+    "message": "取消"
+  },
+  "factoryResetConfirmButton": {
+    "message": "全部重置"
+  },
+  "factoryResetProgress": {
+    "message": "正在重置…"
+  },
+  "factoryResetFailed": {
+    "message": "Lurkloot 未能完全重置，请重试。"
+  },
+  "factoryResetRetry": {
+    "message": "重新尝试重置"
+  },
   "diagnosticLoggingTitle": {
     "message": "包含诊断日志"
   },
@@ -758,23 +830,57 @@
   "activityChallengeClaimed": {
     "message": "已领取 $2 挑战的 $1 卡片"
   },
-  "activityAuthHealthChanged": { "message": "$1 的身份验证状态从 $2 变为 $3。" },
-  "activityCriticalFailureDetected": { "message": "$1 无法正常工作：$2。" },
-  "activityCriticalFailureCleared": { "message": "已忽略 $1 的严重故障，正在重试。" },
-  "criticalFailureReasonNoProgress": { "message": "尽管反复出错，仍无进展" },
-  "criticalFailureReasonPageContextChurn": { "message": "有一个标签页不断重新打开" },
-  "criticalFailureTitle": { "message": "Lurkloot 已停止工作" },
-  "criticalFailureBodyNoProgress": { "message": "长时间反复出错且掉宝没有任何进度。该平台可能发生了变化，扩展已无法获得掉宝。" },
-  "criticalFailureBodyTabChurn": { "message": "某个标签页不断重新打开。已停止重新打开，让你可以正常使用浏览器，该平台的挂机已暂停。" },
-  "criticalFailureCopyAndReport": { "message": "复制日志并提交问题" },
-  "criticalFailureDismiss": { "message": "忽略并重试" },
-  "criticalFailureClipboardFallback": { "message": "无法自动复制。请选中并复制以下内容，然后提交问题。" },
-  "activityPageContextOpened": { "message": "已在 $1 打开后台上下文，因为$2。" },
-  "activityPageContextClosed": { "message": "已关闭 $1 的后台上下文，因为$2。" },
-  "activityPageContextOpenReasonBackgroundRejected": { "message": "Kick 拒绝了无标签页请求" },
-  "activityPageContextReasonManagedContextUnusable": { "message": "之前的后台上下文无法使用" },
-  "activityPageContextCloseReasonBackgroundRecovered": { "message": "无标签页请求已恢复" },
-  "activityPageContextCloseReasonUserTabAvailable": { "message": "已有 Kick 标签页可用" },
+  "activityAuthHealthChanged": {
+    "message": "$1 的身份验证状态从 $2 变为 $3。"
+  },
+  "activityCriticalFailureDetected": {
+    "message": "$1 无法正常工作：$2。"
+  },
+  "activityCriticalFailureCleared": {
+    "message": "已忽略 $1 的严重故障，正在重试。"
+  },
+  "criticalFailureReasonNoProgress": {
+    "message": "尽管反复出错，仍无进展"
+  },
+  "criticalFailureReasonPageContextChurn": {
+    "message": "有一个标签页不断重新打开"
+  },
+  "criticalFailureTitle": {
+    "message": "Lurkloot 已停止工作"
+  },
+  "criticalFailureBodyNoProgress": {
+    "message": "长时间反复出错且掉宝没有任何进度。该平台可能发生了变化，扩展已无法获得掉宝。"
+  },
+  "criticalFailureBodyTabChurn": {
+    "message": "某个标签页不断重新打开。已停止重新打开，让你可以正常使用浏览器，该平台的挂机已暂停。"
+  },
+  "criticalFailureCopyAndReport": {
+    "message": "复制日志并提交问题"
+  },
+  "criticalFailureDismiss": {
+    "message": "忽略并重试"
+  },
+  "criticalFailureClipboardFallback": {
+    "message": "无法自动复制。请选中并复制以下内容，然后提交问题。"
+  },
+  "activityPageContextOpened": {
+    "message": "已在 $1 打开后台上下文，因为$2。"
+  },
+  "activityPageContextClosed": {
+    "message": "已关闭 $1 的后台上下文，因为$2。"
+  },
+  "activityPageContextOpenReasonBackgroundRejected": {
+    "message": "Kick 拒绝了无标签页请求"
+  },
+  "activityPageContextReasonManagedContextUnusable": {
+    "message": "之前的后台上下文无法使用"
+  },
+  "activityPageContextCloseReasonBackgroundRecovered": {
+    "message": "无标签页请求已恢复"
+  },
+  "activityPageContextCloseReasonUserTabAvailable": {
+    "message": "已有 Kick 标签页可用"
+  },
   "activityInterruption": {
     "message": "领取已中断：$1。"
   },
@@ -787,7 +893,9 @@
   "activityReasonPlatformDisabled": {
     "message": "平台已停用"
   },
-  "activityReasonAuthenticationUnhealthy": { "message": "身份验证不可用" },
+  "activityReasonAuthenticationUnhealthy": {
+    "message": "身份验证不可用"
+  },
   "activityReasonPlatformBackoff": {
     "message": "平台正在暂时等待"
   },
@@ -950,6 +1058,9 @@
   "compatibilityOptionTwitchInventoryV1": {
     "message": "库存查询 v1"
   },
+  "compatibilityOptionTwitchInventoryV2": {
+    "message": "库存查询 v2"
+  },
   "compatibilityOptionKickProfile202607": {
     "message": "Kick 2026 年 7 月版"
   },
@@ -959,21 +1070,55 @@
   "compatibilityOptionKickClaimV2": {
     "message": "链接处理 v2"
   },
-  "automationChecking": { "message": "正在检查" },
-  "automationNeedsSignIn": { "message": "需要登录" },
-  "automationBlocked": { "message": "已阻止" },
-  "automationUnavailable": { "message": "暂时不可用" },
-  "authCheckingDetail": { "message": "正在检查你的登录会话…" },
-  "authSignInMissing": { "message": "请登录以继续获取掉宝。" },
-  "authSignInRejected": { "message": "你的会话已失效。请重新登录以继续。" },
-  "signInToTwitch": { "message": "登录 Twitch" },
-  "signInToKick": { "message": "登录 Kick" },
-  "authBrowserProfileBlocked": { "message": "Kick 拒绝了此浏览器配置文件。仅重新登录可能无法解决问题。" },
-  "authCredentialCheckUnavailable": { "message": "无法检查浏览器会话。Lurkloot 将自动重试。" },
-  "authNetworkTemporarilyUnavailable": { "message": "网络暂时不可用。Lurkloot 将自动重试。" },
-  "authPlatformTemporarilyUnavailable": { "message": "平台暂时不可用。Lurkloot 将自动重试。" },
-  "automationPausedTabClosed": { "message": "已暂停 — 标签页已关闭" },
-  "watchTabClosedPauseDetail": { "message": "你关闭了挂机标签页，因此 Lurkloot 已停止在此挂机。" },
-  "resumeFarming": { "message": "恢复挂机" },
-  "activityReasonManualTabClose": { "message": "挂机标签页已关闭" }
+  "automationChecking": {
+    "message": "正在检查"
+  },
+  "automationNeedsSignIn": {
+    "message": "需要登录"
+  },
+  "automationBlocked": {
+    "message": "已阻止"
+  },
+  "automationUnavailable": {
+    "message": "暂时不可用"
+  },
+  "authCheckingDetail": {
+    "message": "正在检查你的登录会话…"
+  },
+  "authSignInMissing": {
+    "message": "请登录以继续获取掉宝。"
+  },
+  "authSignInRejected": {
+    "message": "你的会话已失效。请重新登录以继续。"
+  },
+  "signInToTwitch": {
+    "message": "登录 Twitch"
+  },
+  "signInToKick": {
+    "message": "登录 Kick"
+  },
+  "authBrowserProfileBlocked": {
+    "message": "Kick 拒绝了此浏览器配置文件。仅重新登录可能无法解决问题。"
+  },
+  "authCredentialCheckUnavailable": {
+    "message": "无法检查浏览器会话。Lurkloot 将自动重试。"
+  },
+  "authNetworkTemporarilyUnavailable": {
+    "message": "网络暂时不可用。Lurkloot 将自动重试。"
+  },
+  "authPlatformTemporarilyUnavailable": {
+    "message": "平台暂时不可用。Lurkloot 将自动重试。"
+  },
+  "automationPausedTabClosed": {
+    "message": "已暂停 — 标签页已关闭"
+  },
+  "watchTabClosedPauseDetail": {
+    "message": "你关闭了挂机标签页，因此 Lurkloot 已停止在此挂机。"
+  },
+  "resumeFarming": {
+    "message": "恢复挂机"
+  },
+  "activityReasonManualTabClose": {
+    "message": "挂机标签页已关闭"
+  }
 }

--- a/packages/popup-ui/src/compatibilitySettings.tsx
+++ b/packages/popup-ui/src/compatibilitySettings.tsx
@@ -38,6 +38,7 @@ const OPTION_TITLE_KEYS: Readonly<Record<string, string>> = Object.freeze({
   "twitch-heartbeat-spade-v1": "compatibilityOptionTwitchHeartbeatSpadeV1",
   "twitch-heartbeat-trowel-v1": "compatibilityOptionTwitchHeartbeatTrowelV1",
   "twitch-inventory-v1": "compatibilityOptionTwitchInventoryV1",
+  "twitch-inventory-v2": "compatibilityOptionTwitchInventoryV2",
   "kick-2026-07": "compatibilityOptionKickProfile202607",
   "kick-claim-v1": "compatibilityOptionKickClaimV1",
   "kick-claim-v2": "compatibilityOptionKickClaimV2",

--- a/packages/shared/src/compatibility.ts
+++ b/packages/shared/src/compatibility.ts
@@ -9,7 +9,7 @@ export type TwitchHeartbeatId =
   | "twitch-heartbeat-gql-v1"
   | "twitch-heartbeat-spade-v1"
   | "twitch-heartbeat-trowel-v1";
-export type TwitchInventoryId = "twitch-inventory-v1";
+export type TwitchInventoryId = "twitch-inventory-v1" | "twitch-inventory-v2";
 export type KickProfileId = "kick-2026-07";
 export type KickClaimId = "kick-claim-v1" | "kick-claim-v2";
 


### PR DESCRIPTION
## Summary

Closes #271. Depends on #270 (branched from it, so review that first).

Claim state for a watch tier was inferred from two sources, neither of which is per-tier:

| Source | Limitation |
|---|---|
| `self.isClaimed` | authoritative, but only exists while the campaign is in `dropCampaignsInProgress` |
| `gameEventDrops` | always present, but campaign-agnostic and **deduplicated by benefit id** |

Campaigns that award one benefit across several tiers break both, in opposite directions — #268 (owning the benefit marked every tier claimed, stranding a pending claim) and #270 (withholding that inference left a finished campaign farmable forever).

`earnedDropRewards` settles it: campaign-scoped, **one edge per claim**. From a real capture, four crate claims for four crate tiers plus the skin:

```
9a0d24bc  Supply Crate           CLAIMED  earnedAt=2026-07-25T13:33:09.586Z
9a0d24bc  Supply Crate           CLAIMED  earnedAt=2026-07-25T12:33:11.274Z
9a0d24bc  Supply Crate           CLAIMED  earnedAt=2026-07-25T11:33:07.886Z
9a0d24bc  Supply Crate           CLAIMED  earnedAt=2026-07-25T11:03:10.765Z
8152c851  Random Legendary Skin  CLAIMED  earnedAt=2026-07-25T14:33:08.131Z
```

## Change

- New `twitch-inventory-v2` capability requesting `earnedDropRewards`, using the persisted hash Twitch's **own web client** sends (`8337eb85…`), whose stored query already returns the field alongside everything v1 relies on — verified against the capture. The inline fallback additionally requests `dropCampaigns`, which the stored query omits.
- Claims resolve by counting CLAIMED edges per benefit within a campaign and assigning them to the N cheapest tiers awarding it: Twitch releases a tier's claim only once its watch requirement is met, so claims accrue in ascending `requiredMinutesWatched`.
- Counts are **authoritative** for benefits they mention, so the owned-benefit fallback no longer adds claims on top — otherwise 3 claims across 4 tiers would still mark the fourth claimed. Benefits absent from the counts keep the fallback.
- `twitch-inventory-v1` becomes `legacy` with `replacement: twitch-inventory-v2`; the recommended profile resolves to v2. v1 stays selectable, so the compatibility override is a rollback path.
- Locale entries for the new option in all 11 catalogs.

## Testing

- New `twitch-inventory-v2` test group: N earned edges claim exactly N tiers (3 of 4 leaves the 180 tier owed), all tiers earned completes the campaign, non-`CLAIMED` edges are ignored, and one campaign's claims never settle another's tiers.
- A fixture built from the real capture resolves the finished Hunt campaign through the v2 capability.
- The full **unmodified** captured response passes v2's schema validation and parses — it carries fields the fixture does not (`eventBasedDrops`, `localizedContent`, `__typename`).
- Updated the compatibility tests that pin registry contents and the resolved profile.
- `pnpm check` green: 995 extension tests, 126 CLI, all typechecks, site build.

## Caveats worth reviewing

**Truncation.** Twitch's inventory UI states claimed rewards are only shown for the last six months, so `earnedDropRewards` is likely time-limited. An old campaign could return no edges and undercount. That is why counts are only authoritative for benefits they actually mention, and why the fallback is retained otherwise; a campaign old enough to be truncated is also expired and not farmed. Not directly verifiable from one capture.

**Ordering assumption.** Assigning N claims to the N cheapest tiers assumes claims accrue in ascending watch requirement. That holds because a tier's claim is only released once its requirement is met, but I have no capture of tiers claimed out of order to confirm it. The edges are keyed by benefit id, not tier id, so this mapping cannot be avoided without a different field.

**Hash change.** v2 sends a different persisted hash than v1. The stored query omits `dropCampaigns`, which the retry path in `discoverCampaigns` uses when inventory *and* dashboard both return zero campaigns; there the dashboard call independently supplies reward campaigns, so the impact is limited, but it is a behaviour difference worth a second opinion.