### PR TITLE
feat(popup): add a header button that opens the platform inventory page

### DIFF
--- a/packages/extension/tests/popupInventoryLink.test.tsx
+++ b/packages/extension/tests/popupInventoryLink.test.tsx
@@ -1,0 +1,64 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Platform } from "@lurkloot/shared/models";
+import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
+import { resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
+
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
+
+let root: Root | undefined;
+
+afterEach(() => {
+  resetCatalogTracking();
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+async function mountForPlatform(platform: Platform) {
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(Date.now());
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+
+  const demo = createDemoPopupAdapter();
+  const openLink = vi.fn();
+  const adapter: PopupAdapter = {
+    ...demo,
+    openLink,
+    getStorage: async () => ({ "popup:selectedPlatform": platform }),
+  };
+  const container = document.getElementById("app")!;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} />);
+  });
+  await waitForCatalog();
+
+  const button = container.querySelector('button[aria-label="Open inventory"]');
+  if (!button) throw new Error("Missing inventory button");
+  return { button: button as HTMLButtonElement, openLink };
+}
+
+describe("popup inventory link", () => {
+  it("opens the Twitch inventory page for the Twitch platform", async () => {
+    const { button, openLink } = await mountForPlatform("twitch");
+    act(() => button.click());
+    expect(openLink).toHaveBeenCalledWith("https://www.twitch.tv/drops/inventory");
+  });
+
+  it("opens the Kick inventory page for the Kick platform", async () => {
+    const { button, openLink } = await mountForPlatform("kick");
+    act(() => button.click());
+    expect(openLink).toHaveBeenCalledWith("https://kick.com/drops/inventory");
+  });
+});

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "تحديث الجدول"
   },
+  "openInventory": {
+    "message": "فتح المخزون"
+  },
   "openActivity": {
     "message": "فتح النشاط"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "Zeitplan aktualisieren"
   },
+  "openInventory": {
+    "message": "Inventar öffnen"
+  },
   "openActivity": {
     "message": "Aktivität öffnen"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "Refresh schedule"
   },
+  "openInventory": {
+    "message": "Open inventory"
+  },
   "openActivity": {
     "message": "Open activity"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "Actualizar programación"
   },
+  "openInventory": {
+    "message": "Abrir inventario"
+  },
   "openActivity": {
     "message": "Abrir actividad"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "Actualiser le planning"
   },
+  "openInventory": {
+    "message": "Ouvrir l’inventaire"
+  },
   "openActivity": {
     "message": "Ouvrir l’activité"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "शेड्यूल रीफ़्रेश करें"
   },
+  "openInventory": {
+    "message": "इन्वेंटरी खोलें"
+  },
   "openActivity": {
     "message": "गतिविधि खोलें"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "Aggiorna pianificazione"
   },
+  "openInventory": {
+    "message": "Apri inventario"
+  },
   "openActivity": {
     "message": "Apri attività"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "Atualizar programação"
   },
+  "openInventory": {
+    "message": "Abrir inventário"
+  },
   "openActivity": {
     "message": "Abrir atividade"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "Обновить расписание"
   },
+  "openInventory": {
+    "message": "Открыть инвентарь"
+  },
   "openActivity": {
     "message": "Открыть активность"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "Yenile"
   },
+  "openInventory": {
+    "message": "Envanteri aç"
+  },
   "openActivity": {
     "message": "Geçmişi aç"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -86,6 +86,9 @@
   "refreshSchedule": {
     "message": "刷新计划"
   },
+  "openInventory": {
+    "message": "打开库存"
+  },
   "openActivity": {
     "message": "打开活动"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   Clock3,
   Gift,
+  Package,
   Play,
   RotateCcw,
   Settings as SettingsIcon,
@@ -17,6 +18,7 @@ import { loadCatalog } from "@lurkloot/locales";
 import { buildFailureReport } from "@lurkloot/shared/failureReport";
 import { I18nContext, PopupRuntimeContext } from "./context";
 import {
+  PLATFORM_INVENTORY_URLS,
   PLATFORMS,
   RATE_NUDGE_MIN_DAYS,
   SCREENSHOT_VARIANTS,
@@ -58,6 +60,7 @@ import { RateNudge, shouldShowRateNudge } from "./rateNudge";
 import { UpdateNotice } from "./updateNotice";
 import { DropsPanel } from "./drops";
 import { CriticalFailurePanel } from "./criticalFailure";
+import { openHttpsLink } from "./links";
 import { IdleWatchlistPanel } from "./idleWatchlist";
 import { AutomationHero, PlatformSwitcher } from "./automation";
 import { automationPresentation, type AutomationPresentation } from "./automationStatus";
@@ -583,6 +586,12 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
               <>
                 <IconButton label={t("refreshSchedule")} onClick={() => void refreshNow()} disabled={refreshing}>
                   <RotateCcw size={16} className={cn(refreshing && "animate-spin")} />
+                </IconButton>
+                <IconButton
+                  label={t("openInventory")}
+                  onClick={() => openHttpsLink(PLATFORM_INVENTORY_URLS[platform], adapter.openLink)}
+                >
+                  <Package size={16} />
                 </IconButton>
                 <IconButton label={t("openActivity")} onClick={() => { setActivityOpen(true); setSettingsOpen(false); }}>
                   <Clock3 size={16} />

--- a/packages/popup-ui/src/constants.ts
+++ b/packages/popup-ui/src/constants.ts
@@ -7,6 +7,13 @@ export const PLATFORMS: Record<Platform, { label: string; mark: string; color: s
   kick: { label: "Kick", mark: "K", color: "#53fc18" },
 };
 
+// Public drop-inventory pages, opened from the popup header so the user does not
+// have to navigate there by hand.
+export const PLATFORM_INVENTORY_URLS: Record<Platform, string> = {
+  twitch: "https://www.twitch.tv/drops/inventory",
+  kick: "https://kick.com/drops/inventory",
+};
+
 export const SELECTED_PLATFORM_KEY = "popup:selectedPlatform";
 export const COLLAPSED_SETTINGS_SECTIONS_KEY = "popup:collapsedSettingsSections";
 export const SHOW_ADVANCED_SETTINGS_KEY = "popup:showAdvancedSettings";


### PR DESCRIPTION
Closes #279.

## Summary

Adds an inventory button to the popup header, next to refresh/activity/settings, that opens the drops inventory page for the currently selected platform:

- Twitch → `https://www.twitch.tv/drops/inventory`
- Kick → `https://kick.com/drops/inventory`

The URLs live in a new `PLATFORM_INVENTORY_URLS` map in `packages/popup-ui/src/constants.ts`. They are deliberately *not* reused from `TWITCH_PAGE_CONTEXT_URL` / `KICK_PAGE_CONTEXT_URL`: those happen to point at the same pages today, but they are the farming page-context targets, and coupling a user-facing link to them would let a future page-context change silently move this button.

The click goes through the existing `openHttpsLink(..., adapter.openLink)` boundary, the same https-only guard the critical-failure prompt uses. The button is hidden in the settings and activity views along with the rest of the group.

`openInventory` was added to all 11 locale catalogs — it is a tooltip/aria label, not a diagnostic.

## Testing

- `pnpm typecheck` — clean across all 7 packages.
- `pnpm test` — extension 55 files / 1040 tests, CLI 132, site 3; all pass.
- New `packages/extension/tests/popupInventoryLink.test.tsx` clicks the button under each selected platform and asserts the URL handed to `openLink`.
- Visually checked in the site demo: the header shows four evenly spaced icons with no crowding.