### PR TITLE
fix(controller): preempt in-flight scheduler ticks

### DIFF
--- a/docs/superpowers/plans/2026-07-28-preempt-in-flight-tick.md
+++ b/docs/superpowers/plans/2026-07-28-preempt-in-flight-tick.md
@@ -1,0 +1,300 @@
+# Preempt In-Flight Scheduler Ticks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cancel in-flight scheduler work before factory reset or runtime shutdown so stale work cannot delay or race cleanup.
+
+**Architecture:** Each controller tick owns an `AbortController` registered for its full lifetime. Its signal flows through scheduler options and adapter operations into transports, integrity acquisition, and page-context work; reset and shutdown abort registered ticks before serialized cleanup, while cancellation rolls back without error persistence.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Vitest, WXT WebExtension APIs, Node fetch.
+
+## Global Constraints
+
+- Keep `@lurkloot/core` browser-free and do not import WXT or browser globals.
+- Preserve the controller's settings/state serialization around host storage reset.
+- Treat cancellation as expected control flow: no partial state save, interruption event, or error diagnostic.
+- Preserve ordinary scheduler failure behavior.
+- Use deterministic mocked tests rather than live Twitch or Kick calls.
+
+---
+
+### Task 1: Define Scheduler Cancellation Contract
+
+**Files:**
+- Modify: `packages/core/src/platforms/adapter.ts`
+- Modify: `packages/core/src/core/scheduler.ts`
+- Test: `packages/extension/tests/scheduler.test.ts`
+
+**Interfaces:**
+- Produces: `SchedulerTickOptions.signal?: AbortSignal`
+- Produces: optional `signal?: AbortSignal` final argument on every async `PlatformAdapter` operation used by a scheduler tick.
+
+- [ ] **Step 1: Write a failing scheduler test**
+
+Add a test that creates an `AbortController`, blocks the first mocked adapter
+operation, aborts it, and asserts later adapter side effects are not called:
+
+```ts
+it("stops scheduler side effects when its signal aborts", async () => {
+  const abort = new AbortController();
+  const tickAdapters = adapters();
+  tickAdapters.twitch.discoverCampaigns.mockImplementation(async (signal?: AbortSignal) => {
+    abort.abort(new DOMException("reset", "AbortError"));
+    signal?.throwIfAborted();
+    return [];
+  });
+
+  await expect(runSchedulerTick(baseState, tickSettings, tickAdapters, {
+    signal: abort.signal,
+  })).rejects.toMatchObject({ name: "AbortError" });
+  expect(tickAdapters.twitch.readProgress).not.toHaveBeenCalled();
+  expect(tickAdapters.twitch.prepareWatchTab).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- scheduler.test.ts
+```
+
+Expected: FAIL because `signal` is not passed to `discoverCampaigns`.
+
+- [ ] **Step 3: Add signal parameters and phase checks**
+
+Add `signal?: AbortSignal` to `SchedulerTickOptions`. Add an optional final
+signal argument to adapter methods, for example:
+
+```ts
+discoverCampaigns(signal?: AbortSignal): Promise<DropCampaign[]>;
+readProgress(
+  campaigns: DropCampaign[],
+  session?: WatchSession,
+  signal?: AbortSignal,
+): Promise<DropCampaign[]>;
+```
+
+Use `options.signal?.throwIfAborted()` before each scheduler phase and pass
+`options.signal` to every adapter call.
+
+- [ ] **Step 4: Run scheduler tests and verify GREEN**
+
+Run the focused command from Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit the contract**
+
+```bash
+git add packages/core/src/platforms/adapter.ts packages/core/src/core/scheduler.ts packages/extension/tests/scheduler.test.ts
+git commit -m "refactor(scheduler): add tick cancellation contract"
+```
+
+### Task 2: Propagate Cancellation Through Platform I/O
+
+**Files:**
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Modify: `packages/core/src/platforms/kick/index.ts`
+- Modify: `packages/core/src/core/tabs.ts`
+- Modify: `packages/extension/src/core/tabs.ts`
+- Modify: `packages/cli/src/transport/common.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+- Test: `packages/extension/tests/tabs.test.ts`
+- Test: `packages/cli/tests/transport.test.ts`
+
+**Interfaces:**
+- Consumes: optional signal arguments from `PlatformAdapter`.
+- Produces: `TwitchIntegrityRequest.signal?: AbortSignal`.
+- Produces: transport calls whose `RequestInit.signal` is the active tick signal.
+
+- [ ] **Step 1: Write failing propagation tests**
+
+Add focused tests asserting an adapter request receives the scheduler-owned
+signal, an integrity refresh rejects promptly when it aborts, and the CLI
+transport forwards caller cancellation:
+
+```ts
+const abort = new AbortController();
+await adapter.discoverCampaigns(abort.signal);
+expect(fetchJson).toHaveBeenCalledWith(
+  expect.any(String),
+  expect.objectContaining({ signal: abort.signal }),
+  expect.any(Function),
+);
+```
+
+- [ ] **Step 2: Run adapter, tabs, and CLI transport tests and verify RED**
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts tabs.test.ts
+pnpm --filter @lurkloot/cli test -- transport.test.ts
+```
+
+Expected: at least one assertion fails because the signal is dropped.
+
+- [ ] **Step 3: Forward signals through implementations**
+
+Add `signal?: AbortSignal` to adapter implementations and thread it into
+transport `RequestInit`, `ensureIntegrity({ signal })`, page-context acquisition,
+and abort-aware wait helpers. Call `signal?.throwIfAborted()` before retries and
+side effects.
+
+- [ ] **Step 4: Run focused propagation tests and verify GREEN**
+
+Run the commands from Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit propagation**
+
+```bash
+git add packages/core/src/platforms packages/core/src/core/tabs.ts packages/extension/src/core/tabs.ts packages/extension/tests packages/cli/src/transport packages/cli/tests
+git commit -m "refactor(platforms): propagate scheduler cancellation"
+```
+
+### Task 3: Preempt Ticks During Reset and Shutdown
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/cli/src/runtime/run.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/cli/tests/runtime.test.ts`
+
+**Interfaces:**
+- Consumes: `SchedulerTickOptions.signal`.
+- Produces: `controller.shutdown(): void`.
+- Produces: controller-owned collection of active tick `AbortController`s.
+
+- [ ] **Step 1: Write failing controller tests**
+
+Add deferred-adapter tests that start a tick, observe its signal, then call
+reset or shutdown:
+
+```ts
+it("preempts an in-flight tick before host reset", async () => {
+  const env = harness(farming(DEFAULT_SETTINGS));
+  let tickSignal!: AbortSignal;
+  env.twitch.discoverCampaigns.mockImplementation((signal?: AbortSignal) => {
+    tickSignal = signal!;
+    return new Promise((_resolve, reject) => {
+      signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+    });
+  });
+
+  const ticking = env.controller.tick();
+  await vi.waitFor(() => expect(tickSignal).toBeDefined());
+  const resetHostStorage = vi.fn();
+  await env.controller.prepareForHostReset(resetHostStorage);
+  await ticking;
+
+  expect(tickSignal.aborted).toBe(true);
+  expect(resetHostStorage).toHaveBeenCalledOnce();
+  expect(env.deps.saveState).not.toHaveBeenCalledWith(
+    expect.objectContaining({ lastTickAt: expect.any(String) }),
+  );
+});
+```
+
+Add a parallel test for `shutdown()`, repeat invocation, and absence of
+interruption/error persistence.
+
+- [ ] **Step 2: Run controller tests and verify RED**
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+```
+
+Expected: FAIL because ticks have no owned controller and `shutdown` is absent.
+
+- [ ] **Step 3: Implement tick ownership and cancellation rollback**
+
+Register a new controller at the start of `tick`, pass its signal through auth
+refresh and `runSchedulerTick`, and remove it in `finally`. Add:
+
+```ts
+function abortActiveTicks(reason: unknown): void {
+  for (const controller of activeTicks) controller.abort(reason);
+}
+
+function shutdown(): void {
+  abortActiveTicks(new DOMException("Controller shutdown", "AbortError"));
+  abortClaimHandoffs();
+}
+```
+
+Call `abortActiveTicks` at the beginning of `prepareForHostReset`. In the
+scheduler catch path, if the owned signal is aborted, clear observations and
+return without `persistAndReport`. Ensure `tickAndHandOff` skips handoff after
+cancellation.
+
+- [ ] **Step 4: Wire runtime shutdown**
+
+Replace CLI teardown's direct `abortClaimHandoffs()` call with
+`controller.shutdown()`. Wire any existing browser runtime teardown hook to the
+same idempotent method without relying on asynchronous completion.
+
+- [ ] **Step 5: Run controller and CLI runtime tests and verify GREEN**
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+pnpm --filter @lurkloot/cli test -- runtime.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit controller behavior**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts packages/cli/src/runtime/run.ts packages/cli/tests/runtime.test.ts
+git commit -m "fix(controller): preempt ticks during reset and shutdown"
+```
+
+### Task 4: Regression and Release Verification
+
+**Files:**
+- Modify only files required by failures attributable to Tasks 1–3.
+
+**Interfaces:**
+- Consumes: completed cancellation behavior.
+- Produces: a verified PR branch that closes issue 293.
+
+- [ ] **Step 1: Run formatting and diff checks**
+
+```bash
+git diff --check origin/develop...HEAD
+git status --short
+```
+
+Expected: no whitespace errors and only intentional changes.
+
+- [ ] **Step 2: Run repository verification**
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, workspace typechecks, extension tests, site build, and
+both browser extension builds all pass.
+
+- [ ] **Step 3: Inspect the final diff**
+
+```bash
+git diff --stat origin/develop...HEAD
+git diff origin/develop...HEAD
+```
+
+Confirm cancellation reaches every scheduler adapter call, reset aborts before
+locking, shutdown is idempotent, and no cancellation path persists an error.
+
+- [ ] **Step 4: Commit any verification-only fixes**
+
+```bash
+git add <only-files-fixed-after-verification>
+git commit -m "fix(controller): complete tick cancellation coverage"
+```
+
+Skip this commit when verification required no changes.
+
+- [ ] **Step 5: Push and open the PR**
+
+Push `fix/preempt-in-flight-tick` and create a ready-for-review PR into
+`develop` with a Conventional Commit title, a concise summary, verification
+results, and `Closes #293`.

--- a/docs/superpowers/specs/2026-07-28-preempt-in-flight-tick-design.md
+++ b/docs/superpowers/specs/2026-07-28-preempt-in-flight-tick-design.md
@@ -1,0 +1,128 @@
+# Preempt In-Flight Scheduler Ticks
+
+## Context
+
+Factory reset currently calls `prepareForHostReset`, which waits for the
+controller's settings and state locks. A scheduler tick holds the state lock
+across network-bound platform work, so reset can remain stuck on "Resetting…"
+until that tick completes. Runtime shutdown has the same underlying problem:
+post-claim handoffs can be aborted, but the scheduler tick itself has no
+cancellation path.
+
+The fix must cancel in-flight work before reset or shutdown cleanup begins.
+Merely releasing the state lock or racing the caller against the scheduler
+would leave abandoned work running and able to write stale state after storage
+has been cleared.
+
+## Goals
+
+- Factory reset promptly cancels all active scheduler ticks before waiting for
+  controller locks.
+- Controller shutdown cancels the same work, including integrity waits and
+  network requests reached by the tick.
+- A cancelled tick rolls back without persisting partial scheduler state or
+  reporting a user-facing platform failure.
+- Existing serialization still prevents new mutations from crossing the host
+  storage reset.
+- Ordinary, non-cancellation scheduler failures retain their current reporting
+  and persistence behavior.
+
+## Non-Goals
+
+- Redesigning the controller's global state or settings locks.
+- Adding cancellation controls to the popup.
+- Changing platform retry, timeout, or integrity-refresh policies.
+- Cancelling unrelated operations that are not owned by a scheduler tick.
+
+## Design
+
+### Tick Lifetime Ownership
+
+The background controller will own an `AbortController` for every active
+scheduler tick. A collection is required rather than a single current
+controller because tick calls may overlap before they serialize on the state
+lock.
+
+Each tick registers its controller before beginning asynchronous work and
+removes it in a `finally` block. Reset and shutdown synchronously abort every
+registered controller. A tick whose signal is already aborted must stop before
+starting or persisting further work.
+
+Post-claim handoffs remain independently tracked because their bounded loop has
+a distinct lifetime. Reset and shutdown abort both active ticks and handoffs.
+
+### Signal Propagation
+
+`runSchedulerTick` will accept an optional signal in `SchedulerTickOptions`.
+Scheduler code will pass that signal to every platform-adapter operation it
+invokes. `PlatformAdapter` methods will accept an optional `AbortSignal`, and
+implementations will forward it to their transports, integrity acquisition,
+page-context work, and other cancellable waits.
+
+The propagation must cover the full tick path, including:
+
+- campaign discovery and progress reads;
+- candidate listing and channel checks;
+- reward, channel-points, and challenge claims;
+- watch-tab preparation and teardown;
+- Twitch integrity refresh and page-context acquisition;
+- browser and Node HTTP transports.
+
+The scheduler will also check the signal at phase boundaries. This handles
+adapters that complete normally after cancellation and prevents subsequent
+side effects from starting.
+
+### Reset and Shutdown
+
+`prepareForHostReset` will abort active ticks and claim handoffs before taking
+the settings and state locks. It will then use the existing locked cleanup
+sequence to close managed tabs, stop watchers, clear in-memory registries, run
+the host storage reset callback, and report best-effort cleanup diagnostics.
+Waiting for the lock remains intentional: the cancelled tick must finish its
+rollback before storage is wiped.
+
+The controller will expose a shutdown operation that aborts active ticks and
+handoffs. Runtime teardown paths, including the CLI's existing final cleanup,
+will call it. The shutdown API will be safe to invoke repeatedly.
+
+### Cancellation Semantics
+
+Cancellation is an expected control-flow outcome, not a platform failure.
+When a scheduler tick is aborted:
+
+- partially computed state and claimed-reward observations are discarded;
+- no interruption activity event or error diagnostic is persisted;
+- no state save occurs for the aborted scheduler result;
+- no post-claim handoff begins;
+- the tick lifecycle finish diagnostic may still be emitted for observability.
+
+Errors unrelated to the tick signal continue through the existing error path.
+Cancellation detection will be based on the owned signal's aborted state, so
+an unrelated exception named `AbortError` is not silently swallowed.
+
+### Concurrency Guarantees
+
+Abort happens before reset or shutdown waits for controller locks. The active
+tick releases the state lock only after its cancellation path has stopped
+further side effects and skipped persistence. Reset then acquires the lock and
+wipes storage. New controller mutations remain queued behind the reset's
+settings/state lock sequence and therefore cannot interleave with the wipe.
+
+Registering the tick controller before asynchronous setup closes the race where
+reset begins between tick creation and signal registration.
+
+## Testing
+
+Deterministic controller and scheduler tests will verify:
+
+- reset aborts a tick blocked in an adapter call and starts cleanup promptly;
+- shutdown aborts the same in-flight work and is idempotent;
+- an aborted tick cannot save scheduler state after host storage reset;
+- adapter calls and Twitch integrity/network paths receive the tick signal;
+- cancellation produces no platform interruption or error persistence;
+- a tick queued during reset still cannot cross the storage wipe;
+- ordinary scheduler failures retain their current diagnostics and rollback.
+
+Focused tests will use deferred promises and mocked adapters/transports rather
+than live Twitch or Kick calls. Final verification will run the repository's
+full `pnpm verify` command.

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -87,7 +87,7 @@ export async function runLoop(options: RunOptions): Promise<void> {
       // Before disposing the transport: a post-claim handoff started by the last
       // tick would otherwise keep refreshing against disposed resources, and its
       // pending delay would hold the process open until the handoff's deadline.
-      controller.abortClaimHandoffs();
+      controller.shutdown();
       await transport.dispose();
       resolveLoop();
     };

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -556,12 +556,19 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     });
   }
 
-  async function probeAuthHealth(platform: Platform, adapter: PlatformAdapter): Promise<PlatformAuthHealth> {
+  async function probeAuthHealth(
+    platform: Platform,
+    adapter: PlatformAdapter,
+    signal?: AbortSignal,
+  ): Promise<PlatformAuthHealth> {
     // A probe must always resolve to a terminal status. If reading the session
     // cookies (or the adapter probe) throws, mapping it to "unavailable" here
     // keeps the failure from propagating into the tick, where a rollback would
     // strand the popup on "Checking your signed-in session…" indefinitely.
     const abort = new AbortController();
+    const abortFromTick = () => abort.abort(signal?.reason);
+    signal?.throwIfAborted();
+    signal?.addEventListener("abort", abortFromTick, { once: true });
     let timeout: ReturnType<typeof setTimeout> | undefined;
     const terminalProbe = (async (): Promise<PlatformAuthHealth> => {
       try {
@@ -584,6 +591,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         }
         return await adapter.checkAuthHealth(abort.signal);
       } catch {
+        signal?.throwIfAborted();
         return {
           status: "unavailable",
           checkedAt: new Date().toISOString(),
@@ -606,6 +614,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     try {
       return await Promise.race([terminalProbe, timedOut]);
     } finally {
+      signal?.removeEventListener("abort", abortFromTick);
       if (timeout !== undefined) clearTimeout(timeout);
     }
   }
@@ -666,7 +675,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     platforms: Platform[],
     loadedSettings?: S,
     reportCompatibility = false,
+    signal?: AbortSignal,
   ): Promise<void> {
+    signal?.throwIfAborted();
     const generations = await beginAuthRefresh(platforms);
     const settings = loadedSettings ?? await deps.loadSettings();
     const enabled = platforms.filter((platform) => settings.platform[platform].enabled);
@@ -684,12 +695,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           );
         }
         health = adapter
-          ? await probeAuthHealth(platform, adapter)
+          ? await probeAuthHealth(platform, adapter, signal)
           : unavailableAfterAdapterSetup();
         return { health, events, setupFailure };
       });
       const generation = generations[platform];
       if (generation === undefined) return;
+      signal?.throwIfAborted();
       let accepted: boolean;
       try {
         accepted = await persistAuthHealth(platform, result.health, result.events, generation);
@@ -729,27 +741,39 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   let tickSequence = 0;
   // Chain of detached ticks, drained by settleBackgroundWork().
   let backgroundWork: Promise<unknown> = Promise.resolve();
+  const activeTicks = new Set<AbortController>();
 
   async function tick(platforms?: Platform[], trigger: TickTrigger = "unknown"): Promise<ClaimedRewards> {
+    const abort = new AbortController();
+    activeTicks.add(abort);
     const tickId = ++tickSequence;
     const tickStartedAt = Date.now();
     const scope = platforms ? platforms.join("+") : "all";
     diagnosticEvent("debug", `Tick #${tickId} started (trigger=${trigger}, platforms=${scope})`);
     try {
-      return await runTick(tickId, tickStartedAt, platforms);
+      return await runTick(tickId, tickStartedAt, platforms, abort.signal);
+    } catch (error) {
+      if (abort.signal.aborted) return {};
+      throw error;
     } finally {
+      activeTicks.delete(abort);
       diagnosticEvent("debug", `Tick #${tickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${scope})`);
     }
   }
 
-  async function runTick(tickId: number, tickStartedAt: number, platforms?: Platform[]): Promise<ClaimedRewards> {
+  async function runTick(
+    tickId: number,
+    tickStartedAt: number,
+    platforms: Platform[] | undefined,
+    signal: AbortSignal,
+  ): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
     const settings = await deps.loadSettings();
     const setupFailedPlatforms = new Set<Platform>();
     if (isFarmingActive(settings)) {
       const authStartedAt = Date.now();
       try {
-        await refreshAuthHealth(platforms ?? PLATFORMS, settings);
+        await refreshAuthHealth(platforms ?? PLATFORMS, settings, false, signal);
         diagnosticEvent("debug", `Tick #${tickId} refreshed auth health in ${Date.now() - authStartedAt}ms`);
       } catch (error) {
         const failures = flattenedRefreshFailures(error);
@@ -780,6 +804,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       !setupFailedPlatforms.has(platform));
     if (schedulerPlatforms.length === 0) return claimedRewards;
     await withStateLock(() => withEventCollector(async (emit, events) => {
+      signal.throwIfAborted();
       const settings = await deps.loadSettings();
       const state = await deps.loadState();
       const nextWaitingClaimRewardIds: Record<Platform, Set<string>> = {
@@ -806,12 +831,17 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           stopPageContextTabs: deps.stopPageContextTabs,
           waitingClaimRewardIds: nextWaitingClaimRewardIds,
           emit: claimObservingEmit,
+          signal,
         });
+        signal.throwIfAborted();
         const lifecycleEvents = farmingLifecycleEvents(state, result.state);
         for (const event of lifecycleEvents) emit(event);
         await emitNotifications(settings, state, result.state, result.events);
+        signal.throwIfAborted();
         await applyAdFocusForState(result.state, emit);
+        signal.throwIfAborted();
         await reconcileTablessWatchers(result.state, settings, adapters, emit, schedulerPlatforms);
+        signal.throwIfAborted();
         nextState = result.state;
         if (settings.criticalFailurePromptEnabled) {
           // Page-context tabs are created deep inside tabs.ts, which has no access
@@ -835,6 +865,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         // The tick was rolled back, so any partial claim set is not actionable.
         for (const key of Object.keys(claimedRewards) as Platform[]) delete claimedRewards[key];
         clearOperationalEvents(events);
+        if (signal.aborted) return;
         const detail = error instanceof Error ? error.message : "Scheduler tick failed";
         emit({ category: "activity", code: "interruption", level: "error", data: { reason: "platform_error", detail } });
         emit({ category: "diagnostic", level: "error", message: detail });
@@ -1131,7 +1162,19 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
+  function abortActiveTicks(reason: string): void {
+    for (const controller of activeTicks) {
+      controller.abort(new Error(reason));
+    }
+  }
+
+  function shutdown(): void {
+    abortActiveTicks("Controller shutdown");
+    abortClaimHandoffs();
+  }
+
   async function prepareForHostReset(resetHostStorage?: () => Promise<void>): Promise<void> {
+    abortActiveTicks("Host reset");
     abortClaimHandoffs();
     await withSettingsLock(() => withStateLock(() => withEventCollector(async (emit, events) => {
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
@@ -1748,6 +1791,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     runWatchHeartbeat,
     runClaimHandoff,
     abortClaimHandoffs,
+    shutdown,
     prepareForHostReset,
     settleBackgroundWork,
   };

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -566,7 +566,14 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     // keeps the failure from propagating into the tick, where a rollback would
     // strand the popup on "Checking your signed-in session…" indefinitely.
     const abort = new AbortController();
-    const abortFromTick = () => abort.abort(signal?.reason);
+    let rejectCancelled: (reason?: unknown) => void = () => {};
+    const cancelled = new Promise<PlatformAuthHealth>((_resolve, reject) => {
+      rejectCancelled = reject;
+    });
+    const abortFromTick = () => {
+      abort.abort(signal?.reason);
+      rejectCancelled(signal?.reason);
+    };
     signal?.throwIfAborted();
     signal?.addEventListener("abort", abortFromTick, { once: true });
     let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -612,7 +619,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       }, deps.authProbeTimeoutMs ?? DEFAULT_AUTH_PROBE_TIMEOUT_MS);
     });
     try {
-      return await Promise.race([terminalProbe, timedOut]);
+      return await Promise.race([terminalProbe, timedOut, cancelled]);
     } finally {
       signal?.removeEventListener("abort", abortFromTick);
       if (timeout !== undefined) clearTimeout(timeout);

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -217,7 +217,7 @@ export async function chooseCampaignDecision(
 
     const excludedChannels = settings.platform[platform].excludedChannels ?? [];
     signal?.throwIfAborted();
-    const candidates = (await adapter.listCandidateChannels(campaign, signal))
+    const candidates = (await adapter.listCandidateChannels(campaign, { signal }))
       .filter((candidate) => !excludedChannels.includes(candidate.username.toLowerCase()))
       .sort((left, right) => {
         if (left.isAclMatch !== right.isAclMatch) return left.isAclMatch ? -1 : 1;
@@ -346,7 +346,7 @@ async function firstValidCandidate(
 ): Promise<ChannelCandidate | undefined> {
   for (const candidate of candidates) {
     signal?.throwIfAborted();
-    const check = await adapter.checkChannel(candidate, campaign, signal);
+    const check = await adapter.checkChannel(candidate, { campaign, signal });
     if (check.live && check.categoryMatches && check.campaignMatches !== false) {
       return channelFromCheck(candidate, check);
     }
@@ -474,7 +474,7 @@ export async function runSchedulerTick(
     adapter: PlatformAdapter,
   ): Promise<void> {
     try {
-      await adapter.stopWatchTab?.(previous, undefined, options.signal);
+      await adapter.stopWatchTab?.(previous, { signal: options.signal });
     } catch (error) {
       emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop watch tab");
     }
@@ -564,7 +564,7 @@ export async function runSchedulerTick(
       // recovering on this (or any later) tick. Checked before every other gate
       // so nothing re-opens a tab behind the user's back.
       if (nextState.manualClosePause?.[platform]) {
-        await adapter.stopWatchTab?.(previous, undefined, options.signal);
+        await adapter.stopWatchTab?.(previous, { signal: options.signal });
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",
@@ -591,7 +591,7 @@ export async function runSchedulerTick(
         continue;
       }
       if (settings.pauseOnManualWatch && hasRecentManualWatch(nextState, platform)) {
-        await adapter.stopWatchTab?.(previous, undefined, options.signal);
+        await adapter.stopWatchTab?.(previous, { signal: options.signal });
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",
@@ -623,7 +623,7 @@ export async function runSchedulerTick(
         // enabled; this one being off while the other still farms stays a
         // platform-scoped stop. Both reason codes remain meaningful.
         const automationOff = !isFarmingActive(settings);
-        await adapter.stopWatchTab?.(previous, undefined, options.signal);
+        await adapter.stopWatchTab?.(previous, { signal: options.signal });
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",
@@ -671,7 +671,7 @@ export async function runSchedulerTick(
           [platform]: { lastCheckedAt: new Date().toISOString() },
         };
         try {
-          for (const challenge of await adapter.claimChallenges(options.signal)) {
+          for (const challenge of await adapter.claimChallenges({ signal: options.signal })) {
             emit({
               category: "activity",
               code: "challenge_claimed",
@@ -709,9 +709,9 @@ export async function runSchedulerTick(
       let campaigns: DropCampaign[];
       let discoveryFailed = false;
       try {
-        const discovered = await adapter.discoverCampaigns(options.signal);
+        const discovered = await adapter.discoverCampaigns({ signal: options.signal });
         options.signal?.throwIfAborted();
-        campaigns = await adapter.readProgress(discovered, previous, options.signal);
+        campaigns = await adapter.readProgress(discovered, previous, { signal: options.signal });
       } catch (error) {
         options.signal?.throwIfAborted();
         if (authHealthFromError(error)) throw error;
@@ -886,7 +886,7 @@ export async function runSchedulerTick(
         emitDiagnostic(emit, platform, decisionLevel, decision.reason);
       }
       if (decision.action === "idle") {
-        await adapter.stopWatchTab?.(previous, undefined, options.signal);
+        await adapter.stopWatchTab?.(previous, { signal: options.signal });
         nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
       }
       const session = sessionForDecision(decision, previous, shouldKeep);
@@ -898,7 +898,7 @@ export async function runSchedulerTick(
         // The `finally` on this loop still applies the tick's observation, which
         // is what prunes the churn window and eventually releases the breaker.
         if (settings.criticalFailurePromptEnabled && isManagedTabBreakerOpen(nextState, platform)) {
-          await adapter.stopWatchTab?.(previous, undefined, options.signal);
+          await adapter.stopWatchTab?.(previous, { signal: options.signal });
           nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
           nextState.sessions[platform] = {
             ...session,
@@ -921,7 +921,7 @@ export async function runSchedulerTick(
         if (useTabless) {
           // Tabless: no video tab. Close any tab we previously opened for this
           // platform; the controller starts/keeps the heartbeat watcher.
-          await adapter.stopWatchTab?.(previous, undefined, options.signal);
+          await adapter.stopWatchTab?.(previous, { signal: options.signal });
           nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
           session.watchMode = "tabless";
           session.tablessFallback = false;
@@ -946,8 +946,7 @@ export async function runSchedulerTick(
           const prepared = await adapter.prepareWatchTab(
             decision.channel,
             previous,
-            watchTabOptions,
-            options.signal,
+            { ...watchTabOptions, signal: options.signal },
           );
           // Only a genuinely NEW extension-managed tab counts as churn evidence.
           // Reusing the tab we already track happens on every ordinary tick, and
@@ -988,7 +987,7 @@ export async function runSchedulerTick(
         }
         if (autoClaimChannelPointsFor(settings, platform) && adapter.claimChannelPoints) {
           try {
-            const claimed = await adapter.claimChannelPoints(decision.channel, options.signal);
+            const claimed = await adapter.claimChannelPoints(decision.channel, { signal: options.signal });
             if (claimed) {
               emitDiagnostic(emit, platform, "info", `Claimed channel points for ${decision.channel.displayName ?? decision.channel.username}`);
             }
@@ -1120,7 +1119,7 @@ async function claimReadyRewards(
           continue;
         }
         try {
-          const claimed = await adapter.claimReward(campaign, reward, signal);
+          const claimed = await adapter.claimReward(campaign, reward, { signal });
           rewards.push(claimed ? { ...reward, status: "claimed", watchedMinutes: reward.requiredMinutes } : reward);
           if (claimed) {
             events.push({
@@ -1233,7 +1232,7 @@ async function shouldKeepWatching(
   // switch the channel based on liveness/category, so skip playback retries.
   const isTabless = previous.watchMode === "tabless";
   if (!settings.idleWatchlistFallbackOnly && !previous.campaignId && nextDecision.action === "watch") {
-    const fallbackCheck = await adapter.checkChannel(previous.channel, undefined, signal);
+    const fallbackCheck = await adapter.checkChannel(previous.channel, { signal });
     const fallbackOfflineChecks = fallbackCheck.live ? 0 : previous.offlineChecks + 1;
     if (fallbackCheck.live && fallbackCheck.categoryMatches) {
       const fallbackPlaybackChecks = nextPlaybackChecks(previous, isTabless);
@@ -1268,7 +1267,7 @@ async function shouldKeepWatching(
     return { keep: false, offlineChecks: 0, playbackChecks: 0, reason: "Higher priority Idle Watchlist channel available", reasonCode: "higher_priority_idle_watchlist" };
   }
 
-  const check = await adapter.checkChannel(previous.channel, undefined, signal);
+  const check = await adapter.checkChannel(previous.channel, { signal });
   const offlineChecks = check.live ? 0 : previous.offlineChecks + 1;
   if (offlineChecks >= settings.offlineRetryLimit) {
     return { keep: false, offlineChecks, playbackChecks: 0, reason: check.reason ?? "Channel offline retry limit reached", reasonCode: "channel_offline" };

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -217,9 +217,7 @@ export async function chooseCampaignDecision(
 
     const excludedChannels = settings.platform[platform].excludedChannels ?? [];
     signal?.throwIfAborted();
-    const candidates = (await (signal
-      ? adapter.listCandidateChannels(campaign, signal)
-      : adapter.listCandidateChannels(campaign)))
+    const candidates = (await adapter.listCandidateChannels(campaign, signal))
       .filter((candidate) => !excludedChannels.includes(candidate.username.toLowerCase()))
       .sort((left, right) => {
         if (left.isAclMatch !== right.isAclMatch) return left.isAclMatch ? -1 : 1;
@@ -348,9 +346,7 @@ async function firstValidCandidate(
 ): Promise<ChannelCandidate | undefined> {
   for (const candidate of candidates) {
     signal?.throwIfAborted();
-    const check = await (signal
-      ? adapter.checkChannel(candidate, campaign, signal)
-      : adapter.checkChannel(candidate, campaign));
+    const check = await adapter.checkChannel(candidate, campaign, signal);
     if (check.live && check.categoryMatches && check.campaignMatches !== false) {
       return channelFromCheck(candidate, check);
     }
@@ -478,8 +474,7 @@ export async function runSchedulerTick(
     adapter: PlatformAdapter,
   ): Promise<void> {
     try {
-      if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
-      else await adapter.stopWatchTab?.(previous);
+      await adapter.stopWatchTab?.(previous, undefined, options.signal);
     } catch (error) {
       emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop watch tab");
     }
@@ -569,8 +564,7 @@ export async function runSchedulerTick(
       // recovering on this (or any later) tick. Checked before every other gate
       // so nothing re-opens a tab behind the user's back.
       if (nextState.manualClosePause?.[platform]) {
-        if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
-        else await adapter.stopWatchTab?.(previous);
+        await adapter.stopWatchTab?.(previous, undefined, options.signal);
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",
@@ -597,8 +591,7 @@ export async function runSchedulerTick(
         continue;
       }
       if (settings.pauseOnManualWatch && hasRecentManualWatch(nextState, platform)) {
-        if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
-        else await adapter.stopWatchTab?.(previous);
+        await adapter.stopWatchTab?.(previous, undefined, options.signal);
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",
@@ -630,8 +623,7 @@ export async function runSchedulerTick(
         // enabled; this one being off while the other still farms stays a
         // platform-scoped stop. Both reason codes remain meaningful.
         const automationOff = !isFarmingActive(settings);
-        if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
-        else await adapter.stopWatchTab?.(previous);
+        await adapter.stopWatchTab?.(previous, undefined, options.signal);
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",
@@ -679,10 +671,7 @@ export async function runSchedulerTick(
           [platform]: { lastCheckedAt: new Date().toISOString() },
         };
         try {
-          const challenges = options.signal
-            ? await adapter.claimChallenges(options.signal)
-            : await adapter.claimChallenges();
-          for (const challenge of challenges) {
+          for (const challenge of await adapter.claimChallenges(options.signal)) {
             emit({
               category: "activity",
               code: "challenge_claimed",
@@ -720,13 +709,9 @@ export async function runSchedulerTick(
       let campaigns: DropCampaign[];
       let discoveryFailed = false;
       try {
-        const discovered = options.signal
-          ? await adapter.discoverCampaigns(options.signal)
-          : await adapter.discoverCampaigns();
+        const discovered = await adapter.discoverCampaigns(options.signal);
         options.signal?.throwIfAborted();
-        campaigns = options.signal
-          ? await adapter.readProgress(discovered, previous, options.signal)
-          : await adapter.readProgress(discovered, previous);
+        campaigns = await adapter.readProgress(discovered, previous, options.signal);
       } catch (error) {
         options.signal?.throwIfAborted();
         if (authHealthFromError(error)) throw error;
@@ -901,8 +886,7 @@ export async function runSchedulerTick(
         emitDiagnostic(emit, platform, decisionLevel, decision.reason);
       }
       if (decision.action === "idle") {
-        if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
-        else await adapter.stopWatchTab?.(previous);
+        await adapter.stopWatchTab?.(previous, undefined, options.signal);
         nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
       }
       const session = sessionForDecision(decision, previous, shouldKeep);
@@ -914,8 +898,7 @@ export async function runSchedulerTick(
         // The `finally` on this loop still applies the tick's observation, which
         // is what prunes the churn window and eventually releases the breaker.
         if (settings.criticalFailurePromptEnabled && isManagedTabBreakerOpen(nextState, platform)) {
-          if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
-          else await adapter.stopWatchTab?.(previous);
+          await adapter.stopWatchTab?.(previous, undefined, options.signal);
           nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
           nextState.sessions[platform] = {
             ...session,
@@ -938,8 +921,7 @@ export async function runSchedulerTick(
         if (useTabless) {
           // Tabless: no video tab. Close any tab we previously opened for this
           // platform; the controller starts/keeps the heartbeat watcher.
-          if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
-          else await adapter.stopWatchTab?.(previous);
+          await adapter.stopWatchTab?.(previous, undefined, options.signal);
           nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
           session.watchMode = "tabless";
           session.tablessFallback = false;
@@ -961,9 +943,12 @@ export async function runSchedulerTick(
             ? { managedTab: nextState.managedWatchTabs[platform] }
             : {};
           const previousManagedTabId = nextState.managedWatchTabs?.[platform]?.tabId;
-          const prepared = options.signal
-            ? await adapter.prepareWatchTab(decision.channel, previous, watchTabOptions, options.signal)
-            : await adapter.prepareWatchTab(decision.channel, previous, watchTabOptions);
+          const prepared = await adapter.prepareWatchTab(
+            decision.channel,
+            previous,
+            watchTabOptions,
+            options.signal,
+          );
           // Only a genuinely NEW extension-managed tab counts as churn evidence.
           // Reusing the tab we already track happens on every ordinary tick, and
           // counting it would trip the breaker during completely normal farming.
@@ -1003,9 +988,7 @@ export async function runSchedulerTick(
         }
         if (autoClaimChannelPointsFor(settings, platform) && adapter.claimChannelPoints) {
           try {
-            const claimed = options.signal
-              ? await adapter.claimChannelPoints(decision.channel, options.signal)
-              : await adapter.claimChannelPoints(decision.channel);
+            const claimed = await adapter.claimChannelPoints(decision.channel, options.signal);
             if (claimed) {
               emitDiagnostic(emit, platform, "info", `Claimed channel points for ${decision.channel.displayName ?? decision.channel.username}`);
             }
@@ -1137,9 +1120,7 @@ async function claimReadyRewards(
           continue;
         }
         try {
-          const claimed = signal
-            ? await adapter.claimReward(campaign, reward, signal)
-            : await adapter.claimReward(campaign, reward);
+          const claimed = await adapter.claimReward(campaign, reward, signal);
           rewards.push(claimed ? { ...reward, status: "claimed", watchedMinutes: reward.requiredMinutes } : reward);
           if (claimed) {
             events.push({
@@ -1252,9 +1233,7 @@ async function shouldKeepWatching(
   // switch the channel based on liveness/category, so skip playback retries.
   const isTabless = previous.watchMode === "tabless";
   if (!settings.idleWatchlistFallbackOnly && !previous.campaignId && nextDecision.action === "watch") {
-    const fallbackCheck = signal
-      ? await adapter.checkChannel(previous.channel, undefined, signal)
-      : await adapter.checkChannel(previous.channel);
+    const fallbackCheck = await adapter.checkChannel(previous.channel, undefined, signal);
     const fallbackOfflineChecks = fallbackCheck.live ? 0 : previous.offlineChecks + 1;
     if (fallbackCheck.live && fallbackCheck.categoryMatches) {
       const fallbackPlaybackChecks = nextPlaybackChecks(previous, isTabless);
@@ -1289,9 +1268,7 @@ async function shouldKeepWatching(
     return { keep: false, offlineChecks: 0, playbackChecks: 0, reason: "Higher priority Idle Watchlist channel available", reasonCode: "higher_priority_idle_watchlist" };
   }
 
-  const check = signal
-    ? await adapter.checkChannel(previous.channel, undefined, signal)
-    : await adapter.checkChannel(previous.channel);
+  const check = await adapter.checkChannel(previous.channel, undefined, signal);
   const offlineChecks = check.live ? 0 : previous.offlineChecks + 1;
   if (offlineChecks >= settings.offlineRetryLimit) {
     return { keep: false, offlineChecks, playbackChecks: 0, reason: check.reason ?? "Channel offline retry limit reached", reasonCode: "channel_offline" };

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -204,6 +204,7 @@ export async function chooseCampaignDecision(
   campaigns: DropCampaign[],
   settings: EngineSettings,
   adapter: Pick<PlatformAdapter, "listCandidateChannels" | "checkChannel">,
+  signal?: AbortSignal,
 ): Promise<WatchDecision> {
   const sorted = sortCampaigns(campaigns.filter((campaign) => isEligible(campaign, settings)), settings);
   const noCampaignReason = noEligibleCampaignReason(campaigns, settings);
@@ -215,14 +216,17 @@ export async function chooseCampaignDecision(
     if (!reward) continue;
 
     const excludedChannels = settings.platform[platform].excludedChannels ?? [];
-    const candidates = (await adapter.listCandidateChannels(campaign))
+    signal?.throwIfAborted();
+    const candidates = (await (signal
+      ? adapter.listCandidateChannels(campaign, signal)
+      : adapter.listCandidateChannels(campaign)))
       .filter((candidate) => !excludedChannels.includes(candidate.username.toLowerCase()))
       .sort((left, right) => {
         if (left.isAclMatch !== right.isAclMatch) return left.isAclMatch ? -1 : 1;
         return (right.viewerCount ?? 0) - (left.viewerCount ?? 0);
       });
 
-    const channel = await firstValidCandidate(candidates, campaign, adapter);
+    const channel = await firstValidCandidate(candidates, campaign, adapter, signal);
     if (channel) {
       return {
         platform,
@@ -340,9 +344,13 @@ async function firstValidCandidate(
   candidates: ChannelCandidate[],
   campaign: DropCampaign | undefined,
   adapter: Pick<PlatformAdapter, "checkChannel">,
+  signal?: AbortSignal,
 ): Promise<ChannelCandidate | undefined> {
   for (const candidate of candidates) {
-    const check = await adapter.checkChannel(candidate, campaign);
+    signal?.throwIfAborted();
+    const check = await (signal
+      ? adapter.checkChannel(candidate, campaign, signal)
+      : adapter.checkChannel(candidate, campaign));
     if (check.live && check.categoryMatches && check.campaignMatches !== false) {
       return channelFromCheck(candidate, check);
     }
@@ -436,6 +444,7 @@ export interface SchedulerTickOptions {
   stopPageContextTabs?: StopPageContextTabs;
   waitingClaimRewardIds?: Partial<Record<Platform, Set<string>>>;
   emit?: EventEmitter;
+  signal?: AbortSignal;
 }
 
 export async function runSchedulerTick(
@@ -444,6 +453,7 @@ export async function runSchedulerTick(
   adapters: Record<Platform, PlatformAdapter>,
   options: SchedulerTickOptions = {},
 ): Promise<SchedulerTickResult> {
+  options.signal?.throwIfAborted();
   const stopPageContextTabs = options.stopPageContextTabs ?? forgetManagedPageContextTabs;
   registerManagedPageContextTabs(state.managedPageContextTabs ?? {});
   let nextState: SchedulerState = {
@@ -468,7 +478,8 @@ export async function runSchedulerTick(
     adapter: PlatformAdapter,
   ): Promise<void> {
     try {
-      await adapter.stopWatchTab?.(previous);
+      if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
+      else await adapter.stopWatchTab?.(previous);
     } catch (error) {
       emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Could not stop watch tab");
     }
@@ -522,6 +533,7 @@ export async function runSchedulerTick(
 
   const platforms = options.platforms ?? PLATFORMS;
   for (const platform of platforms) {
+    options.signal?.throwIfAborted();
     const previous = nextState.sessions[platform];
     const platformSettings = settings.platform[platform];
     const adapter = adapters[platform];
@@ -557,7 +569,8 @@ export async function runSchedulerTick(
       // recovering on this (or any later) tick. Checked before every other gate
       // so nothing re-opens a tab behind the user's back.
       if (nextState.manualClosePause?.[platform]) {
-        await adapter.stopWatchTab?.(previous);
+        if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
+        else await adapter.stopWatchTab?.(previous);
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",
@@ -584,7 +597,8 @@ export async function runSchedulerTick(
         continue;
       }
       if (settings.pauseOnManualWatch && hasRecentManualWatch(nextState, platform)) {
-        await adapter.stopWatchTab?.(previous);
+        if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
+        else await adapter.stopWatchTab?.(previous);
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",
@@ -616,7 +630,8 @@ export async function runSchedulerTick(
         // enabled; this one being off while the other still farms stays a
         // platform-scoped stop. Both reason codes remain meaningful.
         const automationOff = !isFarmingActive(settings);
-        await adapter.stopWatchTab?.(previous);
+        if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
+        else await adapter.stopWatchTab?.(previous);
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",
@@ -664,7 +679,10 @@ export async function runSchedulerTick(
           [platform]: { lastCheckedAt: new Date().toISOString() },
         };
         try {
-          for (const challenge of await adapter.claimChallenges()) {
+          const challenges = options.signal
+            ? await adapter.claimChallenges(options.signal)
+            : await adapter.claimChallenges();
+          for (const challenge of challenges) {
             emit({
               category: "activity",
               code: "challenge_claimed",
@@ -674,6 +692,7 @@ export async function runSchedulerTick(
             });
           }
         } catch (error) {
+          options.signal?.throwIfAborted();
           if (authHealthFromError(error)) throw error;
           emitDiagnostic(emit, platform, "warn", error instanceof Error ? error.message : "Challenge claim failed");
         }
@@ -701,9 +720,15 @@ export async function runSchedulerTick(
       let campaigns: DropCampaign[];
       let discoveryFailed = false;
       try {
-        const discovered = await adapter.discoverCampaigns();
-        campaigns = await adapter.readProgress(discovered, previous);
+        const discovered = options.signal
+          ? await adapter.discoverCampaigns(options.signal)
+          : await adapter.discoverCampaigns();
+        options.signal?.throwIfAborted();
+        campaigns = options.signal
+          ? await adapter.readProgress(discovered, previous, options.signal)
+          : await adapter.readProgress(discovered, previous);
       } catch (error) {
+        options.signal?.throwIfAborted();
         if (authHealthFromError(error)) throw error;
         if (!hasIdleWatchlistChannels(settings, platform)) throw error;
         // Nothing is farmable this tick, so the decision logic below runs
@@ -794,6 +819,7 @@ export async function runSchedulerTick(
           adapter,
           campaigns,
           options.waitingClaimRewardIds?.[platform] ?? new Set<string>(),
+          options.signal,
         );
         campaigns = claimResult.campaigns;
         if (!discoveryFailed) {
@@ -820,8 +846,8 @@ export async function runSchedulerTick(
         }
       }
 
-      let decision = await chooseCampaignDecision(platform, campaigns, settings, adapter);
-      const shouldKeep = await shouldKeepWatching(previous, decision, campaigns, settings, adapter);
+      let decision = await chooseCampaignDecision(platform, campaigns, settings, adapter, options.signal);
+      const shouldKeep = await shouldKeepWatching(previous, decision, campaigns, settings, adapter, options.signal);
       // The single site where a stop reason is decided for an existing watch, so
       // the precondition-break arm is set here rather than at every consumer.
       if (!shouldKeep.keep && previous.status === "watching" && ACCRUAL_PRECONDITION_BREAK_REASONS.has(shouldKeep.reasonCode)) {
@@ -875,7 +901,8 @@ export async function runSchedulerTick(
         emitDiagnostic(emit, platform, decisionLevel, decision.reason);
       }
       if (decision.action === "idle") {
-        await adapter.stopWatchTab?.(previous);
+        if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
+        else await adapter.stopWatchTab?.(previous);
         nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
       }
       const session = sessionForDecision(decision, previous, shouldKeep);
@@ -887,7 +914,8 @@ export async function runSchedulerTick(
         // The `finally` on this loop still applies the tick's observation, which
         // is what prunes the churn window and eventually releases the breaker.
         if (settings.criticalFailurePromptEnabled && isManagedTabBreakerOpen(nextState, platform)) {
-          await adapter.stopWatchTab?.(previous);
+          if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
+          else await adapter.stopWatchTab?.(previous);
           nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
           nextState.sessions[platform] = {
             ...session,
@@ -910,7 +938,8 @@ export async function runSchedulerTick(
         if (useTabless) {
           // Tabless: no video tab. Close any tab we previously opened for this
           // platform; the controller starts/keeps the heartbeat watcher.
-          await adapter.stopWatchTab?.(previous);
+          if (options.signal) await adapter.stopWatchTab?.(previous, undefined, options.signal);
+          else await adapter.stopWatchTab?.(previous);
           nextState.managedWatchTabs = withoutManagedWatchTab(nextState.managedWatchTabs, platform);
           session.watchMode = "tabless";
           session.tablessFallback = false;
@@ -932,7 +961,9 @@ export async function runSchedulerTick(
             ? { managedTab: nextState.managedWatchTabs[platform] }
             : {};
           const previousManagedTabId = nextState.managedWatchTabs?.[platform]?.tabId;
-          const prepared = await adapter.prepareWatchTab(decision.channel, previous, watchTabOptions);
+          const prepared = options.signal
+            ? await adapter.prepareWatchTab(decision.channel, previous, watchTabOptions, options.signal)
+            : await adapter.prepareWatchTab(decision.channel, previous, watchTabOptions);
           // Only a genuinely NEW extension-managed tab counts as churn evidence.
           // Reusing the tab we already track happens on every ordinary tick, and
           // counting it would trip the breaker during completely normal farming.
@@ -972,7 +1003,9 @@ export async function runSchedulerTick(
         }
         if (autoClaimChannelPointsFor(settings, platform) && adapter.claimChannelPoints) {
           try {
-            const claimed = await adapter.claimChannelPoints(decision.channel);
+            const claimed = options.signal
+              ? await adapter.claimChannelPoints(decision.channel, options.signal)
+              : await adapter.claimChannelPoints(decision.channel);
             if (claimed) {
               emitDiagnostic(emit, platform, "info", `Claimed channel points for ${decision.channel.displayName ?? decision.channel.username}`);
             }
@@ -1078,6 +1111,7 @@ async function claimReadyRewards(
   adapter: PlatformAdapter,
   campaigns: DropCampaign[],
   previouslyWaitingRewardIds: Set<string>,
+  signal?: AbortSignal,
 ): Promise<{ campaigns: DropCampaign[]; events: ClaimReadyRewardEvent[] }> {
   const events: ClaimReadyRewardEvent[] = [];
   const updated: DropCampaign[] = [];
@@ -1086,6 +1120,7 @@ async function claimReadyRewards(
   for (const campaign of campaigns) {
     const rewards: DropReward[] = [];
     for (const reward of campaign.rewards) {
+      signal?.throwIfAborted();
       if (reward.status === "claimable" && canClaimReward(reward)) {
         if (adapter.isClaimReady && !adapter.isClaimReady(reward)) {
           // Watched to completion, but the platform hasn't released the claim
@@ -1102,7 +1137,9 @@ async function claimReadyRewards(
           continue;
         }
         try {
-          const claimed = await adapter.claimReward(campaign, reward);
+          const claimed = signal
+            ? await adapter.claimReward(campaign, reward, signal)
+            : await adapter.claimReward(campaign, reward);
           rewards.push(claimed ? { ...reward, status: "claimed", watchedMinutes: reward.requiredMinutes } : reward);
           if (claimed) {
             events.push({
@@ -1180,6 +1217,7 @@ async function shouldKeepWatching(
   campaigns: readonly DropCampaign[],
   settings: EngineSettings,
   adapter: Pick<PlatformAdapter, "checkChannel">,
+  signal?: AbortSignal,
 ): Promise<{ keep: boolean; offlineChecks: number; playbackChecks: number; reason: string; reasonCode: WatchReasonCode; channel?: ChannelCandidate }> {
   if (!previous.channel || previous.status !== "watching") {
     return { keep: false, offlineChecks: 0, playbackChecks: 0, reason: "No existing watch session", reasonCode: "no_existing_session" };
@@ -1214,7 +1252,9 @@ async function shouldKeepWatching(
   // switch the channel based on liveness/category, so skip playback retries.
   const isTabless = previous.watchMode === "tabless";
   if (!settings.idleWatchlistFallbackOnly && !previous.campaignId && nextDecision.action === "watch") {
-    const fallbackCheck = await adapter.checkChannel(previous.channel);
+    const fallbackCheck = signal
+      ? await adapter.checkChannel(previous.channel, undefined, signal)
+      : await adapter.checkChannel(previous.channel);
     const fallbackOfflineChecks = fallbackCheck.live ? 0 : previous.offlineChecks + 1;
     if (fallbackCheck.live && fallbackCheck.categoryMatches) {
       const fallbackPlaybackChecks = nextPlaybackChecks(previous, isTabless);
@@ -1249,7 +1289,9 @@ async function shouldKeepWatching(
     return { keep: false, offlineChecks: 0, playbackChecks: 0, reason: "Higher priority Idle Watchlist channel available", reasonCode: "higher_priority_idle_watchlist" };
   }
 
-  const check = await adapter.checkChannel(previous.channel);
+  const check = signal
+    ? await adapter.checkChannel(previous.channel, undefined, signal)
+    : await adapter.checkChannel(previous.channel);
   const offlineChecks = check.live ? 0 : previous.offlineChecks + 1;
   if (offlineChecks >= settings.offlineRetryLimit) {
     return { keep: false, offlineChecks, playbackChecks: 0, reason: check.reason ?? "Channel offline retry limit reached", reasonCode: "channel_offline" };

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -251,7 +251,7 @@ export async function chooseCampaignDecision(
     .map((username) => username.trim().toLowerCase())
     .filter(Boolean)
     .map((username) => fallbackChannel(platform, username));
-  const fallback = await firstValidCandidate(fallbackCandidates, undefined, adapter);
+  const fallback = await firstValidCandidate(fallbackCandidates, undefined, adapter, signal);
 
   if (fallback) {
     return {
@@ -992,6 +992,7 @@ export async function runSchedulerTick(
               emitDiagnostic(emit, platform, "info", `Claimed channel points for ${decision.channel.displayName ?? decision.channel.username}`);
             }
           } catch (error) {
+            options.signal?.throwIfAborted();
             if (authHealthFromError(error)) throw error;
             emitDiagnostic(
               emit,

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -112,6 +112,7 @@ export async function openPinnedMutedTabWithBrowser(
   emit: EventEmitter = ignoreEvent,
 ): Promise<PreparedWatchTab> {
   const tabOptions = { ...DEFAULT_WATCH_TAB_OPTIONS, ...options };
+  tabOptions.signal?.throwIfAborted();
   const registered = tabOptions.managedTab ?? managedTabFromSession(session, channel.url);
 
   if (registered) {
@@ -129,6 +130,7 @@ export async function openPinnedMutedTabWithBrowser(
           await maybePrimeTabPlayback(browserApi, tab.id, channel, emit);
         }
         diagnostic(emit, "debug", `Reusing managed watch tab ${tab.id} for ${channel.username}`, channel.platform);
+        tabOptions.signal?.throwIfAborted();
         return {
           tabId: tab.id,
           managedByExtension: true,
@@ -154,6 +156,7 @@ export async function openPinnedMutedTabWithBrowser(
           await maybePrimeTabPlayback(browserApi, tab.id, channel, emit);
         }
         diagnostic(emit, "debug", `Reusing your tab ${tab.id} for ${channel.username}`, channel.platform);
+        tabOptions.signal?.throwIfAborted();
         return { tabId: tab.id, managedByExtension: false };
       }
     } catch {
@@ -183,6 +186,16 @@ export async function openPinnedMutedTabWithBrowser(
   if (tab.id == null) {
     diagnostic(emit, "error", `Could not create ${channel.platform} watch tab for ${channel.username}`, channel.platform);
     throw new Error(`Could not create ${channel.platform} watch tab`);
+  }
+  if (tabOptions.signal?.aborted) {
+    if (browserApi.tabs.remove) {
+      try {
+        await browserApi.tabs.remove(tab.id);
+      } catch {
+        // The new managed tab may already have been closed independently.
+      }
+    }
+    tabOptions.signal.throwIfAborted();
   }
   await browserApi.tabs.update(tab.id, { pinned: true, muted: tabOptions.muted, active: false });
   if (tabOptions.keepVideosUnmuted) {
@@ -321,11 +334,13 @@ function managedTab(channel: ChannelCandidate, tabId: number): ManagedWatchTab {
 
 export async function stopWatchTabWithBrowser(browserApi: BrowserTabApi, session: WatchSession, options?: Partial<WatchTabOptions>, emit: EventEmitter = ignoreEvent): Promise<void> {
   const tabOptions = { ...DEFAULT_WATCH_TAB_OPTIONS, ...options };
+  tabOptions.signal?.throwIfAborted();
   if (!session.tabId) return;
   try {
     if (session.tabManagedByExtension && tabOptions.closeManagedTabs && browserApi.tabs.remove) {
       await browserApi.tabs.remove(session.tabId);
       diagnostic(emit, "debug", `Closed managed watch tab ${session.tabId}`, session.platform);
+      tabOptions.signal?.throwIfAborted();
       return;
     }
     await browserApi.tabs.update(session.tabId, {
@@ -338,6 +353,7 @@ export async function stopWatchTabWithBrowser(browserApi: BrowserTabApi, session
     // The user may have closed the tab already.
     diagnostic(emit, "debug", `Watch tab ${session.tabId} was already closed`, session.platform);
   }
+  tabOptions.signal?.throwIfAborted();
 }
 
 // While an ad is rolling, the managed watch tab must be the active tab in a

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -551,6 +551,7 @@ export function setTwitchIntegrity(value: TwitchIntegrity | undefined, options?:
 // token must also differ from the one that was rejected.
 export interface TwitchIntegrityRequest {
   forceRefresh?: boolean;
+  signal?: AbortSignal;
   // The token the rejected request actually sent, captured before it was issued.
   // Without it a forced refresh cannot tell "this caller was rejected on a token
   // someone has already replaced" from "this caller was rejected on the token we
@@ -602,14 +603,20 @@ function hasReplacementTwitchIntegrity(rejectedToken?: string): boolean {
 // Integrity does not gate on expiry — so resolvers re-check hasValidTwitchIntegrity.
 // When rejectedToken is set, re-capturing that same token does not settle the
 // wait; the page may replay it before minting a replacement.
-function waitForIntegrityCapture(timeoutMs: number, rejectedToken?: string): Promise<boolean> {
+function waitForIntegrityCapture(
+  timeoutMs: number,
+  rejectedToken?: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  signal?.throwIfAborted();
   if (hasReplacementTwitchIntegrity(rejectedToken)) return Promise.resolve(true);
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let settled = false;
     const finish = () => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
       resolve(hasReplacementTwitchIntegrity(rejectedToken));
     };
     const onCapture = () => {
@@ -622,7 +629,14 @@ function waitForIntegrityCapture(timeoutMs: number, rejectedToken?: string): Pro
       }
       finish();
     };
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
     const timer = setTimeout(finish, timeoutMs);
+    signal?.addEventListener("abort", onAbort, { once: true });
     integrityWaiters.push(onCapture);
   });
 }
@@ -642,10 +656,11 @@ export async function ensureTwitchIntegrityWithBrowser(
   emit: EventEmitter = ignoreEvent,
   request?: TwitchIntegrityRequest,
 ): Promise<boolean> {
+  request?.signal?.throwIfAborted();
   const forceRefresh = request?.forceRefresh === true;
   if (!forceRefresh) {
     if (hasValidTwitchIntegrity()) return true;
-    return mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, undefined, false);
+    return mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, undefined, false, request?.signal);
   }
 
   // Another operation's refresh already replaced the token this caller was
@@ -658,11 +673,11 @@ export async function ensureTwitchIntegrityWithBrowser(
 
   if (inFlightForcedRefresh) {
     diagnostic(emit, "debug", "Joining the Twitch integrity refresh already in flight", "twitch");
-    return inFlightForcedRefresh;
+    return withAbortSignal(inFlightForcedRefresh, request?.signal);
   }
 
   const rejectedToken = request?.rejectedToken ?? twitchIntegrity?.integrity;
-  const refresh = mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, rejectedToken, true)
+  const refresh = mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, rejectedToken, true, request?.signal)
     .finally(() => {
       inFlightForcedRefresh = undefined;
     });
@@ -685,6 +700,7 @@ async function mintTwitchIntegrity(
   // a plain mint, which may inherit an idle tab that issues no request and can
   // only ever time out.
   forceRefresh: boolean,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   diagnostic(
     emit,
@@ -701,7 +717,7 @@ async function mintTwitchIntegrity(
       retainPageContext: { platform: "twitch" },
       emit,
       requireFreshPageContext: forceRefresh,
-    });
+    }, signal);
     // Which context we got decides whether waiting can work at all: only a
     // freshly created tab is guaranteed to boot the SPA and issue authenticated
     // GQL for the listener to read a token from. An inherited or already-idle tab
@@ -711,7 +727,7 @@ async function mintTwitchIntegrity(
     // On success the capture itself is logged once by setTwitchIntegrity (info);
     // here we only surface the failure case so the log isn't doubled up.
     const startedAt = Date.now();
-    const captured = await waitForIntegrityCapture(timeoutMs, rejectedToken);
+    const captured = await waitForIntegrityCapture(timeoutMs, rejectedToken, signal);
     const settledAt = Date.now();
     // Logged on both outcomes, not just the failure: a success that took 20s is
     // the same latency problem as a timeout, and only the phase split says which
@@ -725,11 +741,14 @@ async function mintTwitchIntegrity(
     }
     return captured;
   } catch (error) {
+    signal?.throwIfAborted();
     const message = error instanceof Error ? error.message : String(error);
     diagnostic(emit, "warn", `Could not open a twitch.tv tab to capture an integrity token: ${message}`, "twitch");
     return false;
   } finally {
-    if (pageContext) await releasePageContextTab(browserApi, origin, pageContext);
+    if (pageContext) {
+      await releasePageContextTab(browserApi, origin, pageContext, emit, signal?.aborted === true);
+    }
   }
 }
 

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -45,25 +45,25 @@ export interface PlatformAdapter {
   platform: Platform;
   readonly compatibility?: ResolvedCompatibility[Platform];
   checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth>;
-  discoverCampaigns(): Promise<DropCampaign[]>;
-  readProgress(campaigns: DropCampaign[], session?: WatchSession): Promise<DropCampaign[]>;
-  listCandidateChannels(campaign: DropCampaign): Promise<ChannelCandidate[]>;
-  checkChannel(channel: ChannelCandidate, campaign?: DropCampaign): Promise<ChannelCheck>;
-  claimReward(campaign: DropCampaign, reward: DropReward): Promise<boolean>;
+  discoverCampaigns(signal?: AbortSignal): Promise<DropCampaign[]>;
+  readProgress(campaigns: DropCampaign[], session?: WatchSession, signal?: AbortSignal): Promise<DropCampaign[]>;
+  listCandidateChannels(campaign: DropCampaign, signal?: AbortSignal): Promise<ChannelCandidate[]>;
+  checkChannel(channel: ChannelCandidate, campaign?: DropCampaign, signal?: AbortSignal): Promise<ChannelCheck>;
+  claimReward(campaign: DropCampaign, reward: DropReward, signal?: AbortSignal): Promise<boolean>;
   // Whether a "claimable" reward can actually be claimed right now. Twitch only
   // exposes the real drop-instance id once it releases the claim, so auto-claim
   // must defer until then instead of POSTing a value Twitch will reject.
   isClaimReady?(reward: DropReward): boolean;
-  claimChannelPoints?(channel: ChannelCandidate): Promise<boolean>;
+  claimChannelPoints?(channel: ChannelCandidate, signal?: AbortSignal): Promise<boolean>;
   // Claims any completed, unclaimed gamification challenges for the logged-in
   // account and reports what was won. Account-level, so it takes no channel and
   // runs regardless of whether a watch session is active.
-  claimChallenges?(): Promise<ClaimedChallenge[]>;
+  claimChallenges?(signal?: AbortSignal): Promise<ClaimedChallenge[]>;
   // Live search of the platform's categories/games, powering the "Farm only these
   // categories" picker in Settings. Returns id + name (+ box art) matches.
   searchCategories?(query: string): Promise<CategorySelection[]>;
-  prepareWatchTab(channel: ChannelCandidate, session?: WatchSession, options?: Partial<WatchTabOptions>): Promise<PreparedWatchTab>;
-  stopWatchTab?(session: WatchSession, options?: Partial<WatchTabOptions>): Promise<void>;
+  prepareWatchTab(channel: ChannelCandidate, session?: WatchSession, options?: Partial<WatchTabOptions>, signal?: AbortSignal): Promise<PreparedWatchTab>;
+  stopWatchTab?(session: WatchSession, options?: Partial<WatchTabOptions>, signal?: AbortSignal): Promise<void>;
   // Tabless (low-resource) farming. When supported, the controller drives a
   // TablessWatchController instead of opening a watch tab; the tab path stays as
   // the automatic fallback when heartbeats stop earning.

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -31,6 +31,11 @@ export interface WatchTabOptions {
   closeManagedTabs: boolean;
   keepVideosUnmuted: boolean;
   managedTab?: ManagedWatchTab;
+  signal?: AbortSignal;
+}
+
+export interface AdapterOperationOptions {
+  signal?: AbortSignal;
 }
 
 // A gamification challenge that was just claimed. Account-level, so unlike
@@ -45,25 +50,25 @@ export interface PlatformAdapter {
   platform: Platform;
   readonly compatibility?: ResolvedCompatibility[Platform];
   checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth>;
-  discoverCampaigns(signal?: AbortSignal): Promise<DropCampaign[]>;
-  readProgress(campaigns: DropCampaign[], session?: WatchSession, signal?: AbortSignal): Promise<DropCampaign[]>;
-  listCandidateChannels(campaign: DropCampaign, signal?: AbortSignal): Promise<ChannelCandidate[]>;
-  checkChannel(channel: ChannelCandidate, campaign?: DropCampaign, signal?: AbortSignal): Promise<ChannelCheck>;
-  claimReward(campaign: DropCampaign, reward: DropReward, signal?: AbortSignal): Promise<boolean>;
+  discoverCampaigns(options?: AdapterOperationOptions): Promise<DropCampaign[]>;
+  readProgress(campaigns: DropCampaign[], session?: WatchSession, options?: AdapterOperationOptions): Promise<DropCampaign[]>;
+  listCandidateChannels(campaign: DropCampaign, options?: AdapterOperationOptions): Promise<ChannelCandidate[]>;
+  checkChannel(channel: ChannelCandidate, options?: AdapterOperationOptions & { campaign?: DropCampaign }): Promise<ChannelCheck>;
+  claimReward(campaign: DropCampaign, reward: DropReward, options?: AdapterOperationOptions): Promise<boolean>;
   // Whether a "claimable" reward can actually be claimed right now. Twitch only
   // exposes the real drop-instance id once it releases the claim, so auto-claim
   // must defer until then instead of POSTing a value Twitch will reject.
   isClaimReady?(reward: DropReward): boolean;
-  claimChannelPoints?(channel: ChannelCandidate, signal?: AbortSignal): Promise<boolean>;
+  claimChannelPoints?(channel: ChannelCandidate, options?: AdapterOperationOptions): Promise<boolean>;
   // Claims any completed, unclaimed gamification challenges for the logged-in
   // account and reports what was won. Account-level, so it takes no channel and
   // runs regardless of whether a watch session is active.
-  claimChallenges?(signal?: AbortSignal): Promise<ClaimedChallenge[]>;
+  claimChallenges?(options?: AdapterOperationOptions): Promise<ClaimedChallenge[]>;
   // Live search of the platform's categories/games, powering the "Farm only these
   // categories" picker in Settings. Returns id + name (+ box art) matches.
   searchCategories?(query: string): Promise<CategorySelection[]>;
-  prepareWatchTab(channel: ChannelCandidate, session?: WatchSession, options?: Partial<WatchTabOptions>, signal?: AbortSignal): Promise<PreparedWatchTab>;
-  stopWatchTab?(session: WatchSession, options?: Partial<WatchTabOptions>, signal?: AbortSignal): Promise<void>;
+  prepareWatchTab(channel: ChannelCandidate, session?: WatchSession, options?: Partial<WatchTabOptions>): Promise<PreparedWatchTab>;
+  stopWatchTab?(session: WatchSession, options?: Partial<WatchTabOptions>): Promise<void>;
   // Tabless (low-resource) farming. When supported, the controller drives a
   // TablessWatchController instead of opening a watch tab; the tab path stays as
   // the automatic fallback when heartbeats stop earning.

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -378,7 +378,7 @@ export class KickAdapter implements PlatformAdapter {
     } catch (error) {
       signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
-      return this.checkChannelFromPage(channel, campaign, error);
+      return this.checkChannelFromPage(channel, campaign, error, signal);
     }
   }
 
@@ -507,11 +507,12 @@ export class KickAdapter implements PlatformAdapter {
     channel: ChannelCandidate,
     campaign: DropCampaign | undefined,
     originalError: unknown,
+    signal?: AbortSignal,
   ): Promise<ChannelCheck> {
     const originalMessage = originalError instanceof Error ? originalError.message : String(originalError);
     diagnostic(this.emit, "debug", `Kick API channel check failed for ${channel.username}, falling back to the channel page: ${originalMessage}`, "kick");
     try {
-      const page = await this.fetcher.fetchJson<{ html?: string }>(channel.url, undefined, this.emit);
+      const page = await this.fetcher.fetchJson<{ html?: string }>(channel.url, { signal }, this.emit);
       const html = page.html ?? "";
       const live = parseBooleanField(html, ["is_live", "isLive", "live"]) ?? html.includes("livestream");
       const actualCategoryId = parseCategoryId(html);
@@ -526,6 +527,7 @@ export class KickAdapter implements PlatformAdapter {
         },
       };
     } catch {
+      signal?.throwIfAborted();
       return {
         live: false,
         categoryMatches: false,

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -271,12 +271,12 @@ export class KickAdapter implements PlatformAdapter {
     );
   }
 
-  async discoverCampaigns(): Promise<DropCampaign[]> {
-    const data = await this.fetcher.fetchJson<unknown>("https://web.kick.com/api/v1/drops/campaigns", undefined, this.emit);
+  async discoverCampaigns(signal?: AbortSignal): Promise<DropCampaign[]> {
+    const data = await this.fetcher.fetchJson<unknown>("https://web.kick.com/api/v1/drops/campaigns", { signal }, this.emit);
     return parseKickCampaigns(data as Parameters<typeof parseKickCampaigns>[0]);
   }
 
-  async readProgress(campaigns: DropCampaign[]): Promise<DropCampaign[]> {
+  async readProgress(campaigns: DropCampaign[], _session?: WatchSession, signal?: AbortSignal): Promise<DropCampaign[]> {
     try {
       // Kick's WAF rejects authed drops endpoints that omit X-Client-Token with
       // "Request blocked by security policy." — the reference sends it on
@@ -284,10 +284,12 @@ export class KickAdapter implements PlatformAdapter {
       // 131, 67). pageFetchJson adds the Bearer from session_token on top.
       const data = await this.fetcher.fetchJson<unknown>("https://web.kick.com/api/v1/drops/progress", {
         headers: { "X-Client-Token": KICK_CLIENT_TOKEN },
+        signal,
       }, this.emit);
       const progress = mergeKickProgress(campaigns, data as Parameters<typeof mergeKickProgress>[1]);
       return this.claimCapability.reconcileProgress?.(progress, affirmativelyLinkedCampaignIds(data)) ?? progress;
     } catch (error) {
+      signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
       const message = error instanceof Error ? error.message : String(error);
       diagnostic(this.emit, "warn", `Could not read Kick drop progress; using last-known progress: ${message}`, "kick");
@@ -308,7 +310,7 @@ export class KickAdapter implements PlatformAdapter {
     return parseKickCategories(data);
   }
 
-  async listCandidateChannels(campaign: DropCampaign): Promise<ChannelCandidate[]> {
+  async listCandidateChannels(campaign: DropCampaign, signal?: AbortSignal): Promise<ChannelCandidate[]> {
     const aclCandidates = kickCandidatesFromCampaign(campaign);
     if (aclCandidates.length > 0) return aclCandidates;
 
@@ -317,7 +319,7 @@ export class KickAdapter implements PlatformAdapter {
     url.searchParams.set("sort", "viewer_count_desc");
     if (campaign.categoryId) url.searchParams.set("category_id", campaign.categoryId);
 
-    const response = await this.fetcher.fetchJson<KickLivestreamsResponse>(url.toString(), undefined, this.emit);
+    const response = await this.fetcher.fetchJson<KickLivestreamsResponse>(url.toString(), { signal }, this.emit);
     const streams = Array.isArray(response.data) ? response.data : response.data?.livestreams ?? [];
     return streams.map((stream): ChannelCandidate => {
       const username = stream.channel?.slug ?? stream.channel?.username ?? stream.slug ?? "";
@@ -337,11 +339,11 @@ export class KickAdapter implements PlatformAdapter {
     }).filter((candidate) => Boolean(candidate.username));
   }
 
-  async checkChannel(channel: ChannelCandidate, campaign?: DropCampaign): Promise<ChannelCheck> {
+  async checkChannel(channel: ChannelCandidate, campaign?: DropCampaign, signal?: AbortSignal): Promise<ChannelCheck> {
     try {
       const data = await this.fetcher.fetchJson<KickChannelResponse>(
         `https://kick.com/api/v2/channels/${encodeURIComponent(channel.username)}`,
-        undefined,
+        { signal },
         this.emit,
       );
       const livestream = data.livestream;
@@ -364,12 +366,13 @@ export class KickAdapter implements PlatformAdapter {
         },
       };
     } catch (error) {
+      signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
       return this.checkChannelFromPage(channel, campaign, error);
     }
   }
 
-  async claimReward(campaign: DropCampaign, reward: DropReward): Promise<boolean> {
+  async claimReward(campaign: DropCampaign, reward: DropReward, signal?: AbortSignal): Promise<boolean> {
     if (!reward.claimId && reward.status !== "claimable") return false;
     if (this.claimCapability.isSuppressed?.(campaign, reward)) return false;
     // JSON.stringify drops `undefined`, so when no claim id was carried by
@@ -394,6 +397,7 @@ export class KickAdapter implements PlatformAdapter {
             reward_id: reward.id,
             claim_id: reward.claimId,
           }),
+          signal,
         },
         this.emit,
       );
@@ -405,6 +409,7 @@ export class KickAdapter implements PlatformAdapter {
       }
       return false;
     } catch (error) {
+      signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
       // Kick accrues watch progress before the account is linked, but rejects
       // the claim until you connect the org account. Turn that into actionable
@@ -424,10 +429,10 @@ export class KickAdapter implements PlatformAdapter {
     }
   }
 
-  async claimChallenges(): Promise<ClaimedChallenge[]> {
+  async claimChallenges(signal?: AbortSignal): Promise<ClaimedChallenge[]> {
     const response = await this.fetcher.fetchJson<KickChallengesResponse>(
       "https://web.kick.com/api/v1/gamification/challenges",
-      undefined,
+      { signal },
       this.emit,
     );
     const claimed: ClaimedChallenge[] = [];
@@ -441,7 +446,7 @@ export class KickAdapter implements PlatformAdapter {
       try {
         const result = await this.fetcher.fetchJson<KickChallengeClaimResponse>(
           `https://web.kick.com/api/v1/gamification/challenges/${encodeURIComponent(id)}/claim`,
-          { method: "POST" },
+          { method: "POST", signal },
           this.emit,
         );
         const rarity = result?.data?.winner?.rarity;
@@ -451,6 +456,7 @@ export class KickAdapter implements PlatformAdapter {
           recurrence: typeof challenge.recurrence === "string" && challenge.recurrence.trim() ? challenge.recurrence.trim() : "unknown",
         });
       } catch (error) {
+        signal?.throwIfAborted();
         if (authHealthFromError(error)) throw error;
         diagnostic(this.emit, "warn", `Kick challenge ${id} claim failed: ${error instanceof Error ? error.message : String(error)}`, "kick");
       }

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -3,7 +3,7 @@ import type { EventEmitter } from "@lurkloot/shared/events";
 import type { TablessWatchController } from "../../core/tablessWatch";
 import { KickWafBlockedError } from "../../core/tabs";
 import { authHealthFromError } from "../../core/fetchError";
-import { diagnostic, ignoreEvent, unavailableWatchTabPort, type ClaimedChallenge, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
+import { diagnostic, ignoreEvent, unavailableWatchTabPort, type AdapterOperationOptions, type ClaimedChallenge, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { kickCandidatesFromCampaign, mergeKickProgress, parseKickCampaigns } from "./parser";
 import { KICK_CLIENT_TOKEN, KickWatcher, type WebSocketFactory } from "./watch";
 import type { ResolvedCompatibility } from "../../compatibility/types";
@@ -271,12 +271,16 @@ export class KickAdapter implements PlatformAdapter {
     );
   }
 
-  async discoverCampaigns(signal?: AbortSignal): Promise<DropCampaign[]> {
+  async discoverCampaigns({ signal }: AdapterOperationOptions = {}): Promise<DropCampaign[]> {
     const data = await this.fetcher.fetchJson<unknown>("https://web.kick.com/api/v1/drops/campaigns", { signal }, this.emit);
     return parseKickCampaigns(data as Parameters<typeof parseKickCampaigns>[0]);
   }
 
-  async readProgress(campaigns: DropCampaign[], _session?: WatchSession, signal?: AbortSignal): Promise<DropCampaign[]> {
+  async readProgress(
+    campaigns: DropCampaign[],
+    _session?: WatchSession,
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<DropCampaign[]> {
     try {
       // Kick's WAF rejects authed drops endpoints that omit X-Client-Token with
       // "Request blocked by security policy." — the reference sends it on
@@ -310,7 +314,10 @@ export class KickAdapter implements PlatformAdapter {
     return parseKickCategories(data);
   }
 
-  async listCandidateChannels(campaign: DropCampaign, signal?: AbortSignal): Promise<ChannelCandidate[]> {
+  async listCandidateChannels(
+    campaign: DropCampaign,
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<ChannelCandidate[]> {
     const aclCandidates = kickCandidatesFromCampaign(campaign);
     if (aclCandidates.length > 0) return aclCandidates;
 
@@ -339,7 +346,10 @@ export class KickAdapter implements PlatformAdapter {
     }).filter((candidate) => Boolean(candidate.username));
   }
 
-  async checkChannel(channel: ChannelCandidate, campaign?: DropCampaign, signal?: AbortSignal): Promise<ChannelCheck> {
+  async checkChannel(
+    channel: ChannelCandidate,
+    { campaign, signal }: AdapterOperationOptions & { campaign?: DropCampaign } = {},
+  ): Promise<ChannelCheck> {
     try {
       const data = await this.fetcher.fetchJson<KickChannelResponse>(
         `https://kick.com/api/v2/channels/${encodeURIComponent(channel.username)}`,
@@ -372,7 +382,11 @@ export class KickAdapter implements PlatformAdapter {
     }
   }
 
-  async claimReward(campaign: DropCampaign, reward: DropReward, signal?: AbortSignal): Promise<boolean> {
+  async claimReward(
+    campaign: DropCampaign,
+    reward: DropReward,
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<boolean> {
     if (!reward.claimId && reward.status !== "claimable") return false;
     if (this.claimCapability.isSuppressed?.(campaign, reward)) return false;
     // JSON.stringify drops `undefined`, so when no claim id was carried by
@@ -429,7 +443,7 @@ export class KickAdapter implements PlatformAdapter {
     }
   }
 
-  async claimChallenges(signal?: AbortSignal): Promise<ClaimedChallenge[]> {
+  async claimChallenges({ signal }: AdapterOperationOptions = {}): Promise<ClaimedChallenge[]> {
     const response = await this.fetcher.fetchJson<KickChallengesResponse>(
       "https://web.kick.com/api/v1/gamification/challenges",
       { signal },

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -472,6 +472,7 @@ export function createTwitchGqlTransport(
       try {
         raw = await fetcher.fetchJson<unknown>("https://gql.twitch.tv/gql", request, emit);
       } catch (error) {
+        signal?.throwIfAborted();
         if (authHealthFromError(error)) throw error;
         const message = error instanceof Error ? error.message : `${operationName} request failed`;
         throw stamp(new TwitchGqlFailure("network", message));
@@ -599,22 +600,23 @@ export class TwitchAdapter implements PlatformAdapter {
     );
   }
 
-  async discoverCampaigns(): Promise<DropCampaign[]> {
-    let inventory = await this.fetchInventory();
-    let dashboardResult = await this.fetchDashboard(TWITCH_QUERIES.dashboard.variables);
+  async discoverCampaigns(signal?: AbortSignal): Promise<DropCampaign[]> {
+    let inventory = await this.fetchInventory(undefined, signal);
+    let dashboardResult = await this.fetchDashboard(TWITCH_QUERIES.dashboard.variables, signal);
     let inventoryCampaigns = this.inventoryCapability.parse(inventory);
     let dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
 
     if (inventoryCampaigns.length === 0 && dashboardCampaigns.length === 0) {
       try {
-        inventory = await this.fetchInventory({ fetchRewardCampaigns: true });
-        const fallbackDashboardResult = await this.fetchDashboard({ fetchRewardCampaigns: true });
+        inventory = await this.fetchInventory({ fetchRewardCampaigns: true }, signal);
+        const fallbackDashboardResult = await this.fetchDashboard({ fetchRewardCampaigns: true }, signal);
         inventoryCampaigns = this.inventoryCapability.parse(inventory);
         if (fallbackDashboardResult.ok || !dashboardResult.ok) {
           dashboardResult = fallbackDashboardResult;
           dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
         }
       } catch (error) {
+        signal?.throwIfAborted();
         if (authHealthFromError(error)) throw error;
         const message = error instanceof Error ? error.message : String(error);
         diagnostic(
@@ -672,9 +674,10 @@ export class TwitchAdapter implements PlatformAdapter {
         this.gqlWithIntegrityRetry<TwitchCampaignDetailsData>("DropCampaignDetails", TWITCH_QUERIES.campaignDetailsHash, {
           channelLogin: userLogin,
           dropID,
-        }),
+        }, undefined, undefined, this.emit, signal),
       ),
     );
+    signal?.throwIfAborted();
     for (const result of details) {
       if (result.status === "rejected" && authHealthFromError(result.reason)) throw result.reason;
     }
@@ -740,14 +743,14 @@ export class TwitchAdapter implements PlatformAdapter {
     return [...mergedDetails, ...inventoryOnly];
   }
 
-  async readProgress(campaigns: DropCampaign[], session?: WatchSession): Promise<DropCampaign[]> {
-    const inventory = await this.fetchInventory();
+  async readProgress(campaigns: DropCampaign[], session?: WatchSession, signal?: AbortSignal): Promise<DropCampaign[]> {
+    const inventory = await this.fetchInventory(undefined, signal);
     const inventoryProgress = this.inventoryCapability.reconcileProgress(campaigns, inventory);
     if (!session?.channel || session.status !== "watching") return inventoryProgress;
-    return this.mergeCurrentSessionProgress(inventoryProgress, session.channel);
+    return this.mergeCurrentSessionProgress(inventoryProgress, session.channel, signal);
   }
 
-  async listCandidateChannels(campaign: DropCampaign): Promise<ChannelCandidate[]> {
+  async listCandidateChannels(campaign: DropCampaign, signal?: AbortSignal): Promise<ChannelCandidate[]> {
     const aclCandidates = twitchCandidatesFromCampaign(campaign);
     if (aclCandidates.length > 0) return aclCandidates;
     if (!campaign.slug && !campaign.categoryId) return [];
@@ -768,7 +771,7 @@ export class TwitchAdapter implements PlatformAdapter {
       },
       sortTypeIsRecency: false,
       limit: 25,
-    });
+    }, undefined, undefined, this.emit, signal);
 
     return (response.data?.game?.streams?.edges ?? [])
       .map((edge): ChannelCandidate | undefined => {
@@ -792,7 +795,7 @@ export class TwitchAdapter implements PlatformAdapter {
       .filter((candidate): candidate is ChannelCandidate => Boolean(candidate));
   }
 
-  async checkChannel(channel: ChannelCandidate, campaign?: DropCampaign): Promise<ChannelCheck> {
+  async checkChannel(channel: ChannelCandidate, campaign?: DropCampaign, signal?: AbortSignal): Promise<ChannelCheck> {
     try {
       const response = await this.gql<TwitchStreamInfoData>(
         "StreamInfo",
@@ -802,6 +805,8 @@ export class TwitchAdapter implements PlatformAdapter {
         // Anonymous: this is public data, and logged-in GQL calls without an
         // integrity token are rejected (which would mask the channel as live).
         "omit",
+        this.emit,
+        signal,
       );
       const stream = response.data?.user?.stream;
       const channelId = response.data?.user?.id;
@@ -809,7 +814,7 @@ export class TwitchAdapter implements PlatformAdapter {
       const expectedCategoryId = campaign?.categoryId ?? channel.categoryId;
       const categoryMatches = !expectedCategoryId || actualCategoryId === expectedCategoryId;
       const campaignMatches = stream && categoryMatches && campaign && channelId
-        ? await this.checkCampaignAvailability(channelId, campaign.id, channel.username)
+        ? await this.checkCampaignAvailability(channelId, campaign.id, channel.username, signal)
         : undefined;
       return {
         live: Boolean(stream),
@@ -831,6 +836,7 @@ export class TwitchAdapter implements PlatformAdapter {
         },
       };
     } catch (error) {
+      signal?.throwIfAborted();
       return this.checkChannelFromPage(channel, campaign, error);
     }
   }
@@ -839,6 +845,7 @@ export class TwitchAdapter implements PlatformAdapter {
     channelId: string,
     campaignId: string,
     channelLogin: string,
+    signal?: AbortSignal,
   ): Promise<boolean | undefined> {
     const cached = this.availableCampaignsByChannel.get(channelId);
     if (cached && cached.expiresAt > Date.now()) {
@@ -851,6 +858,10 @@ export class TwitchAdapter implements PlatformAdapter {
         "DropsHighlightService_AvailableDrops",
         TWITCH_QUERIES.availableDropsHash,
         { channelID: channelId },
+        undefined,
+        undefined,
+        this.emit,
+        signal,
       );
       const campaigns = response.data?.channel?.viewerDropCampaigns;
       if (!Array.isArray(campaigns)) {
@@ -867,6 +878,7 @@ export class TwitchAdapter implements PlatformAdapter {
       });
       return campaignIds.has(campaignId);
     } catch (error) {
+      signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
       const message = error instanceof Error ? error.message : String(error);
       diagnostic(this.emit, "debug", `Could not confirm available Twitch campaigns for ${channelLogin}; using live/category validation: ${message}`, "twitch");
@@ -895,13 +907,16 @@ export class TwitchAdapter implements PlatformAdapter {
       .filter((category) => category.id && category.name);
   }
 
-  private async fetchInventory(variables: Record<string, unknown> = { ...this.inventoryCapability.variables }): Promise<unknown> {
+  private async fetchInventory(
+    variables: Record<string, unknown> = { ...this.inventoryCapability.variables },
+    signal?: AbortSignal,
+  ): Promise<unknown> {
     try {
-      return await this.gqlWithIntegrityRetry<unknown>("Inventory", this.inventoryCapability.hash, variables);
+      return await this.gqlWithIntegrityRetry<unknown>("Inventory", this.inventoryCapability.hash, variables, undefined, undefined, this.emit, signal);
     } catch (error) {
       if (!(error instanceof Error) || !/PersistedQueryNotFound/i.test(error.message)) throw error;
       diagnostic(this.emit, "debug", `GQL Inventory persisted query not found for ${this.inventoryCapability.id}; retrying with its inline query`, "twitch");
-      return this.gqlWithIntegrityRetry<unknown>("Inventory", this.inventoryCapability.hash, variables, this.inventoryCapability.inlineQuery);
+      return this.gqlWithIntegrityRetry<unknown>("Inventory", this.inventoryCapability.hash, variables, this.inventoryCapability.inlineQuery, undefined, this.emit, signal);
     }
   }
 
@@ -909,15 +924,21 @@ export class TwitchAdapter implements PlatformAdapter {
   // "Twitch says there are no campaigns" from "Twitch did not answer".
   private async fetchDashboard(
     variables: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<{ response: TwitchGqlResponse<TwitchDashboardData>; ok: boolean }> {
     try {
       const response = await this.gqlWithIntegrityRetry<TwitchDashboardData>(
         TWITCH_QUERIES.dashboard.operationName,
         TWITCH_QUERIES.dashboard.sha256Hash,
         variables,
+        undefined,
+        undefined,
+        this.emit,
+        signal,
       );
       return { response, ok: true };
     } catch (error) {
+      signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
       const message = error instanceof Error ? error.message : String(error);
       diagnostic(this.emit, "warn", `Twitch drops dashboard request failed; reusing the last campaign list it returned: ${message}`, "twitch");
@@ -931,7 +952,7 @@ export class TwitchAdapter implements PlatformAdapter {
     return Boolean(reward.claimId);
   }
 
-  async claimReward(campaign: DropCampaign, reward: DropReward): Promise<boolean> {
+  async claimReward(campaign: DropCampaign, reward: DropReward, signal?: AbortSignal): Promise<boolean> {
     if (!reward.claimId) return false;
 
     diagnostic(this.emit, "debug", `Claiming ${reward.name} from ${campaign.name} (instance ${reward.claimId})`, "twitch");
@@ -939,10 +960,11 @@ export class TwitchAdapter implements PlatformAdapter {
     // live twitch.tv page (see src/core/twitchIntegrity.ts). Proactively ensure one
     // exists first so a tabless / no-tab session can still claim. This is a no-op
     // fast path when a token is already captured.
-    await this.ensureIntegrity();
+    if (signal) await this.ensureIntegrity({ signal });
+    else await this.ensureIntegrity();
 
     try {
-      return await this.runClaim(reward);
+      return await this.runClaim(reward, signal);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // Only integrity rejections are worth a refresh + retry; everything else
@@ -952,17 +974,26 @@ export class TwitchAdapter implements PlatformAdapter {
       // Twitch rejected the token it was sent, so the local expiry says nothing:
       // only a forced refresh replaces it. Retry exactly once; a second failure
       // propagates.
-      const refreshed = await this.ensureIntegrity({ forceRefresh: true, rejectedToken: sentIntegrityToken(error) });
-      if (refreshed) return await this.runClaim(reward);
+      const rejectedToken = sentIntegrityToken(error);
+      const refreshed = await this.ensureIntegrity({
+        forceRefresh: true,
+        ...(rejectedToken ? { rejectedToken } : {}),
+        ...(signal ? { signal } : {}),
+      });
+      if (refreshed) return await this.runClaim(reward, signal);
       throw new Error(`Twitch rejected the claim for ${reward.name} (${message}). Keep a logged-in twitch.tv tab open so the extension can capture a valid integrity token, then retry.`);
     }
   }
 
-  private async runClaim(reward: DropReward): Promise<boolean> {
+  private async runClaim(reward: DropReward, signal?: AbortSignal): Promise<boolean> {
     const result = await this.gql<{ claimDropRewards?: { status?: string } }>(
       "DropsPage_ClaimDropRewards",
       TWITCH_QUERIES.claimHash,
       { input: { dropInstanceID: reward.claimId } },
+      undefined,
+      undefined,
+      this.emit,
+      signal,
     );
     const status = result.data?.claimDropRewards?.status;
     if (status === "ELIGIBLE_FOR_ALL" || status === "DROP_INSTANCE_ALREADY_CLAIMED") return true;
@@ -971,11 +1002,15 @@ export class TwitchAdapter implements PlatformAdapter {
     throw new Error(`Twitch refused claim for ${reward.name}: status=${status ?? "unknown"}`);
   }
 
-  async claimChannelPoints(channel: ChannelCandidate): Promise<boolean> {
+  async claimChannelPoints(channel: ChannelCandidate, signal?: AbortSignal): Promise<boolean> {
     const context = await this.gqlWithIntegrityRetry<TwitchChannelPointsData>(
       "ChannelPointsContext",
       TWITCH_QUERIES.channelPointsHash,
       { channelLogin: channel.username },
+      undefined,
+      undefined,
+      this.emit,
+      signal,
     );
     const channelId = context.data?.community?.channel?.id;
     const claimId = context.data?.community?.channel?.self?.communityPoints?.availableClaim?.id;
@@ -985,22 +1020,32 @@ export class TwitchAdapter implements PlatformAdapter {
     // exists first (a no-op fast path when a token is already captured), then
     // recover explicitly rather than through a generic transport retry — the
     // same claim id must never be replayed more than once.
-    await this.ensureIntegrity();
+    if (signal) await this.ensureIntegrity({ signal });
+    else await this.ensureIntegrity();
     try {
-      return await this.runChannelPointsClaim(claimId, channelId);
+      return await this.runChannelPointsClaim(claimId, channelId, signal);
     } catch (error) {
       if (!isIntegrityRejection(error)) throw error;
       diagnostic(this.emit, "warn", `Channel-points claim for ${channel.username} was rejected for integrity; refreshing the token and retrying once`, "twitch");
-      if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken: sentIntegrityToken(error) })) throw error;
-      return await this.runChannelPointsClaim(claimId, channelId);
+      const rejectedToken = sentIntegrityToken(error);
+      if (!await this.ensureIntegrity({
+        forceRefresh: true,
+        ...(rejectedToken ? { rejectedToken } : {}),
+        ...(signal ? { signal } : {}),
+      })) throw error;
+      return await this.runChannelPointsClaim(claimId, channelId, signal);
     }
   }
 
-  private async runChannelPointsClaim(claimId: string, channelId: string): Promise<boolean> {
+  private async runChannelPointsClaim(claimId: string, channelId: string, signal?: AbortSignal): Promise<boolean> {
     const result = await this.gql<{ claimCommunityPoints?: { status?: string } }>(
       "ClaimCommunityPoints",
       TWITCH_QUERIES.claimCommunityPointsHash,
       { input: { claimID: claimId, channelID: channelId } },
+      undefined,
+      undefined,
+      this.emit,
+      signal,
     );
     return result.data?.claimCommunityPoints?.status !== "CLAIM_NOT_AVAILABLE";
   }
@@ -1030,12 +1075,17 @@ export class TwitchAdapter implements PlatformAdapter {
   private async mergeCurrentSessionProgress(
     campaigns: DropCampaign[],
     channel: ChannelCandidate,
+    signal?: AbortSignal,
   ): Promise<DropCampaign[]> {
     try {
       const streamInfo = await this.gqlWithIntegrityRetry<TwitchStreamInfoData>(
         "VideoPlayerStreamInfoOverlayChannel",
         TWITCH_QUERIES.streamInfoHash,
         { channel: channel.username },
+        undefined,
+        undefined,
+        this.emit,
+        signal,
       );
       const channelId = streamInfo.data?.user?.id;
       if (!channelId) return campaigns;
@@ -1044,6 +1094,10 @@ export class TwitchAdapter implements PlatformAdapter {
         "DropCurrentSessionContext",
         TWITCH_QUERIES.currentDropHash,
         { channelID: channelId, channelLogin: "" },
+        undefined,
+        undefined,
+        this.emit,
+        signal,
       );
       const drop = current.data?.currentUser?.dropCurrentSession;
       if (!drop?.dropID || drop.currentMinutesWatched == null) return campaigns;
@@ -1065,6 +1119,7 @@ export class TwitchAdapter implements PlatformAdapter {
           : { ...reward, isCurrentReward: false }),
       }));
     } catch (error) {
+      signal?.throwIfAborted();
       const message = error instanceof Error ? error.message : String(error);
       diagnostic(this.emit, "warn", `Could not merge current session progress for ${channel.username}: ${message}`, "twitch");
       return campaigns;
@@ -1108,7 +1163,12 @@ export class TwitchAdapter implements PlatformAdapter {
       // Taken from the failure, which carries the token the request actually
       // sent. Re-reading it here would race a concurrent capture and could
       // report a token this request never used.
-      if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken: sentIntegrityToken(error) })) throw error;
+      const rejectedToken = sentIntegrityToken(error);
+      if (!await this.ensureIntegrity({
+        forceRefresh: true,
+        ...(rejectedToken ? { rejectedToken } : {}),
+        ...(signal ? { signal } : {}),
+      })) throw error;
       return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
     }
   }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -960,8 +960,7 @@ export class TwitchAdapter implements PlatformAdapter {
     // live twitch.tv page (see src/core/twitchIntegrity.ts). Proactively ensure one
     // exists first so a tabless / no-tab session can still claim. This is a no-op
     // fast path when a token is already captured.
-    if (signal) await this.ensureIntegrity({ signal });
-    else await this.ensureIntegrity();
+    await this.ensureIntegrity({ signal });
 
     try {
       return await this.runClaim(reward, signal);
@@ -977,8 +976,8 @@ export class TwitchAdapter implements PlatformAdapter {
       const rejectedToken = sentIntegrityToken(error);
       const refreshed = await this.ensureIntegrity({
         forceRefresh: true,
-        ...(rejectedToken ? { rejectedToken } : {}),
-        ...(signal ? { signal } : {}),
+        rejectedToken,
+        signal,
       });
       if (refreshed) return await this.runClaim(reward, signal);
       throw new Error(`Twitch rejected the claim for ${reward.name} (${message}). Keep a logged-in twitch.tv tab open so the extension can capture a valid integrity token, then retry.`);
@@ -1020,8 +1019,7 @@ export class TwitchAdapter implements PlatformAdapter {
     // exists first (a no-op fast path when a token is already captured), then
     // recover explicitly rather than through a generic transport retry — the
     // same claim id must never be replayed more than once.
-    if (signal) await this.ensureIntegrity({ signal });
-    else await this.ensureIntegrity();
+    await this.ensureIntegrity({ signal });
     try {
       return await this.runChannelPointsClaim(claimId, channelId, signal);
     } catch (error) {
@@ -1030,8 +1028,8 @@ export class TwitchAdapter implements PlatformAdapter {
       const rejectedToken = sentIntegrityToken(error);
       if (!await this.ensureIntegrity({
         forceRefresh: true,
-        ...(rejectedToken ? { rejectedToken } : {}),
-        ...(signal ? { signal } : {}),
+        rejectedToken,
+        signal,
       })) throw error;
       return await this.runChannelPointsClaim(claimId, channelId, signal);
     }
@@ -1166,8 +1164,8 @@ export class TwitchAdapter implements PlatformAdapter {
       const rejectedToken = sentIntegrityToken(error);
       if (!await this.ensureIntegrity({
         forceRefresh: true,
-        ...(rejectedToken ? { rejectedToken } : {}),
-        ...(signal ? { signal } : {}),
+        rejectedToken,
+        signal,
       })) throw error;
       return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
     }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -5,7 +5,7 @@ import { authHealthFromError, SafeFetchError } from "../../core/fetchError";
 import type { TwitchIntegrityRequest } from "../../core/tabs";
 import type { TwitchIntegrity } from "../../core/twitchIntegrity";
 import { PendingWatcherDiagnostics, type HeartbeatResult, type TablessWatchController, type WatchContext } from "../../core/tablessWatch";
-import { diagnostic, ignoreEvent, unavailableWatchTabPort, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
+import { diagnostic, ignoreEvent, unavailableWatchTabPort, type AdapterOperationOptions, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { campaignHasClaimableReward, mergeTwitchCampaignProgress, parseTwitchCampaigns, twitchCandidatesFromCampaign, withCampaignStatus } from "./parser";
 import type { ResolvedCompatibility, TwitchIdentity } from "../../compatibility/types";
 import { createTwitchHeartbeat } from "./heartbeat/factory";
@@ -600,15 +600,18 @@ export class TwitchAdapter implements PlatformAdapter {
     );
   }
 
-  async discoverCampaigns(signal?: AbortSignal): Promise<DropCampaign[]> {
-    let inventory = await this.fetchInventory(undefined, signal);
+  async discoverCampaigns({ signal }: AdapterOperationOptions = {}): Promise<DropCampaign[]> {
+    let inventory = await this.fetchInventory({ signal });
     let dashboardResult = await this.fetchDashboard(TWITCH_QUERIES.dashboard.variables, signal);
     let inventoryCampaigns = this.inventoryCapability.parse(inventory);
     let dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
 
     if (inventoryCampaigns.length === 0 && dashboardCampaigns.length === 0) {
       try {
-        inventory = await this.fetchInventory({ fetchRewardCampaigns: true }, signal);
+        inventory = await this.fetchInventory({
+          variables: { fetchRewardCampaigns: true },
+          signal,
+        });
         const fallbackDashboardResult = await this.fetchDashboard({ fetchRewardCampaigns: true }, signal);
         inventoryCampaigns = this.inventoryCapability.parse(inventory);
         if (fallbackDashboardResult.ok || !dashboardResult.ok) {
@@ -743,14 +746,21 @@ export class TwitchAdapter implements PlatformAdapter {
     return [...mergedDetails, ...inventoryOnly];
   }
 
-  async readProgress(campaigns: DropCampaign[], session?: WatchSession, signal?: AbortSignal): Promise<DropCampaign[]> {
-    const inventory = await this.fetchInventory(undefined, signal);
+  async readProgress(
+    campaigns: DropCampaign[],
+    session?: WatchSession,
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<DropCampaign[]> {
+    const inventory = await this.fetchInventory({ signal });
     const inventoryProgress = this.inventoryCapability.reconcileProgress(campaigns, inventory);
     if (!session?.channel || session.status !== "watching") return inventoryProgress;
     return this.mergeCurrentSessionProgress(inventoryProgress, session.channel, signal);
   }
 
-  async listCandidateChannels(campaign: DropCampaign, signal?: AbortSignal): Promise<ChannelCandidate[]> {
+  async listCandidateChannels(
+    campaign: DropCampaign,
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<ChannelCandidate[]> {
     const aclCandidates = twitchCandidatesFromCampaign(campaign);
     if (aclCandidates.length > 0) return aclCandidates;
     if (!campaign.slug && !campaign.categoryId) return [];
@@ -795,7 +805,10 @@ export class TwitchAdapter implements PlatformAdapter {
       .filter((candidate): candidate is ChannelCandidate => Boolean(candidate));
   }
 
-  async checkChannel(channel: ChannelCandidate, campaign?: DropCampaign, signal?: AbortSignal): Promise<ChannelCheck> {
+  async checkChannel(
+    channel: ChannelCandidate,
+    { campaign, signal }: AdapterOperationOptions & { campaign?: DropCampaign } = {},
+  ): Promise<ChannelCheck> {
     try {
       const response = await this.gql<TwitchStreamInfoData>(
         "StreamInfo",
@@ -907,10 +920,13 @@ export class TwitchAdapter implements PlatformAdapter {
       .filter((category) => category.id && category.name);
   }
 
-  private async fetchInventory(
-    variables: Record<string, unknown> = { ...this.inventoryCapability.variables },
-    signal?: AbortSignal,
-  ): Promise<unknown> {
+  private async fetchInventory({
+    variables = { ...this.inventoryCapability.variables },
+    signal,
+  }: {
+    variables?: Record<string, unknown>;
+    signal?: AbortSignal;
+  } = {}): Promise<unknown> {
     try {
       return await this.gqlWithIntegrityRetry<unknown>("Inventory", this.inventoryCapability.hash, variables, undefined, undefined, this.emit, signal);
     } catch (error) {
@@ -952,7 +968,11 @@ export class TwitchAdapter implements PlatformAdapter {
     return Boolean(reward.claimId);
   }
 
-  async claimReward(campaign: DropCampaign, reward: DropReward, signal?: AbortSignal): Promise<boolean> {
+  async claimReward(
+    campaign: DropCampaign,
+    reward: DropReward,
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<boolean> {
     if (!reward.claimId) return false;
 
     diagnostic(this.emit, "debug", `Claiming ${reward.name} from ${campaign.name} (instance ${reward.claimId})`, "twitch");
@@ -1001,7 +1021,10 @@ export class TwitchAdapter implements PlatformAdapter {
     throw new Error(`Twitch refused claim for ${reward.name}: status=${status ?? "unknown"}`);
   }
 
-  async claimChannelPoints(channel: ChannelCandidate, signal?: AbortSignal): Promise<boolean> {
+  async claimChannelPoints(
+    channel: ChannelCandidate,
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<boolean> {
     const context = await this.gqlWithIntegrityRetry<TwitchChannelPointsData>(
       "ChannelPointsContext",
       TWITCH_QUERIES.channelPointsHash,

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -850,7 +850,7 @@ export class TwitchAdapter implements PlatformAdapter {
       };
     } catch (error) {
       signal?.throwIfAborted();
-      return this.checkChannelFromPage(channel, campaign, error);
+      return this.checkChannelFromPage(channel, campaign, error, signal);
     }
   }
 
@@ -1198,11 +1198,12 @@ export class TwitchAdapter implements PlatformAdapter {
     channel: ChannelCandidate,
     campaign: DropCampaign | undefined,
     originalError: unknown,
+    signal?: AbortSignal,
   ): Promise<ChannelCheck> {
     const originalMessage = originalError instanceof Error ? originalError.message : String(originalError);
     diagnostic(this.emit, "debug", `Channel GQL check failed for ${channel.username}, falling back to the channel page: ${originalMessage}`, "twitch");
     try {
-      const page = await this.fetcher.fetchJson<{ html?: string }>(channel.url, undefined, this.emit);
+      const page = await this.fetcher.fetchJson<{ html?: string }>(channel.url, { signal }, this.emit);
       const html = page.html ?? "";
       const live = parseLiveState(html);
       if (!live) {
@@ -1220,6 +1221,7 @@ export class TwitchAdapter implements PlatformAdapter {
         },
       };
     } catch {
+      signal?.throwIfAborted();
       return {
         live: false,
         categoryMatches: false,

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2919,7 +2919,10 @@ describe("TwitchAdapter integrity recovery", () => {
 
       expect(attempts.get("DropsPage_ClaimDropRewards")).toBe(2);
       // Proactive fast path first, then an explicit forced refresh.
-      expect(ensureIntegrity.mock.calls).toEqual([[], [{ forceRefresh: true }]]);
+      expect(ensureIntegrity.mock.calls).toEqual([
+        [{ signal: undefined }],
+        [{ forceRefresh: true, rejectedToken: undefined, signal: undefined }],
+      ]);
     });
 
     it("recovers the channel-points context through the safe-read path", async () => {
@@ -2961,7 +2964,10 @@ describe("TwitchAdapter integrity recovery", () => {
       })).resolves.toBe(true);
 
       expect(attempts.get("ClaimCommunityPoints")).toBe(2);
-      expect(ensureIntegrity.mock.calls).toEqual([[], [{ forceRefresh: true }]]);
+      expect(ensureIntegrity.mock.calls).toEqual([
+        [{ signal: undefined }],
+        [{ forceRefresh: true, rejectedToken: undefined, signal: undefined }],
+      ]);
     });
 
     it("propagates a second channel-points rejection without a third attempt", async () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -386,7 +386,10 @@ describe("KickAdapter", () => {
     const campaign = { id: "campaign", categoryId: "99" } as DropCampaign;
     const reward = { id: "reward", status: "claimable", requiredMinutes: 1, watchedMinutes: 1 } as DropReward;
 
-    await expect(adapter.checkChannel({ platform: "kick", username: "creator", url: "https://kick.com/creator" }, campaign))
+    await expect(adapter.checkChannel(
+      { platform: "kick", username: "creator", url: "https://kick.com/creator" },
+      { campaign },
+    ))
       .resolves.toMatchObject({
         live: true,
         categoryMatches: true,
@@ -641,7 +644,7 @@ describe("KickAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "kick", username: "creator", url: "https://kick.com/creator" },
-      { categoryId: "99" } as DropCampaign,
+      { campaign: { categoryId: "99" } as DropCampaign },
     )).resolves.toMatchObject({
       live: true,
       categoryMatches: true,
@@ -664,7 +667,7 @@ describe("KickAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "kick", username: "creator", url: "https://kick.com/creator" },
-      { categoryId: "99" } as DropCampaign,
+      { campaign: { categoryId: "99" } as DropCampaign },
     )).resolves.toMatchObject({
       live: false,
       categoryMatches: false,
@@ -2074,7 +2077,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-      { categoryId: "game" } as DropCampaign,
+      { campaign: { categoryId: "game" } as DropCampaign },
     )).resolves.toMatchObject({
       live: true,
       categoryMatches: true,
@@ -2098,7 +2101,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator", isAclMatch: true },
-      { id: "campaign", categoryId: "game" } as DropCampaign,
+      { campaign: { id: "campaign", categoryId: "game" } as DropCampaign },
     )).resolves.toMatchObject({
       live: true,
       categoryMatches: true,
@@ -2122,7 +2125,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-      { id: "campaign", categoryId: "game" } as DropCampaign,
+      { campaign: { id: "campaign", categoryId: "game" } as DropCampaign },
     )).resolves.toMatchObject({
       live: true,
       categoryMatches: true,
@@ -2144,7 +2147,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-      { id: "campaign", categoryId: "game" } as DropCampaign,
+      { campaign: { id: "campaign", categoryId: "game" } as DropCampaign },
     )).resolves.toMatchObject({
       live: true,
       categoryMatches: true,
@@ -2167,7 +2170,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-      { id: "campaign", categoryId: "game" } as DropCampaign,
+      { campaign: { id: "campaign", categoryId: "game" } as DropCampaign },
     )).resolves.toMatchObject({
       live: true,
       categoryMatches: true,
@@ -2195,7 +2198,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-      { id: "campaign", categoryId: "game" } as DropCampaign,
+      { campaign: { id: "campaign", categoryId: "game" } as DropCampaign },
     )).resolves.toMatchObject({ campaignMatches: true });
     expect(availabilityAttempts).toBe(2);
   });
@@ -2219,14 +2222,20 @@ describe("TwitchAdapter", () => {
       const adapter = new TwitchAdapter(fetcher);
       const candidate = { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" } as const;
 
-      await expect(adapter.checkChannel(candidate, { id: "available", categoryId: "game" } as DropCampaign))
+      await expect(adapter.checkChannel(candidate, {
+        campaign: { id: "available", categoryId: "game" } as DropCampaign,
+      }))
         .resolves.toMatchObject({ campaignMatches: true });
-      await expect(adapter.checkChannel(candidate, { id: "missing", categoryId: "game" } as DropCampaign))
+      await expect(adapter.checkChannel(candidate, {
+        campaign: { id: "missing", categoryId: "game" } as DropCampaign,
+      }))
         .resolves.toMatchObject({ campaignMatches: false });
       expect(availabilityCalls).toBe(1);
 
       vi.advanceTimersByTime(60_001);
-      await adapter.checkChannel(candidate, { id: "available", categoryId: "game" } as DropCampaign);
+      await adapter.checkChannel(candidate, {
+        campaign: { id: "available", categoryId: "game" } as DropCampaign,
+      });
       expect(availabilityCalls).toBe(2);
     } finally {
       vi.useRealTimers();
@@ -2303,7 +2312,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-      { categoryId: "game" } as DropCampaign,
+      { campaign: { categoryId: "game" } as DropCampaign },
     )).resolves.toMatchObject({
       live: true,
       categoryMatches: true,
@@ -2326,7 +2335,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-      { categoryId: "game" } as DropCampaign,
+      { campaign: { categoryId: "game" } as DropCampaign },
     )).resolves.toMatchObject({
       live: false,
       categoryMatches: false,
@@ -2348,7 +2357,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-      { categoryId: "game" } as DropCampaign,
+      { campaign: { categoryId: "game" } as DropCampaign },
     )).resolves.toMatchObject({
       live: false,
       reason: "Twitch GQL check failed; used channel page fallback",
@@ -2821,7 +2830,7 @@ describe("TwitchAdapter integrity recovery", () => {
 
       const check = await new TwitchAdapter(fetcher, ensureIntegrity).checkChannel(
         { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-        { id: "campaign", categoryId: "game" } as DropCampaign,
+        { campaign: { id: "campaign", categoryId: "game" } as DropCampaign },
       );
 
       expect(check.campaignMatches).toBe(true);

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -631,11 +631,13 @@ describe("KickAdapter", () => {
   });
 
   it("falls back to Kick channel page data when the channel API fails", async () => {
-    const fetcher = jsonFetcher((url) => {
+    const abort = new AbortController();
+    const fetcher = jsonFetcher((url, init) => {
       if (url === "https://kick.com/api/v2/channels/creator") {
         throw new Error("Kick API unavailable");
       }
       if (url === "https://kick.com/creator") {
+        expect(init?.signal).toBe(abort.signal);
         return { html: '{"livestream":{"is_live":true,"category":{"id":99,"name":"Game"}}}' };
       }
       throw new Error(`Unexpected URL ${url}`);
@@ -644,7 +646,7 @@ describe("KickAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "kick", username: "creator", url: "https://kick.com/creator" },
-      { campaign: { categoryId: "99" } as DropCampaign },
+      { campaign: { categoryId: "99" } as DropCampaign, signal: abort.signal },
     )).resolves.toMatchObject({
       live: true,
       categoryMatches: true,
@@ -2299,11 +2301,13 @@ describe("TwitchAdapter", () => {
   });
 
   it("falls back to Twitch channel page data when stream info GQL fails", async () => {
+    const abort = new AbortController();
     const fetcher = jsonFetcher((url, init) => {
       if (url === "https://gql.twitch.tv/gql" && operation(init) === "StreamInfo") {
         return { errors: [{ message: "PersistedQueryNotFound" }] };
       }
       if (url === "https://www.twitch.tv/creator") {
+        expect(init?.signal).toBe(abort.signal);
         return { html: '{"isLiveBroadcast":true,"game":{"id":"game","name":"Game"}}' };
       }
       throw new Error(`Unexpected URL ${url}`);
@@ -2312,7 +2316,7 @@ describe("TwitchAdapter", () => {
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
-      { campaign: { categoryId: "game" } as DropCampaign },
+      { campaign: { categoryId: "game" } as DropCampaign, signal: abort.signal },
     )).resolves.toMatchObject({
       live: true,
       categoryMatches: true,

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -379,6 +379,26 @@ describe("background controller", () => {
     }
   });
 
+  it("shutdown preempts a stalled credential availability check", async () => {
+    const checkCredentialAvailability = vi.fn(async () => new Promise<never>(() => undefined));
+    const env = harness(
+      farming(DEFAULT_SETTINGS),
+      {
+        authProbeTimeoutMs: 60_000,
+        checkCredentialAvailability,
+      },
+    );
+
+    const ticking = env.controller.tick();
+    await vi.waitFor(() => {
+      expect(checkCredentialAvailability).toHaveBeenCalled();
+    });
+
+    env.controller.shutdown();
+
+    await expect(ticking).resolves.toEqual({});
+  });
+
   it("does not start a Kick page fallback after the auth deadline aborts background fetch", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1993,13 +1993,11 @@ describe("background controller", () => {
     expect(isFarmingActive(env.settings)).toBe(false);
     expect(env.twitch.stopWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ tabId: 10 }),
-      undefined,
-      expect.any(AbortSignal),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(env.kick.stopWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ tabId: 20 }),
-      undefined,
-      expect.any(AbortSignal),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     // Read from settled state rather than the returned snapshot: the snapshot is
     // now taken before the tick that applies the stop.
@@ -2041,7 +2039,7 @@ describe("background controller", () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     let tickSignal: AbortSignal | undefined;
     vi.mocked(env.twitch.discoverCampaigns).mockImplementation(
-      async (signal?: AbortSignal) => new Promise((_resolve, reject) => {
+      async ({ signal } = {}) => new Promise((_resolve, reject) => {
         tickSignal = signal;
         signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
       }),
@@ -2072,7 +2070,7 @@ describe("background controller", () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     let tickSignal: AbortSignal | undefined;
     vi.mocked(env.twitch.discoverCampaigns).mockImplementation(
-      async (signal?: AbortSignal) => new Promise((_resolve, reject) => {
+      async ({ signal } = {}) => new Promise((_resolve, reject) => {
         tickSignal = signal;
         signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
       }),

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1991,8 +1991,16 @@ describe("background controller", () => {
     await env.controller.handleMessage({ type: "setAutomation", platform: "kick", enabled: false });
 
     expect(isFarmingActive(env.settings)).toBe(false);
-    expect(env.twitch.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 10 }));
-    expect(env.kick.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 20 }));
+    expect(env.twitch.stopWatchTab).toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: 10 }),
+      undefined,
+      expect.any(AbortSignal),
+    );
+    expect(env.kick.stopWatchTab).toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: 20 }),
+      undefined,
+      expect.any(AbortSignal),
+    );
     // Read from settled state rather than the returned snapshot: the snapshot is
     // now taken before the tick that applies the stop.
     expect(env.state.sessions.twitch.status).toBe("paused");
@@ -2027,6 +2035,57 @@ describe("background controller", () => {
       expect.objectContaining({ twitch: expect.objectContaining({ tabId: 66 }) }),
       expect.objectContaining({ platforms: ["twitch", "kick"], emit: expect.any(Function) }),
     );
+  });
+
+  it("preempts an in-flight scheduler tick before resetting host storage", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+    let tickSignal: AbortSignal | undefined;
+    vi.mocked(env.twitch.discoverCampaigns).mockImplementation(
+      async (signal?: AbortSignal) => new Promise((_resolve, reject) => {
+        tickSignal = signal;
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }),
+    );
+
+    const ticking = env.controller.tick();
+    await vi.waitFor(() => expect(tickSignal).toBeDefined());
+    env.reportEvents.mockClear();
+
+    const resetHostStorage = vi.fn();
+    await env.controller.prepareForHostReset(resetHostStorage);
+    await ticking;
+
+    expect(tickSignal?.aborted).toBe(true);
+    expect(resetHostStorage).toHaveBeenCalledOnce();
+    const resetEvents = env.reportEvents.mock.calls.flatMap(([events]) => events);
+    expect(resetEvents).not.toContainEqual(expect.objectContaining({
+      category: "activity",
+      code: "interruption",
+    }));
+    expect(resetEvents).not.toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      level: "error",
+    }));
+  });
+
+  it("aborts in-flight scheduler work when the controller shuts down", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+    let tickSignal: AbortSignal | undefined;
+    vi.mocked(env.twitch.discoverCampaigns).mockImplementation(
+      async (signal?: AbortSignal) => new Promise((_resolve, reject) => {
+        tickSignal = signal;
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }),
+    );
+
+    const ticking = env.controller.tick();
+    await vi.waitFor(() => expect(tickSignal).toBeDefined());
+
+    env.controller.shutdown();
+    env.controller.shutdown();
+    await ticking;
+
+    expect(tickSignal?.aborted).toBe(true);
   });
 
   it("allows host-reset cleanup to be retried", async () => {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -798,7 +798,7 @@ describe("scheduler tick", () => {
       { platforms: ["kick"], stopPageContextTabs },
     );
 
-    expect(kick.stopWatchTab).toHaveBeenCalledWith(previous);
+    expect(kick.stopWatchTab).toHaveBeenCalledWith(previous, undefined, undefined);
     expect(kick.discoverCampaigns).not.toHaveBeenCalled();
     expect(kick.readProgress).not.toHaveBeenCalled();
     expect(kick.claimReward).not.toHaveBeenCalled();
@@ -1034,8 +1034,13 @@ describe("scheduler tick", () => {
       expect.objectContaining({ username: "new", live: true }),
       expect.objectContaining({ tabId: 7 }),
       {},
+      undefined,
     );
-    expect(twitch.readProgress).toHaveBeenCalledWith(expect.any(Array), expect.objectContaining({ channel: first }));
+    expect(twitch.readProgress).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ channel: first }),
+      undefined,
+    );
   });
 
   it("pauses only the platform with recent manual watch activity", async () => {
@@ -1185,6 +1190,7 @@ describe("scheduler tick", () => {
       expect.objectContaining({ username: "old" }),
       expect.objectContaining({ tabId: 7 }),
       {},
+      undefined,
     );
   });
 
@@ -1227,6 +1233,7 @@ describe("scheduler tick", () => {
       expect.objectContaining({ username: "new" }),
       expect.objectContaining({ tabId: 7 }),
       {},
+      undefined,
     );
   });
 
@@ -1415,6 +1422,7 @@ describe("scheduler tick", () => {
       expect.objectContaining({ username: "old" }),
       expect.objectContaining({ tabId: 7 }),
       {},
+      undefined,
     );
     expect(result.events.some((event) => event.category === "diagnostic" && event.message === "Watch tab playback did not become active")).toBe(true);
   });
@@ -1558,6 +1566,7 @@ describe("scheduler tick", () => {
         expect.objectContaining({ username: "old" }),
         expect.objectContaining({ tabId: 7 }),
         {},
+        undefined,
       );
     } finally {
       vi.useRealTimers();
@@ -1653,6 +1662,7 @@ describe("scheduler tick", () => {
       expect.objectContaining({ username: "fallback" }),
       expect.objectContaining({ tabId: 7 }),
       {},
+      undefined,
     );
   });
 
@@ -1673,7 +1683,7 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.claimReward).toHaveBeenCalledWith(ready, ready.rewards[0]);
+    expect(twitch.claimReward).toHaveBeenCalledWith(ready, ready.rewards[0], undefined);
   });
 
   it("claims an obtained non-watch reward without selecting it for farming", async () => {
@@ -1705,7 +1715,7 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.claimReward).toHaveBeenCalledWith(ready, actionReward);
+    expect(twitch.claimReward).toHaveBeenCalledWith(ready, actionReward, undefined);
     expect(twitch.listCandidateChannels).not.toHaveBeenCalled();
     expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
     expect(result.state.sessions.twitch.status).toBe("idle");
@@ -1858,7 +1868,11 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 7 }));
+    expect(twitch.stopWatchTab).toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: 7 }),
+      undefined,
+      undefined,
+    );
     expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
     expect(result.state.sessions.twitch).toMatchObject({
       status: "idle",
@@ -2023,7 +2037,7 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.claimReward).toHaveBeenCalledWith(ready, ready.rewards[0]);
+    expect(twitch.claimReward).toHaveBeenCalledWith(ready, ready.rewards[0], undefined);
     expect(result.state.campaigns.twitch[0].rewards[0].status).toBe("claimed");
   });
 
@@ -2227,6 +2241,7 @@ describe("scheduler tick", () => {
       expect.objectContaining({
         managedTab: expect.objectContaining({ platform: "twitch", tabId: 42 }),
       }),
+      undefined,
     );
   });
 
@@ -2257,7 +2272,11 @@ describe("scheduler tick", () => {
       { stopPageContextTabs },
     );
 
-    expect(twitch.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 7, tabManagedByExtension: true }));
+    expect(twitch.stopWatchTab).toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: 7, tabManagedByExtension: true }),
+      undefined,
+      undefined,
+    );
     expect(result.state.sessions.twitch.tabId).toBeUndefined();
     expect(result.state.sessions.twitch.channel).toBeUndefined();
     expect(result.state.managedPageContextTabs?.twitch).toBeUndefined();
@@ -2283,7 +2302,11 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.stopWatchTab).toHaveBeenCalledWith(expect.objectContaining({ tabId: 7 }));
+    expect(twitch.stopWatchTab).toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: 7 }),
+      undefined,
+      undefined,
+    );
     expect(result.state.sessions.twitch.status).toBe("idle");
     expect(result.state.sessions.twitch.tabId).toBeUndefined();
   });
@@ -2366,6 +2389,7 @@ describe("scheduler tick", () => {
       expect.objectContaining({ username: "fallback", live: true }),
       expect.any(Object),
       {},
+      undefined,
     );
     expect(result.state.sessions.twitch).toMatchObject({
       status: "watching",
@@ -2506,7 +2530,10 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.claimChannelPoints).toHaveBeenCalledWith(expect.objectContaining({ username: "allowed" }));
+    expect(twitch.claimChannelPoints).toHaveBeenCalledWith(
+      expect.objectContaining({ username: "allowed" }),
+      undefined,
+    );
     expect(result.events.some((event) => event.category === "diagnostic" && event.message.includes("Claimed channel points"))).toBe(true);
   });
 

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -798,7 +798,7 @@ describe("scheduler tick", () => {
       { platforms: ["kick"], stopPageContextTabs },
     );
 
-    expect(kick.stopWatchTab).toHaveBeenCalledWith(previous, undefined, undefined);
+    expect(kick.stopWatchTab).toHaveBeenCalledWith(previous, { signal: undefined });
     expect(kick.discoverCampaigns).not.toHaveBeenCalled();
     expect(kick.readProgress).not.toHaveBeenCalled();
     expect(kick.claimReward).not.toHaveBeenCalled();
@@ -1033,13 +1033,12 @@ describe("scheduler tick", () => {
     expect(twitch.prepareWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ username: "new", live: true }),
       expect.objectContaining({ tabId: 7 }),
-      {},
-      undefined,
+      { signal: undefined },
     );
     expect(twitch.readProgress).toHaveBeenCalledWith(
       expect.any(Array),
       expect.objectContaining({ channel: first }),
-      undefined,
+      { signal: undefined },
     );
   });
 
@@ -1189,8 +1188,7 @@ describe("scheduler tick", () => {
     expect(twitch.prepareWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ username: "old" }),
       expect.objectContaining({ tabId: 7 }),
-      {},
-      undefined,
+      { signal: undefined },
     );
   });
 
@@ -1232,8 +1230,7 @@ describe("scheduler tick", () => {
     expect(twitch.prepareWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ username: "new" }),
       expect.objectContaining({ tabId: 7 }),
-      {},
-      undefined,
+      { signal: undefined },
     );
   });
 
@@ -1421,8 +1418,7 @@ describe("scheduler tick", () => {
     expect(twitch.prepareWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ username: "old" }),
       expect.objectContaining({ tabId: 7 }),
-      {},
-      undefined,
+      { signal: undefined },
     );
     expect(result.events.some((event) => event.category === "diagnostic" && event.message === "Watch tab playback did not become active")).toBe(true);
   });
@@ -1565,8 +1561,7 @@ describe("scheduler tick", () => {
       expect(twitch.prepareWatchTab).toHaveBeenCalledWith(
         expect.objectContaining({ username: "old" }),
         expect.objectContaining({ tabId: 7 }),
-        {},
-        undefined,
+        { signal: undefined },
       );
     } finally {
       vi.useRealTimers();
@@ -1661,8 +1656,7 @@ describe("scheduler tick", () => {
     expect(twitch.prepareWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ username: "fallback" }),
       expect.objectContaining({ tabId: 7 }),
-      {},
-      undefined,
+      { signal: undefined },
     );
   });
 
@@ -1683,7 +1677,7 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.claimReward).toHaveBeenCalledWith(ready, ready.rewards[0], undefined);
+    expect(twitch.claimReward).toHaveBeenCalledWith(ready, ready.rewards[0], { signal: undefined });
   });
 
   it("claims an obtained non-watch reward without selecting it for farming", async () => {
@@ -1715,7 +1709,7 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.claimReward).toHaveBeenCalledWith(ready, actionReward, undefined);
+    expect(twitch.claimReward).toHaveBeenCalledWith(ready, actionReward, { signal: undefined });
     expect(twitch.listCandidateChannels).not.toHaveBeenCalled();
     expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
     expect(result.state.sessions.twitch.status).toBe("idle");
@@ -1870,8 +1864,7 @@ describe("scheduler tick", () => {
 
     expect(twitch.stopWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ tabId: 7 }),
-      undefined,
-      undefined,
+      { signal: undefined },
     );
     expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
     expect(result.state.sessions.twitch).toMatchObject({
@@ -2037,7 +2030,7 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.claimReward).toHaveBeenCalledWith(ready, ready.rewards[0], undefined);
+    expect(twitch.claimReward).toHaveBeenCalledWith(ready, ready.rewards[0], { signal: undefined });
     expect(result.state.campaigns.twitch[0].rewards[0].status).toBe("claimed");
   });
 
@@ -2240,8 +2233,8 @@ describe("scheduler tick", () => {
       expect.objectContaining({ tabId: 42 }),
       expect.objectContaining({
         managedTab: expect.objectContaining({ platform: "twitch", tabId: 42 }),
+        signal: undefined,
       }),
-      undefined,
     );
   });
 
@@ -2274,8 +2267,7 @@ describe("scheduler tick", () => {
 
     expect(twitch.stopWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ tabId: 7, tabManagedByExtension: true }),
-      undefined,
-      undefined,
+      { signal: undefined },
     );
     expect(result.state.sessions.twitch.tabId).toBeUndefined();
     expect(result.state.sessions.twitch.channel).toBeUndefined();
@@ -2304,8 +2296,7 @@ describe("scheduler tick", () => {
 
     expect(twitch.stopWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ tabId: 7 }),
-      undefined,
-      undefined,
+      { signal: undefined },
     );
     expect(result.state.sessions.twitch.status).toBe("idle");
     expect(result.state.sessions.twitch.tabId).toBeUndefined();
@@ -2388,8 +2379,7 @@ describe("scheduler tick", () => {
     expect(twitch.prepareWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ username: "fallback", live: true }),
       expect.any(Object),
-      {},
-      undefined,
+      { signal: undefined },
     );
     expect(result.state.sessions.twitch).toMatchObject({
       status: "watching",
@@ -2532,7 +2522,7 @@ describe("scheduler tick", () => {
 
     expect(twitch.claimChannelPoints).toHaveBeenCalledWith(
       expect.objectContaining({ username: "allowed" }),
-      undefined,
+      { signal: undefined },
     );
     expect(result.events.some((event) => event.category === "diagnostic" && event.message.includes("Claimed channel points"))).toBe(true);
   });

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -417,6 +417,32 @@ describe("scheduler campaign selection", () => {
     expect(listCandidateChannels).not.toHaveBeenCalled();
   });
 
+  it("passes cancellation to Idle Watchlist channel checks", async () => {
+    const abort = new AbortController();
+    const checkChannel = vi.fn(async (candidate) => ({ live: true, categoryMatches: true, candidate }));
+
+    await chooseCampaignDecision(
+      "twitch",
+      [],
+      settings({
+        platform: {
+          ...DEFAULT_SETTINGS.platform,
+          twitch: { ...DEFAULT_SETTINGS.platform.twitch, idleWatchlistChannels: ["fallback"] },
+        },
+      }),
+      {
+        listCandidateChannels: vi.fn(async () => []),
+        checkChannel,
+      },
+      abort.signal,
+    );
+
+    expect(checkChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ username: "fallback" }),
+      { campaign: undefined, signal: abort.signal },
+    );
+  });
+
   it("prefers ACL candidates over general category streams", async () => {
     const decision = await chooseCampaignDecision(
       "twitch",

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -520,6 +520,25 @@ describe("tab manager", () => {
     expect(browser.tabs.update).toHaveBeenCalledWith(9, { pinned: true, muted: true, active: false });
   });
 
+  it("closes a newly created managed tab when creation finishes after cancellation", async () => {
+    const browser = browserMock();
+    const abort = new AbortController();
+    vi.mocked(browser.tabs.create).mockImplementation(async () => {
+      abort.abort(new Error("reset"));
+      return { id: 9 };
+    });
+
+    await expect(openPinnedMutedTabWithBrowser(
+      browser,
+      channel,
+      undefined,
+      { signal: abort.signal },
+    )).rejects.toThrow("reset");
+
+    expect(browser.tabs.remove).toHaveBeenCalledWith(9);
+    expect(browser.tabs.update).not.toHaveBeenCalledWith(9, expect.anything());
+  });
+
   it("does not foreground-prime new tabs when page video control is disabled", async () => {
     const browser = browserMock();
 

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1447,6 +1447,26 @@ describe("twitch integrity refresh", () => {
         expect(browser.tabs.create).toHaveBeenCalledTimes(1);
       });
 
+      it("aborts an integrity wait and removes the page context it opened", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 43 });
+        const abort = new AbortController();
+
+        const pending = ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          5_000,
+          undefined,
+          { signal: abort.signal },
+        );
+        await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+
+        abort.abort(new DOMException("Host reset", "AbortError"));
+
+        await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+        expect(browser.tabs.remove).toHaveBeenCalledWith(43);
+      });
+
       it("starts a new forced refresh once the previous one has settled", async () => {
         const browser = browserMock();
         browser.tabs.create.mockResolvedValue({ id: 35 });


### PR DESCRIPTION
## Summary

- give each scheduler tick an owned cancellation signal and abort active ticks before factory reset or controller shutdown
- propagate cancellation through scheduler adapter calls, Twitch/Kick transports, auth probes, and Twitch integrity/page-context work
- roll cancelled ticks back without persisting interruption errors or partial scheduler state
- discard page contexts opened by an integrity wait when that wait is aborted

## Root cause

`prepareForHostReset` waited for the controller state lock while a network-bound scheduler tick held it. The tick had no cancellation path, so reset could not begin until all in-flight platform and integrity work finished.

## Testing

- `pnpm verify`
- focused controller, scheduler, adapter, and tabs tests (506 passing)

Closes #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In-progress scheduler work now stops promptly during shutdown or host reset.
  * Prevents partial updates, unwanted notifications, and misleading error reports after cancellation.
  * Improves cancellation of authentication checks, network requests, reward claims, and browser-based operations.
  * Ensures temporary browser activity is cleaned up when interrupted.

* **Documentation**
  * Added design and implementation guidance for preempting active scheduler work, including verification steps.

* **Tests**
  * Added coverage for cancellation during shutdown, host reset, and browser integrity operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->