### PR TITLE
fix(controller): make automation toggles responsive and derive farming from the platform flags

### DIFF
--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -76,9 +76,13 @@ export const DEFAULT_CLI_SETTINGS: CliSettings = {
   farmingEligibility: { ...DEFAULT_SETTINGS.farmingEligibility },
   notifyRewardEarned: DEFAULT_SETTINGS.notifyRewardEarned,
   notifyNoDropsLeft: DEFAULT_SETTINGS.notifyNoDropsLeft,
+  // Both platforms on by default. The extension ships them off so a fresh
+  // install sits idle until the user opts in; the CLI has no such moment — it is
+  // started deliberately, and running it with everything disabled would do
+  // nothing at all.
   platform: {
-    twitch: { ...DEFAULT_SETTINGS.platform.twitch },
-    kick: { ...DEFAULT_SETTINGS.platform.kick },
+    twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
+    kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
   },
   compatibility: {
     twitch: { ...DEFAULT_SETTINGS.compatibility.twitch },
@@ -121,10 +125,11 @@ const CLI_COMPATIBILITY_KEYS: Record<Platform, Set<string>> = {
 
 // Settings that exist in the extension but are inert in the CLI's tabless path.
 // Called out by name so a config copy-pasted from the extension gets an
-// actionable error instead of a silently-ignored knob. `running` and
-// `tablessMode` live here too: the CLI always runs and is always tabless.
+// actionable error instead of a silently-ignored knob. `tablessMode` lives here
+// too: the CLI is always tabless. `running` is deliberately absent: it was
+// removed from the settings contract, so the schema migration strips it (with a
+// diagnostic) before this scan ever sees it.
 const EXTENSION_ONLY_KEYS = new Set<string>([
-  "running",
   "tablessMode",
   "muteFarmingTabs",
   "keepFarmingVideosUnmuted",
@@ -334,14 +339,13 @@ function normalizePlatform(raw: EngineSettings["platform"] | undefined): Platfor
 }
 
 // Expands the CLI settings into the EngineSettings contract the shared engine
-// consumes. The CLI invariants are pinned: always running, always tabless, never
+// consumes. The CLI invariants are pinned: always tabless, never
 // pausing on a (nonexistent) manual watch, and never auto-starting via the
 // controller (the CLI drives tick() directly). Tab-policy fields are not part of
 // the engine contract — the CLI never opens a tab — so there is nothing to force.
 export function toEngineSettings(cli: CliSettings): EngineSettings {
   return mergeEngineSettings({
     ...cli,
-    running: true,
     tablessMode: true,
     pauseOnManualWatch: false,
     autoStartDropFarming: false,

--- a/packages/cli/tests/settings.test.ts
+++ b/packages/cli/tests/settings.test.ts
@@ -143,7 +143,6 @@ describe("parseCliSettings", () => {
 
   it("hard-errors on extension-only keys, naming them", () => {
     expect(() => parseCliSettings({ adFocusMode: "window" })).toThrow(/"adFocusMode" is an extension-only setting/);
-    expect(() => parseCliSettings({ running: true })).toThrow(/"running" is an extension-only setting/);
     expect(() => parseCliSettings({ tablessMode: true })).toThrow(/"tablessMode" is an extension-only setting/);
     expect(() => parseCliSettings({ diagnosticLogging: true })).toThrow(/"diagnosticLogging" is an extension-only setting/);
   });
@@ -249,7 +248,6 @@ describe("parseCliSettings", () => {
 describe("toEngineSettings", () => {
   it("pins the headless invariants regardless of CLI input", () => {
     const engine = toEngineSettings(DEFAULT_CLI_SETTINGS);
-    expect(engine.running).toBe(true);
     expect(engine.tablessMode).toBe(true);
     expect(engine.pauseOnManualWatch).toBe(false);
     expect(engine.autoStartDropFarming).toBe(false);

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -23,6 +23,22 @@ export const WATCH_ALARM_NAME = "lurkloot.watch";
 // the ids (not just the platforms) so it can tell a genuine successor from the
 // reward that was just claimed.
 export type ClaimedRewards = Partial<Record<Platform, string[]>>;
+// What caused a tick to run. Recorded in the tick's lifecycle diagnostics so an
+// exported log distinguishes a user action from a timer or a post-claim handoff.
+export type TickTrigger =
+  | "alarm"
+  | "watch_alarm"
+  | "startup"
+  | "install"
+  | "automation_toggle"
+  | "platform_toggle"
+  | "settings_saved"
+  | "manual_resume"
+  | "manual_tick"
+  | "critical_failure_dismissed"
+  | "tabless_fallback"
+  | "claim_handoff"
+  | "unknown";
 export type CredentialAvailability =
   | { status: "available" }
   | { status: "missing" }
@@ -365,6 +381,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     await deps.saveState(operationalState);
   }
 
+  // Reports a single diagnostic immediately rather than collecting it into a
+  // tick's event batch. Tick lifecycle lines must land as they happen: batching
+  // them would defeat the point of timing a tick that is still running.
+  function diagnosticEvent(level: "debug" | "info" | "warn", message: string, platform?: Platform): void {
+    void reportBestEffort([{ category: "diagnostic", level, message, platform }]);
+  }
+
   async function reportBestEffort(events: readonly EngineEvent[]): Promise<void> {
     if (events.length === 0 || !deps.reportEvents) return;
     try {
@@ -406,7 +429,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
     await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
     if (settings.autoStartDropFarming && settings.running) {
-      await tick();
+      await tick(undefined, "install");
     } else {
       await refreshAuthHealth(PLATFORMS, settings);
     }
@@ -454,7 +477,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     if (!cleanup.hasStaleSession) {
       const nextSettings = await normalizeStartupSettings();
       if (nextSettings.autoStartDropFarming && nextSettings.running) {
-        await tick();
+        await tick(undefined, "startup");
       } else {
         await refreshAuthHealth(PLATFORMS, nextSettings, true);
       }
@@ -478,7 +501,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const nextSettings = await normalizeStartupSettings();
 
     if (nextSettings.running && nextSettings.autoStartDropFarming) {
-      await tick();
+      await tick(undefined, "startup");
     } else {
       await refreshAuthHealth(PLATFORMS, nextSettings, true);
     }
@@ -676,13 +699,34 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }));
   }
 
-  async function tick(platforms?: Platform[]): Promise<ClaimedRewards> {
+  // Every tick is bracketed by a start/finish diagnostic carrying its trigger and
+  // elapsed time. A tick that succeeds otherwise emits nothing about itself, which
+  // makes a slow one indistinguishable from an idle gap in an exported log.
+  let tickSequence = 0;
+  // Chain of detached ticks, drained by settleBackgroundWork().
+  let backgroundWork: Promise<unknown> = Promise.resolve();
+
+  async function tick(platforms?: Platform[], trigger: TickTrigger = "unknown"): Promise<ClaimedRewards> {
+    const tickId = ++tickSequence;
+    const tickStartedAt = Date.now();
+    const scope = platforms ? platforms.join("+") : "all";
+    diagnosticEvent("debug", `Tick #${tickId} started (trigger=${trigger}, platforms=${scope})`);
+    try {
+      return await runTick(tickId, tickStartedAt, platforms);
+    } finally {
+      diagnosticEvent("debug", `Tick #${tickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${scope})`);
+    }
+  }
+
+  async function runTick(tickId: number, tickStartedAt: number, platforms?: Platform[]): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
     const settings = await deps.loadSettings();
     const setupFailedPlatforms = new Set<Platform>();
     if (settings.running) {
+      const authStartedAt = Date.now();
       try {
         await refreshAuthHealth(platforms ?? PLATFORMS, settings);
+        diagnosticEvent("debug", `Tick #${tickId} refreshed auth health in ${Date.now() - authStartedAt}ms`);
       } catch (error) {
         const failures = flattenedRefreshFailures(error);
         const setupFailures = failures.filter((failure): failure is AuthProbeSetupError =>
@@ -1048,7 +1092,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     // chooseTablessWatch now sees heartbeatChecks past the tabless fallback limit and opens a tab.
     // Run outside the lock: tick() acquires the lock itself.
     for (const platform of fallbackPlatforms) {
-      await tick([platform]);
+      await tick([platform], "tabless_fallback");
     }
   }
 
@@ -1143,7 +1187,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         await wait(Math.min(intervalMs, deadline - Date.now()), abort.signal);
         if (abort.signal.aborted || Date.now() >= deadline) break;
 
-        await tick([platform]);
+        await tick([platform], "claim_handoff");
         if (abort.signal.aborted) break;
 
         const session = (await deps.loadState()).sessions[platform];
@@ -1163,11 +1207,62 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
+  // Runs a tick without holding the caller open for it. A user action gets its
+  // snapshot back immediately; the popup re-polls getSnapshot on its own cadence
+  // and picks the result up when the tick lands.
+  function tickInBackground(platforms: Platform[] | undefined, trigger: TickTrigger): void {
+    const run = tickAndHandOff(platforms, trigger).catch((error) => {
+      diagnosticEvent("warn", `Background tick (trigger=${trigger}) failed: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    backgroundWork = backgroundWork.then(() => run, () => run);
+  }
+
+  // Detached ticks have no caller to await them, which leaves observers (tests,
+  // and the CLI's one-shot mode) with no way to know when the work they just
+  // triggered has actually landed. Settling drains the chain until it stops
+  // growing, so a tick that queues a post-claim handoff is covered too.
+  async function settleBackgroundWork(): Promise<void> {
+    let pending = backgroundWork;
+    for (;;) {
+      await pending;
+      if (backgroundWork === pending) return;
+      pending = backgroundWork;
+    }
+  }
+
+  // The persisted session still describes the platform as it was *before* the
+  // toggle ("Automation disabled"), and nothing rewrites it until the tick
+  // finishes. Detaching the tick alone would not fix that: the popup polls the
+  // stored state, so a slow tick leaves it rendering a status that contradicts
+  // the switch the user just flipped. Stamp the transition up front instead.
+  async function markPlatformsStarting(platforms: readonly Platform[]): Promise<void> {
+    await withStateLock(async () => {
+      const state = await deps.loadState();
+      let changed = false;
+      const sessions = { ...state.sessions };
+      for (const platform of platforms) {
+        const session = state.sessions[platform];
+        // An already-watching platform is not "starting" — leave its live status
+        // (and its channel) alone so a toggle elsewhere never blanks it.
+        if (session.status === "watching") continue;
+        sessions[platform] = {
+          ...session,
+          status: "idle",
+          message: "Starting automation",
+          reasonCode: "no_existing_session",
+        };
+        changed = true;
+      }
+      if (!changed) return;
+      await persistAndReport({ ...state, sessions });
+    });
+  }
+
   // The normal entry point for alarm- and message-driven ticks: run the tick,
   // then hand off for every platform that claimed. Kept separate from tick() so
   // the handoff's own inner ticks cannot recurse into another handoff.
-  async function tickAndHandOff(platforms?: Platform[]): Promise<void> {
-    const claimed = await tick(platforms);
+  async function tickAndHandOff(platforms?: Platform[], trigger: TickTrigger = "unknown"): Promise<void> {
+    const claimed = await tick(platforms, trigger);
     for (const platform of Object.keys(claimed) as Platform[]) {
       await runClaimHandoff(platform, claimed[platform] ?? []);
     }
@@ -1459,8 +1554,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     if (message.type === "setRunning") {
       // Stopping must cancel any loop still refreshing in the background.
       if (!message.running) abortClaimHandoffs();
-      await updateStoredSettings({ running: message.running });
-      await tickAndHandOff();
+      const settings = await updateStoredSettings({ running: message.running });
+      if (message.running) {
+        await markPlatformsStarting(PLATFORMS.filter((platform) => settings.platform[platform].enabled));
+      }
+      tickInBackground(undefined, "automation_toggle");
       return snapshot();
     }
 
@@ -1472,7 +1570,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           },
         },
       });
-      if (settings.running) await tickAndHandOff();
+      if (settings.running) {
+        if (message.enabled) await markPlatformsStarting([message.platform]);
+        // Scoped to the toggled platform: the other one is unaffected by this
+        // change, and making it wait behind an unrelated platform's discovery is
+        // exactly the coupling that made this slow.
+        tickInBackground([message.platform], "platform_toggle");
+      }
       return snapshot();
     }
 
@@ -1484,16 +1588,24 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           },
         },
       };
+      const wasRunning = (await deps.loadSettings()).running;
       if (message.enabled) patch.running = true;
       const settings = await updateStoredSettings(patch);
-      if (settings.running) await tickAndHandOff();
+      if (settings.running) {
+        if (message.enabled) await markPlatformsStarting([message.platform]);
+        // Scoped to the toggled platform so the other one is not dragged through
+        // this platform's discovery. The exception is a patch that also flips the
+        // global `running` flag: that changes the *other* platform's situation
+        // too, and leaving it unreconciled would strand it on a stale status.
+        tickInBackground(settings.running === wasRunning ? [message.platform] : undefined, "automation_toggle");
+      }
       return snapshot();
     }
 
     if (message.type === "saveSettings") {
       const settings = await updateStoredSettings(message.settingsPatch);
       if (message.tickAfterSave && settings.running && hasEnabledPlatform(settings)) {
-        await tickAndHandOff(message.tickAfterSavePlatforms);
+        tickInBackground(message.tickAfterSavePlatforms, "settings_saved");
       }
       return snapshot();
     }
@@ -1502,7 +1614,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       await resumeAfterManualClose(message.platform);
       const settings = await deps.loadSettings();
       if (settings.running && settings.platform[message.platform].enabled) {
-        await tickAndHandOff([message.platform]);
+        await markPlatformsStarting([message.platform]);
+        tickInBackground([message.platform], "manual_resume");
       }
       return snapshot();
     }
@@ -1531,7 +1644,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
 
     if (message.type === "tickNow") {
-      await tickAndHandOff();
+      await tickAndHandOff(undefined, "manual_tick");
       return snapshot();
     }
     if (message.type === "dismissCriticalFailure") {
@@ -1547,7 +1660,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         syncManagedTabBreakers(transition.state);
         await persistAndReport(transition.state, events);
       }));
-      await tickAndHandOff();
+      await tickAndHandOff(undefined, "critical_failure_dismissed");
       return snapshot();
     }
   }
@@ -1639,6 +1752,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     runClaimHandoff,
     abortClaimHandoffs,
     prepareForHostReset,
+    settleBackgroundWork,
   };
 }
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2,6 +2,7 @@ import type { CategorySearchResult, CoreRuntimeMessage, PlaybackControl, Runtime
 import type { DropCampaign, DropReward, EngineSettings, ManagedWatchTab, Platform, PlatformAuthHealth, PlaybackTelemetry, SchedulerState, WatchReasonCode, WatchSession } from "@lurkloot/shared/models";
 import type { ActivityEvent, DiagnosticEvent, EngineEvent, EventEmitter, EventReporter, FarmingStopReason, PageContextOpenReason } from "@lurkloot/shared/events";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
+import { isFarmingActive } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
 import { isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
 import { isPlaybackTelemetryHealthy, MANUAL_WATCH_TTL_MS, runSchedulerTick, type StopPageContextTabs } from "../core/scheduler";
@@ -428,7 +429,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const settings = await deps.loadSettings();
     await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
     await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
-    if (settings.autoStartDropFarming && settings.running) {
+    if (settings.autoStartDropFarming && isFarmingActive(settings)) {
       await tick(undefined, "install");
     } else {
       await refreshAuthHealth(PLATFORMS, settings);
@@ -443,11 +444,23 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     });
   }
 
+  // On restart, autoStartDropFarming decides what happens to the platforms that
+  // were farming: enabled means keep going, disabled means switch them off. It
+  // used to clear a global `running` flag instead, which left the per-platform
+  // flags set — so the popup showed everything off while a stale enabled flag
+  // waited to resurrect a platform the moment the master switch came back.
   async function normalizeStartupSettings(): Promise<S> {
     return withSettingsLock(async () => {
       const settings = await deps.loadSettings();
-      if (!settings.running || settings.autoStartDropFarming) return settings;
-      const nextSettings = { ...settings, running: false };
+      if (settings.autoStartDropFarming || !isFarmingActive(settings)) return settings;
+      const nextSettings = {
+        ...settings,
+        platform: {
+          ...settings.platform,
+          twitch: { ...settings.platform.twitch, enabled: false },
+          kick: { ...settings.platform.kick, enabled: false },
+        },
+      };
       await deps.saveSettings(nextSettings);
       return nextSettings;
     });
@@ -463,7 +476,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     // A restart kills any in-memory watchers; start clean and let tick() rebuild.
     tablessWatchers.clear();
 
-    const preservePageContexts = settings.running && settings.autoStartDropFarming;
+    const preservePageContexts = isFarmingActive(settings) && settings.autoStartDropFarming;
     const { state, cleanup } = await withStateLock(async () => {
       const state = await deps.loadState();
       registerManagedPageContextTabs(preservePageContexts ? state.managedPageContextTabs ?? {} : {});
@@ -476,7 +489,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     });
     if (!cleanup.hasStaleSession) {
       const nextSettings = await normalizeStartupSettings();
-      if (nextSettings.autoStartDropFarming && nextSettings.running) {
+      if (nextSettings.autoStartDropFarming && isFarmingActive(nextSettings)) {
         await tick(undefined, "startup");
       } else {
         await refreshAuthHealth(PLATFORMS, nextSettings, true);
@@ -500,7 +513,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
     const nextSettings = await normalizeStartupSettings();
 
-    if (nextSettings.running && nextSettings.autoStartDropFarming) {
+    if (isFarmingActive(nextSettings) && nextSettings.autoStartDropFarming) {
       await tick(undefined, "startup");
     } else {
       await refreshAuthHealth(PLATFORMS, nextSettings, true);
@@ -722,7 +735,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const claimedRewards: ClaimedRewards = {};
     const settings = await deps.loadSettings();
     const setupFailedPlatforms = new Set<Platform>();
-    if (settings.running) {
+    if (isFarmingActive(settings)) {
       const authStartedAt = Date.now();
       try {
         await refreshAuthHealth(platforms ?? PLATFORMS, settings);
@@ -944,8 +957,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     for (const platform of targets) {
       const session = state.sessions[platform];
       const adapter = adapters[platform];
-      const wantsTabless = settings.running
-        && settings.platform[platform].enabled
+      const wantsTabless = settings.platform[platform].enabled
         && state.authHealth[platform].status === "healthy"
         && session.status === "watching"
         && session.watchMode === "tabless"
@@ -999,7 +1011,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // (by re-running the scheduler) when a heartbeat keeps failing.
   async function runWatchHeartbeat(): Promise<void> {
     const settings = await deps.loadSettings();
-    if (!settings.running) return;
+    if (!isFarmingActive(settings)) return;
     const fallbackPlatforms = await withStateLock<Platform[]>(() => withEventCollector(async (emit, events) => {
       let nextState = await deps.loadState();
       registerManagedPageContextTabs(nextState.managedPageContextTabs ?? {});
@@ -1098,9 +1110,14 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   // Aborts every in-flight handoff. Called when farming stops, when a settings
   // session begins, and on runtime restart.
-  function abortClaimHandoffs(): void {
-    for (const controller of claimHandoffs.values()) controller.abort();
-    claimHandoffs.clear();
+  // Scoped when a single platform is switched off: with per-platform toggles,
+  // cancelling every handoff would abort work the other platform still needs.
+  function abortClaimHandoffs(platform?: Platform): void {
+    for (const [handoffPlatform, controller] of claimHandoffs) {
+      if (platform && handoffPlatform !== platform) continue;
+      controller.abort();
+      claimHandoffs.delete(handoffPlatform);
+    }
   }
 
   async function prepareForHostReset(resetHostStorage?: () => Promise<void>): Promise<void> {
@@ -1149,7 +1166,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     try {
       const settings = await deps.loadSettings();
       if (abort.signal.aborted) return;
-      if (!settings.postClaimHandoff || !settings.running) return;
+      if (!settings.postClaimHandoff) return;
       if (!settings.platform[platform].enabled) return;
 
       // Deliberately bypasses the createAdapters() wrapper: that records every
@@ -1551,60 +1568,30 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       return snapshot();
     }
 
-    if (message.type === "setRunning") {
+    // setPlatformEnabled and setAutomation are the same operation now that there
+    // is no master switch to flip alongside the platform flag. Both are kept:
+    // they are separate wire messages with existing callers.
+    if (message.type === "setPlatformEnabled" || message.type === "setAutomation") {
       // Stopping must cancel any loop still refreshing in the background.
-      if (!message.running) abortClaimHandoffs();
-      const settings = await updateStoredSettings({ running: message.running });
-      if (message.running) {
-        await markPlatformsStarting(PLATFORMS.filter((platform) => settings.platform[platform].enabled));
-      }
-      tickInBackground(undefined, "automation_toggle");
-      return snapshot();
-    }
-
-    if (message.type === "setPlatformEnabled") {
-      const settings = await updateStoredSettings({
+      if (!message.enabled) abortClaimHandoffs(message.platform);
+      await updateStoredSettings({
         platform: {
           [message.platform]: {
             enabled: message.enabled,
           },
         },
       });
-      if (settings.running) {
-        if (message.enabled) await markPlatformsStarting([message.platform]);
-        // Scoped to the toggled platform: the other one is unaffected by this
-        // change, and making it wait behind an unrelated platform's discovery is
-        // exactly the coupling that made this slow.
-        tickInBackground([message.platform], "platform_toggle");
-      }
-      return snapshot();
-    }
-
-    if (message.type === "setAutomation") {
-      const patch: SettingsPatch = {
-        platform: {
-          [message.platform]: {
-            enabled: message.enabled,
-          },
-        },
-      };
-      const wasRunning = (await deps.loadSettings()).running;
-      if (message.enabled) patch.running = true;
-      const settings = await updateStoredSettings(patch);
-      if (settings.running) {
-        if (message.enabled) await markPlatformsStarting([message.platform]);
-        // Scoped to the toggled platform so the other one is not dragged through
-        // this platform's discovery. The exception is a patch that also flips the
-        // global `running` flag: that changes the *other* platform's situation
-        // too, and leaving it unreconciled would strand it on a stale status.
-        tickInBackground(settings.running === wasRunning ? [message.platform] : undefined, "automation_toggle");
-      }
+      if (message.enabled) await markPlatformsStarting([message.platform]);
+      // Always scoped to the toggled platform. Nothing about this change can
+      // affect the other one any more, so it is never dragged through this
+      // platform's discovery.
+      tickInBackground([message.platform], message.type === "setAutomation" ? "automation_toggle" : "platform_toggle");
       return snapshot();
     }
 
     if (message.type === "saveSettings") {
       const settings = await updateStoredSettings(message.settingsPatch);
-      if (message.tickAfterSave && settings.running && hasEnabledPlatform(settings)) {
+      if (message.tickAfterSave && isFarmingActive(settings)) {
         tickInBackground(message.tickAfterSavePlatforms, "settings_saved");
       }
       return snapshot();
@@ -1613,7 +1600,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     if (message.type === "resumeAfterManualClose") {
       await resumeAfterManualClose(message.platform);
       const settings = await deps.loadSettings();
-      if (settings.running && settings.platform[message.platform].enabled) {
+      if (settings.platform[message.platform].enabled) {
         await markPlatformsStarting([message.platform]);
         tickInBackground([message.platform], "manual_resume");
       }
@@ -1719,8 +1706,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
       for (const platform of ["twitch", "kick"] as Platform[]) {
         if (
-          settings.running
-          && settings.platform[platform].enabled
+          settings.platform[platform].enabled
           // Only on the transition into the exhausted state, so the
           // notification fires once instead of re-firing every tick (~1/min)
           // for as long as the platform stays out of earnable drops.

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -14,7 +14,7 @@ import type {
 import { categoryListIndex } from "@lurkloot/shared/categories";
 import { campaignPassesFarmingEligibility, hasCampaignEnded } from "@lurkloot/shared/campaignFilters";
 import { isSubscriptionReward, isWatchReward, reconcileCampaignAfterClaims, rewardFeasibility } from "@lurkloot/shared/rewards";
-import { autoClaimChallengesFor, autoClaimChannelPointsFor } from "@lurkloot/shared/settings";
+import { autoClaimChallengesFor, autoClaimChannelPointsFor, isFarmingActive } from "@lurkloot/shared/settings";
 import type { EngineEvent, EventEmitter, FarmingStopReason, PageContextCloseReason } from "@lurkloot/shared/events";
 import { currentManagedPageContextTabs, forgetManagedPageContextTabs, registerManagedPageContextTabs, syncManagedTabBreakers, type SchedulerManagedPageContexts } from "./tabs";
 import type { LogLevel } from "@lurkloot/shared/logging";
@@ -611,7 +611,11 @@ export async function runSchedulerTick(
         emitDiagnostic(emit, platform, "info", "Manual watch detected; pausing farming for this platform");
         continue;
       }
-      if (!settings.running || !platformSettings.enabled) {
+      if (!platformSettings.enabled) {
+        // With no master switch, "automation is off" simply means no platform is
+        // enabled; this one being off while the other still farms stays a
+        // platform-scoped stop. Both reason codes remain meaningful.
+        const automationOff = !isFarmingActive(settings);
         await adapter.stopWatchTab?.(previous);
         nextState.sessions[platform] = {
           ...previous,
@@ -626,7 +630,7 @@ export async function runSchedulerTick(
           errorChecks: 0,
           retryAfter: undefined,
           message: "Automation disabled",
-          reasonCode: settings.running ? "platform_disabled" : "automation_disabled",
+          reasonCode: automationOff ? "automation_disabled" : "platform_disabled",
           watchMode: undefined,
           tablessFallback: undefined,
           heartbeatChecks: 0,
@@ -636,10 +640,10 @@ export async function runSchedulerTick(
         nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
         nextState.managedPageContextTabs = await stopPageContextTabs(nextState.managedPageContextTabs ?? {}, {
           platforms: [platform],
-          reason: settings.running ? "platform_disabled" : "automation_disabled",
+          reason: automationOff ? "automation_disabled" : "platform_disabled",
           emit,
         });
-        emitDiagnostic(emit, platform, "info", "Automation disabled");
+        emitDiagnostic(emit, platform, "info", automationOff ? "Automation disabled" : "Platform disabled");
         continue;
       }
 

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -251,7 +251,7 @@ export default defineBackground(() => {
 
   browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === ALARM_NAME) {
-      void controller.tickAndHandOff();
+      void controller.tickAndHandOff(undefined, "alarm");
     } else if (alarm.name === WATCH_ALARM_NAME) {
       void controller.runWatchHeartbeat();
     }

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -316,7 +316,6 @@ describe("KickAdapter", () => {
     const adapter = new KickAdapter(fetcher);
     const settings: ExtensionSettings = {
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
@@ -364,7 +363,7 @@ describe("KickAdapter", () => {
         rewards: [{ id: "reward", name: "Reward", requiredMinutes: 30, watchedMinutes: 0, status: "locked" }],
         isGeneralDrop: true,
       }],
-      { ...DEFAULT_SETTINGS, running: true },
+      { ...DEFAULT_SETTINGS },
       adapter,
     );
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -165,8 +165,23 @@ function harness(
       : { authProbeTimeoutMs: overrides.authProbeTimeoutMs }),
   };
 
+  const controller = createBackgroundController(deps);
+  // User-action messages dispatch their scheduler tick in the background and
+  // return the snapshot immediately, so the popup is never held open for a
+  // network-bound tick. Tests here assert on what the tick produced, so the
+  // harness settles that work before handing control back — keeping every
+  // assertion about tick behavior meaningful. Tests that specifically exercise
+  // the detachment use `rawHandleMessage`.
+  const rawHandleMessage = controller.handleMessage;
+  const handleMessage: typeof rawHandleMessage = async (message, sender) => {
+    const result = await rawHandleMessage(message, sender);
+    await controller.settleBackgroundWork();
+    return result;
+  };
+
   return {
-    controller: createBackgroundController(deps),
+    controller: { ...controller, handleMessage },
+    rawController: controller,
     deps,
     get settings() {
       return currentSettings;
@@ -1289,7 +1304,13 @@ describe("background controller", () => {
     const calls: string[] = [];
     const env = harness({ ...DEFAULT_SETTINGS, running: true }, {
       saveState: async () => { calls.push("state"); },
-      reportEvents: async () => { calls.push("events"); },
+      // Tick lifecycle diagnostics are published as they happen and describe no
+      // state, so they are outside the state-before-events batching invariant
+      // this test guards. Only operational batches are recorded.
+      reportEvents: async (events) => {
+        if (events.every((event) => event.category === "diagnostic" && /^Tick #/.test(event.message))) return;
+        calls.push("events");
+      },
     });
 
     await env.controller.tick();
@@ -1314,8 +1335,13 @@ describe("background controller", () => {
 
     expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
     expect(env.deps.saveState).toHaveBeenCalledTimes(2);
-    expect(env.reportEvents).toHaveBeenCalledTimes(1);
-    expect(env.reportEvents.mock.calls[0]?.[0]).toContainEqual(expect.objectContaining({
+    // Tick lifecycle diagnostics publish independently of state, so the
+    // invariant under test is about the operational batches only.
+    const operationalBatches = env.reportEvents.mock.calls
+      .map(([events]) => events)
+      .filter((events) => !events.every((event) => event.category === "diagnostic" && /^Tick #/.test(event.message)));
+    expect(operationalBatches).toHaveLength(1);
+    expect(operationalBatches[0]).toContainEqual(expect.objectContaining({
       category: "activity",
       code: "auth_health_changed",
       platform: "twitch",
@@ -1854,6 +1880,65 @@ describe("background controller", () => {
     expect(env.state.authHealth.kick.status).toBe("healthy");
   });
 
+  it("answers an automation toggle without waiting for the scheduler tick", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    let startDiscovery = (): void => {};
+    const discoveryStarted = new Promise<void>((resolve) => {
+      const blocked = new Promise<void>((release) => { startDiscovery = () => release(); });
+      vi.mocked(env.twitch.discoverCampaigns).mockImplementation(async () => {
+        resolve();
+        await blocked;
+        return [];
+      });
+    });
+
+    // The raw controller, so the harness does not settle the background tick for
+    // us — that is exactly what this test is about.
+    const snapshot = asSnapshot(await env.rawController.handleMessage({
+      type: "setAutomation",
+      platform: "twitch",
+      enabled: true,
+    }));
+
+    // The reply landed while discovery is still blocked: a slow tick can no
+    // longer hold the popup open (the 65s stall reported in the wild).
+    await discoveryStarted;
+    expect(env.twitch.discoverCampaigns).toHaveBeenCalled();
+    expect(snapshot.settings.running).toBe(true);
+    // And the session already reflects the toggle rather than the pre-toggle
+    // "Automation disabled" the popup used to render for the whole tick.
+    expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
+
+    startDiscovery();
+    await env.rawController.settleBackgroundWork();
+  });
+
+  it("brackets every tick with a lifecycle diagnostic naming its trigger and duration", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+
+    await env.controller.tick(["twitch"], "manual_tick");
+
+    const messages = env.reportEvents.mock.calls
+      .flatMap(([events]) => events)
+      .filter((event) => event.category === "diagnostic")
+      .map((event) => event.message);
+    expect(messages).toContainEqual(expect.stringMatching(/^Tick #\d+ started \(trigger=manual_tick, platforms=twitch\)$/));
+    expect(messages).toContainEqual(expect.stringMatching(/^Tick #\d+ finished after \d+ms \(trigger=manual_tick, platforms=twitch\)$/));
+  });
+
+  it("reports a tick lifecycle even when the tick throws", async () => {
+    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    env.deps.saveState.mockRejectedValue(new Error("storage unavailable"));
+
+    await expect(env.controller.tick(["twitch"], "alarm")).rejects.toThrow("storage unavailable");
+
+    const messages = env.reportEvents.mock.calls
+      .flatMap(([events]) => events)
+      .filter((event) => event.category === "diagnostic")
+      .map((event) => event.message);
+    expect(messages).toContainEqual(expect.stringMatching(/^Tick #\d+ finished after \d+ms \(trigger=alarm/));
+  });
+
   it("starts automation, persists settings, creates alarm, and runs an immediate tick", async () => {
     const env = harness({ ...DEFAULT_SETTINGS, running: false });
 
@@ -1863,7 +1948,11 @@ describe("background controller", () => {
     expect(env.deps.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ running: true }));
     expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
     expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
-    expect(snapshot.state.sessions.twitch.status).toBe("watching");
+    // The snapshot returns ahead of the tick, reporting the prompt "starting"
+    // transition; the watching status lands once the tick settles.
+    expect(snapshot.state.sessions.twitch.status).toBe("idle");
+    expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
+    expect(env.state.sessions.twitch.status).toBe("watching");
   });
 
   it("stops automation immediately and applies auto-close behavior to active watch tabs", async () => {
@@ -1879,14 +1968,16 @@ describe("background controller", () => {
       },
     };
 
-    const snapshot = asSnapshot(await env.controller.handleMessage({ type: "setRunning", running: false }));
+    await env.controller.handleMessage({ type: "setRunning", running: false });
 
     expect(env.settings.running).toBe(false);
     expect(env.twitch.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 10 }));
     expect(env.kick.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 20 }));
-    expect(snapshot.state.sessions.twitch.status).toBe("paused");
-    expect(snapshot.state.sessions.kick.status).toBe("paused");
-    expect(snapshot.state.managedPageContextTabs?.twitch).toBeUndefined();
+    // Read from settled state rather than the returned snapshot: the snapshot is
+    // now taken before the tick that applies the stop.
+    expect(env.state.sessions.twitch.status).toBe("paused");
+    expect(env.state.sessions.kick.status).toBe("paused");
+    expect(env.state.managedPageContextTabs?.twitch).toBeUndefined();
   });
 
   it("prepares a host reset by force-closing managed tabs", async () => {
@@ -1981,8 +2072,10 @@ describe("background controller", () => {
 
     expect(snapshot.settings.platform.twitch.enabled).toBe(false);
     expect(snapshot.settings.platform.kick.enabled).toBe(true);
-    expect(snapshot.state.sessions.twitch.status).toBe("paused");
-    expect(snapshot.state.sessions.kick.status).toBe("watching");
+    // Settings are applied synchronously; the session statuses follow from the
+    // background tick, so they are read from settled state.
+    expect(env.state.sessions.twitch.status).toBe("paused");
+    expect(env.state.sessions.kick.status).toBe("watching");
   });
 
   it("enables popup automation with one settings save and one initial scheduler pass", async () => {
@@ -2008,8 +2101,10 @@ describe("background controller", () => {
     expect(env.settings.platform.kick.enabled).toBe(false);
     expect(env.twitch.discoverCampaigns).toHaveBeenCalledTimes(1);
     expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
-    expect(snapshot.state.sessions.twitch.status).toBe("watching");
-    expect(snapshot.state.sessions.kick.status).toBe("paused");
+    // Returned ahead of the tick, so the enabled platform reads as starting.
+    expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
+    expect(env.state.sessions.twitch.status).toBe("watching");
+    expect(env.state.sessions.kick.status).toBe("paused");
   });
 
   it("saves and normalizes settings without forcing a scheduler tick", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -4,7 +4,7 @@ import { resolveCompatibility } from "@lurkloot/core";
 import type { ChannelCandidate, DropCampaign, DropReward, ExtensionSettings, Platform, PlatformAuthHealth, SchedulerState } from "@lurkloot/shared/models";
 import type { DiagnosticEvent, EngineEvent, EventEmitter } from "@lurkloot/shared/events";
 import type { RuntimeSnapshot } from "@lurkloot/shared/messages";
-import { applySettingsPatch, DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
+import { applySettingsPatch, DEFAULT_SETTINGS, isFarmingActive } from "@lurkloot/shared/settings";
 import { DEFAULT_STATE } from "../src/core/storage";
 import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
 import { createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/kick";
@@ -48,6 +48,29 @@ function deferred<T>() {
     reject = nextReject;
   });
   return { promise, resolve, reject };
+}
+
+// `running: true` used to be what made a fixture farm; with the master switch
+// gone, farming means the platform flags are on. DEFAULT_SETTINGS now ships them
+// off (a fresh install sits idle), so fixtures opt in explicitly. Both wrappers
+// apply last so they win over any platform block in the literal they wrap.
+function farming<T extends ExtensionSettings>(settings: T): T {
+  return withPlatformsEnabled(settings, true);
+}
+
+function notFarming<T extends ExtensionSettings>(settings: T): T {
+  return withPlatformsEnabled(settings, false);
+}
+
+function withPlatformsEnabled<T extends ExtensionSettings>(settings: T, enabled: boolean): T {
+  return {
+    ...settings,
+    platform: {
+      ...settings.platform,
+      twitch: { ...settings.platform.twitch, enabled },
+      kick: { ...settings.platform.kick, enabled },
+    },
+  };
 }
 
 function adapter(platform: Platform): PlatformAdapter {
@@ -109,7 +132,7 @@ function twitchCampaignDetails(dropID: string): unknown {
 }
 
 function harness(
-  settings: ExtensionSettings = { ...DEFAULT_SETTINGS, running: true },
+  settings: ExtensionSettings = farming(DEFAULT_SETTINGS),
   overrides: {
     saveState?: (state: SchedulerState) => Promise<void>;
     reportEvents?: (events: readonly EngineEvent[]) => Promise<void>;
@@ -199,7 +222,6 @@ describe("background controller", () => {
   it("retains Twitch discovery when each controller tick constructs a fresh adapter", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true, idleWatchlistChannels: [] },
@@ -245,7 +267,7 @@ describe("background controller", () => {
   });
 
   it("starts enabled auth probes concurrently and persists each before scheduler work", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     const twitchHealth = deferred<PlatformAuthHealth>();
     const kickHealth = deferred<PlatformAuthHealth>();
     vi.mocked(env.twitch.checkAuthHealth).mockReturnValue(twitchHealth.promise);
@@ -281,7 +303,7 @@ describe("background controller", () => {
     vi.useFakeTimers();
     try {
       const env = harness(
-        { ...DEFAULT_SETTINGS, running: true },
+        farming(DEFAULT_SETTINGS),
         { authProbeTimeoutMs: 25 },
       );
       const oldTwitchHealth = deferred<PlatformAuthHealth>();
@@ -331,7 +353,7 @@ describe("background controller", () => {
     vi.useFakeTimers();
     try {
       const env = harness(
-        { ...DEFAULT_SETTINGS, running: false },
+        farming(DEFAULT_SETTINGS),
         { authProbeTimeoutMs: 25 },
       );
       let signal: AbortSignal | undefined;
@@ -361,7 +383,7 @@ describe("background controller", () => {
     vi.useFakeTimers();
     try {
       const env = harness(
-        { ...DEFAULT_SETTINGS, running: false },
+        farming(DEFAULT_SETTINGS),
         { authProbeTimeoutMs: 25 },
       );
       let backgroundStarted!: () => void;
@@ -401,7 +423,7 @@ describe("background controller", () => {
     vi.useFakeTimers();
     try {
       const env = harness(
-        { ...DEFAULT_SETTINGS, running: true },
+        farming(DEFAULT_SETTINGS),
         { authProbeTimeoutMs: 25 },
       );
       vi.mocked(env.twitch.checkAuthHealth).mockImplementation(() => new Promise(() => undefined));
@@ -439,7 +461,7 @@ describe("background controller", () => {
     vi.useFakeTimers();
     try {
       const env = harness(
-        { ...DEFAULT_SETTINGS, running: false },
+        farming(DEFAULT_SETTINGS),
         { authProbeTimeoutMs: 25 },
       );
       const health = deferred<PlatformAuthHealth>();
@@ -467,7 +489,7 @@ describe("background controller", () => {
   });
 
   it("merges a completed auth probe into state written while the probe was pending", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     const health = deferred<PlatformAuthHealth>();
     vi.mocked(env.twitch.checkAuthHealth).mockReturnValue(health.promise);
 
@@ -507,9 +529,9 @@ describe("background controller", () => {
   it("keeps a newer same-platform refresh when an older tick probe settles last", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
@@ -546,7 +568,7 @@ describe("background controller", () => {
   });
 
   it("keeps invalidation checking when it supersedes an in-flight probe", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     const older = deferred<PlatformAuthHealth>();
     vi.mocked(env.twitch.checkAuthHealth).mockReturnValueOnce(older.promise);
 
@@ -565,7 +587,7 @@ describe("background controller", () => {
   });
 
   it("supersedes an in-flight probe without putting a newly disabled platform in checking", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.authHealth = {
       ...env.state.authHealth,
       twitch: {
@@ -604,7 +626,7 @@ describe("background controller", () => {
   });
 
   it("terminalizes direct adapter setup failures with platform context", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     vi.mocked(env.deps.createAdapter).mockImplementation(() => {
       throw new Error("twitch adapter setup failed");
     });
@@ -630,7 +652,7 @@ describe("background controller", () => {
   });
 
   it("surfaces sibling auth persistence failure alongside adapter setup failure", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     const kickHealth = deferred<PlatformAuthHealth>();
     vi.mocked(env.kick.checkAuthHealth).mockReturnValue(kickHealth.promise);
     vi.mocked(env.deps.createAdapter).mockImplementation((platform, emit, settings) => {
@@ -677,7 +699,7 @@ describe("background controller", () => {
   });
 
   it("isolates a consistently failing Kick constructor from Twitch auth health", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     vi.mocked(env.deps.createAdapters).mockImplementation(() => {
       throw new Error("combined construction reached failing Kick adapter");
     });
@@ -721,9 +743,9 @@ describe("background controller", () => {
   it("terminalizes startup adapter setup failure instead of leaving checking", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: false,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
@@ -734,12 +756,12 @@ describe("background controller", () => {
       throw new Error("twitch startup adapter failed");
     });
 
-    const error = await env.controller.handleStartup().catch((caught: unknown) => caught);
+    // Startup now runs a tick (the platform is enabled, and auto-start is on),
+    // and a tick absorbs adapter setup failures into a reported interruption
+    // rather than rethrowing. What matters is the same: the platform lands on a
+    // terminal auth status instead of being stranded in "checking".
+    await env.controller.handleStartup().catch(() => undefined);
 
-    expect(error).toMatchObject({
-      platform: "twitch",
-      message: "twitch startup adapter failed",
-    });
     expect(env.state.authHealth.twitch).toMatchObject({
       status: "unavailable",
       reasonCode: "platform_unavailable",
@@ -747,7 +769,7 @@ describe("background controller", () => {
   });
 
   it("reports missing credentials without calling the platform probe", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+    const env = harness(farming(DEFAULT_SETTINGS), {
       checkCredentialAvailability: async () => ({ status: "missing" }),
     });
 
@@ -761,7 +783,7 @@ describe("background controller", () => {
   });
 
   it("reports credential lookup failure without calling the platform probe", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+    const env = harness(farming(DEFAULT_SETTINGS), {
       checkCredentialAvailability: async () => ({ status: "unavailable" }),
     });
 
@@ -775,7 +797,7 @@ describe("background controller", () => {
   });
 
   it("continues to the authenticated probe when credentials are available", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+    const env = harness(farming(DEFAULT_SETTINGS), {
       checkCredentialAvailability: async () => ({ status: "available" }),
     });
 
@@ -788,7 +810,6 @@ describe("background controller", () => {
   it("blocks startup account work when credentials are missing without disabling the platform", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
@@ -816,7 +837,6 @@ describe("background controller", () => {
   it("automatically resumes a platform after a healthy authentication recheck", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
@@ -855,7 +875,7 @@ describe("background controller", () => {
   });
 
   it("publishes authentication transitions when diagnostic logging is disabled", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, diagnosticLogging: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, diagnosticLogging: false }));
     vi.mocked(env.kick.checkAuthHealth).mockResolvedValueOnce({
       status: "blocked",
       checkedAt: "2026-07-22T12:00:00.000Z",
@@ -876,7 +896,6 @@ describe("background controller", () => {
   it("does not strand the popup on \"checking\" when the credential probe throws", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
@@ -900,7 +919,6 @@ describe("background controller", () => {
   it("preserves a healthy auth-health probe when a later scheduler step throws", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       tablessMode: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
@@ -930,7 +948,6 @@ describe("background controller", () => {
   it("reports authentication as the reason farming stopped after logout", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
@@ -958,7 +975,7 @@ describe("background controller", () => {
   });
 
   it("recovers Twitch authentication health after login without changing enabled settings", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true }, {
+    const env = harness(farming(DEFAULT_SETTINGS), {
       checkCredentialAvailability: async () => ({ status: "available" }),
     });
     vi.mocked(env.twitch.checkAuthHealth)
@@ -990,7 +1007,7 @@ describe("background controller", () => {
   });
 
   it("invalidates only the requested authentication health and reports the transition once", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     vi.mocked(env.twitch.checkAuthHealth).mockResolvedValueOnce({ status: "healthy", checkedAt: "2026-07-22T12:00:00.000Z" });
     vi.mocked(env.kick.checkAuthHealth).mockResolvedValueOnce({
       status: "missing_credentials",
@@ -1033,7 +1050,7 @@ describe("background controller", () => {
   });
 
   it("checks and persists authentication health for only the requested platform", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     vi.mocked(env.kick.checkAuthHealth).mockResolvedValueOnce({
       status: "blocked",
       checkedAt: "2026-07-22T12:00:00.000Z",
@@ -1072,7 +1089,7 @@ describe("background controller", () => {
   });
 
   it("stores timestamp-only auth refreshes without repeating activity", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     vi.mocked(env.kick.checkAuthHealth)
       .mockResolvedValueOnce({ status: "healthy", checkedAt: "2026-07-22T12:00:00.000Z" })
       .mockResolvedValueOnce({ status: "healthy", checkedAt: "2026-07-22T12:05:00.000Z" });
@@ -1086,7 +1103,7 @@ describe("background controller", () => {
   });
 
   it("strips hostile adapter fields before auth state and events are persisted", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     vi.mocked(env.twitch.checkAuthHealth).mockResolvedValueOnce({
       status: "healthy",
       checkedAt: "2026-07-22T12:00:00.000Z",
@@ -1101,7 +1118,7 @@ describe("background controller", () => {
   });
 
   it("reports the effective compatibility profile and capability once per enabled platform", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
 
     await env.controller.tick();
     await env.controller.tick();
@@ -1134,7 +1151,7 @@ describe("background controller", () => {
   });
 
   it("reports enabled compatibility selections on startup while farming is paused", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
 
     await env.controller.handleStartup();
 
@@ -1147,7 +1164,7 @@ describe("background controller", () => {
   });
 
   it("reports compatibility again only when the effective selection changes", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
 
     await env.controller.tick();
     await env.controller.handleMessage({
@@ -1166,9 +1183,8 @@ describe("background controller", () => {
 
   it("emits credential-safe resolver warnings without echoing persisted selections", async () => {
     const hostileSelection = "unknown-auth-token=secret-cookie";
-    const env = harness({
+    const env = harness(farming({
       ...DEFAULT_SETTINGS,
-      running: false,
       compatibility: {
         ...DEFAULT_SETTINGS.compatibility,
         twitch: {
@@ -1176,7 +1192,7 @@ describe("background controller", () => {
           heartbeatTransport: hostileSelection,
         },
       },
-    });
+    }));
 
     await env.controller.handleStartup();
 
@@ -1192,14 +1208,13 @@ describe("background controller", () => {
   });
 
   it("uses profile metadata for profile resolver warnings", async () => {
-    const env = harness({
+    const env = harness(farming({
       ...DEFAULT_SETTINGS,
-      running: false,
       compatibility: {
         ...DEFAULT_SETTINGS.compatibility,
         twitch: { ...DEFAULT_SETTINGS.compatibility.twitch, profile: "unknown-profile" },
       },
-    });
+    }));
 
     await env.controller.handleStartup();
 
@@ -1216,7 +1231,7 @@ describe("background controller", () => {
   });
 
   it("preserves compatibility diagnostics when a scheduler tick fails", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.twitch.discoverCampaigns = vi.fn(async () => { throw new Error("discovery failed"); });
 
     await env.controller.tick();
@@ -1231,10 +1246,10 @@ describe("background controller", () => {
   it("does not emit resolver warnings for a disabled platform", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: false,
       platform: {
         ...DEFAULT_SETTINGS.platform,
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
       },
       compatibility: {
         ...DEFAULT_SETTINGS.compatibility,
@@ -1250,14 +1265,13 @@ describe("background controller", () => {
   });
 
   it("emits a fresh warning when a different invalid selection resolves identically", async () => {
-    const env = harness({
+    const env = harness(farming({
       ...DEFAULT_SETTINGS,
-      running: true,
       compatibility: {
         ...DEFAULT_SETTINGS.compatibility,
         twitch: { ...DEFAULT_SETTINGS.compatibility.twitch, heartbeatTransport: "first-secret" },
       },
-    });
+    }));
 
     await env.controller.handleStartup();
     await env.controller.handleMessage({
@@ -1278,9 +1292,8 @@ describe("background controller", () => {
   });
 
   it("emits a fixed host-incompatible warning with only the safe fallback identifier", async () => {
-    const env = harness({
+    const env = harness(farming({
       ...DEFAULT_SETTINGS,
-      running: false,
       compatibility: {
         ...DEFAULT_SETTINGS.compatibility,
         twitch: {
@@ -1288,7 +1301,7 @@ describe("background controller", () => {
           heartbeatTransport: "twitch-heartbeat-trowel-v1",
         },
       },
-    });
+    }));
 
     await env.controller.handleStartup();
 
@@ -1302,7 +1315,7 @@ describe("background controller", () => {
 
   it("saves each operational state before publishing its ordered batch", async () => {
     const calls: string[] = [];
-    const env = harness({ ...DEFAULT_SETTINGS, running: true }, {
+    const env = harness(farming(DEFAULT_SETTINGS), {
       saveState: async () => { calls.push("state"); },
       // Tick lifecycle diagnostics are published as they happen and describe no
       // state, so they are outside the state-before-events batching invariant
@@ -1323,7 +1336,7 @@ describe("background controller", () => {
   });
 
   it("does not publish tick events when the corresponding state save fails", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     let saveCalls = 0;
     env.deps.saveState.mockImplementation(async (next: SchedulerState) => {
       saveCalls += 1;
@@ -1408,9 +1421,9 @@ describe("background controller", () => {
   it("publishes lifecycle events through the host sink without persisting log history", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
@@ -1433,9 +1446,9 @@ describe("background controller", () => {
   it("does not commit pending-claim diagnostics when scheduler state persistence fails", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
@@ -1455,9 +1468,9 @@ describe("background controller", () => {
   it("publishes one actionable link-required diagnostic while repeated automatic claims are suppressed", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false },
       },
     });
@@ -1518,15 +1531,15 @@ describe("background controller", () => {
   it("publishes a farming stop reason when automation is disabled", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
     await env.controller.tick();
 
-    await env.controller.handleMessage({ type: "setRunning", running: false });
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: false });
 
     const published = env.reportEvents.mock.calls.flatMap(([events]) => events);
     expect(published).toContainEqual(expect.objectContaining({
@@ -1540,10 +1553,10 @@ describe("background controller", () => {
   it("publishes an interruption when an idle platform is paused by manual watch", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       pauseOnManualWatch: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
@@ -1568,7 +1581,7 @@ describe("background controller", () => {
   });
 
   it("creates the scheduler alarm from persisted settings", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, pollIntervalMinutes: 11 });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, pollIntervalMinutes: 11 }));
 
     await env.controller.ensureAlarm();
 
@@ -1576,7 +1589,7 @@ describe("background controller", () => {
   });
 
   it("stamps the install time once through the serialized controller lifecycle", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
 
     await env.controller.ensureInstalledAt("2026-07-26T12:00:00.000Z");
     await env.controller.ensureInstalledAt("2026-07-26T13:00:00.000Z");
@@ -1587,7 +1600,7 @@ describe("background controller", () => {
   it("preserves a state write that lands while startup setup reporting is pending", async () => {
     const setupReported = deferred<void>();
     const env = harness(
-      { ...DEFAULT_SETTINGS, running: false },
+      farming(DEFAULT_SETTINGS),
       { reportEvents: async () => setupReported.promise },
     );
     env.state.sessions.twitch = {
@@ -1614,7 +1627,7 @@ describe("background controller", () => {
   it("preserves a settings patch that lands while startup setup reporting is pending", async () => {
     const setupReported = deferred<void>();
     const env = harness(
-      { ...DEFAULT_SETTINGS, running: true, autoStartDropFarming: false },
+      farming({ ...DEFAULT_SETTINGS, autoStartDropFarming: true }),
       { reportEvents: async () => setupReported.promise },
     );
 
@@ -1628,14 +1641,14 @@ describe("background controller", () => {
     setupReported.resolve();
     await startup;
 
-    expect(env.settings.running).toBe(false);
+    expect(isFarmingActive(env.settings)).toBe(true);
     expect(env.settings.diagnosticLogging).toBe(false);
   });
 
   it("refreshes enabled auth health from ensureAlarm while farming is stopped", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: false,
+      autoStartDropFarming: false,
       platform: {
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
@@ -1650,19 +1663,31 @@ describe("background controller", () => {
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
   });
 
-  it("refreshes enabled auth health on startup without starting farming", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+  // Auth health is only probed for enabled platforms, and auto-start off now
+  // disables them on launch — so startup neither farms nor probes, and the popup
+  // reports auth once the user switches a platform back on.
+  it("neither farms nor probes on startup when auto-start disabled every platform", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoStartDropFarming: false }));
+
+    await env.controller.handleStartup();
+
+    expect(isFarmingActive(env.settings)).toBe(false);
+    expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
+    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+  });
+
+  it("refreshes enabled auth health on startup while auto-start keeps farming", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoStartDropFarming: true }));
 
     await env.controller.handleStartup();
 
     expect(env.state.authHealth.twitch.status).toBe("healthy");
     expect(env.state.authHealth.kick.status).toBe("healthy");
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
   });
 
-  it("auto-starts on launch only when the persisted running state is enabled", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoStartDropFarming: true });
+  it("auto-starts on launch only when a platform is enabled", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoStartDropFarming: true }));
 
     await env.controller.ensureAlarm();
 
@@ -1672,7 +1697,7 @@ describe("background controller", () => {
   });
 
   it("clears stale restart tabs and auto-resumes with fresh tabs when auto-start is enabled", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoStartDropFarming: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoStartDropFarming: true }));
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",
@@ -1731,7 +1756,7 @@ describe("background controller", () => {
   });
 
   it("pauses stale restart sessions and disables running when auto-start is disabled", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoStartDropFarming: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoStartDropFarming: false }));
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",
@@ -1751,8 +1776,7 @@ describe("background controller", () => {
 
     await env.controller.handleStartup();
 
-    expect(env.settings.running).toBe(false);
-    expect(env.deps.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ running: false }));
+    expect(isFarmingActive(env.settings)).toBe(false);
     expect(env.deps.closeManagedTabs).toHaveBeenCalledWith([
       expect.objectContaining({ tabId: 44, channelUrl: "https://www.twitch.tv/twitch-creator", ownedByExtension: true }),
     ]);
@@ -1768,7 +1792,7 @@ describe("background controller", () => {
   });
 
   it("cleans stale restart state without starting farming when automation is already stopped", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, autoStartDropFarming: true });
+    const env = harness(notFarming({ ...DEFAULT_SETTINGS, autoStartDropFarming: true }));
     env.state.sessions.kick = {
       platform: "kick",
       status: "paused",
@@ -1788,7 +1812,7 @@ describe("background controller", () => {
 
     await env.controller.handleStartup();
 
-    expect(env.settings.running).toBe(false);
+    expect(isFarmingActive(env.settings)).toBe(false);
     expect(env.deps.closeManagedTabs).toHaveBeenCalledWith([
       expect.objectContaining({ tabId: 55, channelUrl: "https://kick.com/kick-creator", ownedByExtension: true }),
     ]);
@@ -1798,7 +1822,7 @@ describe("background controller", () => {
   });
 
   it("clears stale retained page-context tabs on startup", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, autoStartDropFarming: true });
+    const env = harness(notFarming({ ...DEFAULT_SETTINGS, autoStartDropFarming: true }));
     env.state.managedPageContextTabs = {
       twitch: {
         platform: "twitch",
@@ -1827,7 +1851,6 @@ describe("background controller", () => {
   it("preserves a retained Kick page context across a running service-worker restart", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       autoStartDropFarming: true,
       platform: {
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false, idleWatchlistChannels: [] },
@@ -1857,7 +1880,7 @@ describe("background controller", () => {
   });
 
   it("does not log startup cleanup when there is no stale farming state", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, autoStartDropFarming: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoStartDropFarming: true }));
 
     await env.controller.handleStartup();
 
@@ -1868,20 +1891,17 @@ describe("background controller", () => {
     )).toBe(false);
   });
 
-  it("disables running on startup when auto-start is disabled even without stale tabs", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoStartDropFarming: false });
+  it("disables every platform on startup when auto-start is disabled even without stale tabs", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoStartDropFarming: false }));
 
     await env.controller.handleStartup();
 
-    expect(env.settings.running).toBe(false);
-    expect(env.deps.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ running: false }));
+    expect(isFarmingActive(env.settings)).toBe(false);
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-    expect(env.state.authHealth.twitch.status).toBe("healthy");
-    expect(env.state.authHealth.kick.status).toBe("healthy");
   });
 
   it("answers an automation toggle without waiting for the scheduler tick", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     let startDiscovery = (): void => {};
     const discoveryStarted = new Promise<void>((resolve) => {
       const blocked = new Promise<void>((release) => { startDiscovery = () => release(); });
@@ -1904,7 +1924,7 @@ describe("background controller", () => {
     // longer hold the popup open (the 65s stall reported in the wild).
     await discoveryStarted;
     expect(env.twitch.discoverCampaigns).toHaveBeenCalled();
-    expect(snapshot.settings.running).toBe(true);
+    expect(isFarmingActive(snapshot.settings)).toBe(true);
     // And the session already reflects the toggle rather than the pre-toggle
     // "Automation disabled" the popup used to render for the whole tick.
     expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
@@ -1914,7 +1934,7 @@ describe("background controller", () => {
   });
 
   it("brackets every tick with a lifecycle diagnostic naming its trigger and duration", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
 
     await env.controller.tick(["twitch"], "manual_tick");
 
@@ -1927,7 +1947,7 @@ describe("background controller", () => {
   });
 
   it("reports a tick lifecycle even when the tick throws", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.deps.saveState.mockRejectedValue(new Error("storage unavailable"));
 
     await expect(env.controller.tick(["twitch"], "alarm")).rejects.toThrow("storage unavailable");
@@ -1940,12 +1960,11 @@ describe("background controller", () => {
   });
 
   it("starts automation, persists settings, creates alarm, and runs an immediate tick", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
 
-    const snapshot = asSnapshot(await env.controller.handleMessage({ type: "setRunning", running: true }));
+    const snapshot = asSnapshot(await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true }));
 
-    expect(env.settings.running).toBe(true);
-    expect(env.deps.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ running: true }));
+    expect(env.settings.platform.twitch.enabled).toBe(true);
     expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
     expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
     // The snapshot returns ahead of the tick, reporting the prompt "starting"
@@ -1956,7 +1975,7 @@ describe("background controller", () => {
   });
 
   it("stops automation immediately and applies auto-close behavior to active watch tabs", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoCloseFinishedDrops: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoCloseFinishedDrops: false }));
     await env.controller.tick();
     env.state.managedPageContextTabs = {
       twitch: {
@@ -1968,9 +1987,10 @@ describe("background controller", () => {
       },
     };
 
-    await env.controller.handleMessage({ type: "setRunning", running: false });
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: false });
+    await env.controller.handleMessage({ type: "setAutomation", platform: "kick", enabled: false });
 
-    expect(env.settings.running).toBe(false);
+    expect(isFarmingActive(env.settings)).toBe(false);
     expect(env.twitch.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 10 }));
     expect(env.kick.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 20 }));
     // Read from settled state rather than the returned snapshot: the snapshot is
@@ -1981,7 +2001,7 @@ describe("background controller", () => {
   });
 
   it("prepares a host reset by force-closing managed tabs", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoCloseFinishedDrops: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoCloseFinishedDrops: false }));
     await env.controller.tick();
     env.state.managedPageContextTabs = {
       twitch: {
@@ -2010,7 +2030,7 @@ describe("background controller", () => {
   });
 
   it("allows host-reset cleanup to be retried", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     await env.controller.tick();
 
     await env.controller.prepareForHostReset();
@@ -2019,7 +2039,7 @@ describe("background controller", () => {
   });
 
   it("force-closes registry-owned tabs even when no live session references them", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.managedWatchTabs = {
       twitch: {
         platform: "twitch",
@@ -2035,7 +2055,7 @@ describe("background controller", () => {
   });
 
   it("holds controller mutations until host storage reset finishes", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     let releaseReset!: () => void;
     const resetBlocked = new Promise<void>((resolve) => {
       releaseReset = resolve;
@@ -2061,7 +2081,7 @@ describe("background controller", () => {
   });
 
   it("toggles one platform and immediately applies the scheduler when running", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     await env.controller.tick();
 
     const snapshot = asSnapshot(await env.controller.handleMessage({
@@ -2079,15 +2099,14 @@ describe("background controller", () => {
   });
 
   it("enables popup automation with one settings save and one initial scheduler pass", async () => {
-    const env = harness({
+    const env = harness(notFarming({
       ...DEFAULT_SETTINGS,
-      running: false,
       platform: {
         ...DEFAULT_SETTINGS.platform,
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false, idleWatchlistChannels: [] },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false, idleWatchlistChannels: [] },
       },
-    });
+    }));
 
     const snapshot = asSnapshot(await env.controller.handleMessage({
       type: "setAutomation",
@@ -2096,7 +2115,7 @@ describe("background controller", () => {
     }));
 
     expect(env.deps.saveSettings).toHaveBeenCalledTimes(1);
-    expect(env.settings.running).toBe(true);
+    expect(isFarmingActive(env.settings)).toBe(true);
     expect(env.settings.platform.twitch.enabled).toBe(true);
     expect(env.settings.platform.kick.enabled).toBe(false);
     expect(env.twitch.discoverCampaigns).toHaveBeenCalledTimes(1);
@@ -2104,14 +2123,14 @@ describe("background controller", () => {
     // Returned ahead of the tick, so the enabled platform reads as starting.
     expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
     expect(env.state.sessions.twitch.status).toBe("watching");
-    expect(env.state.sessions.kick.status).toBe("paused");
+    // Untouched: the toggle ticks only the platform it changed.
+    expect(env.state.sessions.kick.status).toBe("idle");
   });
 
   it("saves and normalizes settings without forcing a scheduler tick", async () => {
     const env = harness();
     const nextSettings = {
       ...DEFAULT_SETTINGS,
-      running: true,
       pollIntervalMinutes: Number.NaN,
       offlineRetryLimit: 0,
       tablessFallbackFailureLimit: 99,
@@ -2143,9 +2162,8 @@ describe("background controller", () => {
   });
 
   it("merges overlapping settings patches without clobbering previous saves", async () => {
-    const env = harness({
+    const env = harness(farming({
       ...DEFAULT_SETTINGS,
-      running: true,
       notifyRewardEarned: true,
       notifyNoDropsLeft: true,
       platform: {
@@ -2153,7 +2171,7 @@ describe("background controller", () => {
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, excludedChannels: [] },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
       },
-    });
+    }));
 
     await Promise.all([
       env.controller.handleMessage({
@@ -2179,12 +2197,11 @@ describe("background controller", () => {
   });
 
   it("preserves rapid scheduling patches without overlapping reconciliation", async () => {
-    const env = harness({
+    const env = harness(farming({
       ...DEFAULT_SETTINGS,
-      running: true,
       notifyRewardEarned: true,
       notifyNoDropsLeft: true,
-    });
+    }));
     let activeDiscoveries = 0;
     let maxActiveDiscoveries = 0;
     let discoveryCalls = 0;
@@ -2232,7 +2249,7 @@ describe("background controller", () => {
   });
 
   it("runs a scheduler tick after saving settings when requested and automation is active", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     const nextSettings = {
       ...env.settings,
       platform: {
@@ -2252,7 +2269,7 @@ describe("background controller", () => {
   });
 
   it("only ticks requested platforms after saving settings with targeted platforms", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     const nextSettings = {
       ...env.settings,
       platform: {
@@ -2275,7 +2292,7 @@ describe("background controller", () => {
   });
 
   it("does not start automation after saving Idle Watchlist settings while paused", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(notFarming(DEFAULT_SETTINGS));
     const nextSettings = {
       ...env.settings,
       platform: {
@@ -2291,12 +2308,12 @@ describe("background controller", () => {
     }));
 
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-    expect(snapshot.settings.running).toBe(false);
+    expect(isFarmingActive(snapshot.settings)).toBe(false);
     expect(snapshot.settings.platform.twitch.idleWatchlistChannels).toEqual(["fallback"]);
   });
 
   it("keeps active farming untouched when saving a non-scheduling setting", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",
@@ -2317,7 +2334,7 @@ describe("background controller", () => {
   });
 
   it("runs an immediate scheduler tick when requested from the popup", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
 
     const snapshot = asSnapshot(await env.controller.handleMessage({ type: "tickNow" }));
 
@@ -2331,7 +2348,7 @@ describe("background controller", () => {
   });
 
   it("reports scheduler diagnostics without consulting host diagnostic settings", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, diagnosticLogging: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, diagnosticLogging: false }));
 
     await env.controller.handleMessage({ type: "tickNow" });
 
@@ -2340,8 +2357,8 @@ describe("background controller", () => {
   });
 
   it("records playback telemetry only for the managed watch tab", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
 
     await env.controller.handleMessage({
       type: "playbackTelemetry",
@@ -2384,8 +2401,8 @@ describe("background controller", () => {
   });
 
   it("clears accumulated playback checks as soon as the watch tab reports playback (#250)", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
     env.state.sessions.twitch = { ...env.state.sessions.twitch, playbackChecks: 2 };
 
     await env.controller.handleMessage({
@@ -2420,8 +2437,8 @@ describe("background controller", () => {
   });
 
   it("records visible playback in a non-managed tab as manual watch activity", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, pauseOnManualWatch: true });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
 
     await env.controller.handleMessage({
       type: "playbackTelemetry",
@@ -2445,7 +2462,7 @@ describe("background controller", () => {
   });
 
   it("clears manual watch activity when the source tab is closed", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, pauseOnManualWatch: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
     env.state.manualWatch = {
       twitch: {
         platform: "twitch",
@@ -2461,7 +2478,7 @@ describe("background controller", () => {
   });
 
   it("marks manual watch inactive when the same tab stops visible playback", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, pauseOnManualWatch: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
     env.state.manualWatch = {
       twitch: {
         platform: "twitch",
@@ -2491,8 +2508,8 @@ describe("background controller", () => {
   });
 
   it("logs playback transitions such as ad starts and blocked playback", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
 
     // Baseline healthy telemetry — no ad, nothing blocked.
     await env.controller.handleMessage({
@@ -2516,10 +2533,10 @@ describe("background controller", () => {
 
   it("publishes focus diagnostics exactly once in the telemetry operation batch", async () => {
     const reported: EngineEvent[][] = [];
-    const env = harness({ ...DEFAULT_SETTINGS, running: false }, {
+    const env = harness(farming(DEFAULT_SETTINGS), {
       reportEvents: async (events) => { reported.push([...events]); },
     });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
     reported.length = 0;
     env.deps.applyAdFocus.mockImplementation(async (_platform, _tabId, _adActive, emit) => {
       emit({ category: "diagnostic", level: "info", message: "focus-adjusted", platform: "twitch" });
@@ -2546,8 +2563,8 @@ describe("background controller", () => {
   });
 
   it("keeps persisted playback telemetry when applying ad focus fails", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
     env.deps.applyAdFocus.mockRejectedValue(new Error("focus callback failed"));
 
     await expect(env.controller.handleMessage({
@@ -2574,8 +2591,8 @@ describe("background controller", () => {
   });
 
   it("focuses the watch tab when an ad is reported on the managed tab", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, adFocusMode: "window" });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, adFocusMode: "window" }));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
     env.deps.applyAdFocus.mockClear();
 
     await env.controller.handleMessage({
@@ -2596,8 +2613,8 @@ describe("background controller", () => {
   });
 
   it("releases ad focus when telemetry reports no ad", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, adFocusMode: "tab" });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, adFocusMode: "tab" }));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
     env.deps.applyAdFocus.mockClear();
 
     await env.controller.handleMessage({
@@ -2618,8 +2635,8 @@ describe("background controller", () => {
   });
 
   it("does not focus for telemetry from a tab that is not the watch tab", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
     env.deps.applyAdFocus.mockClear();
 
     await env.controller.handleMessage({
@@ -2640,8 +2657,8 @@ describe("background controller", () => {
   });
 
   it("ignores playback telemetry without a sender tab", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
     env.deps.applyAdFocus.mockClear();
 
     await env.controller.handleMessage({
@@ -2666,7 +2683,7 @@ describe("background controller", () => {
   });
 
   it("does not treat tabless sessions as managed playback telemetry targets", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",
@@ -2698,7 +2715,7 @@ describe("background controller", () => {
   });
 
   it("re-applies ad focus from playback state on each scheduler tick", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
 
     await env.controller.handleMessage({ type: "tickNow" });
 
@@ -2707,7 +2724,7 @@ describe("background controller", () => {
   });
 
   it("keeps successful scheduler state when re-applying ad focus fails", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.deps.applyAdFocus.mockRejectedValue(new Error("focus refresh failed"));
 
     await env.controller.tick();
@@ -2722,8 +2739,8 @@ describe("background controller", () => {
   });
 
   it("allows playback control only for the current watch tab", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
 
     await expect(env.controller.handleMessage(
       { type: "getPlaybackControl", platform: "twitch" },
@@ -2737,8 +2754,8 @@ describe("background controller", () => {
   });
 
   it("passes the playback control setting to managed watch tabs", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false, keepFarmingVideosUnmuted: false });
-    await env.controller.handleMessage({ type: "setRunning", running: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, keepFarmingVideosUnmuted: false }));
+    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
 
     await expect(env.controller.handleMessage(
       { type: "getPlaybackControl", platform: "twitch" },
@@ -2747,12 +2764,11 @@ describe("background controller", () => {
   });
 
   it("defaults playback control on when stored settings are missing the advanced flag", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: false });
-    env.deps.loadSettings.mockResolvedValueOnce({
+    const env = harness(farming(DEFAULT_SETTINGS));
+    env.deps.loadSettings.mockResolvedValueOnce(farming({
       ...DEFAULT_SETTINGS,
-      running: true,
       keepFarmingVideosUnmuted: undefined,
-    } as unknown as typeof DEFAULT_SETTINGS);
+    } as unknown as typeof DEFAULT_SETTINGS));
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",
@@ -2768,7 +2784,7 @@ describe("background controller", () => {
   });
 
   it("pauses the platform when the user closes the active managed farming tab", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",
@@ -2799,7 +2815,7 @@ describe("background controller", () => {
     });
     expect(env.state.managedWatchTabs?.twitch).toBeUndefined();
     // The user's enabled/running settings are untouched: this is a pause.
-    expect(env.settings.running).toBe(true);
+    expect(isFarmingActive(env.settings)).toBe(true);
     expect(env.settings.platform.twitch.enabled).toBe(true);
 
     await env.controller.tick();
@@ -2812,7 +2828,7 @@ describe("background controller", () => {
   });
 
   it("resumes farming for the platform when the user asks to resume", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",
@@ -2834,7 +2850,7 @@ describe("background controller", () => {
   });
 
   it("does not pause when a watch tab the extension does not own is closed", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",
@@ -2854,7 +2870,7 @@ describe("background controller", () => {
   });
 
   it("does not pause when a managed page-context tab is closed", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.sessions.kick = {
       platform: "kick",
       status: "watching",
@@ -2883,7 +2899,7 @@ describe("background controller", () => {
   });
 
   it("does not confuse a removed page-context tab with the active farming tab", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.sessions.kick = {
       platform: "kick",
       status: "watching",
@@ -2918,7 +2934,7 @@ describe("background controller", () => {
   });
 
   it("ignores removed tabs that are not the active managed watch tab", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     env.state.sessions.twitch = {
       platform: "twitch",
       status: "watching",
@@ -2937,9 +2953,9 @@ describe("background controller", () => {
   it("does not reopen a closed tab for a disabled platform", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false, idleWatchlistChannels: [] },
       },
     });
@@ -2959,7 +2975,7 @@ describe("background controller", () => {
   });
 
   it("tracks one managed watch tab per running platform", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
 
     await env.controller.tick();
 
@@ -2982,7 +2998,7 @@ describe("background controller", () => {
   });
 
   it("completes a campaign after manually claiming its last subscription reward", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoClaim: false }));
     const subscriptionReward: DropReward = {
       ...reward("claimable"),
       id: "subscription-reward",
@@ -3027,7 +3043,7 @@ describe("background controller", () => {
   });
 
   it("keeps a mixed campaign active after manually claiming its subscription reward", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoClaim: false }));
     const subscriptionReward: DropReward = {
       ...reward("claimable"),
       id: "subscription-reward",
@@ -3061,7 +3077,7 @@ describe("background controller", () => {
   });
 
   it("unlocks a dependent watch reward immediately after a manual subscription claim", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoClaim: false }));
     const subscriptionReward: DropReward = {
       ...reward("claimable"),
       id: "subscription-reward",
@@ -3106,7 +3122,7 @@ describe("background controller", () => {
   });
 
   it("does not publish manual-claim events when the corresponding state save fails", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: false }, {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoClaim: false }), {
       saveState: vi.fn().mockRejectedValueOnce(new Error("storage unavailable")),
     });
     env.state.campaigns.twitch = [campaign("twitch", "claimable")];
@@ -3144,7 +3160,7 @@ describe("background controller", () => {
   });
 
   it("emits reward notifications best-effort when rewards become earned", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, notifyRewardEarned: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, notifyRewardEarned: true }));
     env.state.campaigns.twitch = [campaign("twitch", "in_progress")];
     vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimable")]);
 
@@ -3157,7 +3173,7 @@ describe("background controller", () => {
   });
 
   it("emits a notification when a Kick challenge is claimed", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, notifyRewardEarned: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, notifyRewardEarned: true }));
     env.kick.claimChallenges = vi.fn(async () => [{ id: "daily", rarity: "mythic", recurrence: "daily" }]);
 
     await env.controller.tick();
@@ -3169,7 +3185,7 @@ describe("background controller", () => {
   });
 
   it("does not emit a challenge notification when reward notifications are off", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, notifyRewardEarned: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, notifyRewardEarned: false }));
     env.kick.claimChallenges = vi.fn(async () => [{ id: "daily", rarity: "mythic", recurrence: "daily" }]);
 
     await env.controller.tick();
@@ -3180,7 +3196,7 @@ describe("background controller", () => {
   });
 
   it("does not emit disabled reward notifications", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, notifyRewardEarned: false });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, notifyRewardEarned: false }));
     env.state.campaigns.twitch = [campaign("twitch", "in_progress")];
     vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimable")]);
 
@@ -3192,9 +3208,9 @@ describe("background controller", () => {
   it("emits the no-drops-left notification once when entering the exhausted state", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       notifyNoDropsLeft: true,
-      platform: { ...DEFAULT_SETTINGS.platform, kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false } },
+      platform: { ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true }, kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false } },
     });
     // A fully claimed campaign is present but has nothing earnable, so the
     // scheduler goes idle into the "no drops left" condition.
@@ -3208,10 +3224,10 @@ describe("background controller", () => {
   it("does not re-emit the no-drops-left notification while the exhausted state persists", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       notifyNoDropsLeft: true,
       notifyRewardEarned: false,
-      platform: { ...DEFAULT_SETTINGS.platform, kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false } },
+      platform: { ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true }, kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false } },
     });
     vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimed")]);
 
@@ -3259,10 +3275,10 @@ describe("background controller", () => {
     const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       tablessMode: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
@@ -3317,10 +3333,10 @@ describe("background controller", () => {
   function tablessEnv(overrides: Partial<ExtensionSettings> = {}) {
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       tablessMode: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false, idleWatchlistChannels: [] },
       },
       ...overrides,
@@ -3382,10 +3398,10 @@ describe("background controller", () => {
     const reported: EngineEvent[][] = [];
     const env = harness({
       ...DEFAULT_SETTINGS,
-      running: true,
       tablessMode: true,
       platform: {
         ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false, idleWatchlistChannels: [] },
       },
     }, {
@@ -3443,7 +3459,7 @@ describe("background controller", () => {
     await env.controller.tick();
     watcher.stop.mockRejectedValue(new Error("watcher stop failed"));
 
-    await expect(env.controller.handleMessage({ type: "setRunning", running: false })).resolves.toBeDefined();
+    await expect(env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: false })).resolves.toBeDefined();
 
     expect(env.state.sessions.twitch.status).toBe("paused");
     expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(expect.objectContaining({
@@ -3587,7 +3603,7 @@ describe("background controller", () => {
   });
 
   it("reports the reward ids claimed during a tick, per platform", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true, autoClaim: true });
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoClaim: true }));
     env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
 
     const claimed = await env.controller.tick();
@@ -3610,10 +3626,10 @@ describe("background controller", () => {
       const timer = manualWait();
       const env = harness({
         ...DEFAULT_SETTINGS,
-        running: true,
         autoClaim: true,
         platform: {
           ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
           kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false, idleWatchlistChannels: [] },
         },
         ...overrides,
@@ -3816,7 +3832,7 @@ describe("background controller", () => {
 
       const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
       await drainMicrotasks();
-      await env.controller.handleMessage({ type: "setRunning", running: false });
+      await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: false });
       await env.timer.flush();
       await handoff;
 
@@ -3916,7 +3932,7 @@ describe("background controller critical health", () => {
   });
 
   it("records page context opens into the critical health detector", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     // Adapters are constructed with the tick's emitter before discovery runs, so
     // the last recorded call carries the live emitter for this tick.
     const emitFromTick = (): EventEmitter => env.deps.createAdapters.mock.calls.at(-1)![0];
@@ -3943,7 +3959,7 @@ describe("background controller critical health", () => {
   });
 
   it("opens the breaker and syncs the registry after repeated page context opens", async () => {
-    const env = harness({ ...DEFAULT_SETTINGS, running: true });
+    const env = harness(farming(DEFAULT_SETTINGS));
     const emitFromTick = (): EventEmitter => env.deps.createAdapters.mock.calls.at(-1)![0];
     env.kick.discoverCampaigns = vi.fn(async () => {
       emitFromTick()({

--- a/packages/extension/tests/criticalFailurePopup.test.tsx
+++ b/packages/extension/tests/criticalFailurePopup.test.tsx
@@ -46,7 +46,6 @@ async function mountPopup(options: { flagged: Platform | null; promptEnabled?: b
     ...base,
     settings: {
       ...base.settings,
-      running: true,
       criticalFailurePromptEnabled: options.promptEnabled ?? true,
     },
     state: {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -42,11 +42,10 @@ type SettingsPatch = Partial<Omit<ExtensionSettings, "platform">> & {
 function settings(patch: SettingsPatch = {}): ExtensionSettings {
   return {
     ...DEFAULT_SETTINGS,
-    running: true,
     ...patch,
     platform: {
-      twitch: { ...DEFAULT_SETTINGS.platform.twitch, ...patch.platform?.twitch },
-      kick: { ...DEFAULT_SETTINGS.platform.kick, ...patch.platform?.kick },
+      twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true, ...patch.platform?.twitch },
+      kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true, ...patch.platform?.kick },
     },
   };
 }
@@ -2253,7 +2252,7 @@ describe("scheduler tick", () => {
         },
         campaigns: { twitch: [], kick: [] },
       },
-      settings({ running: false }),
+      settings({ platform: { twitch: { enabled: false }, kick: { enabled: false } } }),
       { twitch, kick: adapter("kick", [], []) },
       { stopPageContextTabs },
     );
@@ -3080,7 +3079,7 @@ describe("scheduler critical health observations", () => {
 
   it.each([
     ["platform disabled", () => healthSettings({ platform: { twitch: { enabled: false } } })],
-    ["automation stopped", () => healthSettings({ running: false })],
+    ["automation stopped", () => healthSettings({ platform: { twitch: { enabled: false }, kick: { enabled: false } } })],
   ])("prunes the tab churn window on the %s early exit", async (_name, tickSettings) => {
     const stale = new Date(Date.now() - 60 * 60 * 1000).toISOString();
     const result = await runSchedulerTick(

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -218,7 +218,6 @@ describe("settings", () => {
       excludedCampaignIds: [" Abc ", "abc", "Abc"],
     } as unknown as Parameters<typeof mergeSettings>[0]);
 
-    expect(settings.running).toBe(DEFAULT_SETTINGS.running);
     expect(settings.keepFarmingVideosUnmuted).toBe(false);
     expect(settings.pauseOnManualWatch).toBe(DEFAULT_SETTINGS.pauseOnManualWatch);
     expect(settings.priorityMode).toBe(DEFAULT_SETTINGS.priorityMode);

--- a/packages/extension/tests/settingsMigrations.test.ts
+++ b/packages/extension/tests/settingsMigrations.test.ts
@@ -260,7 +260,7 @@ describe("schema v2", () => {
     // setting; normalization defaults both flags to on.
     expect(result.settings.farmingEligibility).toBeUndefined();
     expect(result.settings.campaignVisibility).toBeUndefined();
-    expect(result.toVersion).toBe(3);
+    expect(result.toVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
     expect(result.changed).toBe(true);
     expect(result.diagnostics).toContainEqual({
       code: "moved_property",
@@ -325,12 +325,72 @@ describe("schema v2", () => {
   });
 });
 
+describe("schema v4", () => {
+  it("drops the running flag and keeps enabled platforms farming when it was on", () => {
+    const migrated = migrateSettings({
+      schemaVersion: 3,
+      running: true,
+      platform: { twitch: { enabled: true }, kick: { enabled: true } },
+    });
+
+    expect(migrated.settings.running).toBeUndefined();
+    expect(migrated.settings.platform).toMatchObject({
+      twitch: { enabled: true },
+      kick: { enabled: true },
+    });
+    expect(migrated.toVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+  });
+
+  // The popup rendered `running && enabled`, so a stored `running: false` showed
+  // every platform as off. Carrying the enabled flags across unchanged would
+  // start farming on upgrade for platforms the user last saw switched off.
+  it("switches every platform off when automation was off, whatever the flags said", () => {
+    const migrated = migrateSettings({
+      schemaVersion: 3,
+      running: false,
+      platform: { twitch: { enabled: true }, kick: { enabled: true } },
+    });
+
+    expect(migrated.settings.running).toBeUndefined();
+    expect(migrated.settings.platform).toMatchObject({
+      twitch: { enabled: false },
+      kick: { enabled: false },
+    });
+    expect(migrated.diagnostics).toContainEqual(expect.objectContaining({
+      code: "deprecated_property",
+      path: "running",
+    }));
+  });
+
+  it("reports nothing when automation was off and the platforms already were", () => {
+    const migrated = migrateSettings({
+      schemaVersion: 3,
+      running: false,
+      platform: { twitch: { enabled: false }, kick: { enabled: false } },
+    });
+
+    expect(migrated.diagnostics.filter((diagnostic) => diagnostic.path === "running")).toEqual([]);
+  });
+
+  it("leaves a document without the flag untouched", () => {
+    const migrated = migrateSettings({
+      schemaVersion: 3,
+      platform: { twitch: { enabled: true }, kick: { enabled: false } },
+    });
+
+    expect(migrated.settings.platform).toMatchObject({
+      twitch: { enabled: true },
+      kick: { enabled: false },
+    });
+  });
+});
+
 describe("schema v3", () => {
   it("adds the critical failure prompt toggle at version 3", () => {
     const migrated = migrateSettings({ schemaVersion: 2, running: true });
 
     expect(migrated.settings.criticalFailurePromptEnabled).toBe(true);
-    expect(migrated.toVersion).toBe(3);
+    expect(migrated.toVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
   });
 
   it("preserves an explicit opt-out through migration", () => {

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -519,8 +519,8 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const idleWatchlistChannels = settings.platform[platform].idleWatchlistChannels;
   const idleWatchlist = idleWatchlistChannels.map((username) => streamerItemFromFallback(username, session, t));
   const automation = {
-    twitch: pendingAutomation.twitch ?? (settings.running && settings.platform.twitch.enabled),
-    kick: pendingAutomation.kick ?? (settings.running && settings.platform.kick.enabled),
+    twitch: pendingAutomation.twitch ?? settings.platform.twitch.enabled,
+    kick: pendingAutomation.kick ?? settings.platform.kick.enabled,
   };
   const enabled = automation[platform];
   const automationPending = pendingAutomation[platform] != null;

--- a/packages/popup-ui/src/demo.ts
+++ b/packages/popup-ui/src/demo.ts
@@ -24,7 +24,6 @@ function handleDemoMessage(message: RuntimeMessage): RuntimeSnapshot | PlaybackC
         ...demoSnapshot(),
         settings: mergeSettings({
           ...demoSnapshot().settings,
-          running: message.enabled,
           platform: {
             ...demoSnapshot().settings.platform,
             [message.platform]: {
@@ -34,8 +33,6 @@ function handleDemoMessage(message: RuntimeMessage): RuntimeSnapshot | PlaybackC
           },
         }),
       };
-    case "setRunning":
-      return { ...demoSnapshot(), settings: mergeSettings({ ...demoSnapshot().settings, running: message.running }) };
     case "setPlatformEnabled":
       return {
         ...demoSnapshot(),
@@ -91,7 +88,6 @@ function demoSnapshot(): RuntimeSnapshot {
   const inHours = (hours: number) => new Date(now + hours * 3_600_000).toISOString();
   const settings = mergeSettings({
     ...DEFAULT_SETTINGS,
-    running: true,
     platform: {
       twitch: {
         enabled: true,

--- a/packages/shared/src/failureReport.ts
+++ b/packages/shared/src/failureReport.ts
@@ -1,6 +1,7 @@
 import type { CriticalHealthState } from "./criticalHealth";
 import type { ActivityHistoryRecord } from "./events";
 import type { EngineSettings, Platform, SchedulerState } from "./models";
+import { isFarmingActive } from "./settings";
 
 export interface FailureReportInput {
   platform: Platform;
@@ -70,7 +71,7 @@ function recentEvents(entries: readonly ActivityHistoryRecord[]): string {
 // motivating user report could not be diagnosed without knowing it.
 function settingsSummary(settings: EngineSettings, platform: Platform): string {
   return bullets([
-    ["running", settings.running],
+    ["farming active", isFarmingActive(settings)],
     ["tablessMode", settings.tablessMode],
     ["autoClaim", settings.autoClaim],
     ["pauseOnManualWatch", settings.pauseOnManualWatch],

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -5,7 +5,6 @@ import type { SettingsPatch } from "./settings";
 export type CoreRuntimeMessage =
   | { type: "getSnapshot" }
   | { type: "getPlaybackControl"; platform: Platform }
-  | { type: "setRunning"; running: boolean }
   | { type: "setPlatformEnabled"; platform: Platform; enabled: boolean }
   | { type: "setAutomation"; platform: Platform; enabled: boolean }
   | { type: "saveSettings"; settingsPatch: SettingsPatch; tickAfterSave?: boolean; tickAfterSavePlatforms?: Platform[] }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -303,7 +303,13 @@ export interface CompatibilitySettings {
 // host (extension or CLI). Host-only knobs (browser tab policy, popup UI) live on
 // ExtensionSettings below, never here.
 export interface EngineSettings {
-  running: boolean;
+  // There is deliberately no global `running` flag. Farming is active for a
+  // platform when that platform is enabled, and nothing else — see
+  // isFarmingActive(). A separate master switch used to drift out of step with
+  // the per-platform flags (the popup rendered `running && enabled`, so a
+  // cleared master hid still-enabled platforms and re-enabling one resurrected
+  // the others), and autoStartDropFarming now expresses "do not resume on
+  // restart" by clearing the per-platform flags instead.
   autoClaim: boolean;
   // Low-resource mode: farm by sending watch signals instead of opening a
   // video tab. Twitch uses API heartbeats; Kick uses a viewer WebSocket. Falls

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -1,5 +1,6 @@
 import type { AdFocusMode, CategorySelection, CompatibilitySettings, EngineSettings, ExtensionSettings, KickPlatformSettings, LanguageOverride, Platform, PriorityMode, RateNudgeStatus, SupportedLocale, TwitchPlatformSettings } from "./models";
 
+const FARMING_PLATFORMS: Platform[] = ["twitch", "kick"];
 const AD_FOCUS_MODES: AdFocusMode[] = ["none", "tab", "window"];
 const PRIORITY_MODES: PriorityMode[] = ["ending_soonest", "lowest_availability", "priority_list_only"];
 const RATE_NUDGE_STATUSES: RateNudgeStatus[] = ["pending", "rated", "dismissed"];
@@ -21,7 +22,6 @@ export type SettingsPatch = Partial<Omit<ExtensionSettings, "platform" | "compat
 
 // The engine-contract defaults: the universal subset every host shares.
 export const DEFAULT_ENGINE_SETTINGS: EngineSettings = {
-  running: false,
   autoClaim: true,
   tablessMode: true,
   pauseOnManualWatch: true,
@@ -32,7 +32,7 @@ export const DEFAULT_ENGINE_SETTINGS: EngineSettings = {
   priorityMode: "ending_soonest",
   platform: {
     twitch: {
-      enabled: true,
+      enabled: false,
       idleWatchlistChannels: [],
       excludedChannels: [],
       farmAllCategories: true,
@@ -40,7 +40,7 @@ export const DEFAULT_ENGINE_SETTINGS: EngineSettings = {
       autoClaimChannelPoints: true,
     },
     kick: {
-      enabled: true,
+      enabled: false,
       idleWatchlistChannels: [],
       excludedChannels: [],
       farmAllCategories: true,
@@ -122,7 +122,6 @@ export function mergeEngineSettings(value: Partial<EngineSettings> | undefined):
   const platform = value?.platform;
   const compatibility = value?.compatibility;
   return {
-    running: booleanOr(value?.running, DEFAULT_ENGINE_SETTINGS.running),
     autoClaim: booleanOr(value?.autoClaim, DEFAULT_ENGINE_SETTINGS.autoClaim),
     tablessMode: booleanOr(value?.tablessMode, DEFAULT_ENGINE_SETTINGS.tablessMode),
     pauseOnManualWatch: booleanOr(value?.pauseOnManualWatch, DEFAULT_ENGINE_SETTINGS.pauseOnManualWatch),
@@ -351,4 +350,11 @@ export function autoClaimChannelPointsFor(settings: EngineSettings, platform: Pl
 
 export function autoClaimChallengesFor(settings: EngineSettings, platform: Platform): boolean {
   return platform === "kick" ? settings.platform.kick.autoClaimChallenges : false;
+}
+
+// Farming is active when at least one platform is enabled. This replaces the
+// former stored `running` master switch: a single source of truth cannot drift
+// out of step with the per-platform flags the way two of them could.
+export function isFarmingActive(settings: EngineSettings): boolean {
+  return FARMING_PLATFORMS.some((platform) => settings.platform[platform].enabled);
 }

--- a/packages/shared/src/settingsSchema.ts
+++ b/packages/shared/src/settingsSchema.ts
@@ -6,7 +6,7 @@
 // See docs/architecture.md ("Settings Migrations") before adding one.
 
 // Incremented for every semantic settings-shape migration.
-export const CURRENT_SETTINGS_SCHEMA_VERSION = 3;
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 4;
 
 // Reserved metadata stored alongside the settings properties. It is stripped
 // before any runtime EngineSettings/ExtensionSettings/CliSettings value is
@@ -68,6 +68,7 @@ const MIGRATIONS: SettingsMigration[] = [
   { to: 1, migrate: migrateToV1 },
   { to: 2, migrate: migrateToV2 },
   { to: 3, migrate: migrateToV3 },
+  { to: 4, migrate: migrateToV4 },
 ];
 
 // Migration 1 consolidates every legacy shape that predates the registry: the
@@ -173,6 +174,37 @@ function migrateToV2(raw: Record<string, unknown>, diagnose: Diagnose): Record<s
 // existing installs get the detector, and an explicit false is preserved.
 function migrateToV3(raw: Record<string, unknown>, _diagnose: Diagnose): Record<string, unknown> {
   if (!Object.hasOwn(raw, "criticalFailurePromptEnabled")) raw.criticalFailurePromptEnabled = true;
+  return raw;
+}
+
+// Drops the global `running` master switch: farming is now active for a platform
+// when that platform is enabled, and nothing else.
+//
+// The value cannot simply be discarded. The popup used to render each toggle as
+// `running && platform.enabled`, so a stored `running: false` displayed every
+// platform as off no matter what the per-platform flags said. Keeping those
+// flags as-is would silently start farming on upgrade for platforms the user
+// last saw switched off. Committing what was displayed is the faithful
+// translation, and it matches how autoStartDropFarming now suspends farming.
+function migrateToV4(raw: Record<string, unknown>, diagnose: Diagnose): Record<string, unknown> {
+  if (!Object.hasOwn(raw, "running")) return raw;
+  const wasRunning = raw.running;
+  delete raw.running;
+  if (wasRunning !== false) return raw;
+  const disabled: string[] = [];
+  for (const key of ["twitch", "kick"]) {
+    const block = platformBlock(raw, key);
+    if (!block || block.enabled === false) continue;
+    block.enabled = false;
+    disabled.push(key);
+  }
+  if (disabled.length > 0) {
+    diagnose({
+      code: "deprecated_property",
+      path: "running",
+      message: `running was removed; automation was switched off, so ${disabled.join(" and ")} kept the disabled state they were shown with`,
+    });
+  }
   return raw;
 }
 


### PR DESCRIPTION
## Summary

Started from a report that resetting and toggling automation took "ages", and that enabling Twitch also enabled Kick. Three defects, all confirmed against real diagnostics exports rather than inspection alone.

Closes #287
Closes #289
Closes #290

## Changes

**The toggle no longer waits for the tick** (#287) — `setAutomation` / `setPlatformEnabled` awaited `tickAndHandOff()` before returning a snapshot, so the popup spun for the whole network-bound tick (24.5s measured, 65s in an earlier report). Detaching alone was not enough: the popup polls `getSnapshot` every 5s and was working fine, but `state.sessions[p].message` still read `"Automation disabled"` because nothing rewrites it until `persistAndReport` at the end of the tick. So the fix is both — stamp the starting transition up front (`markPlatformsStarting`), then dispatch the tick in the background (`tickInBackground`). `settleBackgroundWork()` lets callers that need the result await it.

**`running` is removed from the settings contract** (#289) — it was a global master switch the popup wrote but never cleared, while the popup rendered `running && platform[p].enabled`. A cleared master displayed every platform as off while its `enabled` flag stayed set, so switching Twitch on flipped the shared master and resurrected Kick. Farming is now active for a platform when that platform is enabled, and nothing else (`isFarmingActive()`). `autoStartDropFarming` keeps its meaning and changes mechanism: on restart it switches the enabled platforms off instead of clearing a master switch.

Because no shared flag remains, `setPlatformEnabled` and `setAutomation` are the same operation and **always** scope their tick to the toggled platform. `abortClaimHandoffs()` gained an optional platform scope for the same reason.

**Tick lifecycle diagnostics** (#290) — a successful tick previously emitted nothing about itself, which is why the first 65s report was undiagnosable:

```
Tick #3 started (trigger=automation_toggle, platforms=twitch)
Tick #3 refreshed auth health in 210ms
Tick #3 finished after 64180ms (trigger=automation_toggle, platforms=twitch)
```

Published as they happen rather than batched, so a tick that is still running is visible.

## Migration

Settings schema **v4** drops `running`. A stored `running: false` switches its platforms off, matching what the popup was displaying — carrying the enabled flags across unchanged would silently start farming on upgrade for platforms the user last saw switched off. Four tests cover the migration.

`DEFAULT_ENGINE_SETTINGS` now ships both platforms disabled so a fresh install still sits idle, which `running: false` used to guarantee. The CLI pins them on: it has no opt-in moment and would otherwise do nothing.

## Testing

`pnpm verify` clean: six package typechecks, 132 CLI tests, 1074 extension tests, the Astro site build, and both Chromium and Firefox builds.

New coverage proves the behavior rather than assuming it:

- the toggle's reply lands while discovery is still blocked, and carries `"Starting automation"` — **verified to fail (5s timeout) against the old awaiting code**, so it is not a test that passes either way
- tick lifecycle diagnostics are emitted on both the success and throwing paths
- schema v4: flag dropped, platforms switched off when automation was off, no diagnostic when they already were, untouched document left alone

The bulk of the diff is mechanical: ~150 `running:` test fixtures re-expressed as explicit `farming()` / `notFarming()` wrappers. Worth a skim in review. Where a test's premise no longer exists — "farming stopped while a platform is enabled" — it was re-expressed as not auto-starting rather than weakened.

## Behavior worth flagging in review

Auth health is only probed for enabled platforms, so a launch with `autoStartDropFarming: false` no longer probes until the user switches a platform back on. This falls directly out of the design; I chose to state it in a test rather than contort the code around it.

## Not addressed here

Found during this investigation, filed separately rather than bundled:

- #291 — the Twitch integrity wait times out **31ms** before its token arrives
- #292 — per-operation forced integrity refresh multiplies tick duration (the 12s of the measured 24.5s tick)
- #293 — reset queues behind an in-flight tick instead of preempting it; the tick has no cancellation path
- #294 — Twitch and Kick are still serialized by one global state lock

No new permissions, credential storage, or localized diagnostic keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform automation can now be enabled or disabled independently for Twitch and Kick.
  * Background activity now provides clearer status and lifecycle diagnostics.

* **Bug Fixes**
  * Improved automation behavior during startup, restarts, alarms, manual pauses, and platform changes.
  * Corrected reporting when individual platforms are disabled.

* **Settings**
  * Removed the deprecated global automation switch.
  * Existing settings are automatically migrated to the updated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->