### PR TITLE
fix(twitch): recover rejected integrity tokens across authenticated operations

### DIFF
--- a/docs/superpowers/plans/2026-07-26-twitch-dashboard-integrity-retry.md
+++ b/docs/superpowers/plans/2026-07-26-twitch-dashboard-integrity-retry.md
@@ -1,0 +1,358 @@
+# Twitch Dashboard Integrity Retry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover automatically when Twitch rejects authenticated extension requests for Client-Integrity, without requiring the user to open or reload twitch.tv.
+
+**Architecture:** Keep Twitch's page-minted integrity acquisition behind the injected adapter callback so `@lurkloot/core` remains browser-free. Give that callback an explicit forced-refresh mode, make the browser host obtain a genuinely new token in that mode, and centralize one bounded retry for safe authenticated reads. Keep mutation recovery explicit at each mutation so a generic transport wrapper can never repeat a non-idempotent action accidentally.
+
+**Tech Stack:** TypeScript, WXT browser APIs, Vitest, pnpm workspace
+
+## Global Constraints
+
+- `packages/core` must not import WXT or browser globals.
+- Diagnostic messages remain English literals and are not added to locale catalogs.
+- Retry only Client-Integrity rejections; authentication, network, and other platform failures retain their existing behavior.
+- Make at most one integrity refresh and one dashboard retry per dashboard request.
+- Preserve the existing retained-dashboard fallback if refresh or retry fails.
+- Safe authenticated reads may retry once; mutations must opt in explicitly.
+- Anonymous operations must remain anonymous and must never open a page context.
+- Do not store new credentials or add browser permissions.
+
+---
+
+## Audited Twitch operation scope
+
+| Operation | Policy |
+|---|---|
+| `Inventory`, `ViewerDropsDashboard`, `DropCampaignDetails`, `DirectoryPage_Game`, `DropsHighlightService_AvailableDrops`, `VideoPlayerStreamInfoOverlayChannel`, `DropCurrentSessionContext`, `ChannelPointsContext`, authenticated `CurrentUser` | Use the shared safe-read integrity recovery |
+| `DropsPage_ClaimDropRewards`, `ClaimCommunityPoints` | Ensure integrity before mutation; on an integrity rejection, force refresh and retry exactly once |
+| Anonymous `StreamInfo` and `SearchCategories` | Keep `credentials: \"omit\"`; never refresh integrity |
+| Twitch heartbeat telemetry | Keep its existing transport; do not replay heartbeats through a generic GQL retry |
+| Kick and non-web Twitch CLI identity | No behavior change |
+
+---
+
+### Task 1: Support a forced Twitch integrity refresh
+
+**Files:**
+- Modify: `packages/core/src/core/tabs.ts`
+- Modify: `packages/extension/src/core/tabs.ts`
+- Test: `packages/extension/tests/tabs.test.ts`
+
+**Interfaces:**
+- Produces: `type TwitchIntegrityRequest = { forceRefresh?: boolean }`
+- Produces: `ensureTwitchIntegrityWithBrowser(browserApi, originUrl, timeoutMs, emit, request?): Promise<boolean>`
+- Produces: `ensureTwitchIntegrity(emit?, request?): Promise<boolean>`
+
+- [ ] **Step 1: Write failing tests for forced refresh**
+
+Add focused cases under `describe("ensureTwitchIntegrityWithBrowser")` proving that `{ forceRefresh: true }` does not fast-return when an apparently unexpired token exists, obtains a token different from the rejected token, and does not close or navigate a user-owned Twitch tab. Mock the new-token capture with:
+
+```ts
+setTwitchIntegrity({
+  integrity: "rejected-token",
+  expiresAt: Date.now() + 60_000,
+});
+setTimeout(() => setTwitchIntegrity({
+  integrity: "replacement-token",
+  expiresAt: Date.now() + 60_000,
+}, { isNew: true }), 20);
+```
+
+Assert that a fresh inactive inventory page context is created or an extension-owned context is reloaded, and that the result is `true` only after `replacement-token` is captured.
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts
+```
+
+Expected: FAIL because forced refresh is not supported and the valid-token fast path returns immediately.
+
+- [ ] **Step 3: Implement forced refresh in the browser-free tab port**
+
+Add the request type and extend `ensureTwitchIntegrityWithBrowser`. In forced mode, remember the rejected token, wait specifically for a different valid token, and actively boot a fresh Twitch inventory page context. Never repurpose or navigate a user-owned Twitch tab. Preserve the current fast path when `forceRefresh` is absent:
+
+```ts
+export interface TwitchIntegrityRequest {
+  forceRefresh?: boolean;
+}
+
+const rejectedToken = request?.forceRefresh ? twitchIntegrity?.integrity : undefined;
+if (!request?.forceRefresh && hasValidTwitchIntegrity()) return true;
+```
+
+Update the waiter predicate so forced refresh succeeds only when the captured token is valid and differs from `rejectedToken`. Reuse a retained extension-owned page-context tab only if it is explicitly navigated back to `TWITCH_PAGE_CONTEXT_URL`; otherwise create a new inactive, muted tab.
+
+- [ ] **Step 4: Bind the request through the WXT adapter**
+
+Update the extension wrapper without moving browser APIs into `@lurkloot/core`:
+
+```ts
+export function ensureTwitchIntegrity(
+  emit?: EventEmitter,
+  request?: TwitchIntegrityRequest,
+): Promise<boolean> {
+  return ensureTwitchIntegrityWithBrowser(
+    browser as BrowserTabApi,
+    TWITCH_PAGE_CONTEXT_URL,
+    undefined,
+    emit,
+    request,
+  );
+}
+```
+
+- [ ] **Step 5: Run the tab tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts
+```
+
+Expected: PASS, including existing no-token, reused-tab, timeout, retention, and new forced-refresh cases.
+
+### Task 2: Add bounded recovery for safe authenticated Twitch reads
+
+**Files:**
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Modify: `packages/extension/entrypoints/background.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+- Test: `packages/extension/tests/tablessWatch.test.ts`
+
+**Interfaces:**
+- Consumes: `TwitchIntegrityRequest`
+- Changes constructor callback to: `(request?: TwitchIntegrityRequest) => Promise<boolean>`
+- Produces: `TwitchAdapter.gqlWithIntegrityRetry<T>(...): Promise<TwitchGqlResponse<T>>`
+- Produces: bounded recovery for authenticated reads without changing anonymous calls
+
+- [ ] **Step 1: Write the failing dashboard adapter tests**
+
+Add tests alongside the retained-dashboard failure cases:
+
+```ts
+it("refreshes integrity and retries a rejected dashboard once", async () => {
+  let attempts = 0;
+  const ensureIntegrity = vi.fn(async () => true);
+  const fetcher = jsonFetcher((_url, init) => {
+    const op = operation(init);
+    if (op === "Inventory") return twitchInventory([]);
+    if (op === "ViewerDropsDashboard") {
+      attempts += 1;
+      if (attempts === 1) throw new Error("failed integrity check");
+      return twitchDashboard(["campaign"]);
+    }
+    if (op === "DropCampaignDetails") return twitchCampaignDetails("campaign");
+    throw new Error(`Unexpected op ${op}`);
+  });
+
+  const campaigns = await new TwitchAdapter(fetcher, ensureIntegrity).discoverCampaigns();
+
+  expect(campaigns.map((campaign) => campaign.id)).toEqual(["campaign"]);
+  expect(ensureIntegrity).toHaveBeenCalledOnce();
+  expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+  expect(attempts).toBe(2);
+});
+```
+
+Also cover refresh returning `false`, retry receiving another integrity rejection, and a generic dashboard failure. Those cases must use retained campaigns and must not loop or refresh for non-integrity errors.
+
+- [ ] **Step 2: Write failing safe-read coverage**
+
+Add focused adapter tests that make each authenticated read reject once with `failed integrity check`, then succeed. Use the existing `operation(init)`, `twitchInventory()`, `twitchDashboard()`, and `twitchCampaignDetails()` fixtures, and apply these assertions to every operation:
+
+```ts
+expect(ensureIntegrity).toHaveBeenCalledOnce();
+expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+expect(attemptsByOperation.get(rejectedOperation)).toBe(2);
+```
+
+Create one case for each public entry point: `discoverCampaigns()` for `Inventory`, `ViewerDropsDashboard`, and `DropCampaignDetails`; `listCandidateChannels()` for `DirectoryPage_Game`; `checkChannel()` for `DropsHighlightService_AvailableDrops`; `readProgress()` for `VideoPlayerStreamInfoOverlayChannel` and `DropCurrentSessionContext`; `claimChannelPoints()` for `ChannelPointsContext`; and `checkAuthHealth()` for authenticated `CurrentUser`. Use separate cases where an operation's existing fallback is itself part of the contract: retained campaign details, category-only channel validation, and inventory-only progress. Add a watcher case in `tablessWatch.test.ts` for user-id resolution when the scheduler has not supplied an ID.
+
+- [ ] **Step 3: Prove anonymous calls never acquire integrity**
+
+Extend the existing `StreamInfo` and `SearchCategories` tests with:
+
+```ts
+expect(ensureIntegrity).not.toHaveBeenCalled();
+expect(init?.credentials).toBe("omit");
+```
+
+This guards against an over-broad transport-level retry that would open Twitch tabs for public requests.
+
+- [ ] **Step 4: Run the adapter tests and verify the recovery cases fail**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/adapters.test.ts
+```
+
+Expected: FAIL because authenticated reads currently call `this.gql()` directly and `fetchDashboard()` immediately returns `{ ok: false }`.
+
+- [ ] **Step 5: Add a narrow integrity-rejection predicate**
+
+Keep the predicate local to Twitch transport behavior and case-insensitive:
+
+```ts
+function isIntegrityRejection(error: unknown): boolean {
+  return error instanceof Error && /integrity/i.test(error.message);
+}
+```
+
+Do not classify authentication rejection as integrity failure; the existing `authHealthFromError(error)` branch remains first.
+
+- [ ] **Step 6: Implement the shared safe-read helper**
+
+Add a non-recursive helper on `TwitchAdapter`:
+
+```ts
+private async gqlWithIntegrityRetry<T>(
+  operationName: string,
+  sha256Hash: string,
+  variables: Record<string, unknown>,
+  query?: string,
+  credentials?: RequestCredentials,
+  emit: EventEmitter = this.emit,
+): Promise<TwitchGqlResponse<T>> {
+  try {
+    return await this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit);
+  } catch (error) {
+    if (authHealthFromError(error) || !isIntegrityRejection(error) || credentials === "omit") throw error;
+    const refreshed = await this.ensureIntegrity({ forceRefresh: true });
+    if (!refreshed) throw error;
+    return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit);
+  }
+}
+```
+
+Use this helper only for the authenticated read operations in the audit table. Preserve the special inline-query fallback in `fetchInventory()` by applying recovery to each concrete GQL attempt, and preserve the dashboard retained-campaign catch outside the helper.
+
+- [ ] **Step 7: Implement the dashboard fallback around the shared retry**
+
+Make `fetchDashboard()` call `gqlWithIntegrityRetry()`. Return `{ response, ok: true }` after recovery. If refresh fails or the retry throws, emit the existing retained-campaign warning once with the final reason and return `{ response: {}, ok: false }`.
+
+- [ ] **Step 8: Pass the typed callback from the extension host and watcher**
+
+Keep the existing dependency injection in `packages/extension/entrypoints/background.ts`, forwarding the optional request:
+
+```ts
+(request) => ensureTwitchIntegrity(emit, request)
+```
+
+The CLI remains compatible because the callback has a default implementation and its non-web identity does not require Client-Integrity.
+
+Pass the same callback into `TwitchWatcher` for its authenticated `CurrentUser` fallback. Do not attach it to heartbeat telemetry or anonymous stream lookup.
+
+- [ ] **Step 9: Run focused safe-read tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/adapters.test.ts tests/tabs.test.ts tests/tablessWatch.test.ts
+```
+
+Expected: PASS with exactly one retry for each safe authenticated read, no retry for anonymous reads, and no retained-dashboard warning after successful recovery.
+
+### Task 3: Make Twitch mutation recovery explicit and genuinely fresh
+
+**Files:**
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Consumes: `(request?: TwitchIntegrityRequest) => Promise<boolean>`
+- Produces: one explicit forced-refresh retry for drop and channel-points claims
+
+- [ ] **Step 1: Write a failing stale-token drop-claim test**
+
+Model the callback contract rather than returning `true` unconditionally:
+
+```ts
+const ensureIntegrity = vi.fn(async (request?: TwitchIntegrityRequest) =>
+  request?.forceRefresh === true);
+```
+
+Make the first `DropsPage_ClaimDropRewards` response reject for integrity and the second succeed. Assert the second callback call is exactly `{ forceRefresh: true }`. This replaces the current test's incorrect assumption that calling the non-forcing fast path twice produces a new token.
+
+- [ ] **Step 2: Write failing channel-points mutation tests**
+
+Cover both `ChannelPointsContext` safe-read recovery and `ClaimCommunityPoints` mutation recovery. For the mutation, assert integrity is ensured before the first attempt, an integrity rejection requests one forced refresh, the retry succeeds, and a second rejection propagates without a third attempt.
+
+- [ ] **Step 3: Run the mutation tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/adapters.test.ts
+```
+
+Expected: FAIL because drop claims do not request forced refresh and channel-points claims have no integrity recovery.
+
+- [ ] **Step 4: Correct drop-claim recovery**
+
+Keep the proactive `await this.ensureIntegrity()` before the first claim. Change only the rejection path:
+
+```ts
+const refreshed = await this.ensureIntegrity({ forceRefresh: true });
+```
+
+Retry `runClaim()` once only when refresh succeeds.
+
+- [ ] **Step 5: Add explicit channel-points mutation recovery**
+
+Resolve `ChannelPointsContext` through the safe-read helper. Before `ClaimCommunityPoints`, call the non-forcing ensure fast path. If the mutation is rejected for integrity, force refresh and retry the same claim ID exactly once. Do not use a generic mutation retry wrapper in `createTwitchGqlTransport()`.
+
+- [ ] **Step 6: Run focused mutation tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/adapters.test.ts
+```
+
+Expected: PASS with bounded, explicit mutation recovery.
+
+### Task 4: Verify repository boundaries and regression coverage
+
+**Files:**
+- No additional source files
+
+**Interfaces:**
+- Consumes all behavior from Tasks 1 through 3.
+- Produces a verified release-ready change.
+
+- [ ] **Step 1: Run the core-boundary test**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/coreBoundary.test.ts
+```
+
+Expected: PASS, proving `@lurkloot/core` still has no WXT or browser-global dependency.
+
+- [ ] **Step 2: Run the full repository verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, workspace typechecks, extension tests, site build, and Chromium/Firefox extension builds all pass.
+
+- [ ] **Step 3: Review diagnostic behavior**
+
+Confirm a successful recovery produces one integrity-recovery warning followed by normal discovery, while a failed recovery produces one final retained-campaign warning per tick. Confirm no diagnostic localization keys, manifest permissions, or credential storage were added.
+
+- [ ] **Step 4: Commit the focused fix**
+
+```bash
+git add packages/core/src/core/tabs.ts packages/core/src/platforms/twitch/index.ts packages/extension/src/core/tabs.ts packages/extension/entrypoints/background.ts packages/extension/tests/tabs.test.ts packages/extension/tests/adapters.test.ts packages/extension/tests/tablessWatch.test.ts
+git commit -m "fix(twitch): recover rejected integrity tokens"
+```

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -442,6 +442,12 @@ export interface PageFetchOptions {
   };
   emit?: EventEmitter;
   openReason?: PageContextOpenReason;
+  // Demands a context that is about to boot the SPA from scratch, because the
+  // caller is waiting for the page to issue something (see ensureTwitchIntegrity-
+  // WithBrowser). An already-loaded user tab is idle and would only time out, and
+  // reloading it to force activity is not ours to do — so user tabs are skipped
+  // and an extension-owned context is created or explicitly navigated instead.
+  requireFreshPageContext?: boolean;
 }
 
 export interface CookieApi {
@@ -498,21 +504,45 @@ export function setTwitchIntegrity(value: TwitchIntegrity | undefined, options?:
   }
 }
 
-// Resolves true once a valid token is present, or after timeoutMs (re-checking
+// A forced refresh runs after Twitch rejected a token the extension still
+// considers unexpired, so local expiry alone cannot decide success: the captured
+// token must also differ from the one that was rejected.
+export interface TwitchIntegrityRequest {
+  forceRefresh?: boolean;
+}
+
+function hasReplacementTwitchIntegrity(rejectedToken?: string): boolean {
+  if (!hasValidTwitchIntegrity()) return false;
+  return rejectedToken == null || twitchIntegrity?.integrity !== rejectedToken;
+}
+
+// Resolves true once a usable token is present, or after timeoutMs (re-checking
 // validity at the deadline). A captured token can be near-expiry — captureTwitch-
 // Integrity does not gate on expiry — so resolvers re-check hasValidTwitchIntegrity.
-function waitForIntegrityCapture(timeoutMs: number): Promise<boolean> {
-  if (hasValidTwitchIntegrity()) return Promise.resolve(true);
+// When rejectedToken is set, re-capturing that same token does not settle the
+// wait; the page may replay it before minting a replacement.
+function waitForIntegrityCapture(timeoutMs: number, rejectedToken?: string): Promise<boolean> {
+  if (hasReplacementTwitchIntegrity(rejectedToken)) return Promise.resolve(true);
   return new Promise((resolve) => {
     let settled = false;
     const finish = () => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolve(hasValidTwitchIntegrity());
+      resolve(hasReplacementTwitchIntegrity(rejectedToken));
+    };
+    const onCapture = () => {
+      if (settled) return;
+      // Not a replacement yet — keep waiting until the deadline instead of
+      // reporting the rejected token back as a successful refresh.
+      if (!hasReplacementTwitchIntegrity(rejectedToken)) {
+        integrityWaiters.push(onCapture);
+        return;
+      }
+      finish();
     };
     const timer = setTimeout(finish, timeoutMs);
-    integrityWaiters.push(finish);
+    integrityWaiters.push(onCapture);
   });
 }
 
@@ -520,21 +550,36 @@ function waitForIntegrityCapture(timeoutMs: number): Promise<boolean> {
 // (drop claims). When none is captured — e.g. tabless farming with no twitch.tv
 // tab open — opens or reuses a logged-in twitch.tv page-context tab so the SPA
 // mints one the webRequest listener captures, waits for it, then releases the tab.
+// A forced refresh additionally covers the case where Twitch rejected a token
+// that has not locally expired: it skips the fast path, demands a token
+// different from the rejected one, and only ever boots an extension-owned
+// context so a user's own twitch.tv tab is never navigated or closed.
 export async function ensureTwitchIntegrityWithBrowser(
   browserApi: BrowserTabApi,
   originUrl: string,
   timeoutMs: number = INTEGRITY_REFRESH_TIMEOUT_MS,
   emit: EventEmitter = ignoreEvent,
+  request?: TwitchIntegrityRequest,
 ): Promise<boolean> {
-  if (hasValidTwitchIntegrity()) return true;
+  const forceRefresh = request?.forceRefresh === true;
+  const rejectedToken = forceRefresh ? twitchIntegrity?.integrity : undefined;
+  if (!forceRefresh && hasValidTwitchIntegrity()) return true;
 
-  diagnostic(emit, "info", "No valid Twitch integrity token; using a twitch.tv page context to capture one", "twitch");
+  diagnostic(
+    emit,
+    "info",
+    forceRefresh
+      ? "Twitch rejected the current integrity token; using a twitch.tv page context to mint a replacement"
+      : "No valid Twitch integrity token; using a twitch.tv page context to capture one",
+    "twitch",
+  );
   const origin = new URL(originUrl).origin;
   let pageContext: PageContextTab | undefined;
   try {
     pageContext = await acquirePageContextTab(browserApi, originUrl, origin, {
       retainPageContext: { platform: "twitch" },
       emit,
+      requireFreshPageContext: forceRefresh,
     });
     // Which context we got decides whether waiting can work at all: only a
     // freshly created tab is guaranteed to boot the SPA and issue authenticated
@@ -545,7 +590,7 @@ export async function ensureTwitchIntegrityWithBrowser(
     // On success the capture itself is logged once by setTwitchIntegrity (info);
     // here we only surface the failure case so the log isn't doubled up.
     const startedAt = Date.now();
-    const captured = await waitForIntegrityCapture(timeoutMs);
+    const captured = await waitForIntegrityCapture(timeoutMs, rejectedToken);
     if (!captured) {
       diagnostic(emit, "warn", `Timed out waiting for a Twitch integrity token after ${Date.now() - startedAt}ms from a ${source} page context (is twitch.tv logged in?)`, "twitch");
     }
@@ -928,8 +973,10 @@ async function findOrCreatePageContextTab(
       .filter((tab): tab is ManagedPageContextTab => tab != null && tab.origin === origin)
       .map((tab) => tab.tabId),
   );
+  const requireFresh = options?.requireFreshPageContext === true;
   let tabId: number | undefined;
   for (const tab of tabs) {
+    if (requireFresh) break;
     if (tab.id == null || retainedIds.has(tab.id)) continue;
     if (await isUsablePageContext(browserApi, tab.id, origin, signal)) {
       tabId = tab.id;
@@ -968,6 +1015,16 @@ async function findOrCreatePageContextTab(
       const tab = await withAbortSignal(browserApi.tabs.get(retained.tabId), signal);
       if (tab?.id && tab.url?.startsWith(origin) && await isUsablePageContext(browserApi, tab.id, origin, signal)) {
         retainedPageContextTabs.set(retained.platform, retained);
+        // We own this tab, so re-navigating it to boot the SPA again is safe —
+        // it is the only way a retained (and by now idle) context issues the
+        // authenticated request the caller is waiting on.
+        if (requireFresh) {
+          signal?.throwIfAborted();
+          await withAbortSignal(browserApi.tabs.update(tab.id, { url: originUrl }), signal);
+          await waitForPageContextReady(browserApi, tab.id, origin, signal);
+          diagnostic(options?.emit ?? ignoreEvent, "debug", `Reloaded managed page context on ${new URL(origin).host} to force a fresh page request`, retained.platform);
+          return { tabId: tab.id, createdByExtension: true, retainedContext: retained, openedForRequest: true, source: "managed_tab" };
+        }
         diagnostic(options?.emit ?? ignoreEvent, "debug", `Reused managed page context on ${new URL(origin).host}`, retained.platform);
         return { tabId: tab.id, createdByExtension: true, retainedContext: retained, source: "managed_tab" };
       }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -172,6 +172,18 @@ interface TwitchGqlResponse<T> {
   message?: string;
 }
 
+// The single definition of "Twitch rejected this for Client-Integrity, and a
+// fresh token could fix it" — shared by the adapter's safe reads, both claim
+// mutations, and the tabless watcher, so the rule cannot drift between them.
+// Authentication rejection is excluded first: an invalid session fails the same
+// request, but no integrity token can repair it. Anonymous requests are excluded
+// because they carry no token and must never open a page context.
+function isIntegrityRejection(error: unknown, credentials?: RequestCredentials): boolean {
+  if (credentials === "omit") return false;
+  if (authHealthFromError(error)) return false;
+  return error instanceof Error && /integrity/i.test(error.message);
+}
+
 type TwitchGqlFailureKind = "network" | "credentials" | "platform";
 
 class TwitchGqlFailure extends Error {
@@ -897,7 +909,7 @@ export class TwitchAdapter implements PlatformAdapter {
       const message = error instanceof Error ? error.message : String(error);
       // Only integrity rejections are worth a refresh + retry; everything else
       // (e.g. an unexpected status or a stale id) propagates unchanged.
-      if (!/integrity/i.test(message)) throw error;
+      if (!isIntegrityRejection(error)) throw error;
       diagnostic(this.emit, "warn", `Claim for ${reward.name} was rejected for integrity; refreshing the token and retrying once`, "twitch");
       // Twitch rejected the token it was sent, so the local expiry says nothing:
       // only a forced refresh replaces it. Retry exactly once; a second failure
@@ -939,7 +951,7 @@ export class TwitchAdapter implements PlatformAdapter {
     try {
       return await this.runChannelPointsClaim(claimId, channelId);
     } catch (error) {
-      if (!this.shouldRecoverIntegrity(error)) throw error;
+      if (!isIntegrityRejection(error)) throw error;
       diagnostic(this.emit, "warn", `Channel-points claim for ${channel.username} was rejected for integrity; refreshing the token and retrying once`, "twitch");
       if (!await this.ensureIntegrity({ forceRefresh: true })) throw error;
       return await this.runChannelPointsClaim(claimId, channelId);
@@ -1053,19 +1065,11 @@ export class TwitchAdapter implements PlatformAdapter {
     try {
       return await this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
     } catch (error) {
-      if (!this.shouldRecoverIntegrity(error, credentials)) throw error;
+      if (!isIntegrityRejection(error, credentials)) throw error;
       diagnostic(emit, "debug", `GQL ${operationName} was rejected for integrity; refreshing the token and retrying once`, "twitch");
       if (!await this.ensureIntegrity({ forceRefresh: true })) throw error;
       return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
     }
-  }
-
-  // Authentication rejection is checked first: an invalid session also fails the
-  // request, but no integrity token can fix it.
-  private shouldRecoverIntegrity(error: unknown, credentials?: RequestCredentials): boolean {
-    if (credentials === "omit") return false;
-    if (authHealthFromError(error)) return false;
-    return error instanceof Error && /integrity/i.test(error.message);
   }
 
   private async checkChannelFromPage(
@@ -1203,7 +1207,7 @@ class TwitchWatcher implements TablessWatchController {
       } catch (error) {
         // Bounded to one forced refresh and one identical replay, like the
         // adapter's safe authenticated reads.
-        if (authHealthFromError(error) || !(error instanceof Error) || !/integrity/i.test(error.message)) throw error;
+        if (!isIntegrityRejection(error)) throw error;
         this.log("debug", "Twitch viewer id lookup was rejected for integrity; refreshing the token and retrying once");
         if (!await this.ensureIntegrity({ forceRefresh: true })) throw error;
         response = await currentUser();

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -2,6 +2,7 @@ import type { CategorySelection, ChannelCandidate, ChannelCheck, DropCampaign, D
 import type { EventEmitter } from "@lurkloot/shared/events";
 import type { LogLevel } from "@lurkloot/shared/logging";
 import { authHealthFromError, SafeFetchError } from "../../core/fetchError";
+import type { TwitchIntegrityRequest } from "../../core/tabs";
 import { PendingWatcherDiagnostics, type HeartbeatResult, type TablessWatchController, type WatchContext } from "../../core/tablessWatch";
 import { diagnostic, ignoreEvent, unavailableWatchTabPort, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { campaignHasClaimableReward, mergeTwitchCampaignProgress, parseTwitchInventory, twitchCandidatesFromCampaign, withCampaignStatus } from "./parser";
@@ -478,7 +479,7 @@ export class TwitchAdapter implements PlatformAdapter {
   async checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth> {
     const checkedAt = new Date().toISOString();
     try {
-      const response = await this.gqlTransport<{ currentUser?: { id?: string } | null }>(
+      const response = await this.gqlWithIntegrityRetry<{ currentUser?: { id?: string } | null }>(
         "CurrentUser",
         "",
         {},
@@ -530,7 +531,7 @@ export class TwitchAdapter implements PlatformAdapter {
     // this is only meaningful under that id (the extension, which captures the
     // page-minted token). A runtime using a non-web client id never needs it, so
     // it defaults to "no integrity available".
-    private readonly ensureIntegrity: () => Promise<boolean> = async () => false,
+    private readonly ensureIntegrity: (request?: TwitchIntegrityRequest) => Promise<boolean> = async () => false,
     // Tab-based watch is browser-bound, so it is injected (see WatchTabPort).
     private readonly watchTabPort: WatchTabPort = unavailableWatchTabPort,
     // Identity the GQL requests present. Defaults to the WEB client (what the
@@ -618,7 +619,7 @@ export class TwitchAdapter implements PlatformAdapter {
 
     const details = await Promise.allSettled(
       discoverableCampaignIds.map((dropID) =>
-        this.gql<TwitchCampaignDetailsData>("DropCampaignDetails", TWITCH_QUERIES.campaignDetailsHash, {
+        this.gqlWithIntegrityRetry<TwitchCampaignDetailsData>("DropCampaignDetails", TWITCH_QUERIES.campaignDetailsHash, {
           channelLogin: userLogin,
           dropID,
         }),
@@ -701,7 +702,7 @@ export class TwitchAdapter implements PlatformAdapter {
     if (aclCandidates.length > 0) return aclCandidates;
     if (!campaign.slug && !campaign.categoryId) return [];
 
-    const response = await this.gql<TwitchDirectoryData>("DirectoryPage_Game", TWITCH_QUERIES.gameDirectoryHash, {
+    const response = await this.gqlWithIntegrityRetry<TwitchDirectoryData>("DirectoryPage_Game", TWITCH_QUERIES.gameDirectoryHash, {
       slug: campaign.slug ?? campaign.gameName,
       imageWidth: 50,
       includeCostreaming: false,
@@ -796,7 +797,7 @@ export class TwitchAdapter implements PlatformAdapter {
     if (cached) this.availableCampaignsByChannel.delete(channelId);
 
     try {
-      const response = await this.gql<TwitchAvailableDropsData>(
+      const response = await this.gqlWithIntegrityRetry<TwitchAvailableDropsData>(
         "DropsHighlightService_AvailableDrops",
         TWITCH_QUERIES.availableDropsHash,
         { channelID: channelId },
@@ -846,11 +847,11 @@ export class TwitchAdapter implements PlatformAdapter {
 
   private async fetchInventory(variables: Record<string, unknown> = { ...this.inventoryCapability.variables }): Promise<unknown> {
     try {
-      return await this.gql<unknown>("Inventory", this.inventoryCapability.hash, variables);
+      return await this.gqlWithIntegrityRetry<unknown>("Inventory", this.inventoryCapability.hash, variables);
     } catch (error) {
       if (!(error instanceof Error) || !/PersistedQueryNotFound/i.test(error.message)) throw error;
       diagnostic(this.emit, "debug", `GQL Inventory persisted query not found for ${this.inventoryCapability.id}; retrying with its inline query`, "twitch");
-      return this.gql<unknown>("Inventory", this.inventoryCapability.hash, variables, this.inventoryCapability.inlineQuery);
+      return this.gqlWithIntegrityRetry<unknown>("Inventory", this.inventoryCapability.hash, variables, this.inventoryCapability.inlineQuery);
     }
   }
 
@@ -860,7 +861,7 @@ export class TwitchAdapter implements PlatformAdapter {
     variables: Record<string, unknown>,
   ): Promise<{ response: TwitchGqlResponse<TwitchDashboardData>; ok: boolean }> {
     try {
-      const response = await this.gql<TwitchDashboardData>(
+      const response = await this.gqlWithIntegrityRetry<TwitchDashboardData>(
         TWITCH_QUERIES.dashboard.operationName,
         TWITCH_QUERIES.dashboard.sha256Hash,
         variables,
@@ -898,9 +899,10 @@ export class TwitchAdapter implements PlatformAdapter {
       // (e.g. an unexpected status or a stale id) propagates unchanged.
       if (!/integrity/i.test(message)) throw error;
       diagnostic(this.emit, "warn", `Claim for ${reward.name} was rejected for integrity; refreshing the token and retrying once`, "twitch");
-      // The captured token may have just expired or been anonymous; force one
-      // refresh and retry exactly once. A second failure propagates.
-      const refreshed = await this.ensureIntegrity();
+      // Twitch rejected the token it was sent, so the local expiry says nothing:
+      // only a forced refresh replaces it. Retry exactly once; a second failure
+      // propagates.
+      const refreshed = await this.ensureIntegrity({ forceRefresh: true });
       if (refreshed) return await this.runClaim(reward);
       throw new Error(`Twitch rejected the claim for ${reward.name} (${message}). Keep a logged-in twitch.tv tab open so the extension can capture a valid integrity token, then retry.`);
     }
@@ -920,7 +922,7 @@ export class TwitchAdapter implements PlatformAdapter {
   }
 
   async claimChannelPoints(channel: ChannelCandidate): Promise<boolean> {
-    const context = await this.gql<TwitchChannelPointsData>(
+    const context = await this.gqlWithIntegrityRetry<TwitchChannelPointsData>(
       "ChannelPointsContext",
       TWITCH_QUERIES.channelPointsHash,
       { channelLogin: channel.username },
@@ -929,6 +931,22 @@ export class TwitchAdapter implements PlatformAdapter {
     const claimId = context.data?.community?.channel?.self?.communityPoints?.availableClaim?.id;
     if (!channelId || !claimId) return false;
 
+    // Like a drop claim, this mutation is gated on Client-Integrity. Ensure one
+    // exists first (a no-op fast path when a token is already captured), then
+    // recover explicitly rather than through a generic transport retry — the
+    // same claim id must never be replayed more than once.
+    await this.ensureIntegrity();
+    try {
+      return await this.runChannelPointsClaim(claimId, channelId);
+    } catch (error) {
+      if (!this.shouldRecoverIntegrity(error)) throw error;
+      diagnostic(this.emit, "warn", `Channel-points claim for ${channel.username} was rejected for integrity; refreshing the token and retrying once`, "twitch");
+      if (!await this.ensureIntegrity({ forceRefresh: true })) throw error;
+      return await this.runChannelPointsClaim(claimId, channelId);
+    }
+  }
+
+  private async runChannelPointsClaim(claimId: string, channelId: string): Promise<boolean> {
     const result = await this.gql<{ claimCommunityPoints?: { status?: string } }>(
       "ClaimCommunityPoints",
       TWITCH_QUERIES.claimCommunityPointsHash,
@@ -956,7 +974,7 @@ export class TwitchAdapter implements PlatformAdapter {
   supportsPostClaimHandoff = true;
 
   createTablessWatcher(): TablessWatchController {
-    return new TwitchWatcher(this.gqlTransport, this.options);
+    return new TwitchWatcher(this.gqlTransport, this.options, this.ensureIntegrity);
   }
 
   private async mergeCurrentSessionProgress(
@@ -964,7 +982,7 @@ export class TwitchAdapter implements PlatformAdapter {
     channel: ChannelCandidate,
   ): Promise<DropCampaign[]> {
     try {
-      const streamInfo = await this.gql<TwitchStreamInfoData>(
+      const streamInfo = await this.gqlWithIntegrityRetry<TwitchStreamInfoData>(
         "VideoPlayerStreamInfoOverlayChannel",
         TWITCH_QUERIES.streamInfoHash,
         { channel: channel.username },
@@ -972,7 +990,7 @@ export class TwitchAdapter implements PlatformAdapter {
       const channelId = streamInfo.data?.user?.id;
       if (!channelId) return campaigns;
 
-      const current = await this.gql<TwitchCurrentDropData>(
+      const current = await this.gqlWithIntegrityRetry<TwitchCurrentDropData>(
         "DropCurrentSessionContext",
         TWITCH_QUERIES.currentDropHash,
         { channelID: channelId, channelLogin: "" },
@@ -1010,8 +1028,44 @@ export class TwitchAdapter implements PlatformAdapter {
     query?: string,
     credentials?: RequestCredentials,
     emit: EventEmitter = this.emit,
+    signal?: AbortSignal,
   ): Promise<TwitchGqlResponse<T>> {
-    return this.gqlTransport(operationName, sha256Hash, variables, query, credentials, emit);
+    return this.gqlTransport(operationName, sha256Hash, variables, query, credentials, emit, signal);
+  }
+
+  // Twitch can reject an authenticated request for Client-Integrity while the
+  // session itself is fine and the captured token has not locally expired, so
+  // the only recovery is a genuinely fresh token. Bounded to one forced refresh
+  // and one identical replay; the caller's own fallback handles the rest.
+  //
+  // This deliberately lives above the transport rather than inside it: the same
+  // transport carries mutations (which must never be replayed implicitly) and
+  // anonymous requests (which must never open a page context).
+  private async gqlWithIntegrityRetry<T>(
+    operationName: string,
+    sha256Hash: string,
+    variables: Record<string, unknown>,
+    query?: string,
+    credentials?: RequestCredentials,
+    emit: EventEmitter = this.emit,
+    signal?: AbortSignal,
+  ): Promise<TwitchGqlResponse<T>> {
+    try {
+      return await this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
+    } catch (error) {
+      if (!this.shouldRecoverIntegrity(error, credentials)) throw error;
+      diagnostic(emit, "debug", `GQL ${operationName} was rejected for integrity; refreshing the token and retrying once`, "twitch");
+      if (!await this.ensureIntegrity({ forceRefresh: true })) throw error;
+      return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
+    }
+  }
+
+  // Authentication rejection is checked first: an invalid session also fails the
+  // request, but no integrity token can fix it.
+  private shouldRecoverIntegrity(error: unknown, credentials?: RequestCredentials): boolean {
+    if (credentials === "omit") return false;
+    if (authHealthFromError(error)) return false;
+    return error instanceof Error && /integrity/i.test(error.message);
   }
 
   private async checkChannelFromPage(
@@ -1064,6 +1118,9 @@ class TwitchWatcher implements TablessWatchController {
   constructor(
     private readonly gql: TwitchGqlTransport,
     options: TwitchAdapterOptions,
+    // Only the authenticated CurrentUser fallback below uses this. The anonymous
+    // stream lookup and the heartbeat telemetry are deliberately excluded.
+    private readonly ensureIntegrity: (request?: TwitchIntegrityRequest) => Promise<boolean> = async () => false,
   ) {
     this.heartbeatStrategy = options.heartbeatStrategy ?? createTwitchHeartbeat(
       options.compatibility?.heartbeat ?? "twitch-heartbeat-gql-v1",
@@ -1138,8 +1195,19 @@ class TwitchWatcher implements TablessWatchController {
 
   private async resolveUserId(): Promise<string | undefined> {
     if (this.viewerUserId) return this.viewerUserId;
+    const currentUser = () => this.gql<{ currentUser?: { id?: string } }>("CurrentUser", "", {}, CURRENT_USER_QUERY, undefined, this.diagnostics.emit);
     try {
-      const response = await this.gql<{ currentUser?: { id?: string } }>("CurrentUser", "", {}, CURRENT_USER_QUERY, undefined, this.diagnostics.emit);
+      let response;
+      try {
+        response = await currentUser();
+      } catch (error) {
+        // Bounded to one forced refresh and one identical replay, like the
+        // adapter's safe authenticated reads.
+        if (authHealthFromError(error) || !(error instanceof Error) || !/integrity/i.test(error.message)) throw error;
+        this.log("debug", "Twitch viewer id lookup was rejected for integrity; refreshing the token and retrying once");
+        if (!await this.ensureIntegrity({ forceRefresh: true })) throw error;
+        response = await currentUser();
+      }
       this.viewerUserId = response.data?.currentUser?.id;
     } catch (error) {
       // Leave unresolved; tick() reports the missing-user case to the scheduler.

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -94,7 +94,7 @@ function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings
   const adapter = platform === "twitch"
     ? new TwitchAdapter(
       { fetchJson: (url, init) => fetchTwitchInBackground(url, init) },
-      () => ensureTwitchIntegrity(emit),
+      (request) => ensureTwitchIntegrity(emit, request),
       watchTabPort,
       {
         compatibility: resolution.compatibility.twitch,

--- a/packages/extension/src/core/tabs.ts
+++ b/packages/extension/src/core/tabs.ts
@@ -17,6 +17,7 @@ import {
   type CookieApi,
   type PageFetchOptions,
   type SchedulerManagedPageContexts,
+  type TwitchIntegrityRequest,
 } from "@lurkloot/core/tabs";
 import type { PreparedWatchTab, WatchTabOptions } from "@lurkloot/core/adapter";
 
@@ -38,8 +39,8 @@ export function applyAdFocus(platform: Platform, tabId: number | undefined, adAc
   return applyAdFocusWithBrowser(browser as BrowserTabApi, platform, tabId, adActive, mode, emit);
 }
 
-export function ensureTwitchIntegrity(emit?: EventEmitter): Promise<boolean> {
-  return ensureTwitchIntegrityWithBrowser(browser as BrowserTabApi, TWITCH_PAGE_CONTEXT_URL, undefined, emit);
+export function ensureTwitchIntegrity(emit?: EventEmitter, request?: TwitchIntegrityRequest): Promise<boolean> {
+  return ensureTwitchIntegrityWithBrowser(browser as BrowserTabApi, TWITCH_PAGE_CONTEXT_URL, undefined, emit, request);
 }
 
 export function fetchTwitchInBackground<T>(url: string, init?: RequestInit): Promise<T> {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2594,3 +2594,350 @@ describe("TwitchAdapter client identity", () => {
     expect(headers["User-Agent"]).toBeUndefined();
   });
 });
+
+// Twitch can reject an authenticated request with "failed integrity check" even
+// while the session is healthy and the captured token has not locally expired.
+// Recovery is a single forced refresh plus a single identical retry — never a
+// loop, never for anonymous requests, and never for other failure kinds.
+describe("TwitchAdapter integrity recovery", () => {
+  const INTEGRITY_REJECTION = { error: "failed integrity check" };
+
+  // Models the real callback contract: only a forced request can produce a token
+  // different from the one Twitch just rejected.
+  function integrityCallback() {
+    return vi.fn(async (request?: { forceRefresh?: boolean }) => request?.forceRefresh === true);
+  }
+
+  // Rejects the named operation on its first call only, then serves `payload`.
+  function rejectFirst(target: string, payload: (init?: RequestInit) => unknown) {
+    const attempts = new Map<string, number>();
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      attempts.set(op, (attempts.get(op) ?? 0) + 1);
+      if (op === target && attempts.get(op) === 1) return INTEGRITY_REJECTION;
+      return payload(init);
+    });
+    return { fetcher, attempts };
+  }
+
+  describe("safe authenticated reads", () => {
+    const dropID = (init?: RequestInit) =>
+      String((requestBody(init).variables as Record<string, unknown>).dropID);
+
+    const discoveryPayload = (init?: RequestInit) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([]);
+      if (op === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+      if (op === "DropCampaignDetails") return twitchCampaignDetails(dropID(init));
+      throw new Error(`Unexpected op ${op}`);
+    };
+
+    it.each(["ViewerDropsDashboard", "Inventory", "DropCampaignDetails"])(
+      "refreshes integrity once and retries %s once during discovery",
+      async (target) => {
+        const ensureIntegrity = integrityCallback();
+        const { fetcher, attempts } = rejectFirst(target, discoveryPayload);
+
+        const campaigns = await new TwitchAdapter(fetcher, ensureIntegrity).discoverCampaigns();
+
+        expect(campaigns.map((campaign) => campaign.id)).toEqual(["campaign"]);
+        expect(ensureIntegrity).toHaveBeenCalledOnce();
+        expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+        expect(attempts.get(target)).toBe(2);
+      },
+    );
+
+    it("recovers the dashboard without warning about retained campaigns", async () => {
+      const events: EngineEvent[] = [];
+      const ensureIntegrity = integrityCallback();
+      const { fetcher } = rejectFirst("ViewerDropsDashboard", discoveryPayload);
+
+      const campaigns = await new TwitchAdapter(
+        fetcher,
+        ensureIntegrity,
+        undefined,
+        {},
+        (event) => events.push(event),
+      ).discoverCampaigns();
+
+      expect(campaigns.map((campaign) => campaign.id)).toEqual(["campaign"]);
+      expect(events).not.toContainEqual(expect.objectContaining({
+        message: expect.stringContaining("reusing the last campaign list"),
+      }));
+    });
+
+    it("falls back to retained campaigns when the forced refresh fails", async () => {
+      const events: EngineEvent[] = [];
+      const ensureIntegrity = vi.fn(async () => false);
+      let dashboardAttempts = 0;
+      const fetcher = jsonFetcher((_url, init) => {
+        const op = operation(init);
+        if (op === "Inventory") return twitchInventory([]);
+        if (op === "ViewerDropsDashboard") {
+          dashboardAttempts += 1;
+          return INTEGRITY_REJECTION;
+        }
+        if (op === "DropCampaignDetails") return twitchCampaignDetails(dropID(init));
+        throw new Error(`Unexpected op ${op}`);
+      });
+
+      await new TwitchAdapter(fetcher, ensureIntegrity, undefined, {}, (event) => events.push(event))
+        .discoverCampaigns();
+
+      // Discovery makes two dashboard requests when both lists come back empty
+      // (the second asks for reward campaigns). Each gets one refresh attempt
+      // and, because the refresh failed, no retry at all.
+      expect(ensureIntegrity).toHaveBeenCalledTimes(2);
+      expect(ensureIntegrity.mock.calls).toEqual([[{ forceRefresh: true }], [{ forceRefresh: true }]]);
+      expect(dashboardAttempts).toBe(2);
+      expect(events).toContainEqual(expect.objectContaining({
+        level: "warn",
+        message: expect.stringContaining("reusing the last campaign list"),
+      }));
+    });
+
+    it("stops after one retry when the refreshed token is rejected again", async () => {
+      const ensureIntegrity = integrityCallback();
+      let dashboardAttempts = 0;
+      const fetcher = jsonFetcher((_url, init) => {
+        const op = operation(init);
+        if (op === "Inventory") return twitchInventory([]);
+        if (op === "ViewerDropsDashboard") {
+          dashboardAttempts += 1;
+          return INTEGRITY_REJECTION;
+        }
+        throw new Error(`Unexpected op ${op}`);
+      });
+
+      await new TwitchAdapter(fetcher, ensureIntegrity).discoverCampaigns();
+
+      // Two dashboard requests, each bounded to exactly one refresh and one
+      // retry — the second rejection is never refreshed or replayed again.
+      expect(ensureIntegrity).toHaveBeenCalledTimes(2);
+      expect(dashboardAttempts).toBe(4);
+    });
+
+    it("does not enter integrity recovery for a generic dashboard failure", async () => {
+      const ensureIntegrity = integrityCallback();
+      let dashboardAttempts = 0;
+      const fetcher = jsonFetcher((_url, init) => {
+        const op = operation(init);
+        if (op === "Inventory") return twitchInventory([]);
+        if (op === "ViewerDropsDashboard") {
+          dashboardAttempts += 1;
+          throw new Error("dashboard unavailable");
+        }
+        throw new Error(`Unexpected op ${op}`);
+      });
+
+      await new TwitchAdapter(fetcher, ensureIntegrity).discoverCampaigns();
+
+      // Both dashboard requests fail generically: no refresh, and no replay of
+      // either request.
+      expect(ensureIntegrity).not.toHaveBeenCalled();
+      expect(dashboardAttempts).toBe(2);
+    });
+
+    it("refreshes integrity once and retries DirectoryPage_Game once", async () => {
+      const ensureIntegrity = integrityCallback();
+      const { fetcher, attempts } = rejectFirst("DirectoryPage_Game", () => ({
+        data: {
+          game: {
+            streams: {
+              edges: [{ node: { broadcaster: { login: "Creator", displayName: "Creator" }, viewersCount: 5 } }],
+            },
+          },
+        },
+      }));
+
+      const candidates = await new TwitchAdapter(fetcher, ensureIntegrity)
+        .listCandidateChannels({ id: "campaign", slug: "game-slug" } as DropCampaign);
+
+      expect(candidates.map((candidate) => candidate.username)).toEqual(["creator"]);
+      expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+      expect(attempts.get("DirectoryPage_Game")).toBe(2);
+    });
+
+    it("refreshes integrity once and retries DropsHighlightService_AvailableDrops once", async () => {
+      const ensureIntegrity = integrityCallback();
+      const { fetcher, attempts } = rejectFirst("DropsHighlightService_AvailableDrops", (init) => {
+        const op = operation(init);
+        if (op === "StreamInfo") {
+          return { data: { user: { id: "channel-id", displayName: "Creator", stream: { id: "b", game: { id: "game" } } } } };
+        }
+        if (op === "DropsHighlightService_AvailableDrops") {
+          return { data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } } };
+        }
+        throw new Error(`Unexpected op ${op}`);
+      });
+
+      const check = await new TwitchAdapter(fetcher, ensureIntegrity).checkChannel(
+        { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+        { id: "campaign", categoryId: "game" } as DropCampaign,
+      );
+
+      expect(check.campaignMatches).toBe(true);
+      expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+      expect(attempts.get("DropsHighlightService_AvailableDrops")).toBe(2);
+    });
+
+    it.each(["VideoPlayerStreamInfoOverlayChannel", "DropCurrentSessionContext"])(
+      "refreshes integrity once and retries %s once while merging session progress",
+      async (target) => {
+        const ensureIntegrity = integrityCallback();
+        const { fetcher, attempts } = rejectFirst(target, (init) => {
+          const op = operation(init);
+          if (op === "Inventory") return twitchInventory(["campaign"]);
+          if (op === "VideoPlayerStreamInfoOverlayChannel") return { data: { user: { id: "channel-id" } } };
+          if (op === "DropCurrentSessionContext") {
+            return { data: { currentUser: { dropCurrentSession: { dropID: "campaign-drop", currentMinutesWatched: 42 } } } };
+          }
+          throw new Error(`Unexpected op ${op}`);
+        });
+        const campaigns = [{
+          id: "campaign",
+          rewards: [{ id: "campaign-drop", name: "Reward", requiredMinutes: 60, watchedMinutes: 20, status: "in_progress" }],
+        }] as DropCampaign[];
+
+        const progressed = await new TwitchAdapter(fetcher, ensureIntegrity).readProgress(campaigns, {
+          platform: "twitch",
+          status: "watching",
+          offlineChecks: 0,
+          channel: { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+        } as never);
+
+        expect(progressed[0]?.rewards[0]?.watchedMinutes).toBe(42);
+        expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+        expect(attempts.get(target)).toBe(2);
+      },
+    );
+
+    it("refreshes integrity once and retries the authenticated CurrentUser probe once", async () => {
+      const ensureIntegrity = integrityCallback();
+      const { fetcher, attempts } = rejectFirst("CurrentUser", () => ({
+        data: { currentUser: { id: "user-id" } },
+      }));
+
+      const health = await new TwitchAdapter(fetcher, ensureIntegrity).checkAuthHealth();
+
+      expect(health.status).toBe("healthy");
+      expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+      expect(attempts.get("CurrentUser")).toBe(2);
+    });
+  });
+
+  describe("anonymous reads", () => {
+    it.each([
+      ["StreamInfo", (adapter: TwitchAdapter) => adapter.checkChannel({ platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" })],
+      ["SearchCategories", (adapter: TwitchAdapter) => adapter.searchCategories("rust")],
+    ])("keeps %s anonymous and never acquires integrity", async (target, run) => {
+      const ensureIntegrity = integrityCallback();
+      let captured: RequestInit | undefined;
+      let attempts = 0;
+      const fetcher = jsonFetcher((_url, init) => {
+        if (operation(init) !== target) throw new Error(`Unexpected op ${operation(init)}`);
+        captured = init;
+        attempts += 1;
+        return INTEGRITY_REJECTION;
+      });
+
+      await run(new TwitchAdapter(fetcher, ensureIntegrity)).catch(() => undefined);
+
+      expect(captured?.credentials).toBe("omit");
+      expect(ensureIntegrity).not.toHaveBeenCalled();
+      // Anonymous requests must not be replayed by integrity recovery.
+      expect(attempts).toBe(1);
+    });
+  });
+
+  describe("mutations", () => {
+    const reward = {
+      id: "drop",
+      name: "Reward",
+      requiredMinutes: 60,
+      watchedMinutes: 60,
+      status: "claimable",
+      claimId: "instance-id",
+    } as DropReward;
+
+    it("forces a genuinely fresh token before retrying a rejected drop claim", async () => {
+      const ensureIntegrity = integrityCallback();
+      const { fetcher, attempts } = rejectFirst("DropsPage_ClaimDropRewards", () => ({
+        data: { claimDropRewards: { status: "ELIGIBLE_FOR_ALL" } },
+      }));
+
+      await expect(new TwitchAdapter(fetcher, ensureIntegrity)
+        .claimReward({ id: "campaign" } as DropCampaign, reward)).resolves.toBe(true);
+
+      expect(attempts.get("DropsPage_ClaimDropRewards")).toBe(2);
+      // Proactive fast path first, then an explicit forced refresh.
+      expect(ensureIntegrity.mock.calls).toEqual([[], [{ forceRefresh: true }]]);
+    });
+
+    it("recovers the channel-points context through the safe-read path", async () => {
+      const ensureIntegrity = integrityCallback();
+      const { fetcher, attempts } = rejectFirst("ChannelPointsContext", (init) => {
+        const op = operation(init);
+        if (op === "ChannelPointsContext") {
+          return { data: { community: { channel: { id: "channel-id", self: { communityPoints: { availableClaim: { id: "claim-id" } } } } } } };
+        }
+        if (op === "ClaimCommunityPoints") return { data: { claimCommunityPoints: { status: "SUCCESS" } } };
+        throw new Error(`Unexpected op ${op}`);
+      });
+
+      await expect(new TwitchAdapter(fetcher, ensureIntegrity).claimChannelPoints({
+        platform: "twitch",
+        username: "creator",
+        url: "https://www.twitch.tv/creator",
+      })).resolves.toBe(true);
+
+      expect(attempts.get("ChannelPointsContext")).toBe(2);
+      expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+    });
+
+    it("ensures integrity before the channel-points mutation and retries it exactly once", async () => {
+      const ensureIntegrity = integrityCallback();
+      const { fetcher, attempts } = rejectFirst("ClaimCommunityPoints", (init) => {
+        const op = operation(init);
+        if (op === "ChannelPointsContext") {
+          return { data: { community: { channel: { id: "channel-id", self: { communityPoints: { availableClaim: { id: "claim-id" } } } } } } };
+        }
+        if (op === "ClaimCommunityPoints") return { data: { claimCommunityPoints: { status: "SUCCESS" } } };
+        throw new Error(`Unexpected op ${op}`);
+      });
+
+      await expect(new TwitchAdapter(fetcher, ensureIntegrity).claimChannelPoints({
+        platform: "twitch",
+        username: "creator",
+        url: "https://www.twitch.tv/creator",
+      })).resolves.toBe(true);
+
+      expect(attempts.get("ClaimCommunityPoints")).toBe(2);
+      expect(ensureIntegrity.mock.calls).toEqual([[], [{ forceRefresh: true }]]);
+    });
+
+    it("propagates a second channel-points rejection without a third attempt", async () => {
+      const ensureIntegrity = integrityCallback();
+      let claimAttempts = 0;
+      const fetcher = jsonFetcher((_url, init) => {
+        const op = operation(init);
+        if (op === "ChannelPointsContext") {
+          return { data: { community: { channel: { id: "channel-id", self: { communityPoints: { availableClaim: { id: "claim-id" } } } } } } };
+        }
+        if (op === "ClaimCommunityPoints") {
+          claimAttempts += 1;
+          return INTEGRITY_REJECTION;
+        }
+        throw new Error(`Unexpected op ${op}`);
+      });
+
+      await expect(new TwitchAdapter(fetcher, ensureIntegrity).claimChannelPoints({
+        platform: "twitch",
+        username: "creator",
+        url: "https://www.twitch.tv/creator",
+      })).rejects.toThrow(/integrity/i);
+
+      expect(claimAttempts).toBe(2);
+    });
+  });
+});

--- a/packages/extension/tests/tablessWatch.test.ts
+++ b/packages/extension/tests/tablessWatch.test.ts
@@ -498,4 +498,43 @@ describe("adapter-created twitch watcher diagnostics", () => {
     ]));
     expect(creationEvents.filter((event) => event.message.includes("GQL StreamInfo returned a transient error"))).toEqual([]);
   });
+
+  // The watcher resolves its own viewer id when discovery did not supply one.
+  // That CurrentUser read is authenticated, so an integrity rejection must be
+  // recoverable — while the anonymous StreamInfo and the heartbeat telemetry
+  // around it stay out of integrity recovery entirely.
+  it("recovers its authenticated CurrentUser fallback from an integrity rejection", async () => {
+    let currentUserCalls = 0;
+    let sendEventsCalls = 0;
+    const fetchJson = vi.fn(async (_url: string, init?: RequestInit) => {
+      const operationName = JSON.parse(String(init?.body)).operationName;
+      if (operationName === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game", name: "Game" } } } } };
+      }
+      if (operationName === "CurrentUser") {
+        currentUserCalls += 1;
+        if (currentUserCalls === 1) return { error: "failed integrity check" };
+        return { data: { currentUser: { id: "viewer-id" } } };
+      }
+      if (operationName === "SendEvents") {
+        sendEventsCalls += 1;
+        return { data: { sendSpadeEvents: { statusCode: 204 } } };
+      }
+      throw new Error(`unexpected operation ${operationName}`);
+    });
+    const ensureIntegrity = vi.fn(async (request?: { forceRefresh?: boolean }) => request?.forceRefresh === true);
+    const adapter = new TwitchAdapter({ fetchJson: fetchJson as never }, ensureIntegrity);
+    const watcher = adapter.createTablessWatcher?.();
+
+    // No userId in the context, so the watcher must resolve it itself.
+    await watcher?.start({ platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" }, {});
+    const result = await watcher?.tick({});
+
+    expect(result).toMatchObject({ ok: true });
+    expect(currentUserCalls).toBe(2);
+    expect(ensureIntegrity).toHaveBeenCalledOnce();
+    expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+    // The heartbeat itself is never replayed by integrity recovery.
+    expect(sendEventsCalls).toBe(1);
+  });
 });

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1235,6 +1235,129 @@ describe("twitch integrity refresh", () => {
         message: expect.stringContaining("from a created page context (tab 21)"),
       }));
     });
+
+    // Twitch can reject a token the extension still considers unexpired. Forced
+    // refresh exists for exactly that case, so the local expiry must not be
+    // allowed to short-circuit it.
+    describe("forced refresh", () => {
+      const rejected = () => ({
+        integrity: "rejected-token",
+        clientSessionId: "page-session",
+        deviceId: "page-device",
+        expiresAt: Date.now() + 60_000,
+      });
+
+      const replacement = () => ({
+        integrity: "replacement-token",
+        clientSessionId: "page-session",
+        deviceId: "page-device",
+        expiresAt: Date.now() + 60_000,
+      });
+
+      it("does not fast-return for an apparently unexpired rejected token", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 31 });
+        setTwitchIntegrity(rejected());
+
+        setTimeout(() => setTwitchIntegrity(replacement(), { isNew: true }), 20);
+        const ok = await ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          5_000,
+          undefined,
+          { forceRefresh: true },
+        );
+
+        expect(ok).toBe(true);
+        expect(browser.tabs.create).toHaveBeenCalledTimes(1);
+      });
+
+      it("succeeds only once a token different from the rejected one is captured", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 32 });
+        setTwitchIntegrity(rejected());
+
+        // Re-capturing the same token must not satisfy the wait.
+        setTimeout(() => setTwitchIntegrity(rejected(), { isNew: true }), 10);
+        const ok = await ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          60,
+          undefined,
+          { forceRefresh: true },
+        );
+
+        expect(ok).toBe(false);
+      });
+
+      it("creates a fresh inactive page context instead of reusing a user-owned tab", async () => {
+        const browser = browserMock();
+        browser.tabs.query.mockResolvedValue([{ id: 3 }]);
+        browser.tabs.create.mockResolvedValue({ id: 33 });
+        setTwitchIntegrity(rejected());
+
+        setTimeout(() => setTwitchIntegrity(replacement(), { isNew: true }), 20);
+        const ok = await ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          5_000,
+          undefined,
+          { forceRefresh: true },
+        );
+
+        expect(ok).toBe(true);
+        expect(browser.tabs.create).toHaveBeenCalledWith({
+          url: "https://www.twitch.tv/drops/inventory",
+          pinned: false,
+          active: false,
+        });
+        // The user's own twitch.tv tab must never be navigated, reloaded or closed.
+        const touchedTabIds = (browser.tabs.update.mock.calls as unknown as unknown[][]).map((call) => call[0]);
+        expect(touchedTabIds).not.toContain(3);
+        expect(browser.tabs.remove).not.toHaveBeenCalledWith(3);
+      });
+
+      it("reloads an extension-owned retained context rather than opening another tab", async () => {
+        const browser = browserMock();
+        registerManagedPageContextTabs({
+          twitch: {
+            platform: "twitch",
+            tabId: 44,
+            origin: "https://www.twitch.tv",
+            originUrl: "https://www.twitch.tv/drops/inventory",
+            ownedByExtension: true,
+          },
+        });
+        browser.tabs.get.mockResolvedValue({ id: 44, url: "https://www.twitch.tv/drops/inventory" });
+        setTwitchIntegrity(rejected());
+
+        setTimeout(() => setTwitchIntegrity(replacement(), { isNew: true }), 20);
+        const ok = await ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          5_000,
+          undefined,
+          { forceRefresh: true },
+        );
+
+        expect(ok).toBe(true);
+        expect(browser.tabs.create).not.toHaveBeenCalled();
+        expect(browser.tabs.update).toHaveBeenCalledWith(44, {
+          url: "https://www.twitch.tv/drops/inventory",
+        });
+      });
+
+      it("leaves the non-forced fast path intact", async () => {
+        const browser = browserMock();
+        setTwitchIntegrity(fresh());
+
+        const ok = await ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory");
+
+        expect(ok).toBe(true);
+        expect(browser.tabs.query).not.toHaveBeenCalled();
+        expect(browser.tabs.create).not.toHaveBeenCalled();
+      });
+    });
   });
 });
 

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1377,13 +1377,27 @@ describe("twitch integrity refresh", () => {
         await expect(ensureTwitchIntegrityWithBrowser(
           browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined, { forceRefresh: true },
         )).resolves.toBe(true);
+        const contextsAfterFirstRefresh = browser.tabs.create.mock.calls.length;
 
-        // Twitch later rejects the replacement too: a genuinely new refresh must
-        // run rather than handing back the settled result.
-        setTimeout(() => setTwitchIntegrity({ ...replacement(), integrity: "third-token" }, { isNew: true }), 20);
-        await expect(ensureTwitchIntegrityWithBrowser(
+        // Twitch later rejects the replacement too. Even though replacement-token
+        // is still locally valid, the second forced refresh must boot its own
+        // page context and stay pending until a genuinely different token lands —
+        // never hand back the first refresh's settled result.
+        let settled = false;
+        const second = ensureTwitchIntegrityWithBrowser(
           browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined, { forceRefresh: true },
-        )).resolves.toBe(true);
+        ).then((ok) => {
+          settled = true;
+          return ok;
+        });
+
+        await vi.waitFor(() => {
+          expect(browser.tabs.create.mock.calls.length).toBeGreaterThan(contextsAfterFirstRefresh);
+        });
+        expect(settled).toBe(false);
+
+        setTwitchIntegrity({ ...replacement(), integrity: "third-token" }, { isNew: true });
+        await expect(second).resolves.toBe(true);
       });
 
       it("leaves the non-forced fast path intact", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1347,6 +1347,45 @@ describe("twitch integrity refresh", () => {
         });
       });
 
+      // Concurrent authenticated reads (discovery fans DropCampaignDetails out
+      // with Promise.allSettled) can all be rejected by the same token and all
+      // force a refresh at once. Without sharing, a later caller reads the
+      // *replacement* as its own rejected token and waits for one that never comes.
+      it("shares one in-flight forced refresh between concurrent callers", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 34 });
+        setTwitchIntegrity(rejected());
+
+        setTimeout(() => setTwitchIntegrity(replacement(), { isNew: true }), 20);
+        const results = await Promise.all([
+          ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined, { forceRefresh: true }),
+          ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined, { forceRefresh: true }),
+          ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined, { forceRefresh: true }),
+        ]);
+
+        expect(results).toEqual([true, true, true]);
+        // One page context booted for the whole burst, not one per caller.
+        expect(browser.tabs.create).toHaveBeenCalledTimes(1);
+      });
+
+      it("starts a new forced refresh once the previous one has settled", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 35 });
+        setTwitchIntegrity(rejected());
+
+        setTimeout(() => setTwitchIntegrity(replacement(), { isNew: true }), 20);
+        await expect(ensureTwitchIntegrityWithBrowser(
+          browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined, { forceRefresh: true },
+        )).resolves.toBe(true);
+
+        // Twitch later rejects the replacement too: a genuinely new refresh must
+        // run rather than handing back the settled result.
+        setTimeout(() => setTwitchIntegrity({ ...replacement(), integrity: "third-token" }, { isNew: true }), 20);
+        await expect(ensureTwitchIntegrityWithBrowser(
+          browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined, { forceRefresh: true },
+        )).resolves.toBe(true);
+      });
+
       it("leaves the non-forced fast path intact", async () => {
         const browser = browserMock();
         setTwitchIntegrity(fresh());


### PR DESCRIPTION
## Summary

Recovers automatically when Twitch rejects an authenticated request for Client-Integrity, so a logged-in user no longer has to manually open or reload `https://www.twitch.tv/drops/inventory`.

Previously, recovery was inconsistent: drops-dashboard discovery never acquired a fresh token and fell straight back to retained campaigns (repeating `failed integrity check` once per scheduler tick), drop claiming called a non-forcing fast path that could reuse the very token Twitch had just rejected, and the remaining authenticated reads plus the channel-points mutation had no recovery at all.

Closes #281

## Changes

**Genuine forced refresh** (`packages/core/src/core/tabs.ts`) — `ensureTwitchIntegrityWithBrowser` accepts a `TwitchIntegrityRequest`. In forced mode it skips the unexpired-token fast path, remembers the rejected token, and succeeds only once a *different* valid token is captured — re-capturing the same token no longer settles the wait. A new `requireFreshPageContext` page-context option makes it boot a fresh inactive tab or explicitly re-navigate an extension-owned retained context. User-owned twitch.tv tabs are skipped entirely: never navigated, reloaded, or closed.

**Bounded safe-read recovery** (`packages/core/src/platforms/twitch/index.ts`) — a new `gqlWithIntegrityRetry` helper performs one forced refresh plus one identical replay, only for Client-Integrity rejections on authenticated requests. Authentication, network, and generic platform failures keep their existing behavior. Applied to every operation in the issue's audit table:

| Operation | Entry point |
|---|---|
| `Inventory` (both attempts), `ViewerDropsDashboard`, `DropCampaignDetails` | `discoverCampaigns()` |
| `DirectoryPage_Game` | `listCandidateChannels()` |
| `DropsHighlightService_AvailableDrops` | `checkChannel()` |
| `VideoPlayerStreamInfoOverlayChannel`, `DropCurrentSessionContext` | `readProgress()` |
| `ChannelPointsContext` | `claimChannelPoints()` |
| authenticated `CurrentUser` | `checkAuthHealth()` |

The helper sits above the transport rather than inside `createTwitchGqlTransport()`, because that transport also carries mutations (which must never be replayed implicitly) and anonymous requests (which must never open a page context).

**Explicit mutation recovery** — drop claims now request `{ forceRefresh: true }` after a rejection instead of re-calling the non-forcing fast path. Channel points gained recovery it never had: safe-read context, proactive ensure before the mutation, then one forced refresh and one retry of the same claim id. Neither path recurses or makes a third attempt.

**Tabless watcher** — `resolveUserId`'s authenticated `CurrentUser` fallback recovers the same way. The anonymous `StreamInfo` lookup and the heartbeat telemetry are deliberately excluded, so heartbeats are never replayed.

**Preserved fallbacks** — retained dashboard IDs, retained campaign details, category-only channel validation, and inventory-only progress all still apply when recovery ultimately fails.

## Testing

`pnpm verify` passes clean: six package typechecks, 132 CLI tests, 1062 extension tests (28 new), the Astro site build, and both Chromium and Firefox extension builds.

New coverage in `tests/tabs.test.ts`, `tests/adapters.test.ts`, and `tests/tablessWatch.test.ts` proves:

- forced refresh does not fast-return for an apparently unexpired rejected token, and succeeds only after a genuinely different token is captured;
- it creates a fresh inactive context or reloads an extension-owned one, and never touches a user-owned tab;
- each authenticated read refreshes once and retries once, asserting the callback receives exactly `{ forceRefresh: true }`;
- a failed refresh and a second rejection fall through to the existing fallback without looping;
- anonymous `StreamInfo` / `SearchCategories` keep `credentials: "omit"`, never acquire integrity, and are never replayed;
- drop and channel-points mutations force-refresh and retry exactly once, with a second rejection propagating without a third attempt.

Existing no-token acquisition, timeout, retention, and capture diagnostics are unchanged, and `tests/coreBoundary.test.ts` still passes — `@lurkloot/core` remains free of WXT and browser globals.

## Notes for review

Two things worth a look, both deliberate:

- **`discoverCampaigns` makes two dashboard requests, not one.** The second is the `fetchRewardCampaigns` fallback issued when both lists come back empty. Each request is independently bounded to one refresh and one retry, so a fully-rejected discovery produces 2 refresh calls rather than 1. The tests assert this structure explicitly instead of weakening the per-request bound.
- **A concurrent caller can bypass forced refresh.** `acquirePageContextTab` dedupes by origin, so if another request is already holding a context for `twitch.tv`, the forced caller inherits it and `requireFreshPageContext` has no effect. This is pre-existing behavior, self-corrects on the next tick, and widening it felt out of scope here.

No new permissions, credential storage, or localized diagnostic keys. Kick and the non-web Twitch CLI identity are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Client-Integrity recovery for authenticated Twitch reads and certain mutations, with a single bounded retry.
  * Added forced integrity refresh to guarantee replacement tokens and refreshed page context when required (including tabless viewer resolution).
* **Bug Fixes**
  * Prevented retry loops and ensured integrity-related failures surface after the bounded recovery attempts.
  * Ensured anonymous requests are never retried and never trigger integrity handling.
* **Tests**
  * Expanded coverage for authenticated/discovery/dashboard/session/claims, anonymous behavior, forced refresh replacement, and watcher recovery.
* **Documentation**
  * Added an end-to-end implementation plan for Twitch Client-Integrity retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->