### PR TITLE
fix(twitch): preserve discovery retention across scheduler ticks

### DIFF
--- a/docs/superpowers/plans/2026-07-26-twitch-discovery-state.md
+++ b/docs/superpowers/plans/2026-07-26-twitch-discovery-state.md
@@ -1,0 +1,366 @@
+# Twitch Discovery Retention State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve Twitch dashboard and campaign-detail discovery retention across fresh adapter constructions during one extension background or CLI transport lifetime.
+
+**Architecture:** Extract the existing adapter-owned discovery caches into an injectable `TwitchDiscoveryState`. Each host owns one state at its process/transport boundary and supplies it to every short-lived `TwitchAdapter`, while all settings, emitters, and operation-scoped ports remain fresh.
+
+**Tech Stack:** TypeScript, pnpm workspace, Vitest, WXT WebExtension, Node CLI
+
+## Global Constraints
+
+- Retention is process-lifetime only; it does not survive extension/background, browser, or CLI restarts.
+- Preserve the existing 30-minute discovery retention TTL.
+- A successful empty dashboard is authoritative and replaces retained dashboard IDs with `[]`.
+- Authentication failures continue to propagate.
+- `@lurkloot/core` remains browser-free.
+- Extension and CLI hosts must use the same `TwitchDiscoveryState` behavior.
+
+---
+
+## File Structure
+
+- `packages/core/src/platforms/twitch/index.ts`: define and export `TwitchDiscoveryState`; let `TwitchAdapter` consume an injected instance.
+- `packages/extension/entrypoints/background.ts`: own one extension-process discovery state and inject it into each Twitch adapter.
+- `packages/cli/src/transport/http.ts`: own one state per HTTP transport and inject it into reconstructed adapters.
+- `packages/cli/src/transport/impersonate.ts`: own one state per impersonate transport and inject it into reconstructed adapters.
+- `packages/extension/tests/adapters.test.ts`: prove state retention and authoritative empty responses across adapter instances.
+- `packages/extension/tests/backgroundController.test.ts`: prove two controller ticks reconstruct adapters while preserving a not-started Twitch campaign through a transient failure.
+- `packages/extension/tests/compatibility.test.ts`: guard extension host state construction/injection.
+- `packages/cli/tests/transport.test.ts`: prove the HTTP transport shares discovery state across adapter constructions.
+- `packages/cli/tests/impersonate.test.ts`: prove the impersonate transport shares discovery state across adapter constructions.
+
+### Task 1: Extract and inject Twitch discovery state
+
+**Files:**
+
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+
+- Produces: `export class TwitchDiscoveryState`
+- Produces: `TwitchAdapterOptions.discoveryState?: TwitchDiscoveryState`
+- State methods remain internal to Twitch discovery behavior; hosts only construct and inject the object.
+
+- [ ] **Step 1: Write cross-instance failing tests**
+
+Import `TwitchDiscoveryState` in `adapters.test.ts`. Change the existing warm-cache tests to construct a shared state and two adapters:
+
+```ts
+const discoveryState = new TwitchDiscoveryState();
+const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+
+expect((await firstAdapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+
+dashboardFails = true;
+const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+expect((await secondAdapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+```
+
+Add the equivalent reconstruction to the campaign-detail failure test. Update the successful-empty-dashboard test so the second adapter shares the same state, receives `[]`, and a third adapter facing a dashboard failure does not revive the obsolete campaign.
+
+- [ ] **Step 2: Run the focused adapter tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/adapters.test.ts
+```
+
+Expected: TypeScript/Vitest fails because `TwitchDiscoveryState` and `discoveryState` do not exist, or the reconstructed adapter loses the retained campaign.
+
+- [ ] **Step 3: Implement the minimal shared state**
+
+In `packages/core/src/platforms/twitch/index.ts`, add:
+
+```ts
+export class TwitchDiscoveryState {
+  private readonly campaignDetailsByDropId = new Map<string, CachedCampaignDetails>();
+  private retainedDashboard?: CachedDashboardCampaigns;
+
+  rememberDashboardCampaignIds(campaignIds: string[]): void {
+    this.retainedDashboard = {
+      campaignIds,
+      expiresAt: Date.now() + DISCOVERY_RETENTION_TTL_MS,
+    };
+  }
+
+  retainedDashboardCampaignIds(): string[] {
+    if (!this.retainedDashboard) return [];
+    if (this.retainedDashboard.expiresAt <= Date.now()) {
+      this.retainedDashboard = undefined;
+      return [];
+    }
+    return this.retainedDashboard.campaignIds;
+  }
+
+  rememberCampaignDetails(dropID: string, campaign: unknown): void {
+    this.campaignDetailsByDropId.set(dropID, {
+      campaign,
+      expiresAt: Date.now() + DISCOVERY_RETENTION_TTL_MS,
+    });
+  }
+
+  retainedCampaignDetails(dropID: string): unknown {
+    const cached = this.campaignDetailsByDropId.get(dropID);
+    if (!cached) return undefined;
+    if (cached.expiresAt <= Date.now()) {
+      this.campaignDetailsByDropId.delete(dropID);
+      return undefined;
+    }
+    return cached.campaign;
+  }
+}
+```
+
+Extend the options:
+
+```ts
+export interface TwitchAdapterOptions {
+  // existing fields
+  discoveryState?: TwitchDiscoveryState;
+}
+```
+
+Replace the two adapter fields with:
+
+```ts
+private readonly discoveryState: TwitchDiscoveryState;
+```
+
+Initialize it in the constructor:
+
+```ts
+this.discoveryState = options.discoveryState ?? new TwitchDiscoveryState();
+```
+
+Delegate the four existing retention call sites to `this.discoveryState`, then remove the adapter's private retention helper methods.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/adapters.test.ts
+```
+
+Expected: all adapter tests pass.
+
+- [ ] **Step 5: Commit the core state extraction**
+
+```bash
+git add packages/core/src/platforms/twitch/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "fix(twitch): share discovery retention state"
+```
+
+### Task 2: Prove retention across controller ticks and wire the extension host
+
+**Files:**
+
+- Modify: `packages/extension/entrypoints/background.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/extension/tests/compatibility.test.ts`
+
+**Interfaces:**
+
+- Consumes: `new TwitchDiscoveryState()`
+- Consumes: `TwitchAdapterOptions.discoveryState`
+- Produces: one extension-background state shared by every `deps.createAdapters` invocation.
+
+- [ ] **Step 1: Write the controller-level failing regression**
+
+In `backgroundController.test.ts`, import `TwitchAdapter` and `TwitchDiscoveryState`. Add Twitch response helpers equivalent to the adapter test helpers. Configure the harness with Twitch enabled, Kick disabled, and no idle-watchlist channels. Override `deps.createAdapters` so it constructs a new `TwitchAdapter` on every call with one shared `TwitchDiscoveryState`.
+
+The test sequence is:
+
+```ts
+await env.controller.tick();
+expect(env.state.campaigns.twitch.map((item) => item.id)).toEqual(["retained"]);
+
+dashboardFails = true;
+detailsFail = true;
+await env.controller.tick();
+
+expect(env.deps.createAdapters).toHaveBeenCalledTimes(2);
+expect(env.state.campaigns.twitch.map((item) => item.id)).toEqual(["retained"]);
+```
+
+The first tick returns an empty inventory, dashboard ID `retained`, and valid details. The second tick uses a newly constructed adapter while dashboard and detail requests fail.
+
+Add a source-boundary assertion to `compatibility.test.ts`:
+
+```ts
+expect(backgroundSource).toContain("const twitchDiscoveryState = new TwitchDiscoveryState();");
+expect(backgroundSource).toContain("discoveryState: twitchDiscoveryState,");
+```
+
+- [ ] **Step 2: Run controller and construction tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/backgroundController.test.ts tests/compatibility.test.ts
+```
+
+Expected: the source assertion fails and the second tick loses `retained` until the host injects shared state.
+
+- [ ] **Step 3: Wire extension process state**
+
+Update the Twitch import:
+
+```ts
+import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
+```
+
+Create one state beside the existing long-lived host state, outside `createAdapters`:
+
+```ts
+const twitchDiscoveryState = new TwitchDiscoveryState();
+```
+
+Pass it through Twitch options:
+
+```ts
+{
+  compatibility: resolution.compatibility.twitch,
+  discoveryState: twitchDiscoveryState,
+  // existing heartbeat fields
+}
+```
+
+- [ ] **Step 4: Run controller and extension construction tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/backgroundController.test.ts tests/compatibility.test.ts
+```
+
+Expected: both files pass, including the two-tick reconstruction regression.
+
+- [ ] **Step 5: Commit extension wiring and regression**
+
+```bash
+git add packages/extension/entrypoints/background.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/compatibility.test.ts
+git commit -m "fix(extension): retain Twitch discovery across ticks"
+```
+
+### Task 3: Wire both CLI transport lifetimes
+
+**Files:**
+
+- Modify: `packages/cli/src/transport/http.ts`
+- Modify: `packages/cli/src/transport/impersonate.ts`
+- Test: `packages/cli/tests/transport.test.ts`
+- Test: `packages/cli/tests/impersonate.test.ts`
+
+**Interfaces:**
+
+- Consumes: `new TwitchDiscoveryState()`
+- Consumes: `TwitchAdapterOptions.discoveryState`
+- Produces: one state per transport handle, isolated from other handles.
+
+- [ ] **Step 1: Write failing HTTP and impersonate transport tests**
+
+For the HTTP test, stub global `fetch` to decode the Twitch GQL operation name and return:
+
+- an authenticated empty inventory;
+- dashboard campaign `retained` on the first construction, then throw;
+- valid campaign details on the first construction, then throw.
+
+Call `discoverCampaigns()` on Twitch adapters returned by two separate `handle.createAdapters(...)` calls and assert both results contain `retained`.
+
+For impersonate, keep the fake CycleTLS client because Twitch discovery still uses global fetch. Add the same two-construction assertion to `impersonate.test.ts`.
+
+- [ ] **Step 2: Run CLI transport tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/cli test -- tests/transport.test.ts tests/impersonate.test.ts
+```
+
+Expected: the second adapter construction returns no `retained` campaign.
+
+- [ ] **Step 3: Wire state into both transports**
+
+In both transport files, import `TwitchDiscoveryState`, then create it beside `KickClaimState`:
+
+```ts
+const twitchDiscoveryState = new TwitchDiscoveryState();
+```
+
+Pass it in each Twitch adapter options object:
+
+```ts
+{
+  ...identity,
+  compatibility: resolution.compatibility.twitch,
+  discoveryState: twitchDiscoveryState,
+  // existing heartbeat fields
+}
+```
+
+- [ ] **Step 4: Run CLI transport tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/cli test -- tests/transport.test.ts tests/impersonate.test.ts
+```
+
+Expected: both transport suites pass and each second adapter retains `retained`.
+
+- [ ] **Step 5: Commit CLI wiring**
+
+```bash
+git add packages/cli/src/transport/http.ts packages/cli/src/transport/impersonate.ts packages/cli/tests/transport.test.ts packages/cli/tests/impersonate.test.ts
+git commit -m "fix(cli): retain Twitch discovery across ticks"
+```
+
+### Task 4: Verify boundaries and repository health
+
+**Files:**
+
+- Verify only; no planned source changes.
+
+**Interfaces:**
+
+- Confirms the core package remains browser-free and every workspace compiles against the new option.
+
+- [ ] **Step 1: Run focused boundary and affected tests**
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/adapters.test.ts tests/backgroundController.test.ts tests/compatibility.test.ts tests/coreBoundary.test.ts
+pnpm --filter @lurkloot/cli test -- tests/transport.test.ts tests/impersonate.test.ts
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run workspace typechecks**
+
+```bash
+pnpm typecheck
+```
+
+Expected: all workspace typechecks pass.
+
+- [ ] **Step 3: Run full repository verification**
+
+```bash
+pnpm verify
+```
+
+Expected: script policies, typechecks, all tests, site build, and Chromium/Firefox extension builds pass.
+
+- [ ] **Step 4: Inspect the final diff**
+
+```bash
+git diff origin/develop...HEAD --check
+git status --short
+git log --oneline origin/develop..HEAD
+```
+
+Expected: no whitespace errors; only the design, plan, Twitch state, host wiring, and regression tests are changed.

--- a/docs/superpowers/plans/2026-07-26-twitch-discovery-state.md
+++ b/docs/superpowers/plans/2026-07-26-twitch-discovery-state.md
@@ -31,6 +31,10 @@
 - `packages/cli/tests/transport.test.ts`: prove the HTTP transport shares discovery state across adapter constructions.
 - `packages/cli/tests/impersonate.test.ts`: prove the impersonate transport shares discovery state across adapter constructions.
 
+## As Built
+
+Final review hardened the planned state boundary in two ways. `TwitchDiscoveryState` tracks the stable authenticated Twitch user ID and clears both retained dashboard IDs and campaign-detail payloads whenever that identity changes. Successful authoritative responses also invalidate obsolete retained data: an empty dashboard clears dashboard IDs, and an explicit null campaign-detail response clears that campaign's cached details. Regression coverage includes account switching, empty-dashboard fallback failures, null detail responses, expired detail pruning, and isolation between separate CLI transport handles.
+
 ### Task 1: Extract and inject Twitch discovery state
 
 **Files:**

--- a/docs/superpowers/specs/2026-07-26-twitch-discovery-state-design.md
+++ b/docs/superpowers/specs/2026-07-26-twitch-discovery-state-design.md
@@ -1,0 +1,80 @@
+# Twitch Discovery Retention State Design
+
+## Problem
+
+`TwitchAdapter` retains the last successful dashboard campaign IDs and campaign-detail responses for 30 minutes so transient Twitch failures do not remove campaigns that are absent from inventory. The extension and CLI reconstruct their adapters for each controller operation or tick, so the adapter-owned retention state is discarded before it can protect the next refresh.
+
+## Scope
+
+Retention must survive `TwitchAdapter` reconstruction during the lifetime of one extension background process or CLI transport. It does not need to survive an extension/background restart, browser restart, or CLI restart. The existing 30-minute expiration remains unchanged.
+
+The fix must preserve these behaviors:
+
+- Transient dashboard failures reuse the last successful dashboard campaign IDs.
+- Transient campaign-detail failures reuse the last successful detail response for that campaign.
+- Authentication failures still propagate.
+- A successful empty dashboard is authoritative and clears the retained dashboard campaign IDs.
+- Extension and CLI hosts use the same retention semantics.
+- Adapters continue to receive current settings, compatibility resolution, event emitters, and operation-scoped ports when reconstructed.
+
+## Design
+
+Add an exported `TwitchDiscoveryState` class to the Twitch platform module. It owns only the process-lifetime discovery data:
+
+- the retained dashboard campaign IDs and their expiration;
+- the campaign-detail response map and each entry's expiration.
+
+The state exposes focused methods to remember and retrieve those values. Retrieval removes expired entries. Remembering a successful empty dashboard stores an empty ID list, so a later failure cannot revive obsolete campaigns.
+
+`TwitchAdapterOptions` gains an optional `discoveryState`. A `TwitchAdapter` uses the supplied state or creates a private state when none is supplied. The private default preserves existing standalone callers and tests without introducing global state.
+
+Each host creates one shared state at its existing process-lifetime boundary:
+
+- The extension background module creates one state beside other long-lived host state and passes it through every `createAdapters` call.
+- Each CLI HTTP or impersonate transport creates one state when the transport is created and passes it through every transport `createAdapters` call.
+
+This follows the existing injected-state pattern used by `KickClaimState`. It keeps Twitch-specific retention inside the Twitch platform implementation while allowing short-lived adapters to share it.
+
+## Alternatives Considered
+
+### Persist a `TwitchAdapter`
+
+Keeping one adapter instance would preserve its cache, but would also retain compatibility settings, emitters, and operation-scoped ports. Those dependencies are intentionally refreshed, so adapter persistence has a larger and less safe lifecycle.
+
+### Move retention into the controller
+
+The controller is process-lived and could retain complete discovery results, but it would need knowledge of Twitch-specific dashboard and campaign-detail failure semantics. That would weaken the platform abstraction and duplicate logic already owned by `TwitchAdapter`.
+
+### Use module-global state
+
+A module singleton would survive reconstruction with minimal wiring, but would leak state between independently created transports, tests, or identities in the same process. Explicit host-owned injection gives each runtime instance a clear isolation boundary.
+
+## Data Flow
+
+1. A host creates one `TwitchDiscoveryState`.
+2. Each controller operation constructs a fresh `TwitchAdapter` with current dependencies and the shared state.
+3. Successful Twitch dashboard and detail responses update the shared state with a 30-minute expiration.
+4. A later adapter reads the shared state only when the corresponding Twitch request fails.
+5. Successful responses, including an empty dashboard, remain authoritative and replace retained data.
+6. State disappears naturally when the extension background process or CLI transport ends.
+
+## Testing
+
+Adapter regression tests will share one `TwitchDiscoveryState` across two separate `TwitchAdapter` instances:
+
+- The first adapter completes discovery successfully.
+- The second adapter encounters a dashboard failure and still returns a previously discovered campaign not present in inventory.
+- The second adapter encounters a campaign-detail failure and still returns the retained campaign details.
+- A separate reconstruction test receives a successful empty dashboard and confirms obsolete dashboard campaigns are not retained.
+
+Host tests or source-boundary assertions will verify that the extension background and both CLI transports create one state outside their adapter factories and inject it into reconstructed Twitch adapters.
+
+Focused adapter, controller/transport, boundary, and typecheck tests will run before the repository-wide verification command.
+
+## Non-Goals
+
+- Persisting retention data in browser or filesystem storage.
+- Changing the 30-minute retention window.
+- Retaining complete `TwitchAdapter` instances.
+- Changing scheduler campaign replacement behavior.
+- Generalizing this state into a cross-platform cache abstraction.

--- a/docs/superpowers/specs/2026-07-26-twitch-discovery-state-design.md
+++ b/docs/superpowers/specs/2026-07-26-twitch-discovery-state-design.md
@@ -26,6 +26,8 @@ Add an exported `TwitchDiscoveryState` class to the Twitch platform module. It o
 
 The state exposes focused methods to remember and retrieve those values. Retrieval removes expired entries. Remembering a successful empty dashboard stores an empty ID list, so a later failure cannot revive obsolete campaigns.
 
+The state also tracks the stable authenticated Twitch user ID. Every discovery establishes that identity before reading or writing retained data. When the user ID changes, the state clears both dashboard IDs and campaign-detail responses so one account can never inherit another account's discovery or progress fields.
+
 `TwitchAdapterOptions` gains an optional `discoveryState`. A `TwitchAdapter` uses the supplied state or creates a private state when none is supplied. The private default preserves existing standalone callers and tests without introducing global state.
 
 Each host creates one shared state at its existing process-lifetime boundary:
@@ -53,10 +55,11 @@ A module singleton would survive reconstruction with minimal wiring, but would l
 
 1. A host creates one `TwitchDiscoveryState`.
 2. Each controller operation constructs a fresh `TwitchAdapter` with current dependencies and the shared state.
-3. Successful Twitch dashboard and detail responses update the shared state with a 30-minute expiration.
-4. A later adapter reads the shared state only when the corresponding Twitch request fails.
-5. Successful responses, including an empty dashboard, remain authoritative and replace retained data.
-6. State disappears naturally when the extension background process or CLI transport ends.
+3. Each discovery binds the state to the authenticated Twitch user ID, clearing both caches if the account changed.
+4. Successful Twitch dashboard and detail responses update the shared state with a 30-minute expiration.
+5. A later adapter reads the shared state only when the corresponding Twitch request fails.
+6. Successful responses, including an empty dashboard or a missing campaign detail, remain authoritative and invalidate obsolete retained data.
+7. State disappears naturally when the extension background process or CLI transport ends.
 
 ## Testing
 
@@ -66,6 +69,7 @@ Adapter regression tests will share one `TwitchDiscoveryState` across two separa
 - The second adapter encounters a dashboard failure and still returns a previously discovered campaign not present in inventory.
 - The second adapter encounters a campaign-detail failure and still returns the retained campaign details.
 - A separate reconstruction test receives a successful empty dashboard and confirms obsolete dashboard campaigns are not retained.
+- Account-switch tests confirm dashboard IDs and raw campaign details from the previous authenticated user are cleared.
 
 Host tests or source-boundary assertions will verify that the extension background and both CLI transports create one state outside their adapter factories and inject it into reconstructed Twitch adapters.
 

--- a/packages/cli/src/transport/http.ts
+++ b/packages/cli/src/transport/http.ts
@@ -1,6 +1,6 @@
 import { fetchKickInBackgroundWith, fetchTwitchInBackgroundWith } from "@lurkloot/core/tabs";
 import { KickAdapter, KickClaimState } from "@lurkloot/core/kick";
-import { TwitchAdapter } from "@lurkloot/core/twitch";
+import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import { resolveCompatibility } from "@lurkloot/core";
 import type { EventEmitter } from "@lurkloot/shared/events";
 import { DEFAULT_ENGINE_SETTINGS } from "@lurkloot/shared/settings";
@@ -18,6 +18,7 @@ export function createHttpTransport(creds: PlatformCredentials, _enabled: Enable
   const twitchApi = twitchCookieApi(creds);
   const kickApi = kickCookieApi(creds);
   const kickClaimState = new KickClaimState();
+  const twitchDiscoveryState = new TwitchDiscoveryState();
   const createAdapter = (platform: Platform, emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
     const identity = twitchClientIdentity(creds);
     const twitchIdentity = identity.userAgent ? "android" : "web";
@@ -30,6 +31,7 @@ export function createHttpTransport(creds: PlatformCredentials, _enabled: Enable
         {
           ...identity,
           compatibility: resolution.compatibility.twitch,
+          discoveryState: twitchDiscoveryState,
           heartbeatIdentity: twitchIdentity,
           heartbeatFetchText: async (url, init) => {
             const response = await withHeartbeatTimeout(

--- a/packages/cli/src/transport/impersonate.ts
+++ b/packages/cli/src/transport/impersonate.ts
@@ -1,6 +1,6 @@
 import { fetchTwitchInBackgroundWith } from "@lurkloot/core/tabs";
 import { KickAdapter, KickClaimState } from "@lurkloot/core/kick";
-import { TwitchAdapter } from "@lurkloot/core/twitch";
+import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import { resolveCompatibility } from "@lurkloot/core";
 import type { EventEmitter } from "@lurkloot/shared/events";
 import { DEFAULT_ENGINE_SETTINGS } from "@lurkloot/shared/settings";
@@ -28,6 +28,7 @@ export async function createImpersonateTransport(
 ): Promise<TransportHandle> {
   const cycleTLS = await (deps.initClient ?? initCycle)();
   const kickClaimState = new KickClaimState();
+  const twitchDiscoveryState = new TwitchDiscoveryState();
   const createAdapter = (platform: Platform, emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
     const identity = twitchClientIdentity(creds);
     const twitchIdentity = identity.userAgent ? "android" : "web";
@@ -40,6 +41,7 @@ export async function createImpersonateTransport(
         {
           ...identity,
           compatibility: resolution.compatibility.twitch,
+          discoveryState: twitchDiscoveryState,
           heartbeatIdentity: twitchIdentity,
           heartbeatFetchText: async (url, init) => {
             const response = await withHeartbeatTimeout(() => cycleTLS(url, {

--- a/packages/cli/tests/impersonate.test.ts
+++ b/packages/cli/tests/impersonate.test.ts
@@ -10,6 +10,57 @@ const ENABLED = { twitch: true, kick: true };
 
 afterEach(() => vi.unstubAllGlobals());
 
+function twitchOperation(init?: RequestInit): string {
+  return JSON.parse(String(init?.body)).operationName;
+}
+
+function twitchResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function emptyTwitchInventory(): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: "viewer-id",
+        inventory: { dropCampaignsInProgress: [] },
+      },
+    },
+  };
+}
+
+function retainedTwitchDashboard(): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: "viewer-id",
+        login: "viewer",
+        dropCampaigns: [{ id: "retained", status: "ACTIVE", self: { isAccountConnected: true } }],
+      },
+    },
+  };
+}
+
+function retainedTwitchCampaignDetails(): unknown {
+  return {
+    data: {
+      dropCampaign: {
+        id: "retained",
+        name: "Retained Campaign",
+        game: { id: "game", slug: "game-slug", displayName: "Game" },
+        timeBasedDrops: [{
+          id: "retained-drop",
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit: { id: "benefit", name: "Reward" } }],
+        }],
+      },
+    },
+  };
+}
+
 interface Captured {
   url: string;
   options: { ja3?: string; userAgent?: string; headers: Record<string, string>; disableRedirect?: boolean };
@@ -89,6 +140,40 @@ describe("impersonate transport", () => {
     await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.kick.claimReward(campaign, reward);
 
     expect(claimPosts).toBe(1);
+    await handle.dispose();
+  });
+
+  it("retains Twitch discovery across fresh impersonated adapter constructions", async () => {
+    let dashboardAvailable = true;
+    let detailsAvailable = true;
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+      switch (twitchOperation(init)) {
+        case "Inventory":
+          return twitchResponse(emptyTwitchInventory());
+        case "ViewerDropsDashboard":
+          if (dashboardAvailable) {
+            dashboardAvailable = false;
+            return twitchResponse(retainedTwitchDashboard());
+          }
+          throw new Error("dashboard unavailable");
+        case "DropCampaignDetails":
+          if (detailsAvailable) {
+            detailsAvailable = false;
+            return twitchResponse(retainedTwitchCampaignDetails());
+          }
+          throw new Error("details unavailable");
+        default:
+          throw new Error(`Unexpected Twitch operation ${twitchOperation(init)}`);
+      }
+    }));
+    const client = fakeClient(() => Promise.resolve({ status: 200, data: {} }));
+    const handle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
+
+    const first = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.discoverCampaigns();
+    const second = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.discoverCampaigns();
+
+    expect(first.map((campaign) => campaign.id)).toEqual(["retained"]);
+    expect(second.map((campaign) => campaign.id)).toEqual(["retained"]);
     await handle.dispose();
   });
 

--- a/packages/cli/tests/impersonate.test.ts
+++ b/packages/cli/tests/impersonate.test.ts
@@ -177,6 +177,34 @@ describe("impersonate transport", () => {
     await handle.dispose();
   });
 
+  it("isolates retained Twitch discovery between impersonated transport handles", async () => {
+    let seedFirstHandle = true;
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+      switch (twitchOperation(init)) {
+        case "Inventory":
+          return twitchResponse(emptyTwitchInventory());
+        case "ViewerDropsDashboard":
+          if (seedFirstHandle) return twitchResponse(retainedTwitchDashboard());
+          throw new Error("dashboard unavailable");
+        case "DropCampaignDetails":
+          return twitchResponse(retainedTwitchCampaignDetails());
+        default:
+          throw new Error(`Unexpected Twitch operation ${twitchOperation(init)}`);
+      }
+    }));
+    const client = fakeClient(() => Promise.resolve({ status: 200, data: {} }));
+    const firstHandle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
+    const secondHandle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
+
+    expect((await firstHandle.adapters.twitch.discoverCampaigns()).map((campaign) => campaign.id))
+      .toEqual(["retained"]);
+    seedFirstHandle = false;
+
+    await expect(secondHandle.adapters.twitch.discoverCampaigns()).resolves.toEqual([]);
+    await firstHandle.dispose();
+    await secondHandle.dispose();
+  });
+
   it("sends Trowel through the injected cycletls transport", async () => {
     const calls: Captured[] = [];
     const client = fakeClient((url, options, method) => {

--- a/packages/cli/tests/transport.test.ts
+++ b/packages/cli/tests/transport.test.ts
@@ -134,6 +134,33 @@ describe("createTransport", () => {
     await handle.dispose();
   });
 
+  it("isolates retained Twitch discovery between HTTP transport handles", async () => {
+    let seedFirstHandle = true;
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+      switch (twitchOperation(init)) {
+        case "Inventory":
+          return twitchResponse(emptyTwitchInventory());
+        case "ViewerDropsDashboard":
+          if (seedFirstHandle) return twitchResponse(retainedTwitchDashboard());
+          throw new Error("dashboard unavailable");
+        case "DropCampaignDetails":
+          return twitchResponse(retainedTwitchCampaignDetails());
+        default:
+          throw new Error(`Unexpected Twitch operation ${twitchOperation(init)}`);
+      }
+    }));
+    const firstHandle = await createTransport("http", {}, "/tmp/auth", ENABLED);
+    const secondHandle = await createTransport("http", {}, "/tmp/auth", ENABLED);
+
+    expect((await firstHandle.adapters.twitch.discoverCampaigns()).map((campaign) => campaign.id))
+      .toEqual(["retained"]);
+    seedFirstHandle = false;
+
+    await expect(secondHandle.adapters.twitch.discoverCampaigns()).resolves.toEqual([]);
+    await firstHandle.dispose();
+    await secondHandle.dispose();
+  });
+
   it("sends Trowel through the HTTP transport request path", async () => {
     const fetchMock = vi.fn(async (url: string) => new Response(url.includes("trowel.twitch.tv") ? null : JSON.stringify({
       data: { user: { id: "channel-id", stream: { id: "broadcast-id" } } },

--- a/packages/cli/tests/transport.test.ts
+++ b/packages/cli/tests/transport.test.ts
@@ -8,6 +8,57 @@ const ENABLED = { twitch: true, kick: true };
 
 afterEach(() => vi.unstubAllGlobals());
 
+function twitchOperation(init?: RequestInit): string {
+  return JSON.parse(String(init?.body)).operationName;
+}
+
+function twitchResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function emptyTwitchInventory(): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: "viewer-id",
+        inventory: { dropCampaignsInProgress: [] },
+      },
+    },
+  };
+}
+
+function retainedTwitchDashboard(): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: "viewer-id",
+        login: "viewer",
+        dropCampaigns: [{ id: "retained", status: "ACTIVE", self: { isAccountConnected: true } }],
+      },
+    },
+  };
+}
+
+function retainedTwitchCampaignDetails(): unknown {
+  return {
+    data: {
+      dropCampaign: {
+        id: "retained",
+        name: "Retained Campaign",
+        game: { id: "game", slug: "game-slug", displayName: "Game" },
+        timeBasedDrops: [{
+          id: "retained-drop",
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit: { id: "benefit", name: "Reward" } }],
+        }],
+      },
+    },
+  };
+}
+
 describe("createTransport", () => {
   it("builds a disposable http transport with both adapters", async () => {
     const handle = await createTransport("http", {}, "/tmp/auth", ENABLED);
@@ -47,6 +98,39 @@ describe("createTransport", () => {
     await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.kick.claimReward(campaign, reward);
 
     expect(claimPosts).toBe(1);
+    await handle.dispose();
+  });
+
+  it("retains Twitch discovery across fresh HTTP adapter constructions", async () => {
+    let dashboardAvailable = true;
+    let detailsAvailable = true;
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+      switch (twitchOperation(init)) {
+        case "Inventory":
+          return twitchResponse(emptyTwitchInventory());
+        case "ViewerDropsDashboard":
+          if (dashboardAvailable) {
+            dashboardAvailable = false;
+            return twitchResponse(retainedTwitchDashboard());
+          }
+          throw new Error("dashboard unavailable");
+        case "DropCampaignDetails":
+          if (detailsAvailable) {
+            detailsAvailable = false;
+            return twitchResponse(retainedTwitchCampaignDetails());
+          }
+          throw new Error("details unavailable");
+        default:
+          throw new Error(`Unexpected Twitch operation ${twitchOperation(init)}`);
+      }
+    }));
+    const handle = await createTransport("http", {}, "/tmp/auth", ENABLED);
+
+    const first = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.discoverCampaigns();
+    const second = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.discoverCampaigns();
+
+    expect(first.map((campaign) => campaign.id)).toEqual(["retained"]);
+    expect(second.map((campaign) => campaign.id)).toEqual(["retained"]);
     await handle.dispose();
   });
 

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -39,6 +39,7 @@ export interface TwitchAdapterOptions {
   heartbeatIdentity?: TwitchIdentity;
   heartbeatFetchText?: TwitchHeartbeatFetchText;
   heartbeatPost?: TwitchHeartbeatPost;
+  discoveryState?: TwitchDiscoveryState;
 }
 
 const TWITCH_QUERIES = {
@@ -287,6 +288,44 @@ interface CachedDashboardCampaigns {
   expiresAt: number;
 }
 
+export class TwitchDiscoveryState {
+  private readonly campaignDetailsByDropId = new Map<string, CachedCampaignDetails>();
+  private retainedDashboard?: CachedDashboardCampaigns;
+
+  rememberDashboardCampaignIds(campaignIds: string[]): void {
+    this.retainedDashboard = {
+      campaignIds,
+      expiresAt: Date.now() + DISCOVERY_RETENTION_TTL_MS,
+    };
+  }
+
+  retainedDashboardCampaignIds(): string[] {
+    if (!this.retainedDashboard) return [];
+    if (this.retainedDashboard.expiresAt <= Date.now()) {
+      this.retainedDashboard = undefined;
+      return [];
+    }
+    return this.retainedDashboard.campaignIds;
+  }
+
+  rememberCampaignDetails(dropID: string, campaign: unknown): void {
+    this.campaignDetailsByDropId.set(dropID, {
+      campaign,
+      expiresAt: Date.now() + DISCOVERY_RETENTION_TTL_MS,
+    });
+  }
+
+  retainedCampaignDetails(dropID: string): unknown {
+    const cached = this.campaignDetailsByDropId.get(dropID);
+    if (!cached) return undefined;
+    if (cached.expiresAt <= Date.now()) {
+      this.campaignDetailsByDropId.delete(dropID);
+      return undefined;
+    }
+    return cached.campaign;
+  }
+}
+
 export type TwitchGqlTransport = <T>(
   operationName: string,
   sha256Hash: string,
@@ -444,10 +483,7 @@ export class TwitchAdapter implements PlatformAdapter {
   private readonly gqlTransport: TwitchGqlTransport;
   private readonly inventoryCapability: TwitchInventoryCapability;
   private readonly availableCampaignsByChannel = new Map<string, CachedAvailableCampaigns>();
-  // The adapter instance outlives a tick, so these carry the last discovery
-  // Twitch actually answered across the next few ticks' transient failures.
-  private readonly campaignDetailsByDropId = new Map<string, CachedCampaignDetails>();
-  private retainedDashboard?: CachedDashboardCampaigns;
+  private readonly discoveryState: TwitchDiscoveryState;
 
   constructor(
     // Twitch GQL is unreachable from the twitch.tv page context (CORS / anti-
@@ -470,6 +506,7 @@ export class TwitchAdapter implements PlatformAdapter {
     private readonly emit: EventEmitter = ignoreEvent,
   ) {
     this.compatibility = options.compatibility;
+    this.discoveryState = options.discoveryState ?? new TwitchDiscoveryState();
     this.gqlTransport = createTwitchGqlTransport(fetcher, options);
     this.inventoryCapability = createTwitchInventory(
       options.compatibility?.inventory ?? "twitch-inventory-v1",
@@ -510,8 +547,8 @@ export class TwitchAdapter implements PlatformAdapter {
     // already started — so falling back to it hides every campaign they have
     // not. Reuse the last dashboard we did get instead. `dashboardResponded`
     // stays false so the expiry stamping below never fires off a stale list.
-    if (dashboardResult.ok) this.rememberDashboardCampaignIds(freshCampaignIds);
-    const discoverableCampaignIds = dashboardResult.ok ? freshCampaignIds : this.retainedDashboardCampaignIds();
+    if (dashboardResult.ok) this.discoveryState.rememberDashboardCampaignIds(freshCampaignIds);
+    const discoverableCampaignIds = dashboardResult.ok ? freshCampaignIds : this.discoveryState.retainedDashboardCampaignIds();
     const dashboardResponded = dashboardResult.ok && dashboardCampaigns.length > 0;
 
     if (discoverableCampaignIds.length === 0) {
@@ -538,11 +575,11 @@ export class TwitchAdapter implements PlatformAdapter {
       if (result.status === "fulfilled") {
         const campaign = result.value.data?.dropCampaign ?? result.value.data?.user?.dropCampaign;
         if (!campaign) return;
-        this.rememberCampaignDetails(dropID, campaign);
+        this.discoveryState.rememberCampaignDetails(dropID, campaign);
         detailedCampaigns.push(campaign);
         return;
       }
-      const retained = this.retainedCampaignDetails(dropID);
+      const retained = this.discoveryState.retainedCampaignDetails(dropID);
       const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
       diagnostic(
         this.emit,
@@ -760,33 +797,6 @@ export class TwitchAdapter implements PlatformAdapter {
       diagnostic(this.emit, "warn", `Twitch drops dashboard request failed; reusing the last campaign list it returned: ${message}`, "twitch");
       return { response: {}, ok: false };
     }
-  }
-
-  private rememberDashboardCampaignIds(campaignIds: string[]): void {
-    this.retainedDashboard = { campaignIds, expiresAt: Date.now() + DISCOVERY_RETENTION_TTL_MS };
-  }
-
-  private retainedDashboardCampaignIds(): string[] {
-    if (!this.retainedDashboard) return [];
-    if (this.retainedDashboard.expiresAt <= Date.now()) {
-      this.retainedDashboard = undefined;
-      return [];
-    }
-    return this.retainedDashboard.campaignIds;
-  }
-
-  private rememberCampaignDetails(dropID: string, campaign: unknown): void {
-    this.campaignDetailsByDropId.set(dropID, { campaign, expiresAt: Date.now() + DISCOVERY_RETENTION_TTL_MS });
-  }
-
-  private retainedCampaignDetails(dropID: string): unknown {
-    const cached = this.campaignDetailsByDropId.get(dropID);
-    if (!cached) return undefined;
-    if (cached.expiresAt <= Date.now()) {
-      this.campaignDetailsByDropId.delete(dropID);
-      return undefined;
-    }
-    return cached.campaign;
   }
 
   // A "claimable" reward can only be claimed once Twitch has released its real

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -21,6 +21,7 @@ const CURRENT_USER_QUERY = "query CurrentUser { currentUser { id } }";
 // behind Client-Integrity (Kasada); non-web client ids (Android/TV) are not.
 const TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 const CHANNEL_CAMPAIGN_CACHE_TTL_MS = 60_000;
+const DISCOVERY_DETAIL_PRUNE_LIMIT = 32;
 // How long a discovery result stays usable when Twitch stops answering. Long
 // enough to ride out an outage of many ticks, short enough that a campaign
 // Twitch quietly stopped serving does not linger for a whole session.
@@ -288,6 +289,20 @@ interface CachedDashboardCampaigns {
   expiresAt: number;
 }
 
+function reconcileInventoryCampaignStatuses(
+  campaigns: DropCampaign[],
+  activeDashboardIds: ReadonlySet<string>,
+  dashboardResponded: boolean,
+): DropCampaign[] {
+  return campaigns.map((campaign) =>
+    dashboardResponded
+    && !activeDashboardIds.has(campaign.id)
+    && !campaignHasClaimableReward(campaign)
+      ? withCampaignStatus(campaign, "expired")
+      : campaign,
+  );
+}
+
 export class TwitchDiscoveryState {
   private readonly campaignDetailsByDropId = new Map<string, CachedCampaignDetails>();
   private authenticatedUserId?: string;
@@ -318,10 +333,21 @@ export class TwitchDiscoveryState {
   }
 
   rememberCampaignDetails(dropID: string, campaign: unknown): void {
+    const now = Date.now();
+    let inspected = 0;
+    for (const [cachedDropID, cached] of this.campaignDetailsByDropId) {
+      if (inspected >= DISCOVERY_DETAIL_PRUNE_LIMIT) break;
+      inspected += 1;
+      if (cached.expiresAt <= now) this.campaignDetailsByDropId.delete(cachedDropID);
+    }
     this.campaignDetailsByDropId.set(dropID, {
       campaign,
-      expiresAt: Date.now() + DISCOVERY_RETENTION_TTL_MS,
+      expiresAt: now + DISCOVERY_RETENTION_TTL_MS,
     });
+  }
+
+  forgetCampaignDetails(dropID: string): void {
+    this.campaignDetailsByDropId.delete(dropID);
   }
 
   retainedCampaignDetails(dropID: string): unknown {
@@ -529,12 +555,23 @@ export class TwitchAdapter implements PlatformAdapter {
     let dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
 
     if (inventoryCampaigns.length === 0 && dashboardCampaigns.length === 0) {
-      inventory = await this.fetchInventory({ fetchRewardCampaigns: true });
-      const fallbackDashboardResult = await this.fetchDashboard({ fetchRewardCampaigns: true });
-      inventoryCampaigns = this.inventoryCapability.parse(inventory);
-      if (fallbackDashboardResult.ok || !dashboardResult.ok) {
-        dashboardResult = fallbackDashboardResult;
-        dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
+      try {
+        inventory = await this.fetchInventory({ fetchRewardCampaigns: true });
+        const fallbackDashboardResult = await this.fetchDashboard({ fetchRewardCampaigns: true });
+        inventoryCampaigns = this.inventoryCapability.parse(inventory);
+        if (fallbackDashboardResult.ok || !dashboardResult.ok) {
+          dashboardResult = fallbackDashboardResult;
+          dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
+        }
+      } catch (error) {
+        if (authHealthFromError(error)) throw error;
+        const message = error instanceof Error ? error.message : String(error);
+        diagnostic(
+          this.emit,
+          "warn",
+          `Twitch reward-campaign inventory request failed; preserving the initial dashboard result: ${message}`,
+          "twitch",
+        );
       }
     }
     const dashboard = dashboardResult.response;
@@ -572,7 +609,11 @@ export class TwitchAdapter implements PlatformAdapter {
     const dashboardResponded = dashboardResult.ok && dashboardCampaigns.length > 0;
 
     if (discoverableCampaignIds.length === 0) {
-      return inventoryCampaigns;
+      return reconcileInventoryCampaignStatuses(
+        inventoryCampaigns,
+        new Set(discoverableCampaignIds),
+        dashboardResponded,
+      );
     }
 
     const details = await Promise.allSettled(
@@ -593,8 +634,24 @@ export class TwitchAdapter implements PlatformAdapter {
     details.forEach((result, index) => {
       const dropID = discoverableCampaignIds[index];
       if (result.status === "fulfilled") {
-        const campaign = result.value.data?.dropCampaign ?? result.value.data?.user?.dropCampaign;
-        if (!campaign) return;
+        const data = result.value.data;
+        const campaign = data?.dropCampaign ?? data?.user?.dropCampaign;
+        if (!campaign) {
+          const campaignWasAuthoritativelyMissing = Boolean(
+            data
+            && (
+              Object.prototype.hasOwnProperty.call(data, "dropCampaign")
+              || (
+                data.user
+                && Object.prototype.hasOwnProperty.call(data.user, "dropCampaign")
+              )
+            ),
+          );
+          if (authenticatedUserId && campaignWasAuthoritativelyMissing) {
+            this.discoveryState.forgetCampaignDetails(dropID);
+          }
+          return;
+        }
         if (authenticatedUserId) this.discoveryState.rememberCampaignDetails(dropID, campaign);
         detailedCampaigns.push(campaign);
         return;
@@ -624,15 +681,11 @@ export class TwitchAdapter implements PlatformAdapter {
     // inventory-only campaign as expired (unless it still has a claimable reward
     // we should keep surfacing so the user can claim it).
     const activeDashboardIds = new Set(discoverableCampaignIds);
-    const inventoryOnly = inventoryCampaigns
-      .filter((campaign) => !detailedIds.has(campaign.id))
-      .map((campaign) =>
-        dashboardResponded
-        && !activeDashboardIds.has(campaign.id)
-        && !campaignHasClaimableReward(campaign)
-          ? withCampaignStatus(campaign, "expired")
-          : campaign,
-      );
+    const inventoryOnly = reconcileInventoryCampaignStatuses(
+      inventoryCampaigns.filter((campaign) => !detailedIds.has(campaign.id)),
+      activeDashboardIds,
+      dashboardResponded,
+    );
     return [...mergedDetails, ...inventoryOnly];
   }
 

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -290,7 +290,16 @@ interface CachedDashboardCampaigns {
 
 export class TwitchDiscoveryState {
   private readonly campaignDetailsByDropId = new Map<string, CachedCampaignDetails>();
+  private authenticatedUserId?: string;
   private retainedDashboard?: CachedDashboardCampaigns;
+
+  setAuthenticatedUser(userId: string): void {
+    if (this.authenticatedUserId && this.authenticatedUserId !== userId) {
+      this.retainedDashboard = undefined;
+      this.campaignDetailsByDropId.clear();
+    }
+    this.authenticatedUserId = userId;
+  }
 
   rememberDashboardCampaignIds(campaignIds: string[]): void {
     this.retainedDashboard = {
@@ -521,9 +530,12 @@ export class TwitchAdapter implements PlatformAdapter {
 
     if (inventoryCampaigns.length === 0 && dashboardCampaigns.length === 0) {
       inventory = await this.fetchInventory({ fetchRewardCampaigns: true });
-      dashboardResult = await this.fetchDashboard({ fetchRewardCampaigns: true });
+      const fallbackDashboardResult = await this.fetchDashboard({ fetchRewardCampaigns: true });
       inventoryCampaigns = this.inventoryCapability.parse(inventory);
-      dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
+      if (fallbackDashboardResult.ok || !dashboardResult.ok) {
+        dashboardResult = fallbackDashboardResult;
+        dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
+      }
     }
     const dashboard = dashboardResult.response;
 
@@ -534,7 +546,9 @@ export class TwitchAdapter implements PlatformAdapter {
       });
     }
 
-    const userLogin = twitchCurrentUserId(inventory) ?? dashboard.data?.currentUser?.id ?? dashboard.data?.currentUser?.login ?? "";
+    const authenticatedUserId = twitchCurrentUserId(inventory) ?? dashboard.data?.currentUser?.id;
+    if (authenticatedUserId) this.discoveryState.setAuthenticatedUser(authenticatedUserId);
+    const userLogin = authenticatedUserId ?? dashboard.data?.currentUser?.login ?? "";
     const freshCampaignIds = dashboardCampaigns
       .filter((campaign) =>
         campaign.id
@@ -547,8 +561,14 @@ export class TwitchAdapter implements PlatformAdapter {
     // already started — so falling back to it hides every campaign they have
     // not. Reuse the last dashboard we did get instead. `dashboardResponded`
     // stays false so the expiry stamping below never fires off a stale list.
-    if (dashboardResult.ok) this.discoveryState.rememberDashboardCampaignIds(freshCampaignIds);
-    const discoverableCampaignIds = dashboardResult.ok ? freshCampaignIds : this.discoveryState.retainedDashboardCampaignIds();
+    if (dashboardResult.ok && authenticatedUserId) {
+      this.discoveryState.rememberDashboardCampaignIds(freshCampaignIds);
+    }
+    const discoverableCampaignIds = dashboardResult.ok
+      ? freshCampaignIds
+      : authenticatedUserId
+        ? this.discoveryState.retainedDashboardCampaignIds()
+        : [];
     const dashboardResponded = dashboardResult.ok && dashboardCampaigns.length > 0;
 
     if (discoverableCampaignIds.length === 0) {
@@ -575,11 +595,13 @@ export class TwitchAdapter implements PlatformAdapter {
       if (result.status === "fulfilled") {
         const campaign = result.value.data?.dropCampaign ?? result.value.data?.user?.dropCampaign;
         if (!campaign) return;
-        this.discoveryState.rememberCampaignDetails(dropID, campaign);
+        if (authenticatedUserId) this.discoveryState.rememberCampaignDetails(dropID, campaign);
         detailedCampaigns.push(campaign);
         return;
       }
-      const retained = this.discoveryState.retainedCampaignDetails(dropID);
+      const retained = authenticatedUserId
+        ? this.discoveryState.retainedCampaignDetails(dropID)
+        : undefined;
       const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
       diagnostic(
         this.emit,

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -22,7 +22,7 @@ import type { ExtensionSettings, Platform, SupportedLocale } from "@lurkloot/sha
 import type { EventEmitter } from "@lurkloot/shared/events";
 import type { WatchTabPort } from "@lurkloot/core/adapter";
 import { createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/kick";
-import { TwitchAdapter } from "@lurkloot/core/twitch";
+import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import { isMinorOrMajorBump } from "../src/core/version";
 import { savePendingChangelogVersion } from "../src/core/updateNotice";
 import { appendActivityEvents, clearActivityEvents, loadActivityEvents } from "../src/core/activityStorage";
@@ -46,6 +46,7 @@ const reportEvents = createActivityEventReporter({
   append: appendActivityEvents,
 });
 const kickClaimState = new KickClaimState();
+const twitchDiscoveryState = new TwitchDiscoveryState();
 const KICK_PAGE_CONTEXT_URL = "https://kick.com/drops/inventory";
 const checkCredentialAvailability = createCredentialAvailabilityProvider({
   get: (details) => browser.cookies.get(details),
@@ -97,6 +98,7 @@ function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings
       watchTabPort,
       {
         compatibility: resolution.compatibility.twitch,
+        discoveryState: twitchDiscoveryState,
         heartbeatIdentity: "web",
         heartbeatFetchText: twitchHeartbeatFetchText,
         heartbeatPost: twitchHeartbeatPost,

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -1343,6 +1343,61 @@ describe("TwitchAdapter", () => {
     expect(campaigns).toEqual([]);
   });
 
+  it("keeps a successful empty dashboard authoritative when the reward-campaign inventory fallback fails", async () => {
+    let refresh = 1;
+    let fallbackInventoryFails = false;
+    let dashboardFails = false;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      const variables = requestBody(init).variables as { fetchRewardCampaigns?: boolean };
+      if (op === "Inventory") {
+        if (fallbackInventoryFails && variables.fetchRewardCampaigns) {
+          throw new Error("reward-campaign inventory unavailable");
+        }
+        return twitchInventory([]);
+      }
+      if (op === "ViewerDropsDashboard") {
+        if (dashboardFails) throw new Error("dashboard unavailable");
+        return twitchDashboard(refresh === 1 ? ["retained"] : []);
+      }
+      if (op === "DropCampaignDetails") {
+        return twitchCampaignDetails(String((requestBody(init).variables as Record<string, unknown>).dropID));
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+      .map((campaign) => campaign.id)).toEqual(["retained"]);
+    refresh = 2;
+    fallbackInventoryFails = true;
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+      .resolves.toEqual([]);
+
+    fallbackInventoryFails = false;
+    dashboardFails = true;
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+      .resolves.toEqual([]);
+  });
+
+  it("still propagates authentication failures from the reward-campaign inventory fallback", async () => {
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      const variables = requestBody(init).variables as { fetchRewardCampaigns?: boolean };
+      if (op === "Inventory") {
+        if (variables.fetchRewardCampaigns) {
+          throw new SafeFetchError({ kind: "authentication_rejected", status: 401, reason: "rejected" });
+        }
+        return twitchInventory([]);
+      }
+      if (op === "ViewerDropsDashboard") return twitchDashboard([]);
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    await expect(new TwitchAdapter(fetcher).discoverCampaigns()).rejects.toThrow(SafeFetchError);
+  });
+
   it("does not reuse discovery retained for another authenticated Twitch user", async () => {
     let userId = "user-a";
     let dashboardFails = false;
@@ -1394,6 +1449,75 @@ describe("TwitchAdapter", () => {
     const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns();
 
     expect(campaigns).toEqual([]);
+  });
+
+  it("marks inventory campaigns expired when a successful dashboard contains only ended campaigns", async () => {
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory(["ended"]);
+      if (op === "ViewerDropsDashboard") {
+        return {
+          data: {
+            currentUser: {
+              id: "user-id",
+              login: "viewer",
+              dropCampaigns: [{ id: "ended", status: "EXPIRED" }],
+            },
+          },
+        };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+
+    expect(campaigns).toHaveLength(1);
+    expect(campaigns[0]).toMatchObject({ id: "ended", status: "expired", eligibility: "expired" });
+  });
+
+  it("does not reuse retained campaign details after Twitch authoritatively returns no campaign", async () => {
+    let detailResponse: "campaign" | "missing" | "failure" = "campaign";
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([]);
+      if (op === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+      if (op === "DropCampaignDetails") {
+        if (detailResponse === "failure") throw new Error("details unavailable");
+        if (detailResponse === "missing") return { data: { dropCampaign: null } };
+        return twitchCampaignDetails("campaign");
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+      .map((campaign) => campaign.id)).toEqual(["campaign"]);
+    detailResponse = "missing";
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+      .resolves.toEqual([]);
+    detailResponse = "failure";
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+      .resolves.toEqual([]);
+  });
+
+  it("prunes expired retained campaign details during a later write", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-07-26T12:00:00.000Z");
+      const discoveryState = new TwitchDiscoveryState();
+      const details = (discoveryState as unknown as {
+        campaignDetailsByDropId: Map<string, unknown>;
+      }).campaignDetailsByDropId;
+
+      discoveryState.rememberCampaignDetails("expired", { id: "expired" });
+      vi.setSystemTime("2026-07-26T12:31:00.000Z");
+      discoveryState.rememberCampaignDetails("fresh", { id: "fresh" });
+
+      expect([...details.keys()]).toEqual(["fresh"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("marks in-progress inventory campaigns the dashboard no longer lists active as expired", async () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -3,7 +3,7 @@ import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
 import { createKickClaimCapability, createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/kick";
 import { fetchTwitchInBackgroundWith, KickWafBlockedError } from "@lurkloot/core/tabs";
 import { readFileSync } from "node:fs";
-import { TwitchAdapter } from "@lurkloot/core/twitch";
+import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import type { EngineEvent } from "@lurkloot/shared/events";
 import type { DropCampaign, DropReward, ExtensionSettings } from "@lurkloot/shared/models";
 import { chooseCampaignDecision } from "@lurkloot/core/scheduler";
@@ -1206,11 +1206,13 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
     const events: EngineEvent[] = [];
-    const adapter = new TwitchAdapter(fetcher, undefined, undefined, undefined, (event) => events.push(event));
+    const discoveryState = new TwitchDiscoveryState();
+    const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
-    expect((await adapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
+    expect((await firstAdapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
     failing = "b";
-    const campaigns = await adapter.discoverCampaigns();
+    const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
+    const campaigns = await secondAdapter.discoverCampaigns();
 
     expect(campaigns.map((campaign) => campaign.id)).toEqual(["a", "b"]);
     expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("b"))).toBe(true);
@@ -1266,38 +1268,51 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
     const events: EngineEvent[] = [];
-    const adapter = new TwitchAdapter(fetcher, undefined, undefined, undefined, (event) => events.push(event));
+    const discoveryState = new TwitchDiscoveryState();
+    const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
-    expect((await adapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+    expect((await firstAdapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
     dashboardFails = true;
-    const campaigns = await adapter.discoverCampaigns();
+    const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
+    const campaigns = await secondAdapter.discoverCampaigns();
 
     expect(campaigns.map((campaign) => campaign.id)).toEqual(["a"]);
     expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("dashboard"))).toBe(true);
 
     dashboardFails = false;
-    expect((await adapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
   });
 
   it("does not retain dashboard campaigns when the dashboard genuinely returns none", async () => {
     let dashboardIds = ["campaign"];
+    let dashboardFails = false;
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
-      if (op === "Inventory") return twitchInventory(["campaign"]);
-      if (op === "ViewerDropsDashboard") return twitchDashboard(dashboardIds);
+      if (op === "Inventory") return twitchInventory([]);
+      if (op === "ViewerDropsDashboard") {
+        if (dashboardFails) throw new Error("service unavailable");
+        return twitchDashboard(dashboardIds);
+      }
       if (op === "DropCampaignDetails") {
         return twitchCampaignDetails(String((requestBody(init).variables as Record<string, unknown>).dropID));
       }
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const discoveryState = new TwitchDiscoveryState();
+    const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
-    expect((await adapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["campaign"]);
+    expect((await firstAdapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["campaign"]);
     dashboardIds = [];
-    const campaigns = await adapter.discoverCampaigns();
+    const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const campaigns = await secondAdapter.discoverCampaigns();
 
-    expect(campaigns).toHaveLength(1);
-    expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Inventory Campaign", status: "active" });
+    expect(campaigns).toEqual([]);
+
+    dashboardFails = true;
+    const thirdAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const failedCampaigns = await thirdAdapter.discoverCampaigns();
+
+    expect(failedCampaigns).toEqual([]);
   });
 
   it("marks in-progress inventory campaigns the dashboard no longer lists active as expired", async () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -26,11 +26,11 @@ function requestBody(init?: RequestInit): Record<string, unknown> {
   return JSON.parse(String(init?.body)) as Record<string, unknown>;
 }
 
-function twitchInventory(campaignIds: string[]): unknown {
+function twitchInventory(campaignIds: string[], userId = "user-id"): unknown {
   return {
     data: {
       currentUser: {
-        id: "user-id",
+        id: userId,
         inventory: {
           dropCampaignsInProgress: campaignIds.map((id) => ({
             id,
@@ -49,11 +49,11 @@ function twitchInventory(campaignIds: string[]): unknown {
   };
 }
 
-function twitchDashboard(campaignIds: string[]): unknown {
+function twitchDashboard(campaignIds: string[], userId = "user-id"): unknown {
   return {
     data: {
       currentUser: {
-        id: "user-id",
+        id: userId,
         login: "viewer",
         dropCampaigns: campaignIds.map((id) => ({ id, status: "ACTIVE", self: { isAccountConnected: true } })),
       },
@@ -1313,6 +1313,87 @@ describe("TwitchAdapter", () => {
     const failedCampaigns = await thirdAdapter.discoverCampaigns();
 
     expect(failedCampaigns).toEqual([]);
+  });
+
+  it("keeps a successful empty first dashboard authoritative when the reward-campaign fallback fails", async () => {
+    let refresh = 1;
+    let fallbackDashboard = false;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([]);
+      if (op === "ViewerDropsDashboard") {
+        if (refresh === 1) return twitchDashboard(["retained"]);
+        if (fallbackDashboard) throw new Error("reward-campaign dashboard unavailable");
+        fallbackDashboard = true;
+        return twitchDashboard([]);
+      }
+      if (op === "DropCampaignDetails") {
+        return twitchCampaignDetails(String((requestBody(init).variables as Record<string, unknown>).dropID));
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+      .map((campaign) => campaign.id)).toEqual(["retained"]);
+    refresh = 2;
+
+    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns();
+
+    expect(campaigns).toEqual([]);
+  });
+
+  it("does not reuse discovery retained for another authenticated Twitch user", async () => {
+    let userId = "user-a";
+    let dashboardFails = false;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([], userId);
+      if (op === "ViewerDropsDashboard") {
+        if (dashboardFails) throw new Error("dashboard unavailable");
+        return twitchDashboard(["user-a-campaign"], userId);
+      }
+      if (op === "DropCampaignDetails") {
+        if (dashboardFails) throw new Error("details unavailable");
+        return twitchCampaignDetails(String((requestBody(init).variables as Record<string, unknown>).dropID));
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+      .map((campaign) => campaign.id)).toEqual(["user-a-campaign"]);
+    userId = "user-b";
+    dashboardFails = true;
+
+    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns();
+
+    expect(campaigns).toEqual([]);
+  });
+
+  it("does not reuse campaign details retained for another authenticated Twitch user", async () => {
+    let userId = "user-a";
+    let detailsFail = false;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([], userId);
+      if (op === "ViewerDropsDashboard") return twitchDashboard(["shared-campaign-id"], userId);
+      if (op === "DropCampaignDetails") {
+        if (detailsFail) throw new Error("details unavailable");
+        return twitchCampaignDetails("shared-campaign-id");
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+      .map((campaign) => campaign.id)).toEqual(["shared-campaign-id"]);
+    userId = "user-b";
+    detailsFail = true;
+
+    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns();
+
+    expect(campaigns).toEqual([]);
   });
 
   it("marks in-progress inventory campaigns the dashboard no longer lists active as expired", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -8,6 +8,7 @@ import { applySettingsPatch, DEFAULT_SETTINGS } from "@lurkloot/shared/settings"
 import { DEFAULT_STATE } from "../src/core/storage";
 import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
 import { createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/kick";
+import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import type { TablessWatchController } from "@lurkloot/core/tablessWatch";
 import type { StopPageContextTabs } from "@lurkloot/core/scheduler";
 import { forgetManagedPageContextTabs, KickWafBlockedError, managedTabBreakerOpen, recordManagedPageContextFallback, registerManagedPageContextTabs, syncManagedTabBreakers } from "@lurkloot/core/tabs";
@@ -60,6 +61,50 @@ function adapter(platform: Platform): PlatformAdapter {
     claimReward: vi.fn(async () => true),
     prepareWatchTab: vi.fn(async () => ({ tabId: platform === "twitch" ? 10 : 20, managedByExtension: true })),
     stopWatchTab: vi.fn(async () => undefined),
+  };
+}
+
+function twitchOperation(init?: RequestInit): string {
+  return JSON.parse(String(init?.body)).operationName;
+}
+
+function twitchInventory(): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: "user-id",
+        inventory: { dropCampaignsInProgress: [] },
+      },
+    },
+  };
+}
+
+function twitchDashboard(campaignIds: string[]): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: "user-id",
+        login: "viewer",
+        dropCampaigns: campaignIds.map((id) => ({ id, status: "ACTIVE", self: { isAccountConnected: true } })),
+      },
+    },
+  };
+}
+
+function twitchCampaignDetails(dropID: string): unknown {
+  return {
+    data: {
+      dropCampaign: {
+        id: dropID,
+        name: `Campaign ${dropID}`,
+        game: { id: "game", slug: "game-slug", displayName: "Game" },
+        timeBasedDrops: [{
+          id: `${dropID}-drop`,
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit: { id: "benefit", name: "Reward" } }],
+        }],
+      },
+    },
   };
 }
 
@@ -136,6 +181,54 @@ function harness(
 }
 
 describe("background controller", () => {
+  it("retains Twitch discovery when each controller tick constructs a fresh adapter", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      running: true,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true, idleWatchlistChannels: [] },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false, idleWatchlistChannels: [] },
+      },
+    });
+    let dashboardFails = false;
+    let detailsFail = false;
+    const discoveryState = new TwitchDiscoveryState();
+    const fetcher: PageFetcher = {
+      fetchJson: vi.fn(async (_url: string, init?: RequestInit): Promise<unknown> => {
+        const operation = twitchOperation(init);
+        if (operation === "CurrentUser") return { data: { currentUser: { id: "user-id" } } };
+        if (operation === "Inventory") return twitchInventory();
+        if (operation === "ViewerDropsDashboard") {
+          if (dashboardFails) throw new Error("service unavailable");
+          return twitchDashboard(["retained"]);
+        }
+        if (operation === "DropCampaignDetails") {
+          if (detailsFail) throw new Error("service unavailable");
+          return twitchCampaignDetails("retained");
+        }
+        if (operation === "DirectoryPage_Game") return { data: { game: { streams: { edges: [] } } } };
+        throw new Error(`Unexpected Twitch operation ${operation}`);
+      }) as PageFetcher["fetchJson"],
+    };
+    vi.mocked(env.deps.createAdapters).mockImplementation((emit, settings) => ({
+      adapters: {
+        twitch: new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, emit),
+      },
+      ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
+    }));
+
+    await env.controller.tick();
+    expect(env.state.campaigns.twitch.map((item) => item.id)).toEqual(["retained"]);
+
+    dashboardFails = true;
+    detailsFail = true;
+    await env.controller.tick();
+
+    expect(env.deps.createAdapters).toHaveBeenCalledTimes(2);
+    expect(env.state.campaigns.twitch.map((item) => item.id)).toEqual(["retained"]);
+  });
+
   it("starts enabled auth probes concurrently and persists each before scheduler work", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: true });
     const twitchHealth = deferred<PlatformAuthHealth>();

--- a/packages/extension/tests/compatibility.test.ts
+++ b/packages/extension/tests/compatibility.test.ts
@@ -38,7 +38,9 @@ describe("extension compatibility construction", () => {
   it("injects the resolved web selection into both adapter option boundaries", () => {
     const backgroundSource = readFileSync(new URL("../entrypoints/background.ts", import.meta.url), "utf8");
 
+    expect(backgroundSource).toContain("const twitchDiscoveryState = new TwitchDiscoveryState();");
     expect(backgroundSource).toContain("compatibility: resolution.compatibility.twitch,");
+    expect(backgroundSource).toContain("discoveryState: twitchDiscoveryState,");
     expect(backgroundSource).toContain("heartbeatIdentity: \"web\",");
     expect(backgroundSource).toContain("{ compatibility: resolution.compatibility.kick, claimState: kickClaimState }");
   });


### PR DESCRIPTION
## Summary

- extract Twitch dashboard and campaign-detail retention into a process-lifetime `TwitchDiscoveryState`
- share that state across reconstructed adapters in the extension background and both CLI transports
- scope retained data to the authenticated Twitch user and clear it on account changes
- preserve authoritative empty dashboard responses, including when the optional reward-campaign fallback fails
- add controller-level, adapter-level, CLI transport, and transport-isolation regressions

## Root cause

`TwitchAdapter` stored retained dashboard IDs and campaign details in instance fields, but extension and CLI controller operations create fresh adapters. The cache therefore disappeared between scheduler ticks, allowing transient dashboard or detail failures to overwrite a complete campaign list with inventory-only results.

## Impact

Previously discovered Twitch campaigns that are absent from inventory now remain available for the existing 30-minute retention window across scheduler ticks and transient failures. Retention remains process-local, does not retain stale emitters/settings, does not cross authenticated users, and successful empty dashboards remain authoritative.

## Testing

- `pnpm test` — CLI 132 tests, extension 1,033 tests, site 3 tests passed
- `pnpm typecheck`
- `pnpm verify` — script/release tests, workspace tests/typechecks, Astro site build, Chromium build, and Firefox build passed
- focused mutation-backed regressions for adapter reconstruction, user switching, authoritative empty dashboards, and CLI transport-handle isolation

Closes #274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Twitch discovery results now persist across adapter refreshes within the same extension session or CLI transport.
  * Previously discovered campaigns can remain visible during temporary dashboard or campaign-detail failures.
  * Successful empty dashboard responses now correctly clear previously retained campaigns.
  * Discovery data remains isolated between different transport sessions and authenticated Twitch accounts.

* **Documentation**
  * Added design and implementation documentation for Twitch discovery retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->