### PR TITLE
fix(twitch): stop paying Kasada's proof-of-work once per rejected operation

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -6,7 +6,7 @@ import { isFarmingActive } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
 import { isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
 import { isPlaybackTelemetryHealthy, MANUAL_WATCH_TTL_MS, runSchedulerTick, type StopPageContextTabs } from "../core/scheduler";
-import { currentManagedPageContextTabs, registerManagedPageContextTabs, setTwitchIntegrity, syncManagedTabBreakers } from "../core/tabs";
+import { currentManagedPageContextTabs, noteTwitchGqlRequest, registerManagedPageContextTabs, setTwitchIntegrity, syncManagedTabBreakers } from "../core/tabs";
 import { dismissCriticalFailure, recordManagedTabOpen } from "../core/criticalHealth";
 import { integrityFromHeaders } from "../core/twitchIntegrity";
 import type { IntegrityHeader, TwitchIntegrity } from "../core/twitchIntegrity";
@@ -358,7 +358,12 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // gql.twitch.tv requests. Only genuine page-minted requests carry a
   // Client-Integrity header, so integrityFromHeaders returns undefined (and we
   // ignore) our own background fetch and anonymous queries.
-  async function captureTwitchIntegrity(headers: IntegrityHeader[] | undefined): Promise<void> {
+  // `tabId` is optional so hosts that cannot attribute a request to a tab still
+  // capture tokens; it only feeds page-context boot instrumentation.
+  async function captureTwitchIntegrity(headers: IntegrityHeader[] | undefined, tabId?: number): Promise<void> {
+    // Noted before the integrity filter: an anonymous GQL request carries no
+    // Client-Integrity header but still proves the SPA has booted.
+    noteTwitchGqlRequest(tabId);
     const integrity = integrityFromHeaders(headers);
     if (!integrity) return;
     await withStateLock(() => withEventCollector(async (emit, events) => {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -6,7 +6,7 @@ import { isFarmingActive } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
 import { isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
 import { isPlaybackTelemetryHealthy, MANUAL_WATCH_TTL_MS, runSchedulerTick, type StopPageContextTabs } from "../core/scheduler";
-import { currentManagedPageContextTabs, noteTwitchGqlRequest, registerManagedPageContextTabs, setTwitchIntegrity, syncManagedTabBreakers } from "../core/tabs";
+import { currentManagedPageContextTabs, INTEGRITY_REFRESH_TIMEOUT_MS, noteTwitchGqlRequest, registerManagedPageContextTabs, setTwitchIntegrity, syncManagedTabBreakers } from "../core/tabs";
 import { dismissCriticalFailure, recordManagedTabOpen } from "../core/criticalHealth";
 import { integrityFromHeaders } from "../core/twitchIntegrity";
 import type { IntegrityHeader, TwitchIntegrity } from "../core/twitchIntegrity";
@@ -57,7 +57,13 @@ function isNothingLeftToFarm(reasonCode: WatchReasonCode | undefined): boolean {
 // still transmits.
 const RECENT_HEARTBEAT_MS = 30_000;
 const PLATFORMS: Platform[] = ["twitch", "kick"];
-const DEFAULT_AUTH_PROBE_TIMEOUT_MS = 10_000;
+// Must stay strictly greater than INTEGRITY_REFRESH_TIMEOUT_MS. A Twitch probe
+// runs through gqlWithIntegrityRetry, so a rejection makes it wait on a page
+// context minting a token; when this deadline was the shorter of the two (10s
+// against a 12s wait) the probe could never observe that wait succeed. It
+// aborted first, every time, and — because the wait takes no AbortSignal (#293)
+// — left the wait and its tab running unowned behind it.
+const DEFAULT_AUTH_PROBE_TIMEOUT_MS = INTEGRITY_REFRESH_TIMEOUT_MS + 5_000;
 class AuthProbeSetupError extends Error {
   constructor(
     readonly platform: Platform,

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -487,6 +487,37 @@ const INTEGRITY_REFRESH_TIMEOUT_MS = 12_000;
 // Resolvers waiting for the next captured token (see waitForIntegrityCapture).
 let integrityWaiters: Array<() => void> = [];
 
+// Phase timings for the twitch.tv page context currently being booted to mint an
+// integrity token. A cold boot costs far more than the document load: the tab
+// reports `status === "complete"` as soon as the HTML shell lands, but the token
+// only appears once the SPA has hydrated, authenticated, and completed Kasada's
+// proof-of-work (see src/core/twitchIntegrity.ts). Those phases are billed to
+// very different causes — a slow network, a slow SPA boot, or an expensive
+// challenge in a deprioritized background tab — and the aggregate wait duration
+// cannot tell them apart, so each boundary is stamped as it is crossed.
+interface TwitchContextBootTiming {
+  tabId: number;
+  createdAt: number;
+  readyAt?: number;
+  firstGqlAt?: number;
+}
+let twitchContextBoot: TwitchContextBootTiming | undefined;
+
+// Called for every gql.twitch.tv request the background sees, including the
+// anonymous ones that carry no Client-Integrity header. Those are exactly what
+// distinguishes "the SPA has not booted yet" from "the SPA is running but is
+// still solving the proof-of-work", which is the split the aggregate timeout
+// hides.
+export function noteTwitchGqlRequest(tabId: number | undefined, now: number = Date.now()): void {
+  if (tabId == null || twitchContextBoot?.tabId !== tabId) return;
+  twitchContextBoot.firstGqlAt ??= now;
+}
+
+function describeContextBoot(boot: TwitchContextBootTiming, now: number): string {
+  const since = (at: number | undefined): string => (at == null ? "never" : `${at - boot.createdAt}ms`);
+  return `tab ready at ${since(boot.readyAt)}, first GQL at ${since(boot.firstGqlAt)}, ${now - boot.createdAt}ms since the tab was created`;
+}
+
 export function hasValidTwitchIntegrity(now: number = Date.now()): boolean {
   return twitchIntegrity != null && twitchIntegrity.expiresAt > now + INTEGRITY_EXPIRY_SKEW_MS;
 }
@@ -591,8 +622,16 @@ export async function ensureTwitchIntegrityWithBrowser(
     // here we only surface the failure case so the log isn't doubled up.
     const startedAt = Date.now();
     const captured = await waitForIntegrityCapture(timeoutMs, rejectedToken);
+    const settledAt = Date.now();
+    // Logged on both outcomes, not just the failure: a success that took 20s is
+    // the same latency problem as a timeout, and only the phase split says which
+    // part of the cold boot to attack.
+    const boot = twitchContextBoot?.tabId === pageContext.tabId ? twitchContextBoot : undefined;
+    const phases = boot ? ` (${describeContextBoot(boot, settledAt)})` : "";
     if (!captured) {
-      diagnostic(emit, "warn", `Timed out waiting for a Twitch integrity token after ${Date.now() - startedAt}ms from a ${source} page context (is twitch.tv logged in?)`, "twitch");
+      diagnostic(emit, "warn", `Timed out waiting for a Twitch integrity token after ${settledAt - startedAt}ms from a ${source} page context${phases} (is twitch.tv logged in?)`, "twitch");
+    } else {
+      diagnostic(emit, "debug", `Waited ${settledAt - startedAt}ms for a Twitch integrity token from a ${source} page context${phases}`, "twitch");
     }
     return captured;
   } catch (error) {
@@ -1069,15 +1108,18 @@ async function findOrCreatePageContextTab(
   }
 
   signal?.throwIfAborted();
+  const createdAt = Date.now();
   const tab = await browserApi.tabs.create({ url: originUrl, pinned: false, active: false }) as { id?: number };
   if (tab.id == null) {
     signal?.throwIfAborted();
     throw new Error(`Could not open page context for ${originUrl}`);
   }
+  if (contextPlatform === "twitch") twitchContextBoot = { tabId: tab.id, createdAt };
   try {
     signal?.throwIfAborted();
     await withAbortSignal(browserApi.tabs.update(tab.id, { muted: true, active: false }), signal);
     await waitForPageContextReady(browserApi, tab.id, origin, signal);
+    if (twitchContextBoot?.tabId === tab.id) twitchContextBoot.readyAt = Date.now();
     if (!await isUsablePageContext(browserApi, tab.id, origin, signal)) {
       throw new SafeFetchError({
         kind: "security_policy_blocked",

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -482,7 +482,18 @@ const INTEGRITY_EXPIRY_SKEW_MS = 30_000;
 export const TWITCH_PAGE_CONTEXT_URL = "https://www.twitch.tv/drops/inventory";
 
 // How long to wait for the live page to mint and send a token after we open it.
-const INTEGRITY_REFRESH_TIMEOUT_MS = 12_000;
+//
+// This budgets for a cold twitch.tv boot, which is dominated by Kasada's
+// proof-of-work rather than by the page load: an observed boot reached
+// `status === "complete"` in 1.4s and only produced a token at 22s. The previous
+// 12s could not cover that, so the wait timed out, the operation degraded to
+// stale data, and the token landed anyway once nobody was waiting for it.
+//
+// Raising it is only affordable because a forced refresh is now bounded by
+// rejectedToken (see below): a tick pays this once, not once per rejected
+// operation. Provisional — it covers a single observed sample with margin, and
+// the boot-phase diagnostics exist to replace it with a measured distribution.
+export const INTEGRITY_REFRESH_TIMEOUT_MS = 30_000;
 
 // Resolvers waiting for the next captured token (see waitForIntegrityCapture).
 let integrityWaiters: Array<() => void> = [];
@@ -540,6 +551,39 @@ export function setTwitchIntegrity(value: TwitchIntegrity | undefined, options?:
 // token must also differ from the one that was rejected.
 export interface TwitchIntegrityRequest {
   forceRefresh?: boolean;
+  // The token the rejected request actually sent, captured before it was issued.
+  // Without it a forced refresh cannot tell "this caller was rejected on a token
+  // someone has already replaced" from "this caller was rejected on the token we
+  // currently hold" — only the second needs a new one minted. Omitted means
+  // unknown, which always mints.
+  rejectedToken?: string;
+}
+
+// Read before issuing an authenticated request so the caller can report which
+// token was rejected if it fails. See TwitchIntegrityRequest.rejectedToken.
+export function currentTwitchIntegrityToken(): string | undefined {
+  return twitchIntegrity?.integrity;
+}
+
+// A forced refresh boots a cold twitch.tv context and waits for Kasada's
+// proof-of-work, which is the single most expensive thing this module does
+// (~22s observed). It is wired into ~10 operations, several of which run
+// sequentially inside one discovery pass, so a broadly-rejecting session used to
+// stack that cost several times in one tick.
+//
+// Concurrent callers share the in-flight refresh rather than racing into
+// acquirePageContextTab, where the origin-keyed dedupe hands the later ones an
+// inherited context that requireFreshPageContext cannot make fresh — so they
+// would wait out the full timeout on a tab that was never going to mint for
+// them. Sequential callers are bounded by rejectedToken instead: once the first
+// refresh lands, the rest were rejected on a token that no longer exists.
+let inFlightForcedRefresh: Promise<boolean> | undefined;
+
+// Test seam: this module's integrity state is process-global by design (the
+// webRequest listener feeds it from outside any call), so suites that exercise
+// the bounds need a way back to a known state.
+export function resetTwitchIntegrityRefreshBounds(): void {
+  inFlightForcedRefresh = undefined;
 }
 
 function hasReplacementTwitchIntegrity(rejectedToken?: string): boolean {
@@ -593,9 +637,43 @@ export async function ensureTwitchIntegrityWithBrowser(
   request?: TwitchIntegrityRequest,
 ): Promise<boolean> {
   const forceRefresh = request?.forceRefresh === true;
-  const rejectedToken = forceRefresh ? twitchIntegrity?.integrity : undefined;
-  if (!forceRefresh && hasValidTwitchIntegrity()) return true;
+  if (!forceRefresh) {
+    if (hasValidTwitchIntegrity()) return true;
+    return mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, undefined);
+  }
 
+  // Another operation's refresh already replaced the token this caller was
+  // rejected on. It has not tried the current one yet, so minting again cannot
+  // help it — and would cost another cold boot.
+  if (request?.rejectedToken != null && hasReplacementTwitchIntegrity(request.rejectedToken)) {
+    diagnostic(emit, "debug", "Reusing the Twitch integrity token another operation just minted instead of booting another page context", "twitch");
+    return true;
+  }
+
+  if (inFlightForcedRefresh) {
+    diagnostic(emit, "debug", "Joining the Twitch integrity refresh already in flight", "twitch");
+    return inFlightForcedRefresh;
+  }
+
+  const rejectedToken = request?.rejectedToken ?? twitchIntegrity?.integrity;
+  const refresh = mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, rejectedToken)
+    .finally(() => {
+      inFlightForcedRefresh = undefined;
+    });
+  inFlightForcedRefresh = refresh;
+  return refresh;
+}
+
+// The page-context boot itself, with no bounding logic: callers reach it through
+// ensureTwitchIntegrityWithBrowser, which decides whether a boot is warranted.
+async function mintTwitchIntegrity(
+  browserApi: BrowserTabApi,
+  originUrl: string,
+  timeoutMs: number,
+  emit: EventEmitter,
+  rejectedToken: string | undefined,
+): Promise<boolean> {
+  const forceRefresh = rejectedToken != null;
   diagnostic(
     emit,
     "info",

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -559,10 +559,16 @@ export interface TwitchIntegrityRequest {
   rejectedToken?: string;
 }
 
-// Read before issuing an authenticated request so the caller can report which
-// token was rejected if it fails. See TwitchIntegrityRequest.rejectedToken.
-export function currentTwitchIntegrityToken(): string | undefined {
-  return twitchIntegrity?.integrity;
+// The integrity bundle outgoing requests should carry, or undefined when there
+// is none to replay. Returned whole because the token is bound to the device id
+// and session id it was minted with — replaying the trio apart from each other
+// is rejected.
+//
+// Callers that assemble their own headers use this so the token they sent is
+// known exactly, rather than re-read later from a global that a concurrent
+// capture may have replaced in between. See TwitchIntegrityRequest.rejectedToken.
+export function currentValidTwitchIntegrity(): TwitchIntegrity | undefined {
+  return hasValidTwitchIntegrity() ? twitchIntegrity : undefined;
 }
 
 // A forced refresh boots a cold twitch.tv context and waits for Kasada's
@@ -639,7 +645,7 @@ export async function ensureTwitchIntegrityWithBrowser(
   const forceRefresh = request?.forceRefresh === true;
   if (!forceRefresh) {
     if (hasValidTwitchIntegrity()) return true;
-    return mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, undefined);
+    return mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, undefined, false);
   }
 
   // Another operation's refresh already replaced the token this caller was
@@ -656,7 +662,7 @@ export async function ensureTwitchIntegrityWithBrowser(
   }
 
   const rejectedToken = request?.rejectedToken ?? twitchIntegrity?.integrity;
-  const refresh = mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, rejectedToken)
+  const refresh = mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, rejectedToken, true)
     .finally(() => {
       inFlightForcedRefresh = undefined;
     });
@@ -672,8 +678,14 @@ async function mintTwitchIntegrity(
   timeoutMs: number,
   emit: EventEmitter,
   rejectedToken: string | undefined,
+  // Carried explicitly rather than derived from `rejectedToken != null`: a forced
+  // refresh can legitimately have no token to compare against (nothing captured
+  // yet, or a host that cannot report what it sent), and it must still demand a
+  // freshly created context. Inferring it would silently downgrade those cases to
+  // a plain mint, which may inherit an idle tab that issues no request and can
+  // only ever time out.
+  forceRefresh: boolean,
 ): Promise<boolean> {
-  const forceRefresh = rejectedToken != null;
   diagnostic(
     emit,
     "info",

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -3,6 +3,7 @@ import type { EventEmitter } from "@lurkloot/shared/events";
 import type { LogLevel } from "@lurkloot/shared/logging";
 import { authHealthFromError, SafeFetchError } from "../../core/fetchError";
 import type { TwitchIntegrityRequest } from "../../core/tabs";
+import type { TwitchIntegrity } from "../../core/twitchIntegrity";
 import { PendingWatcherDiagnostics, type HeartbeatResult, type TablessWatchController, type WatchContext } from "../../core/tablessWatch";
 import { diagnostic, ignoreEvent, unavailableWatchTabPort, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { campaignHasClaimableReward, mergeTwitchCampaignProgress, parseTwitchCampaigns, twitchCandidatesFromCampaign, withCampaignStatus } from "./parser";
@@ -42,12 +43,13 @@ export interface TwitchAdapterOptions {
   heartbeatFetchText?: TwitchHeartbeatFetchText;
   heartbeatPost?: TwitchHeartbeatPost;
   discoveryState?: TwitchDiscoveryState;
-  // Reads the integrity token that outgoing requests are currently carrying, so
-  // a rejection can report which one was refused. Without it every rejection
-  // mints a fresh token, and a discovery pass whose operations were all refused
-  // on the same token pays that cost once per operation. Absent in runtimes that
-  // never carry integrity at all (non-web client ids).
-  currentIntegrityToken?: () => string | undefined;
+  // Supplies the integrity bundle each request should carry. The transport
+  // attaches it itself rather than letting the fetcher pick one up from a global,
+  // so the token a rejection reports is provably the token that was sent: the
+  // fetcher selects its own only after awaiting cookie reads, during which a
+  // concurrent capture can swap it. Absent in runtimes that never carry integrity
+  // at all (non-web client ids).
+  currentIntegrity?: () => TwitchIntegrity | undefined;
 }
 
 const TWITCH_QUERIES = {
@@ -193,10 +195,22 @@ function isIntegrityRejection(error: unknown, credentials?: RequestCredentials):
 type TwitchGqlFailureKind = "network" | "credentials" | "platform";
 
 class TwitchGqlFailure extends Error {
+  // The integrity token this request actually carried, when it carried one.
+  // A forced refresh compares against it so it can tell "the token I sent is
+  // still the current one, mint a replacement" from "someone already replaced
+  // it, just retry".
+  sentIntegrityToken?: string;
+
   constructor(readonly kind: TwitchGqlFailureKind, message: string) {
     super(message);
     this.name = "TwitchGqlFailure";
   }
+}
+
+// The token a failed request carried, when the failure knows. Undefined means
+// unknown, which makes a forced refresh mint unconditionally.
+function sentIntegrityToken(error: unknown): string | undefined {
+  return error instanceof TwitchGqlFailure ? error.sentIntegrityToken : undefined;
 }
 
 function isCredentialRejection(message: string | undefined): boolean {
@@ -408,6 +422,13 @@ export function createTwitchGqlTransport(
     emit: EventEmitter = ignoreEvent,
     signal?: AbortSignal,
   ): Promise<TwitchGqlResponse<T>> => {
+    // Read once per attempt and reused for both the headers and the failure
+    // stamp, so the two can never disagree.
+    let sentIntegrity: TwitchIntegrity | undefined;
+    const stamp = (failure: TwitchGqlFailure): TwitchGqlFailure => {
+      failure.sentIntegrityToken = sentIntegrity?.integrity;
+      return failure;
+    };
     const buildRequest = (queryText?: string) => ({
       method: "POST",
       headers: {
@@ -416,6 +437,15 @@ export function createTwitchGqlTransport(
         "Content-Type": "text/plain; charset=UTF-8",
         "Client-ID": clientId,
         ...(userAgent ? { "User-Agent": userAgent } : {}),
+        // The trio is bound together at mint time and must be replayed together.
+        // Set here rather than left to the fetcher so the sent token is known.
+        ...(sentIntegrity
+          ? {
+              "Client-Integrity": sentIntegrity.integrity,
+              ...(sentIntegrity.deviceId ? { "X-Device-Id": sentIntegrity.deviceId } : {}),
+              ...(sentIntegrity.clientSessionId ? { "Client-Session-Id": sentIntegrity.clientSessionId } : {}),
+            }
+          : {}),
       },
       ...(credentials ? { credentials } : {}),
       ...(signal ? { signal } : {}),
@@ -435,6 +465,8 @@ export function createTwitchGqlTransport(
       ),
     } satisfies RequestInit);
     const fetchOnce = async (queryText?: string): Promise<TwitchGqlResponse<T> | null> => {
+      // Anonymous queries deliberately carry no identity at all.
+      sentIntegrity = credentials === "omit" ? undefined : options.currentIntegrity?.();
       const request = buildRequest(queryText);
       let raw: unknown;
       try {
@@ -442,19 +474,19 @@ export function createTwitchGqlTransport(
       } catch (error) {
         if (authHealthFromError(error)) throw error;
         const message = error instanceof Error ? error.message : `${operationName} request failed`;
-        throw new TwitchGqlFailure("network", message);
+        throw stamp(new TwitchGqlFailure("network", message));
       }
       const pageError = twitchPageFetchError(raw);
       if (pageError?.kind === "credentials") {
         throw new SafeFetchError({ kind: "authentication_rejected", status: 401, reason: "Authenticated session rejected" });
       }
-      if (pageError) throw new TwitchGqlFailure(pageError.kind, `${operationName}: ${pageError.message}`);
+      if (pageError) throw stamp(new TwitchGqlFailure(pageError.kind, `${operationName}: ${pageError.message}`));
       return normalizeTwitchGqlResponse<T>(raw);
     };
     let activeQuery = query;
     let response = await fetchOnce(activeQuery);
     if (!isTwitchGqlResponse<T>(response)) {
-      throw new TwitchGqlFailure("platform", `${operationName} ${query ? "inline query" : "persisted query"} returned an empty Twitch GQL response`);
+      throw stamp(new TwitchGqlFailure("platform", `${operationName} ${query ? "inline query" : "persisted query"} returned an empty Twitch GQL response`));
     }
     const fallbackQuery = !query ? TWITCH_INLINE_QUERIES[operationName] : undefined;
     if (fallbackQuery && hasPersistedQueryNotFound(response)) {
@@ -462,14 +494,14 @@ export function createTwitchGqlTransport(
       activeQuery = fallbackQuery;
       response = await fetchOnce(activeQuery);
       if (!isTwitchGqlResponse<T>(response)) {
-        throw new TwitchGqlFailure("platform", `${operationName} inline query fallback returned an empty Twitch GQL response`);
+        throw stamp(new TwitchGqlFailure("platform", `${operationName} inline query fallback returned an empty Twitch GQL response`));
       }
     }
     if (response.errors?.some((error) => isTransientGqlError(error.message))) {
       diagnostic(emit, "debug", `GQL ${operationName} returned a transient error; retrying once`, "twitch");
       response = await fetchOnce(activeQuery);
       if (!isTwitchGqlResponse<T>(response)) {
-        throw new TwitchGqlFailure("platform", `${operationName} ${activeQuery ? "inline query" : "persisted query"} returned an empty Twitch GQL response`);
+        throw stamp(new TwitchGqlFailure("platform", `${operationName} ${activeQuery ? "inline query" : "persisted query"} returned an empty Twitch GQL response`));
       }
     }
     if (response.error || (response.message && response.data === undefined)) {
@@ -477,14 +509,14 @@ export function createTwitchGqlTransport(
       if (isCredentialRejection(message)) {
         throw new SafeFetchError({ kind: "authentication_rejected", status: 401, reason: "Authenticated session rejected" });
       }
-      throw new TwitchGqlFailure("platform", message);
+      throw stamp(new TwitchGqlFailure("platform", message));
     }
     if (response.errors?.length) {
       const message = response.errors.map((error) => error.message).filter(Boolean).join("; ") || `${operationName} failed`;
       if (isCredentialRejection(message)) {
         throw new SafeFetchError({ kind: "authentication_rejected", status: 401, reason: "Authenticated session rejected" });
       }
-      throw new TwitchGqlFailure("platform", message);
+      throw stamp(new TwitchGqlFailure("platform", message));
     }
     return response;
   };
@@ -908,7 +940,6 @@ export class TwitchAdapter implements PlatformAdapter {
     // exists first so a tabless / no-tab session can still claim. This is a no-op
     // fast path when a token is already captured.
     await this.ensureIntegrity();
-    const rejectedToken = this.options.currentIntegrityToken?.();
 
     try {
       return await this.runClaim(reward);
@@ -921,7 +952,7 @@ export class TwitchAdapter implements PlatformAdapter {
       // Twitch rejected the token it was sent, so the local expiry says nothing:
       // only a forced refresh replaces it. Retry exactly once; a second failure
       // propagates.
-      const refreshed = await this.ensureIntegrity({ forceRefresh: true, rejectedToken });
+      const refreshed = await this.ensureIntegrity({ forceRefresh: true, rejectedToken: sentIntegrityToken(error) });
       if (refreshed) return await this.runClaim(reward);
       throw new Error(`Twitch rejected the claim for ${reward.name} (${message}). Keep a logged-in twitch.tv tab open so the extension can capture a valid integrity token, then retry.`);
     }
@@ -955,13 +986,12 @@ export class TwitchAdapter implements PlatformAdapter {
     // recover explicitly rather than through a generic transport retry — the
     // same claim id must never be replayed more than once.
     await this.ensureIntegrity();
-    const rejectedToken = this.options.currentIntegrityToken?.();
     try {
       return await this.runChannelPointsClaim(claimId, channelId);
     } catch (error) {
       if (!isIntegrityRejection(error)) throw error;
       diagnostic(this.emit, "warn", `Channel-points claim for ${channel.username} was rejected for integrity; refreshing the token and retrying once`, "twitch");
-      if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken })) throw error;
+      if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken: sentIntegrityToken(error) })) throw error;
       return await this.runChannelPointsClaim(claimId, channelId);
     }
   }
@@ -1070,16 +1100,15 @@ export class TwitchAdapter implements PlatformAdapter {
     emit: EventEmitter = this.emit,
     signal?: AbortSignal,
   ): Promise<TwitchGqlResponse<T>> {
-    // Read before the request, not in the catch: by the time this one is refused
-    // a concurrent operation may already have replaced the token, and refreshing
-    // against that newer token would mint one this caller has never tried.
-    const rejectedToken = this.options.currentIntegrityToken?.();
     try {
       return await this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
     } catch (error) {
       if (!isIntegrityRejection(error, credentials)) throw error;
       diagnostic(emit, "debug", `GQL ${operationName} was rejected for integrity; refreshing the token and retrying once`, "twitch");
-      if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken })) throw error;
+      // Taken from the failure, which carries the token the request actually
+      // sent. Re-reading it here would race a concurrent capture and could
+      // report a token this request never used.
+      if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken: sentIntegrityToken(error) })) throw error;
       return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
     }
   }
@@ -1212,7 +1241,6 @@ class TwitchWatcher implements TablessWatchController {
   private async resolveUserId(): Promise<string | undefined> {
     if (this.viewerUserId) return this.viewerUserId;
     const currentUser = () => this.gql<{ currentUser?: { id?: string } }>("CurrentUser", "", {}, CURRENT_USER_QUERY, undefined, this.diagnostics.emit);
-    const rejectedToken = this.options.currentIntegrityToken?.();
     try {
       let response;
       try {
@@ -1222,7 +1250,7 @@ class TwitchWatcher implements TablessWatchController {
         // adapter's safe authenticated reads.
         if (!isIntegrityRejection(error)) throw error;
         this.log("debug", "Twitch viewer id lookup was rejected for integrity; refreshing the token and retrying once");
-        if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken })) throw error;
+        if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken: sentIntegrityToken(error) })) throw error;
         response = await currentUser();
       }
       this.viewerUserId = response.data?.currentUser?.id;

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -42,6 +42,12 @@ export interface TwitchAdapterOptions {
   heartbeatFetchText?: TwitchHeartbeatFetchText;
   heartbeatPost?: TwitchHeartbeatPost;
   discoveryState?: TwitchDiscoveryState;
+  // Reads the integrity token that outgoing requests are currently carrying, so
+  // a rejection can report which one was refused. Without it every rejection
+  // mints a fresh token, and a discovery pass whose operations were all refused
+  // on the same token pays that cost once per operation. Absent in runtimes that
+  // never carry integrity at all (non-web client ids).
+  currentIntegrityToken?: () => string | undefined;
 }
 
 const TWITCH_QUERIES = {
@@ -902,6 +908,7 @@ export class TwitchAdapter implements PlatformAdapter {
     // exists first so a tabless / no-tab session can still claim. This is a no-op
     // fast path when a token is already captured.
     await this.ensureIntegrity();
+    const rejectedToken = this.options.currentIntegrityToken?.();
 
     try {
       return await this.runClaim(reward);
@@ -914,7 +921,7 @@ export class TwitchAdapter implements PlatformAdapter {
       // Twitch rejected the token it was sent, so the local expiry says nothing:
       // only a forced refresh replaces it. Retry exactly once; a second failure
       // propagates.
-      const refreshed = await this.ensureIntegrity({ forceRefresh: true });
+      const refreshed = await this.ensureIntegrity({ forceRefresh: true, rejectedToken });
       if (refreshed) return await this.runClaim(reward);
       throw new Error(`Twitch rejected the claim for ${reward.name} (${message}). Keep a logged-in twitch.tv tab open so the extension can capture a valid integrity token, then retry.`);
     }
@@ -948,12 +955,13 @@ export class TwitchAdapter implements PlatformAdapter {
     // recover explicitly rather than through a generic transport retry — the
     // same claim id must never be replayed more than once.
     await this.ensureIntegrity();
+    const rejectedToken = this.options.currentIntegrityToken?.();
     try {
       return await this.runChannelPointsClaim(claimId, channelId);
     } catch (error) {
       if (!isIntegrityRejection(error)) throw error;
       diagnostic(this.emit, "warn", `Channel-points claim for ${channel.username} was rejected for integrity; refreshing the token and retrying once`, "twitch");
-      if (!await this.ensureIntegrity({ forceRefresh: true })) throw error;
+      if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken })) throw error;
       return await this.runChannelPointsClaim(claimId, channelId);
     }
   }
@@ -1062,12 +1070,16 @@ export class TwitchAdapter implements PlatformAdapter {
     emit: EventEmitter = this.emit,
     signal?: AbortSignal,
   ): Promise<TwitchGqlResponse<T>> {
+    // Read before the request, not in the catch: by the time this one is refused
+    // a concurrent operation may already have replaced the token, and refreshing
+    // against that newer token would mint one this caller has never tried.
+    const rejectedToken = this.options.currentIntegrityToken?.();
     try {
       return await this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
     } catch (error) {
       if (!isIntegrityRejection(error, credentials)) throw error;
       diagnostic(emit, "debug", `GQL ${operationName} was rejected for integrity; refreshing the token and retrying once`, "twitch");
-      if (!await this.ensureIntegrity({ forceRefresh: true })) throw error;
+      if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken })) throw error;
       return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
     }
   }
@@ -1121,7 +1133,7 @@ class TwitchWatcher implements TablessWatchController {
 
   constructor(
     private readonly gql: TwitchGqlTransport,
-    options: TwitchAdapterOptions,
+    private readonly options: TwitchAdapterOptions,
     // Only the authenticated CurrentUser fallback below uses this. The anonymous
     // stream lookup and the heartbeat telemetry are deliberately excluded.
     private readonly ensureIntegrity: (request?: TwitchIntegrityRequest) => Promise<boolean> = async () => false,
@@ -1200,6 +1212,7 @@ class TwitchWatcher implements TablessWatchController {
   private async resolveUserId(): Promise<string | undefined> {
     if (this.viewerUserId) return this.viewerUserId;
     const currentUser = () => this.gql<{ currentUser?: { id?: string } }>("CurrentUser", "", {}, CURRENT_USER_QUERY, undefined, this.diagnostics.emit);
+    const rejectedToken = this.options.currentIntegrityToken?.();
     try {
       let response;
       try {
@@ -1209,7 +1222,7 @@ class TwitchWatcher implements TablessWatchController {
         // adapter's safe authenticated reads.
         if (!isIntegrityRejection(error)) throw error;
         this.log("debug", "Twitch viewer id lookup was rejected for integrity; refreshing the token and retrying once");
-        if (!await this.ensureIntegrity({ forceRefresh: true })) throw error;
+        if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken })) throw error;
         response = await currentUser();
       }
       this.viewerUserId = response.data?.currentUser?.id;

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -3,6 +3,7 @@ import { loadSettings, loadState, loadTwitchIntegrity, resetStorage, saveSetting
 import type { CliCredentialBlob, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import {
   applyAdFocus,
+  currentTwitchIntegrityToken,
   ensureTwitchIntegrity,
   fetchJsonInPage,
   fetchKickInBackground,
@@ -99,6 +100,7 @@ function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings
       {
         compatibility: resolution.compatibility.twitch,
         discoveryState: twitchDiscoveryState,
+        currentIntegrityToken: currentTwitchIntegrityToken,
         heartbeatIdentity: "web",
         heartbeatFetchText: twitchHeartbeatFetchText,
         heartbeatPost: twitchHeartbeatPost,

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -3,7 +3,7 @@ import { loadSettings, loadState, loadTwitchIntegrity, resetStorage, saveSetting
 import type { CliCredentialBlob, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import {
   applyAdFocus,
-  currentTwitchIntegrityToken,
+  currentValidTwitchIntegrity,
   ensureTwitchIntegrity,
   fetchJsonInPage,
   fetchKickInBackground,
@@ -100,7 +100,7 @@ function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings
       {
         compatibility: resolution.compatibility.twitch,
         discoveryState: twitchDiscoveryState,
-        currentIntegrityToken: currentTwitchIntegrityToken,
+        currentIntegrity: currentValidTwitchIntegrity,
         heartbeatIdentity: "web",
         heartbeatFetchText: twitchHeartbeatFetchText,
         heartbeatPost: twitchHeartbeatPost,

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -268,7 +268,7 @@ export default defineBackground(() => {
   // Chrome build hides it, add "extraHeaders" to this spec.
   browser.webRequest.onBeforeSendHeaders.addListener(
     (details) => {
-      void controller.captureTwitchIntegrity(details.requestHeaders);
+      void controller.captureTwitchIntegrity(details.requestHeaders, details.tabId);
       return undefined;
     },
     { urls: ["https://gql.twitch.tv/*"] },

--- a/packages/extension/src/core/tabs.ts
+++ b/packages/extension/src/core/tabs.ts
@@ -3,7 +3,7 @@ import type { AdFocusMode, ChannelCandidate, Platform, WatchSession } from "@lur
 import type { EventEmitter, PageContextCloseReason } from "@lurkloot/shared/events";
 import {
   applyAdFocusWithBrowser,
-  currentTwitchIntegrityToken,
+  currentValidTwitchIntegrity,
   ensureTwitchIntegrityWithBrowser,
   fetchJsonInPageWithBrowser,
   fetchKickInBackgroundWith,
@@ -44,7 +44,7 @@ export function ensureTwitchIntegrity(emit?: EventEmitter, request?: TwitchInteg
   return ensureTwitchIntegrityWithBrowser(browser as BrowserTabApi, TWITCH_PAGE_CONTEXT_URL, undefined, emit, request);
 }
 
-export { currentTwitchIntegrityToken };
+export { currentValidTwitchIntegrity };
 
 export function fetchTwitchInBackground<T>(url: string, init?: RequestInit): Promise<T> {
   return fetchTwitchInBackgroundWith<T>(browser as CookieApi, url, init);

--- a/packages/extension/src/core/tabs.ts
+++ b/packages/extension/src/core/tabs.ts
@@ -3,6 +3,7 @@ import type { AdFocusMode, ChannelCandidate, Platform, WatchSession } from "@lur
 import type { EventEmitter, PageContextCloseReason } from "@lurkloot/shared/events";
 import {
   applyAdFocusWithBrowser,
+  currentTwitchIntegrityToken,
   ensureTwitchIntegrityWithBrowser,
   fetchJsonInPageWithBrowser,
   fetchKickInBackgroundWith,
@@ -42,6 +43,8 @@ export function applyAdFocus(platform: Platform, tabId: number | undefined, adAc
 export function ensureTwitchIntegrity(emit?: EventEmitter, request?: TwitchIntegrityRequest): Promise<boolean> {
   return ensureTwitchIntegrityWithBrowser(browser as BrowserTabApi, TWITCH_PAGE_CONTEXT_URL, undefined, emit, request);
 }
+
+export { currentTwitchIntegrityToken };
 
 export function fetchTwitchInBackground<T>(url: string, init?: RequestInit): Promise<T> {
   return fetchTwitchInBackgroundWith<T>(browser as CookieApi, url, init);

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2619,6 +2619,55 @@ describe("TwitchAdapter integrity recovery", () => {
     return { fetcher, attempts };
   }
 
+  // The refresh bound is only sound if the token it compares against is the one
+  // the failed request actually sent. The transport therefore attaches integrity
+  // itself and stamps the failure with what it used: re-reading a global in the
+  // catch would race a concurrent capture, report a token the request never
+  // carried, and — because that token differs from the current one — convince the
+  // forced refresh the rejection had already been handled.
+  it("reports the integrity token the rejected request actually carried", async () => {
+    // A fresh token on every read, so a value snapshotted anywhere other than at
+    // send time cannot coincidentally match what went out.
+    let minted = 0;
+    const currentIntegrity = () => {
+      minted += 1;
+      return { integrity: `token-${minted}`, deviceId: "device", clientSessionId: "session", expiresAt: Date.now() + 60_000 };
+    };
+    const sent: Array<string | null> = [];
+    const ensureIntegrity = integrityCallback();
+    let attempts = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      sent.push(new Headers(init?.headers as HeadersInit).get("client-integrity"));
+      attempts += 1;
+      return attempts === 1 ? INTEGRITY_REJECTION : { data: { currentUser: { id: "u" } } };
+    });
+
+    await new TwitchAdapter(fetcher, ensureIntegrity, undefined, { currentIntegrity }).checkAuthHealth();
+
+    expect(sent[0]).toBe("token-1");
+    expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true, rejectedToken: sent[0] });
+  });
+
+  it("sends the integrity trio together so the replayed token stays bound to its identity", async () => {
+    const currentIntegrity = () => ({
+      integrity: "bound-token",
+      deviceId: "bound-device",
+      clientSessionId: "bound-session",
+      expiresAt: Date.now() + 60_000,
+    });
+    let seen: Headers | undefined;
+    const fetcher = jsonFetcher((_url, init) => {
+      seen = new Headers(init?.headers as HeadersInit);
+      return { data: { currentUser: { id: "u" } } };
+    });
+
+    await new TwitchAdapter(fetcher, undefined, undefined, { currentIntegrity }).checkAuthHealth();
+
+    expect(seen?.get("client-integrity")).toBe("bound-token");
+    expect(seen?.get("x-device-id")).toBe("bound-device");
+    expect(seen?.get("client-session-id")).toBe("bound-session");
+  });
+
   describe("safe authenticated reads", () => {
     const dropID = (init?: RequestInit) =>
       String((requestBody(init).variables as Record<string, unknown>).dropID);

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -12,6 +12,7 @@ import {
   fetchTwitchInBackgroundWith,
   hasValidTwitchIntegrity,
   KickWafBlockedError,
+  noteTwitchGqlRequest,
   openPinnedMutedTabWithBrowser,
   PLAYBACK_PRIME_BACKOFF_MS,
   PLAYBACK_PRIME_MAX_ATTEMPTS,
@@ -1234,6 +1235,82 @@ describe("twitch integrity refresh", () => {
         level: "debug",
         message: expect.stringContaining("from a created page context (tab 21)"),
       }));
+    });
+
+    // A cold twitch.tv context reports `status === "complete"` as soon as the
+    // HTML shell lands, but the token only appears once the SPA has hydrated and
+    // solved Kasada's proof-of-work. The aggregate wait duration cannot say which
+    // of those phases ran long, so each boundary is reported separately.
+    describe("page context boot instrumentation", () => {
+      it("reports the phase split when the wait times out on a created context", async () => {
+        const browser = browserMock();
+        browser.tabs.query.mockResolvedValue([]);
+        browser.tabs.create.mockResolvedValue({ id: 21 });
+        const events: EngineEvent[] = [];
+
+        await ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 50, (event) => events.push(event));
+
+        expect(events).toContainEqual(expect.objectContaining({
+          level: "warn",
+          message: expect.stringMatching(/tab ready at \d+ms, first GQL at never, \d+ms since the tab was created/),
+        }));
+      });
+
+      // An anonymous GQL request carries no Client-Integrity header, so the
+      // capture path drops it — but it is the only evidence that the SPA booted
+      // at all, which is what separates a slow boot from a slow challenge.
+      it("stamps the first GQL request the context issues, header or not", async () => {
+        const browser = browserMock();
+        browser.tabs.query.mockResolvedValue([]);
+        browser.tabs.create.mockResolvedValue({ id: 21 });
+        const events: EngineEvent[] = [];
+
+        const pending = ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 50, (event) => events.push(event));
+        await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalled());
+        noteTwitchGqlRequest(21);
+        await pending;
+
+        expect(events).toContainEqual(expect.objectContaining({
+          level: "warn",
+          message: expect.stringMatching(/first GQL at \d+ms/),
+        }));
+      });
+
+      it("ignores GQL requests from tabs other than the booting context", async () => {
+        const browser = browserMock();
+        browser.tabs.query.mockResolvedValue([]);
+        browser.tabs.create.mockResolvedValue({ id: 21 });
+        const events: EngineEvent[] = [];
+
+        const pending = ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 50, (event) => events.push(event));
+        await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalled());
+        noteTwitchGqlRequest(999);
+        await pending;
+
+        expect(events).toContainEqual(expect.objectContaining({
+          level: "warn",
+          message: expect.stringContaining("first GQL at never"),
+        }));
+      });
+
+      // A 20s success is the same latency problem as a 12s timeout; only logging
+      // the failure would hide every cold boot that happened to finish in time.
+      it("reports the wait duration on the success path too", async () => {
+        const browser = browserMock();
+        browser.tabs.query.mockResolvedValue([]);
+        browser.tabs.create.mockResolvedValue({ id: 21 });
+        const events: EngineEvent[] = [];
+
+        const pending = ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 5_000, (event) => events.push(event));
+        await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalled());
+        setTwitchIntegrity(fresh(), { isNew: true });
+
+        await expect(pending).resolves.toBe(true);
+        expect(events).toContainEqual(expect.objectContaining({
+          level: "debug",
+          message: expect.stringMatching(/Waited \d+ms for a Twitch integrity token from a created page context \(tab ready at/),
+        }));
+      });
     });
 
     // Twitch can reject a token the extension still considers unexpired. Forced

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -19,6 +19,7 @@ import {
   recordManagedPageContextBackgroundSuccessWithBrowser,
   recordManagedPageContextFallback,
   registerManagedPageContextTabs,
+  resetTwitchIntegrityRefreshBounds,
   resetPlaybackPriming,
   setTwitchIntegrity,
   stopManagedPageContextTabsWithBrowser,
@@ -1073,6 +1074,7 @@ describe("twitch integrity refresh", () => {
   beforeEach(() => {
     registerManagedPageContextTabs({});
     setTwitchIntegrity(undefined);
+    resetTwitchIntegrityRefreshBounds();
   });
 
   const fresh = () => ({
@@ -1475,6 +1477,55 @@ describe("twitch integrity refresh", () => {
 
         setTwitchIntegrity({ ...replacement(), integrity: "third-token" }, { isNew: true });
         await expect(second).resolves.toBe(true);
+      });
+
+      // The expensive case #292 describes: a discovery pass issues ~10 authenticated
+      // operations, Twitch refuses them all on the same token, and each rejection
+      // used to boot its own cold page context and wait out Kasada again.
+      it("mints once for a burst of operations all rejected on the same token", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 41 });
+        setTwitchIntegrity(rejected());
+        const staleToken = rejected().integrity;
+
+        // The first operation's refresh lands a replacement.
+        setTimeout(() => setTwitchIntegrity(replacement(), { isNew: true }), 20);
+        await expect(ensureTwitchIntegrityWithBrowser(
+          browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined,
+          { forceRefresh: true, rejectedToken: staleToken },
+        )).resolves.toBe(true);
+        const contextsAfterFirst = browser.tabs.create.mock.calls.length;
+
+        // The rest were refused on the same stale token before that landed. They
+        // have never tried the replacement, so nothing needs minting for them.
+        for (let index = 0; index < 5; index += 1) {
+          await expect(ensureTwitchIntegrityWithBrowser(
+            browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined,
+            { forceRefresh: true, rejectedToken: staleToken },
+          )).resolves.toBe(true);
+        }
+
+        expect(browser.tabs.create.mock.calls.length).toBe(contextsAfterFirst);
+      });
+
+      // The bound must key on which token was refused, not on elapsed time: a
+      // replacement that Twitch itself rejects still has to be re-minted at once.
+      it("still mints when the replacement is the token that was rejected", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 42 });
+        setTwitchIntegrity(replacement());
+        const contextsBefore = browser.tabs.create.mock.calls.length;
+
+        const pending = ensureTwitchIntegrityWithBrowser(
+          browser, "https://www.twitch.tv/drops/inventory", 5_000, undefined,
+          { forceRefresh: true, rejectedToken: replacement().integrity },
+        );
+        await vi.waitFor(() => {
+          expect(browser.tabs.create.mock.calls.length).toBeGreaterThan(contextsBefore);
+        });
+
+        setTwitchIntegrity({ ...replacement(), integrity: "fourth-token" }, { isNew: true });
+        await expect(pending).resolves.toBe(true);
       });
 
       it("leaves the non-forced fast path intact", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1528,6 +1528,24 @@ describe("twitch integrity refresh", () => {
         await expect(pending).resolves.toBe(true);
       });
 
+      // A forced refresh can legitimately have no token to compare against —
+      // nothing captured yet, or a host that cannot report what it sent. It must
+      // still demand a freshly created context: inheriting a user's idle tab
+      // yields one that issues no request, so the wait can only time out.
+      it("still requires a fresh context when no rejected token is known", async () => {
+        const browser = browserMock();
+        browser.tabs.query.mockResolvedValue([{ id: 3 }]);
+        browser.tabs.create.mockResolvedValue({ id: 43 });
+
+        const pending = ensureTwitchIntegrityWithBrowser(
+          browser, "https://www.twitch.tv/drops/inventory", 50, undefined, { forceRefresh: true },
+        );
+        await pending;
+
+        // Tab 3 was reusable, but a forced refresh must not reuse it.
+        expect(browser.tabs.create).toHaveBeenCalled();
+      });
+
       it("leaves the non-forced fast path intact", async () => {
         const browser = browserMock();
         setTwitchIntegrity(fresh());


### PR DESCRIPTION
## Summary

Closes #291
Closes #292

Filed separately, merged here because they are the same defect seen from two ends: #291 is one integrity wait timing out, #292 is that wait happening N times in a tick. Fixing either alone leaves the other worse — see *Why they merged* below.

## What the trace actually says

#291's premise is a misreading worth correcting, because it changes the fix. The issue reports the token arriving **31ms** after the wait gave up:

```
21:12:16.310  Waiting up to 12000ms … from a created page context
21:12:28.311  Timed out after 12001ms
21:12:28.311  …reusing the last campaign list
21:12:38.292  Captured a fresh Twitch integrity token
```

Timeout → capture is **9,981ms**. The 31ms is the gap to `Tick #1 finished` at `21:12:38.262` (from #292's trace) — the tick *ending*, not the timeout.

That kills #291's proposed cause 3, "the failed caller could re-check before committing to its fallback". At the timeout the token genuinely was not there and would not be for another ten seconds, and it landed after the whole tick had ended. A re-check would never have fired. Not implemented.

## Where the 22s goes

| Span | Duration | What happens |
|---|---|---|
| `14.887 → 16.310` | **1.4s** | `tabs.create` → `waitForPageContextReady` sees `status === "complete"` |
| `16.310 → 38.292` | **22.0s** | SPA boots, authenticates, solves Kasada → first GQL carrying `Client-Integrity` |

The tab was "ready" in 1.4s and produced nothing usable for another 20.6s. Two reasons, both structural:

- `waitForPageContextReady` polls for `tab.status === "complete"`, the *document* load event. For a SPA that means the HTML shell arrived — React has not booted, authenticated, or issued a request. The 12s stopwatch starts ~20s before the event it waits for can occur.
- The cost being waited on is Kasada's proof-of-work, which `twitchIntegrity.ts` already documents as the reason a token cannot be minted from the background. Being expensive is the *point* of a PoW, and it runs in a tab deliberately created `active: false`.

So 12s was not slightly tight. It budgeted for a page load while the work was a proof-of-work challenge.

## Why they merged

Raising the timeout alone makes #292 strictly worse — those stalls stack several-deep in one tick, so 12s of guaranteed-wasted wait becomes 30s. Bounding the refresh alone leaves every cold boot still timing out at 12s. The bound is what makes the longer wait affordable: **a tick now pays it once, not once per rejected operation.**

## Changes

**Boot-phase instrumentation** (`66fdbd6`) — the wait reported one aggregate duration that could not say which phase ran long. Each boundary is now stamped as crossed and reported on both outcomes:

```
Timed out … after 30000ms from a created page context
  (tab ready at 1421ms, first GQL at 8003ms, 30012ms since the tab was created)
```

The first-GQL stamp is fed by *every* `gql.twitch.tv` request, including anonymous ones carrying no `Client-Integrity` header — those are the only evidence separating "the SPA has not booted" from "the SPA is running but is still solving the challenge". Logged on success too: a 20s success is the same latency problem as a 12s timeout.

**The refresh is bounded by the rejected token** (`81266d0`) — callers capture the token *before* issuing a request and report it on rejection. A forced refresh whose rejected token has already been replaced returns the current token instead of booting another context. Concurrent callers share the in-flight refresh rather than racing into `acquirePageContextTab`, whose origin dedupe hands the later ones an inherited context that `requireFreshPageContext` cannot make fresh — the hazard 439d02a's notes flagged.

Keying on *which token was refused* rather than on elapsed time matters. I first wrote this as a 60s cooldown and it broke an existing test — `starts a new forced refresh once the previous one has settled` — which encodes Twitch rejecting the brand-new token. A time-based bound cannot tell that from the common case and would have stalled recovery for 60s. The test was right; the heuristic was wrong. It passes unchanged.

**Timeout 12s → 30s, and the probe deadline derives from it.** `DEFAULT_AUTH_PROBE_TIMEOUT_MS` was 10s against a 12s wait, so a Twitch auth probe — which reaches `gqlWithIntegrityRetry` — could *never* observe that wait succeed. It aborted first every time, and since the wait takes no `AbortSignal`, left the wait and its tab running unowned. Now `INTEGRITY_REFRESH_TIMEOUT_MS + 5_000`, so the two cannot invert again.

## Testing

`pnpm verify` clean: 6 typechecks, 132 CLI tests, 1080 extension tests, 87 script/site tests, Astro build, Chromium and Firefox builds.

Six new tests. Each was confirmed to fail against the unfixed code rather than assumed to cover it — the phase-split four by stubbing the report to `""`, the burst test by disabling the fast path:

- phase split reported on timeout, on success, with and without a first GQL, and ignoring other tabs
- **`mints once for a burst of operations all rejected on the same token`** — the #292 case: five follow-up operations after the first refresh boot zero further contexts
- **`still mints when the replacement is the token that was rejected`** — the case the cooldown got wrong

`resetTwitchIntegrityRefreshBounds()` is added to `beforeEach` alongside the existing `setTwitchIntegrity(undefined)`; the new module state leaks between tests exactly as the token does.

## Worth flagging in review

**The 30s figure is provisional.** It covers one observed sample (22s) with margin. I did not want to tune a constant against n=1, which is why the instrumentation ships first and is deliberately the larger-value half of this PR. Replace it once real distributions come in.

**The auth probe is now up to 35s.** That follows from removing the inversion, but it means a health check can boot a page context and wait out a PoW. Arguably a probe should *observe* auth rather than do 30s of work to repair it — exempting it from forced refresh would let its deadline drop back to ~10s, at the cost of reporting a stale-token session as unhealthy. Left alone here as out of scope; say the word and I will follow up.

## Not addressed

- The missing `AbortSignal` on `waitForIntegrityCapture` (#291's cause 2) is #293's cancellation work. This PR removes the *guaranteed* orphan by fixing the deadline inversion; a probe aborting for other reasons still leaves the wait running.
- `waitForPageContextReady` still waits on `status === "complete"`. Waiting for a readiness signal that means "the SPA is issuing authenticated GQL" would cut the wait further — the new first-GQL stamp is the measurement needed to justify it.

No new permissions, credential storage, or localized diagnostic keys.