### PR TITLE
feat(twitch): proactively warm integrity tokens

### DIFF
--- a/docs/superpowers/plans/2026-07-28-twitch-integrity-warming.md
+++ b/docs/superpowers/plans/2026-07-28-twitch-integrity-warming.md
@@ -1,0 +1,650 @@
+# Twitch Integrity Token Warming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Proactively refresh Twitch integrity tokens before expiry and gate authenticated Twitch work on one bounded acquisition attempt without exposing preparation in the UI.
+
+**Architecture:** Unify Twitch token minting behind one cancellable single-flight primitive in `tabs.ts`. The browser host injects acquisition, cancellation, alarm creation, and alarm clearing into the core controller; the controller owns expiry scheduling and decides when a normal Twitch tick or refresh alarm should acquire a token. A failed acquisition suppresses only Twitch authenticated work until the next normal discovery alarm, leaving Kick independent.
+
+**Tech Stack:** TypeScript, WXT browser APIs, WebExtension alarms/webRequest/tabs, Vitest fake timers and mocks, pnpm workspace scripts.
+
+## Global Constraints
+
+- Implement from `origin/develop` after merge commits `40e6a8c` (#297) and `bb93f6f` (#299/#293).
+- Use a one-shot alarm named `lurkloot.twitch-integrity`; do not add permissions because `alarms` is already declared.
+- Schedule at `expiresAt - 120_000ms - jitter`, where jitter is a stable integer in `[0, 30_000]` derived locally from the token.
+- If that target is not in the future, do not create an immediate alarm; retry on the next normal discovery alarm.
+- A failed acquisition never creates a dedicated retry alarm.
+- Enabling Twitch persists immediately and never waits for acquisition.
+- Do not add popup state, activity events, notifications, locale keys, or user-facing preparation copy.
+- Diagnostic messages are English literals and must not contain tokens, cookies, device/session identifiers, or authenticated response content.
+- Do not classify integrity availability as Twitch authentication health.
+- Do not mint tokens while Twitch is disabled; `EngineSettings` deliberately
+  has no separate global `running` flag.
+- Do not change Kick or CLI behavior.
+- All acquisition paths share one in-flight page-context mint.
+
+---
+
+### Task 1: Make Integrity Acquisition One Cancellable Single Flight
+
+**Files:**
+- Modify: `packages/core/src/core/tabs.ts`
+- Test: `packages/extension/tests/tabs.test.ts`
+
+**Interfaces:**
+- Consumes: Existing `TwitchIntegrityRequest`, `ensureTwitchIntegrityWithBrowser`, `mintTwitchIntegrity`, and #293 `AbortSignal` support.
+- Produces:
+
+```ts
+export const INTEGRITY_EXPIRY_SKEW_MS = 30_000;
+export function isValidTwitchIntegrity(
+  value: TwitchIntegrity | undefined,
+  now?: number,
+): value is TwitchIntegrity;
+export function cancelTwitchIntegrityAcquisition(reason?: unknown): void;
+```
+
+`ensureTwitchIntegrityWithBrowser(...)` remains source compatible, but both forced and ordinary mints share the same underlying acquisition.
+
+- [ ] **Step 1: Write failing tests for ordinary single-flight acquisition**
+
+Add focused cases inside the existing `ensureTwitchIntegrityWithBrowser` describe block:
+
+```ts
+it("shares one page-context mint between concurrent ordinary acquisitions", async () => {
+  const browser = browserMock();
+  browser.tabs.create.mockResolvedValue({ id: 51 });
+
+  const first = ensureTwitchIntegrityWithBrowser(
+    browser,
+    "https://www.twitch.tv/drops/inventory",
+    5_000,
+  );
+  const second = ensureTwitchIntegrityWithBrowser(
+    browser,
+    "https://www.twitch.tv/drops/inventory",
+    5_000,
+  );
+
+  await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledTimes(1));
+  setTwitchIntegrity(fresh(), { isNew: true });
+
+  await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+  expect(browser.tabs.create).toHaveBeenCalledTimes(1);
+});
+```
+
+Also add:
+
+- cancelling the acquisition removes its newly opened page context and rejects every joined caller;
+- after cancellation settles, a later caller can start a new acquisition;
+- aborting only a joined caller rejects that caller without cancelling the shared underlying acquisition;
+- `isValidTwitchIntegrity` accepts a token outside the 30-second skew and rejects missing, expired, and inside-skew values.
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts
+```
+
+Expected: the concurrent ordinary acquisition test observes more than one acquisition or lacks the new exported helpers.
+
+- [ ] **Step 3: Replace the forced-only promise with an owned acquisition**
+
+In `tabs.ts`, replace `inFlightForcedRefresh` with an entry that owns the underlying abort:
+
+```ts
+interface TwitchIntegrityAcquisition {
+  promise: Promise<boolean>;
+  abort: AbortController;
+}
+
+let inFlightIntegrityAcquisition: TwitchIntegrityAcquisition | undefined;
+
+export function cancelTwitchIntegrityAcquisition(reason?: unknown): void {
+  inFlightIntegrityAcquisition?.abort.abort(reason);
+}
+```
+
+Extract the validity predicate so controller policy and request attachment use exactly the same skew:
+
+```ts
+export const INTEGRITY_EXPIRY_SKEW_MS = 30_000;
+
+export function isValidTwitchIntegrity(
+  value: TwitchIntegrity | undefined,
+  now: number = Date.now(),
+): value is TwitchIntegrity {
+  return value != null && value.expiresAt > now + INTEGRITY_EXPIRY_SKEW_MS;
+}
+
+export function hasValidTwitchIntegrity(now: number = Date.now()): boolean {
+  return isValidTwitchIntegrity(twitchIntegrity, now);
+}
+```
+
+Create one internal acquisition for both ordinary and forced requests. The creator’s signal aborts the owned controller because #293 reset/shutdown cancellation owns that operation. Later joiners race only their own signal through `withAbortSignal` and do not cancel the shared acquisition:
+
+```ts
+function startTwitchIntegrityAcquisition(
+  browserApi: BrowserTabApi,
+  originUrl: string,
+  timeoutMs: number,
+  emit: EventEmitter,
+  rejectedToken: string | undefined,
+  forceRefresh: boolean,
+  ownerSignal?: AbortSignal,
+): Promise<boolean> {
+  if (inFlightIntegrityAcquisition) {
+    diagnostic(emit, "debug", "Joining the Twitch integrity acquisition already in flight", "twitch");
+    return withAbortSignal(inFlightIntegrityAcquisition.promise, ownerSignal);
+  }
+
+  const abort = new AbortController();
+  const abortFromOwner = () => abort.abort(ownerSignal?.reason);
+  ownerSignal?.addEventListener("abort", abortFromOwner, { once: true });
+
+  const promise = mintTwitchIntegrity(
+    browserApi,
+    originUrl,
+    timeoutMs,
+    emit,
+    rejectedToken,
+    forceRefresh,
+    abort.signal,
+  ).finally(() => {
+    ownerSignal?.removeEventListener("abort", abortFromOwner);
+    if (inFlightIntegrityAcquisition?.promise === promise) {
+      inFlightIntegrityAcquisition = undefined;
+    }
+  });
+  inFlightIntegrityAcquisition = { promise, abort };
+  return promise;
+}
+```
+
+Keep the rejected-token replacement fast path before joining or starting an acquisition. Update `resetTwitchIntegrityRefreshBounds()` to abort and clear the unified entry so existing suite isolation remains deterministic.
+
+- [ ] **Step 4: Run tabs tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts
+pnpm --filter @lurkloot/core typecheck
+pnpm --filter @lurkloot/extension typecheck
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 5: Commit the acquisition primitive**
+
+```bash
+git add packages/core/src/core/tabs.ts packages/extension/tests/tabs.test.ts
+git commit -m "refactor(twitch): unify integrity token acquisition"
+```
+
+---
+
+### Task 2: Add Expiry Scheduling Policy to the Controller
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 `isValidTwitchIntegrity`, existing stored integrity bundle, and injected host operations.
+- Produces:
+
+```ts
+export const TWITCH_INTEGRITY_ALARM_NAME = "lurkloot.twitch-integrity";
+export const TWITCH_INTEGRITY_REFRESH_LEAD_MS = 120_000;
+export const TWITCH_INTEGRITY_REFRESH_JITTER_MAX_MS = 30_000;
+
+interface BackgroundControllerDeps<S extends EngineSettings> {
+  createAlarm(
+    name: string,
+    options: { periodInMinutes: number } | { when: number },
+  ): Promise<void>;
+  clearAlarm?(name: string): Promise<boolean>;
+  ensureTwitchIntegrity?(
+    emit: EventEmitter,
+    request?: TwitchIntegrityRequest,
+  ): Promise<boolean>;
+  cancelTwitchIntegrityAcquisition?(reason?: unknown): void;
+}
+```
+
+The controller returns a new `runTwitchIntegrityRefresh()` handler for the extension alarm listener.
+
+- [ ] **Step 1: Extend the controller test harness**
+
+Add the new optional dependency mocks:
+
+```ts
+clearAlarm: vi.fn(async () => true),
+ensureTwitchIntegrity: vi.fn(async () => true),
+cancelTwitchIntegrityAcquisition: vi.fn(),
+```
+
+Allow `createAlarm` expectations to accept both periodic and one-shot options.
+
+- [ ] **Step 2: Write failing tests for deterministic scheduling**
+
+Add controller tests using synthetic tokens and fake time:
+
+```ts
+it("schedules integrity refresh from token expiry with stable bounded jitter", async () => {
+  vi.setSystemTime(new Date("2026-07-28T12:00:00.000Z"));
+  const integrity = integrityBundle({
+    integrity: "stable-test-token",
+    expiresAt: Date.now() + 30 * 60_000,
+  });
+  const env = controllerEnv({ loadTwitchIntegrity: vi.fn(async () => integrity) });
+
+  await env.controller.settleBackgroundWork();
+
+  const calls = env.deps.createAlarm.mock.calls.filter(
+    ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+  );
+  expect(calls).toHaveLength(1);
+  const when = (calls[0][1] as { when: number }).when;
+  expect(when).toBeLessThanOrEqual(integrity.expiresAt - 120_000);
+  expect(when).toBeGreaterThanOrEqual(integrity.expiresAt - 150_000);
+});
+```
+
+Add separate tests proving:
+
+- loading an expired token logs a debug diagnostic and creates no integrity alarm;
+- capturing a replacement persists it and replaces the old one-shot schedule;
+- the same token always produces the same jitter;
+- a computed target in the past clears any prior alarm and creates no immediate alarm;
+- alarm creation failure does not discard or invalidate the captured token;
+- no diagnostic includes the token value.
+
+- [ ] **Step 3: Run controller tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/backgroundController.test.ts
+```
+
+Expected: the alarm constant, one-shot alarm dependency, and scheduling behavior do not exist.
+
+- [ ] **Step 4: Implement stable scheduling without exposing token material**
+
+Add an internal non-cryptographic hash used only to distribute alarm times:
+
+```ts
+function integrityRefreshJitter(token: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < token.length; index += 1) {
+    hash ^= token.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) % (TWITCH_INTEGRITY_REFRESH_JITTER_MAX_MS + 1);
+}
+```
+
+Add:
+
+```ts
+async function clearTwitchIntegrityAlarm(): Promise<void> {
+  await deps.clearAlarm?.(TWITCH_INTEGRITY_ALARM_NAME);
+}
+
+async function scheduleTwitchIntegrityRefresh(
+  integrity: TwitchIntegrity,
+  emit?: EventEmitter,
+): Promise<void> {
+  const when = integrity.expiresAt
+    - TWITCH_INTEGRITY_REFRESH_LEAD_MS
+    - integrityRefreshJitter(integrity.integrity);
+  if (when <= Date.now()) {
+    await clearTwitchIntegrityAlarm();
+    return;
+  }
+  await deps.createAlarm(TWITCH_INTEGRITY_ALARM_NAME, { when });
+  emit?.({
+    category: "diagnostic",
+    platform: "twitch",
+    level: "debug",
+    message: `Scheduled proactive Twitch integrity refresh for ${new Date(when).toISOString()}`,
+  });
+}
+```
+
+Call scheduling after a valid stored token is loaded and after a new captured token is persisted. Keep alarm writes best effort: report their failure, but retain the in-memory and stored token.
+
+- [ ] **Step 5: Run controller tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/backgroundController.test.ts
+pnpm --filter @lurkloot/core typecheck
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 6: Commit expiry scheduling**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(twitch): schedule integrity refresh before expiry"
+```
+
+---
+
+### Task 3: Gate Authenticated Twitch Tick Work and Handle the Refresh Alarm
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2 injected `ensureTwitchIntegrity`, alarm helpers, existing tick `AbortSignal`, and `isFarmingActive`.
+- Produces:
+
+```ts
+runTwitchIntegrityRefresh(): Promise<void>;
+```
+
+The normal tick uses its #293 signal for acquisition and excludes only Twitch from auth refresh and scheduler work when acquisition fails.
+
+- [ ] **Step 1: Write failing normal-tick gating tests**
+
+Add tests proving:
+
+```ts
+it("acquires integrity before Twitch auth and scheduler work", async () => {
+  const order: string[] = [];
+  const env = controllerEnv({
+    ensureTwitchIntegrity: vi.fn(async () => {
+      order.push("integrity");
+      return true;
+    }),
+    twitchCheckAuthHealth: vi.fn(async () => {
+      order.push("auth");
+      return healthyAuth("twitch");
+    }),
+  });
+
+  await env.controller.tick(["twitch"], "manual_tick");
+  expect(order).toEqual(["integrity", "auth"]);
+});
+```
+
+Add separate tests proving:
+
+- a successful acquisition lets the same Twitch tick continue;
+- a false result prevents Twitch auth probing and scheduler adapter work;
+- failure emits a warning diagnostic saying retry is deferred to the next normal alarm;
+- acquisition failure does not emit an interruption activity event or mark auth unhealthy;
+- a Twitch acquisition failure does not prevent Kick auth or scheduler work in an all-platform tick;
+- an acquisition throw caused by an aborted tick exits silently through #293 behavior;
+- enabling Twitch returns before the detached tick’s acquisition resolves.
+
+- [ ] **Step 2: Write failing refresh-alarm tests**
+
+Cover:
+
+- the handler reloads settings and token state on every invocation;
+- it clears/no-ops when Twitch is disabled;
+- it reschedules without minting when a newer token is valid beyond the refresh window;
+- it performs one forced fresh-context acquisition when the token is missing or within the refresh window;
+- success relies on capture persistence to schedule the replacement;
+- false/throwing acquisition creates no retry alarm and logs that the next normal alarm will retry;
+- two concurrent alarm/tick invocations reach only one injected acquisition;
+- a late alarm revalidates current state instead of trusting the originally scheduled token.
+
+- [ ] **Step 3: Run controller tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/backgroundController.test.ts
+```
+
+Expected: Twitch auth currently begins without the new prerequisite and no refresh handler exists.
+
+- [ ] **Step 4: Add the internal readiness gate**
+
+Before `refreshAuthHealth` in `runTick`, when the requested scope includes an enabled Twitch platform:
+
+```ts
+async function prepareTwitchIntegrity(
+  settings: S,
+  signal: AbortSignal,
+): Promise<boolean> {
+  if (!settings.platform.twitch.enabled) return true;
+  if (!deps.ensureTwitchIntegrity) return true;
+
+  return withEventCollector(async (emit, events) => {
+    const ready = await deps.ensureTwitchIntegrity(emit, { signal });
+    if (!ready) {
+      emit({
+        category: "diagnostic",
+        platform: "twitch",
+        level: "warn",
+        message: "No valid Twitch integrity token; delaying authenticated Twitch work until the next normal scheduler alarm",
+      });
+    }
+    await reportBestEffort(events);
+    return ready;
+  });
+}
+```
+
+When it returns false, add Twitch to the existing per-tick excluded platform set before auth refresh and scheduler selection. Do not persist auth-health or scheduler-state changes for the skipped Twitch pipeline.
+
+- [ ] **Step 5: Implement the refresh-alarm handler**
+
+The handler:
+
+1. loads current settings and stored integrity;
+2. clears/no-ops unless Twitch is enabled;
+3. reschedules a token whose calculated target is still future;
+4. otherwise creates an owned `AbortController`, calls injected acquisition with `{ forceRefresh: true, signal }`, and reports collected diagnostics;
+5. does not create a retry alarm on false or failure;
+6. removes its controller from active ownership in `finally`.
+
+Keep an `integrityRefreshAbort` owned by the controller. `shutdown`,
+`prepareForHostReset`, and Twitch disable call both
+`integrityRefreshAbort.abort(...)` and
+`deps.cancelTwitchIntegrityAcquisition?.(...)`. This is separate from
+`abortActiveTicks` so disabling Twitch does not cancel Kick.
+
+- [ ] **Step 6: Add lifecycle cleanup**
+
+In the settings toggle path:
+
+- when Twitch becomes disabled, cancel Twitch acquisition and clear the integrity alarm;
+- disabling the last enabled platform needs no additional branch: the Twitch
+  disable path already performs its own cleanup;
+- when Twitch is enabled, return the snapshot immediately and let the existing detached platform tick perform acquisition;
+- do not add a snapshot field or message type for readiness.
+
+In `shutdown()` and `prepareForHostReset()`, cancel acquisition and clear the alarm before waiting for locks. Alarm clearing is asynchronous in reset; shutdown calls cancellation synchronously and leaves host alarm cleanup to the registered lifecycle where necessary.
+
+- [ ] **Step 7: Run controller tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/backgroundController.test.ts
+pnpm --filter @lurkloot/core typecheck
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 8: Commit controller gating and lifecycle**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(twitch): gate authenticated work on integrity readiness"
+```
+
+---
+
+### Task 4: Wire the One-Shot Browser Alarm
+
+**Files:**
+- Modify: `packages/extension/entrypoints/background.ts`
+- Create: `packages/extension/tests/backgroundEntrypoint.test.ts`
+
+**Interfaces:**
+- Consumes: Tasks 1–3 controller dependencies, `cancelTwitchIntegrityAcquisition`, `ensureTwitchIntegrity`, and `TWITCH_INTEGRITY_ALARM_NAME`.
+- Produces: WXT alarm dispatch to `controller.runTwitchIntegrityRefresh()`.
+
+- [ ] **Step 1: Write a focused source-contract test for entrypoint wiring**
+
+Follow the existing source-inspection pattern in
+`packages/extension/tests/compatibility.test.ts`:
+
+```ts
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("background integrity alarm wiring", () => {
+  const source = readFileSync(
+    new URL("../entrypoints/background.ts", import.meta.url),
+    "utf8",
+  );
+
+  it("injects alarm creation, clearing, acquisition, and cancellation", () => {
+    expect(source).toContain("clearAlarm: (name) => browser.alarms.clear(name)");
+    expect(source).toContain("ensureTwitchIntegrity: (emit, request)");
+    expect(source).toContain("cancelTwitchIntegrityAcquisition");
+  });
+
+  it("dispatches the integrity alarm to the controller", () => {
+    expect(source).toContain("alarm.name === TWITCH_INTEGRITY_ALARM_NAME");
+    expect(source).toContain("controller.runTwitchIntegrityRefresh()");
+  });
+});
+```
+
+- [ ] **Step 2: Write failing host-wiring assertions**
+
+In the same source-contract test, also assert:
+
+- `createAlarm(name, { when })` forwards the one-shot timestamp to `browser.alarms.create`;
+- `clearAlarm(name)` calls `browser.alarms.clear`;
+- an alarm named `TWITCH_INTEGRITY_ALARM_NAME` calls `runTwitchIntegrityRefresh`;
+- unrelated alarms remain ignored;
+- the injected `ensureTwitchIntegrity` forwards `TwitchIntegrityRequest.signal`;
+- the injected cancellation hook calls `cancelTwitchIntegrityAcquisition`.
+
+- [ ] **Step 3: Run the focused test and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/backgroundEntrypoint.test.ts
+```
+
+Expected: the new alarm name and host dependencies are not wired.
+
+- [ ] **Step 4: Wire browser dependencies and dispatch**
+
+Update controller construction:
+
+```ts
+createAlarm: (name, options) => browser.alarms.create(name, options),
+clearAlarm: (name) => browser.alarms.clear(name),
+ensureTwitchIntegrity: (emit, request) => ensureTwitchIntegrity(emit, request),
+cancelTwitchIntegrityAcquisition,
+```
+
+Extend the listener:
+
+```ts
+} else if (alarm.name === TWITCH_INTEGRITY_ALARM_NAME) {
+  void controller.runTwitchIntegrityRefresh();
+}
+```
+
+Import the new constant from `@lurkloot/core/controller` and cancellation helper from the extension’s core tabs adapter/export surface.
+
+- [ ] **Step 5: Run entrypoint tests and both relevant typechecks**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/backgroundEntrypoint.test.ts
+pnpm --filter @lurkloot/core typecheck
+pnpm --filter @lurkloot/extension typecheck
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 6: Commit host wiring**
+
+```bash
+git add packages/extension/entrypoints/background.ts packages/extension/tests/backgroundEntrypoint.test.ts
+git commit -m "feat(extension): run expiry-driven integrity refresh alarm"
+```
+
+---
+
+### Task 5: Verify Diagnostics-Only Delivery and Full Regression Safety
+
+**Files:**
+- Modify only if verification reveals a defect in Tasks 1–4.
+- Verify: `packages/locales/messages/*.json`, popup contracts, manifest permissions, and all workspace outputs.
+
+**Interfaces:**
+- Consumes: Completed implementation from Tasks 1–4.
+- Produces: A release-ready branch for issue #298.
+
+- [ ] **Step 1: Prove no user-facing preparation contract was added**
+
+Run:
+
+```bash
+git diff origin/develop...HEAD -- packages/popup-ui packages/shared/src/messages.ts packages/locales packages/extension/wxt.config.ts
+rg -n "preparing|warming|integrity.*ready" packages/popup-ui packages/locales packages/shared/src/messages.ts
+```
+
+Expected: no popup/snapshot/message/locale preparation state and no new permission. Any matches must be pre-existing or diagnostic-only.
+
+- [ ] **Step 2: Run focused regression suites**
+
+```bash
+pnpm --filter @lurkloot/extension test -- tests/tabs.test.ts
+pnpm --filter @lurkloot/extension test -- tests/backgroundController.test.ts
+pnpm --filter @lurkloot/extension test -- tests/adapters.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run repository verification**
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, all workspace typechecks, CLI and extension tests, Astro build, and Chromium/Firefox builds pass.
+
+- [ ] **Step 4: Inspect the final diff and diagnostics**
+
+```bash
+git diff --check origin/develop...HEAD
+git diff --stat origin/develop...HEAD
+git log --oneline origin/develop..HEAD
+```
+
+Confirm every new diagnostic is an English literal, contains no integrity value, and matches the intended warning/debug severity.
+
+- [ ] **Step 5: Keep corrections in the task that owns them**
+
+If verification finds a defect, return to the owning task, add or strengthen
+its focused regression test, make the minimal correction, rerun that task’s
+checks, and amend that task before delivery. Do not create an empty verification
+commit.

--- a/docs/superpowers/specs/2026-07-28-twitch-integrity-warming-design.md
+++ b/docs/superpowers/specs/2026-07-28-twitch-integrity-warming-design.md
@@ -1,0 +1,211 @@
+# Twitch Integrity Token Warming Design
+
+## Scope
+
+This specification adds proactive lifecycle management for Twitch
+`Client-Integrity` tokens in the browser extension. It builds on the bounded
+refresh and cold-boot work from issues #291 and #292 and requires the
+cancellation work from issue #293 before implementation.
+
+The change is extension-only where alarms and browser page contexts are
+concerned. The core controller owns the policy through injected host
+dependencies so `@lurkloot/core` remains free of WXT and browser globals. The
+CLI remains unchanged because its Twitch client does not use browser-minted
+integrity.
+
+## Goals
+
+- Avoid paying for a cold Twitch page-context boot on the critical discovery
+  or reward-claim path whenever a token can be refreshed ahead of expiry.
+- Delay authenticated Twitch work when no valid token is available instead of
+  issuing requests that are expected to fail integrity checks.
+- Keep Twitch enablement responsive and preserve the user's enabled setting
+  while token acquisition happens internally.
+- Retry a failed mint on the next normal discovery alarm rather than creating
+  an aggressive retry loop.
+- Keep Kick and unrelated extension behavior independent from Twitch token
+  readiness.
+- Expose lifecycle details through English diagnostics only. Do not add popup
+  state, activity events, notifications, or locale keys for preparation.
+
+## Non-Goals
+
+- Do not expose a “preparing,” “warming,” or token-readiness state in the popup.
+- Do not make platform enablement wait for token acquisition.
+- Do not introduce a fixed-period integrity alarm.
+- Do not treat integrity availability as Twitch authentication health.
+- Do not mint tokens while Twitch is disabled. The repository deliberately has
+  no separate global running flag; farming is active when at least one platform
+  is enabled.
+- Do not change Kick, the CLI integrity model, or the scheduler’s platform-lock
+  architecture from issue #294.
+
+## Lifecycle Model
+
+The user-facing Twitch setting records intent only. Enabling Twitch persists
+immediately and triggers the ordinary Twitch scheduler path. Internally,
+authenticated Twitch work has a prerequisite: a valid integrity bundle must be
+loaded from storage or minted from a Twitch page context.
+
+On controller startup, the existing stored-token load remains the first source
+of readiness. A token is valid only when its declared `expiresAt` is later than
+the current time plus the existing expiry safety skew. An expired stored token
+is ignored and diagnosed; it is never attached to a request.
+
+When a normal Twitch tick starts without a valid token, it makes one bounded
+mint attempt before authenticated Twitch discovery or account automation. On
+success the tick continues. On timeout, cancellation, or page-context failure,
+the tick skips authenticated Twitch work without disabling Twitch. The next
+normal discovery alarm is the next automatic retry opportunity. No dedicated
+short retry alarm is scheduled.
+
+Public work that is explicitly safe without authenticated integrity may
+continue only where the adapter already models it as anonymous. The readiness
+gate must not silently downgrade an operation intended to use the logged-in
+session into an anonymous request.
+
+## Expiry-Driven Refresh Alarm
+
+Add one browser alarm dedicated to Twitch integrity refresh. It is scheduled
+from the currently captured token’s `expiresAt`, not at a fixed interval. The
+target is two minutes before expiry minus a stable 0–30 second jitter derived
+locally for that token. This leaves more than the 30-second acquisition timeout
+and existing 30-second validity skew while preventing every client from
+refreshing at exactly the same instant. If the computed target is already past,
+the next normal tick owns the attempt; scheduling never creates an immediate
+alarm loop.
+
+Whenever a new integrity bundle is captured—whether from the proactive alarm,
+a normal page request, startup recovery, or a rejection-triggered refresh—the
+controller persists it and replaces the prior alarm with one derived from the
+new expiry. Rescheduling is idempotent.
+
+When the alarm fires, the controller reloads settings before acting. It mints
+only if Twitch is still enabled and the current token is
+missing or inside the refresh window. If a naturally captured replacement is
+already valid beyond that window, the handler only reschedules from the newer
+expiry.
+
+Disabling Twitch, resetting storage, or shutting down the owning host cancels
+an active proactive mint and clears the refresh alarm. Disabling every platform
+therefore also stops warming without requiring a second master switch.
+Re-enabling Twitch recreates the schedule from a still-valid stored token or
+lets the next normal Twitch tick perform the initial mint.
+
+## Single-Flight Acquisition
+
+Startup, normal ticks, the expiry alarm, and integrity-rejection retries all
+enter the same single-flight acquisition primitive. At most one Twitch
+page-context mint may be active. Concurrent callers join its result rather than
+opening competing contexts.
+
+The primitive receives:
+
+- whether a fresh context is required;
+- the rejected token when a request knows exactly what it transmitted;
+- the caller’s `AbortSignal`;
+- the diagnostic emitter.
+
+It returns a bounded success result and does not mutate user settings. The
+token transmitted by a rejected request remains authoritative for replacement
+deduplication, as designed in the #291/#292 fix.
+
+The alarm handler must not hold the controller’s broad scheduler/state lock
+while waiting for Twitch to boot and mint. Persistence and alarm rescheduling
+occur in short serialized sections after capture. This boundary must be
+reconciled with #294’s per-platform locks rather than creating another
+controller-wide critical section.
+
+## Scheduler Gating
+
+The Twitch scheduler pipeline checks integrity readiness before constructing or
+running authenticated adapter work. The gate applies only when:
+
+- Twitch is enabled; and
+- the pending Twitch work requires the logged-in web session.
+
+If acquisition fails, the tick records diagnostics and returns a normal
+no-progress Twitch result. It does not emit an interruption activity event,
+mark authentication unhealthy, clear campaigns, close an existing farming tab,
+or alter Kick state.
+
+An integrity rejection after readiness still uses the existing one-refresh,
+one-retry behavior. Proactive warming reduces how often that recovery path is
+needed but does not replace it because Twitch can reject an otherwise unexpired
+token.
+
+## Diagnostics
+
+All messages are English diagnostic literals and contain no token, cookie,
+device identifier, session identifier, or authenticated response content.
+Diagnostics distinguish:
+
+- no valid token was available and authenticated Twitch work was delayed;
+- proactive refresh started, including the time remaining before expiry;
+- a fresh token was captured and the next refresh was scheduled;
+- a naturally captured token made the pending alarm obsolete;
+- refresh timed out or failed and retry was deferred to the next normal alarm;
+- refresh was cancelled because Twitch stopped;
+- an expired stored token was ignored after service-worker startup.
+
+Routine successful rescheduling should use debug-level diagnostics. Acquisition
+failure uses warning level only when Twitch work was actually delayed; cleanup
+and expected cancellation remain debug level.
+
+## Failure Handling
+
+Alarm creation, removal, token persistence, and page-context acquisition are
+best-effort boundaries with diagnostics. A failed alarm write must not discard
+a freshly captured token. A failed token write leaves the in-memory token
+usable for the current service-worker lifetime and may be retried after the
+next capture.
+
+If the browser was asleep when the scheduled time passed, the alarm may fire
+late. The handler rechecks current token validity and settings rather than
+assuming the state captured at scheduling time is still correct.
+
+Cancellation from #293 is required to close an acquisition cleanly. An aborted
+mint must release its page-context ownership, remove its waiter, settle joined
+callers, and clear the single-flight slot so a later normal alarm can retry.
+
+## Testing
+
+Deterministic controller, tabs, and background-entrypoint tests cover:
+
+- enabling Twitch returns without waiting for a mint;
+- no popup snapshot field or user-facing event represents preparation;
+- a normal Twitch tick with no valid token waits for one bounded acquisition
+  before authenticated work;
+- a successful acquisition allows the same tick to continue;
+- a failed acquisition skips authenticated Twitch work and does not schedule a
+  short retry;
+- the next normal alarm retries after a failed acquisition;
+- Kick continues when Twitch acquisition is pending or fails;
+- a captured token schedules refresh from `expiresAt` with bounded jitter;
+- a replacement token atomically replaces the old refresh schedule;
+- the alarm handler no-ops or reschedules when a newer token already exists;
+- the alarm handler does not mint while Twitch is disabled;
+- Twitch disable, reset, and host shutdown cancel active acquisition and clear
+  the alarm;
+- tick, expiry, and rejection callers share one in-flight mint;
+- cancellation releases all waiters and permits a later retry;
+- late browser alarms revalidate settings and token state;
+- diagnostics contain lifecycle timing but no sensitive integrity values;
+- existing auth-health, discovery, claim, and browser-build suites remain
+  green.
+
+Tests use fake clocks, mocked alarm dependencies, mocked browser tabs, and
+synthetic integrity bundles. They make no live Twitch requests.
+
+## Delivery and Ordering
+
+Implementation starts only after the #291/#292 bounded-refresh work and #293
+cancellation are present on the target branch. It should land before or be
+rebased explicitly onto #294; its alarm and single-flight behavior must not
+restore a controller-wide lock after #294 splits platform pipelines.
+
+The feature is complete when valid tokens schedule proactive refresh,
+authenticated Twitch work waits internally for initial readiness, failed
+acquisition retries only on the next normal discovery alarm, cancellation
+cleans up all ownership, and no preparation state is exposed outside
+diagnostics.

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -384,7 +384,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // Prime the in-memory integrity token from storage whenever the background
   // script (re)evaluates, so a claim right after a service-worker wake can use
   // the last captured token before any fresh page traffic is observed.
-  const initialTwitchIntegrityLoad = loadStoredTwitchIntegrity(integrityLifecycleGeneration);
+  const initialTwitchIntegrityLoad = loadStoredTwitchIntegrity(
+    integrityLifecycleGeneration,
+    twitchSettingsTransitionGeneration,
+  );
 
   function integrityRefreshJitter(token: string): number {
     let hash = 2166136261;
@@ -507,33 +510,36 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
-  async function loadStoredTwitchIntegrity(lifecycleGeneration: number): Promise<void> {
-    await withStateLock(() => withEventCollector(async (emit, events) => {
+  async function loadStoredTwitchIntegrity(
+    lifecycleGeneration: number,
+    settingsTransitionGeneration: number,
+  ): Promise<void> {
+    let twitchEnabled: boolean | undefined;
+    let settingsReadError: unknown;
+    await withSettingsLock(async () => {
       try {
-        const integrity = await deps.loadTwitchIntegrity?.();
-        if (
-          integrityLifecycleGeneration !== lifecycleGeneration
-          || !integrityLifecycleOpen
-        ) return;
-        if (isValidTwitchIntegrity(integrity)) {
-          const current = reconcileStoredTwitchIntegrity(integrity);
-          await scheduleTwitchIntegrityRefreshBestEffort(
-            current!,
-            emit,
-          );
-        } else if (integrity) {
-          emit({
-            category: "diagnostic",
-            level: "debug",
-            platform: "twitch",
-            message: "Stored Twitch integrity token is expired or too close to expiry; ignoring it",
-          });
-        }
+        twitchEnabled = (await deps.loadSettings()).platform.twitch.enabled;
       } catch (error) {
-        if (
-          integrityLifecycleGeneration !== lifecycleGeneration
-          || !integrityLifecycleOpen
-        ) return;
+        settingsReadError = error;
+      }
+    });
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      const ownsStartupLoad = (): boolean =>
+        !controllerShutdown
+        && integrityLifecycleGeneration === lifecycleGeneration
+        && twitchSettingsTransitionGeneration === settingsTransitionGeneration;
+      let integrity: TwitchIntegrity | undefined;
+      if (settingsReadError) {
+        emit({
+          category: "diagnostic",
+          level: "debug",
+          platform: "twitch",
+          message: `Could not read Twitch settings while priming integrity (${settingsReadError instanceof Error ? settingsReadError.message : String(settingsReadError)})`,
+        });
+      }
+      try {
+        integrity = await deps.loadTwitchIntegrity?.();
+      } catch (error) {
         // A missing/corrupt stored token is non-fatal: fresh page traffic will
         // re-capture one, and claims simply stay best-effort until then.
         emit({
@@ -541,6 +547,20 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           level: "debug",
           platform: "twitch",
           message: `No stored Twitch integrity token to prime (${error instanceof Error ? error.message : String(error)})`,
+        });
+      }
+      if (!ownsStartupLoad()) return;
+      if (isValidTwitchIntegrity(integrity)) {
+        const current = reconcileStoredTwitchIntegrity(integrity);
+        if (twitchEnabled === true && integrityLifecycleOpen) {
+          await scheduleTwitchIntegrityRefreshBestEffort(current!, emit);
+        }
+      } else if (integrity) {
+        emit({
+          category: "diagnostic",
+          level: "debug",
+          platform: "twitch",
+          message: "Stored Twitch integrity token is expired or too close to expiry; ignoring it",
         });
       }
       await reportBestEffort(events);
@@ -667,8 +687,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     noteTwitchGqlRequest(tabId);
     const integrity = integrityFromHeaders(headers);
     if (!integrity) return;
+    let isNew = false;
     await withStateLock(() => withEventCollector(async (emit, events) => {
-      const isNew = integrity.integrity !== installedTwitchIntegrity?.integrity;
+      isNew = integrity.integrity !== installedTwitchIntegrity?.integrity;
       installTwitchIntegrity(integrity, isNew, emit);
       if (integrity.integrity !== persistedIntegrityToken && deps.saveTwitchIntegrity) {
         try {
@@ -683,8 +704,29 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           });
         }
       }
-      if (isNew) {
+      await reportBestEffort(events);
+    }));
+    if (!isNew) return;
+    const lifecycleGeneration = integrityLifecycleGeneration;
+    const settingsTransitionGeneration = twitchSettingsTransitionGeneration;
+    const ownsScheduling = (): boolean =>
+      !controllerShutdown
+      && integrityLifecycleOpen
+      && integrityLifecycleGeneration === lifecycleGeneration
+      && twitchSettingsTransitionGeneration === settingsTransitionGeneration;
+    await withSettingsLock(() => withEventCollector(async (emit, events) => {
+      try {
+        if (!ownsScheduling()) return;
+        const settings = await deps.loadSettings();
+        if (!ownsScheduling() || !settings.platform.twitch.enabled) return;
         await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+      } catch (error) {
+        emit({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "warn",
+          message: `Could not check Twitch settings before scheduling integrity refresh (${error instanceof Error ? error.message : String(error)})`,
+        });
       }
       await reportBestEffort(events);
     }));

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -6,7 +6,16 @@ import { isFarmingActive } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
 import { isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
 import { isPlaybackTelemetryHealthy, MANUAL_WATCH_TTL_MS, runSchedulerTick, type StopPageContextTabs } from "../core/scheduler";
-import { currentManagedPageContextTabs, INTEGRITY_REFRESH_TIMEOUT_MS, noteTwitchGqlRequest, registerManagedPageContextTabs, setTwitchIntegrity, syncManagedTabBreakers } from "../core/tabs";
+import {
+  currentManagedPageContextTabs,
+  INTEGRITY_REFRESH_TIMEOUT_MS,
+  isValidTwitchIntegrity,
+  noteTwitchGqlRequest,
+  registerManagedPageContextTabs,
+  setTwitchIntegrity,
+  syncManagedTabBreakers,
+  type TwitchIntegrityRequest,
+} from "../core/tabs";
 import { dismissCriticalFailure, recordManagedTabOpen } from "../core/criticalHealth";
 import { integrityFromHeaders } from "../core/twitchIntegrity";
 import type { IntegrityHeader, TwitchIntegrity } from "../core/twitchIntegrity";
@@ -20,6 +29,9 @@ export const ALARM_NAME = "lurkloot.tick";
 // of the (heavier, configurable) discovery tick. chrome.alarms clamps to a
 // 1-minute minimum, close enough to TwitchDropsMiner's 59s send cadence.
 export const WATCH_ALARM_NAME = "lurkloot.watch";
+export const TWITCH_INTEGRITY_ALARM_NAME = "lurkloot.twitch-integrity";
+export const TWITCH_INTEGRITY_REFRESH_LEAD_MS = 120_000;
+export const TWITCH_INTEGRITY_REFRESH_JITTER_MAX_MS = 30_000;
 // Reward ids claimed during one tick, per platform. The post-claim handoff needs
 // the ids (not just the platforms) so it can tell a genuine successor from the
 // reward that was just claimed.
@@ -142,7 +154,16 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
   saveState(state: SchedulerState): Promise<void>;
   authProbeTimeoutMs?: number;
   reportEvents?: EventReporter;
-  createAlarm(name: string, options: { periodInMinutes: number }): Promise<void>;
+  createAlarm(
+    name: string,
+    options: { periodInMinutes: number } | { when: number },
+  ): Promise<void>;
+  clearAlarm?(name: string): Promise<boolean>;
+  ensureTwitchIntegrity?(
+    emit: EventEmitter,
+    request?: TwitchIntegrityRequest,
+  ): Promise<boolean>;
+  cancelTwitchIntegrityAcquisition?(reason?: unknown): void;
   createAdapters(emit: EventEmitter, settings: S): {
     adapters: Record<Platform, PlatformAdapter>;
     compatibility: ResolvedCompatibility;
@@ -337,27 +358,94 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // Prime the in-memory integrity token from storage whenever the background
   // script (re)evaluates, so a claim right after a service-worker wake can use
   // the last captured token before any fresh page traffic is observed.
-  void loadStoredTwitchIntegrity();
+  const initialTwitchIntegrityLoad = loadStoredTwitchIntegrity();
+
+  function integrityRefreshJitter(token: string): number {
+    let hash = 2166136261;
+    for (let index = 0; index < token.length; index += 1) {
+      hash ^= token.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0) % (TWITCH_INTEGRITY_REFRESH_JITTER_MAX_MS + 1);
+  }
+
+  async function clearTwitchIntegrityAlarm(): Promise<void> {
+    await deps.clearAlarm?.(TWITCH_INTEGRITY_ALARM_NAME);
+  }
+
+  async function scheduleTwitchIntegrityRefresh(
+    integrity: TwitchIntegrity,
+    emit?: EventEmitter,
+  ): Promise<void> {
+    const when = integrity.expiresAt
+      - TWITCH_INTEGRITY_REFRESH_LEAD_MS
+      - integrityRefreshJitter(integrity.integrity);
+    if (when <= Date.now()) {
+      await clearTwitchIntegrityAlarm();
+      return;
+    }
+    await deps.createAlarm(TWITCH_INTEGRITY_ALARM_NAME, { when });
+    emit?.({
+      category: "diagnostic",
+      platform: "twitch",
+      level: "debug",
+      message: `Scheduled proactive Twitch integrity refresh for ${new Date(when).toISOString()}`,
+    });
+  }
+
+  async function scheduleTwitchIntegrityRefreshBestEffort(
+    integrity: TwitchIntegrity,
+    emit?: EventEmitter,
+  ): Promise<void> {
+    try {
+      await scheduleTwitchIntegrityRefresh(integrity, emit);
+    } catch (error) {
+      const event: DiagnosticEvent = {
+        category: "diagnostic",
+        platform: "twitch",
+        level: "warn",
+        message: `Could not schedule Twitch integrity refresh (${error instanceof Error ? error.message : String(error)})`,
+      };
+      if (emit) {
+        emit(event);
+      } else {
+        await reportBestEffort([event]);
+      }
+    }
+  }
 
   async function loadStoredTwitchIntegrity(): Promise<void> {
-    await withStateLock(async () => {
+    await withStateLock(() => withEventCollector(async (emit, events) => {
       try {
         const integrity = await deps.loadTwitchIntegrity?.();
-        if (integrity && integrity.expiresAt > Date.now()) {
+        if (isValidTwitchIntegrity(integrity)) {
           lastIntegrityToken = integrity.integrity;
           setTwitchIntegrity(integrity);
+          await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+        } else if (integrity) {
+          emit({
+            category: "diagnostic",
+            level: "debug",
+            platform: "twitch",
+            message: "Stored Twitch integrity token is expired or too close to expiry; ignoring it",
+          });
         }
       } catch (error) {
         // A missing/corrupt stored token is non-fatal: fresh page traffic will
         // re-capture one, and claims simply stay best-effort until then.
-        await reportBestEffort([{
+        emit({
           category: "diagnostic",
           level: "debug",
           platform: "twitch",
           message: `No stored Twitch integrity token to prime (${error instanceof Error ? error.message : String(error)})`,
-        }]);
+        });
       }
-    });
+      await reportBestEffort(events);
+    }));
+  }
+
+  async function runTwitchIntegrityRefresh(): Promise<void> {
+    await loadStoredTwitchIntegrity();
   }
 
   // Fed by the background's webRequest listener with the outgoing headers of
@@ -378,6 +466,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       if (isNew) {
         lastIntegrityToken = integrity.integrity;
         await deps.saveTwitchIntegrity?.(integrity);
+        await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
       }
       await reportBestEffort(events);
     }));
@@ -1300,6 +1389,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // triggered has actually landed. Settling drains the chain until it stops
   // growing, so a tick that queues a post-claim handoff is covered too.
   async function settleBackgroundWork(): Promise<void> {
+    await initialTwitchIntegrityLoad;
     let pending = backgroundWork;
     for (;;) {
       await pending;
@@ -1791,6 +1881,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     handleMessage,
     resumeAfterManualClose,
     captureTwitchIntegrity,
+    runTwitchIntegrityRefresh,
     checkAuthHealth,
     invalidateAuthHealth,
     tick,

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -350,6 +350,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     kick: new Set<string>(),
   };
   let settingsMutation: Promise<unknown> = Promise.resolve();
+  let integrityRefreshAbort: AbortController | undefined;
 
   // The last token handed to setTwitchIntegrity; used to skip re-persisting on
   // every page GQL call (the page sends integrity on most requests).
@@ -369,17 +370,39 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     return (hash >>> 0) % (TWITCH_INTEGRITY_REFRESH_JITTER_MAX_MS + 1);
   }
 
+  function twitchIntegrityRefreshTarget(integrity: TwitchIntegrity): number {
+    return integrity.expiresAt
+      - TWITCH_INTEGRITY_REFRESH_LEAD_MS
+      - integrityRefreshJitter(integrity.integrity);
+  }
+
   async function clearTwitchIntegrityAlarm(): Promise<void> {
     await deps.clearAlarm?.(TWITCH_INTEGRITY_ALARM_NAME);
+  }
+
+  async function clearTwitchIntegrityAlarmBestEffort(emit?: EventEmitter): Promise<void> {
+    try {
+      await clearTwitchIntegrityAlarm();
+    } catch {
+      const event: DiagnosticEvent = {
+        category: "diagnostic",
+        platform: "twitch",
+        level: "warn",
+        message: "Could not clear the Twitch integrity refresh alarm",
+      };
+      if (emit) {
+        emit(event);
+      } else {
+        await reportBestEffort([event]);
+      }
+    }
   }
 
   async function scheduleTwitchIntegrityRefresh(
     integrity: TwitchIntegrity,
     emit?: EventEmitter,
   ): Promise<void> {
-    const when = integrity.expiresAt
-      - TWITCH_INTEGRITY_REFRESH_LEAD_MS
-      - integrityRefreshJitter(integrity.integrity);
+    const when = twitchIntegrityRefreshTarget(integrity);
     if (when <= Date.now()) {
       await clearTwitchIntegrityAlarm();
       return;
@@ -445,7 +468,73 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function runTwitchIntegrityRefresh(): Promise<void> {
-    await loadStoredTwitchIntegrity();
+    await initialTwitchIntegrityLoad;
+    await withEventCollector(async (emit, events) => {
+      const settings = await deps.loadSettings();
+      let integrity: TwitchIntegrity | undefined;
+      try {
+        integrity = await deps.loadTwitchIntegrity?.();
+      } catch {
+        emit({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "debug",
+          message: "Could not reload stored Twitch integrity before proactive refresh",
+        });
+      }
+
+      if (!settings.platform.twitch.enabled) {
+        integrityRefreshAbort?.abort(new Error("Twitch disabled"));
+        deps.cancelTwitchIntegrityAcquisition?.(new Error("Twitch disabled"));
+        await clearTwitchIntegrityAlarmBestEffort(emit);
+        await reportBestEffort(events);
+        return;
+      }
+
+      if (isValidTwitchIntegrity(integrity)) {
+        lastIntegrityToken = integrity.integrity;
+        setTwitchIntegrity(integrity);
+        if (twitchIntegrityRefreshTarget(integrity) > Date.now()) {
+          await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+          await reportBestEffort(events);
+          return;
+        }
+      }
+
+      if (!deps.ensureTwitchIntegrity || integrityRefreshAbort) {
+        await reportBestEffort(events);
+        return;
+      }
+
+      const abort = new AbortController();
+      integrityRefreshAbort = abort;
+      try {
+        const ready = await deps.ensureTwitchIntegrity(emit, {
+          forceRefresh: true,
+          signal: abort.signal,
+        });
+        if (!ready && !abort.signal.aborted) {
+          emit({
+            category: "diagnostic",
+            platform: "twitch",
+            level: "warn",
+            message: "Could not refresh Twitch integrity; the next normal scheduler alarm will retry",
+          });
+        }
+      } catch {
+        if (!abort.signal.aborted) {
+          emit({
+            category: "diagnostic",
+            platform: "twitch",
+            level: "warn",
+            message: "Could not refresh Twitch integrity; the next normal scheduler alarm will retry",
+          });
+        }
+      } finally {
+        if (integrityRefreshAbort === abort) integrityRefreshAbort = undefined;
+        await reportBestEffort(events);
+      }
+    });
   }
 
   // Fed by the background's webRequest listener with the outgoing headers of
@@ -831,6 +920,30 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }));
   }
 
+  async function prepareTwitchIntegrity(
+    settings: S,
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    const ensureTwitchIntegrity = deps.ensureTwitchIntegrity;
+    if (!settings.platform.twitch.enabled || !ensureTwitchIntegrity) return true;
+    return withEventCollector(async (emit, events) => {
+      try {
+        const ready = await ensureTwitchIntegrity(emit, { signal });
+        if (!ready) {
+          emit({
+            category: "diagnostic",
+            platform: "twitch",
+            level: "warn",
+            message: "No valid Twitch integrity token; delaying authenticated Twitch work until the next normal scheduler alarm",
+          });
+        }
+        return ready;
+      } finally {
+        await reportBestEffort(events);
+      }
+    });
+  }
+
   // Every tick is bracketed by a start/finish diagnostic carrying its trigger and
   // elapsed time. A tick that succeeds otherwise emits nothing about itself, which
   // makes a slow one indistinguishable from an idle gap in an exported log.
@@ -865,39 +978,47 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   ): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
     const settings = await deps.loadSettings();
-    const setupFailedPlatforms = new Set<Platform>();
+    const requestedPlatforms = platforms ?? PLATFORMS;
+    const excludedPlatforms = new Set<Platform>();
     if (isFarmingActive(settings)) {
-      const authStartedAt = Date.now();
-      try {
-        await refreshAuthHealth(platforms ?? PLATFORMS, settings, false, signal);
-        diagnosticEvent("debug", `Tick #${tickId} refreshed auth health in ${Date.now() - authStartedAt}ms`);
-      } catch (error) {
-        const failures = flattenedRefreshFailures(error);
-        const setupFailures = failures.filter((failure): failure is AuthProbeSetupError =>
-          failure instanceof AuthProbeSetupError);
-        if (setupFailures.length === 0) throw error;
-        for (const failure of setupFailures) setupFailedPlatforms.add(failure.platform);
-        let reportingFailure: unknown;
+      if (requestedPlatforms.includes("twitch")) {
+        const twitchReady = await prepareTwitchIntegrity(settings, signal);
+        if (!twitchReady) excludedPlatforms.add("twitch");
+      }
+      const authPlatforms = requestedPlatforms.filter((platform) => !excludedPlatforms.has(platform));
+      if (authPlatforms.length > 0) {
+        const authStartedAt = Date.now();
         try {
-          await reportAuthSetupFailures(setupFailures);
-        } catch (failure) {
-          reportingFailure = failure;
-        }
-        const nonSetupFailures = failures.filter((failure) => !(failure instanceof AuthProbeSetupError));
-        if (nonSetupFailures.length > 0) {
-          if (reportingFailure !== undefined) {
-            throw new AggregateError(
-              [...failures, reportingFailure],
-              "Authentication refresh and interruption persistence failed",
-            );
+          await refreshAuthHealth(authPlatforms, settings, false, signal);
+          diagnosticEvent("debug", `Tick #${tickId} refreshed auth health in ${Date.now() - authStartedAt}ms`);
+        } catch (error) {
+          const failures = flattenedRefreshFailures(error);
+          const setupFailures = failures.filter((failure): failure is AuthProbeSetupError =>
+            failure instanceof AuthProbeSetupError);
+          if (setupFailures.length === 0) throw error;
+          for (const failure of setupFailures) excludedPlatforms.add(failure.platform);
+          let reportingFailure: unknown;
+          try {
+            await reportAuthSetupFailures(setupFailures);
+          } catch (failure) {
+            reportingFailure = failure;
           }
-          throw error;
+          const nonSetupFailures = failures.filter((failure) => !(failure instanceof AuthProbeSetupError));
+          if (nonSetupFailures.length > 0) {
+            if (reportingFailure !== undefined) {
+              throw new AggregateError(
+                [...failures, reportingFailure],
+                "Authentication refresh and interruption persistence failed",
+              );
+            }
+            throw error;
+          }
+          if (reportingFailure !== undefined) throw reportingFailure;
         }
-        if (reportingFailure !== undefined) throw reportingFailure;
       }
     }
-    const schedulerPlatforms = (platforms ?? PLATFORMS).filter((platform) =>
-      !setupFailedPlatforms.has(platform));
+    const schedulerPlatforms = requestedPlatforms.filter((platform) =>
+      !excludedPlatforms.has(platform));
     if (schedulerPlatforms.length === 0) return claimedRewards;
     await withStateLock(() => withEventCollector(async (emit, events) => {
       signal.throwIfAborted();
@@ -909,7 +1030,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       };
       let nextState: SchedulerState;
       try {
-        const adapters = setupFailedPlatforms.size > 0
+        const adapters = excludedPlatforms.size > 0
           ? createSelectedAdapters(settings, emit, schedulerPlatforms)
           : createAdapters(settings, emit);
         // Observed here rather than returned by the scheduler: the controller
@@ -1264,13 +1385,23 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
+  function cancelTwitchIntegrityWork(reason: string): void {
+    const error = new Error(reason);
+    integrityRefreshAbort?.abort(error);
+    deps.cancelTwitchIntegrityAcquisition?.(error);
+  }
+
   function shutdown(): void {
     abortActiveTicks("Controller shutdown");
+    cancelTwitchIntegrityWork("Controller shutdown");
+    void clearTwitchIntegrityAlarmBestEffort();
     abortClaimHandoffs();
   }
 
   async function prepareForHostReset(resetHostStorage?: () => Promise<void>): Promise<void> {
     abortActiveTicks("Host reset");
+    cancelTwitchIntegrityWork("Host reset");
+    await clearTwitchIntegrityAlarmBestEffort();
     abortClaimHandoffs();
     await withSettingsLock(() => withStateLock(() => withEventCollector(async (emit, events) => {
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
@@ -1725,6 +1856,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     if (message.type === "setPlatformEnabled" || message.type === "setAutomation") {
       // Stopping must cancel any loop still refreshing in the background.
       if (!message.enabled) abortClaimHandoffs(message.platform);
+      if (message.platform === "twitch" && !message.enabled) {
+        cancelTwitchIntegrityWork("Twitch disabled");
+        await clearTwitchIntegrityAlarmBestEffort();
+      }
       await updateStoredSettings({
         platform: {
           [message.platform]: {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -368,6 +368,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     kick: new Set<string>(),
   };
   let settingsMutation: Promise<unknown> = Promise.resolve();
+  let twitchSettingsTransitionGeneration = 0;
   let integrityRefreshAbort: AbortController | undefined;
   let integrityLifecycleGeneration = 0;
   let integrityLifecycleOpen = true;
@@ -881,9 +882,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     });
   }
 
-  async function restoreTwitchIntegritySchedule(): Promise<void> {
+  async function restoreTwitchIntegritySchedule(
+    transitionIsCurrent: () => boolean,
+  ): Promise<void> {
     await withStateLock(() => withEventCollector(async (emit, events) => {
-      if (!integrityLifecycleOpen) return;
+      if (!integrityLifecycleOpen || !transitionIsCurrent()) return;
       let stored: TwitchIntegrity | undefined;
       try {
         stored = await deps.loadTwitchIntegrity?.();
@@ -895,9 +898,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           message: "Could not reload stored Twitch integrity after Twitch was enabled",
         });
       }
-      if (!integrityLifecycleOpen) return;
+      if (!integrityLifecycleOpen || !transitionIsCurrent()) return;
       const integrity = reconcileStoredTwitchIntegrity(stored);
-      if (integrity) await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+      if (integrity && transitionIsCurrent()) {
+        await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+      }
       await reportBestEffort(events);
     }));
   }
@@ -1752,9 +1757,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // finishes. Detaching the tick alone would not fix that: the popup polls the
   // stored state, so a slow tick leaves it rendering a status that contradicts
   // the switch the user just flipped. Stamp the transition up front instead.
-  async function markPlatformsStarting(platforms: readonly Platform[]): Promise<void> {
+  async function markPlatformsStarting(
+    platforms: readonly Platform[],
+    transitionIsCurrent: () => boolean = () => true,
+  ): Promise<void> {
     await withStateLock(async () => {
       const state = await deps.loadState();
+      if (!transitionIsCurrent()) return;
       let changed = false;
       const sessions = { ...state.sessions };
       for (const platform of platforms) {
@@ -1771,6 +1780,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         changed = true;
       }
       if (!changed) return;
+      if (!transitionIsCurrent()) return;
       await persistAndReport({ ...state, sessions });
     });
   }
@@ -2074,6 +2084,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     if (message.type === "setPlatformEnabled" || message.type === "setAutomation") {
       // Stopping must cancel any loop still refreshing in the background.
       if (!message.enabled) abortClaimHandoffs(message.platform);
+      const twitchTransitionGeneration = message.platform === "twitch"
+        ? ++twitchSettingsTransitionGeneration
+        : undefined;
+      const twitchTransitionIsCurrent = (): boolean =>
+        twitchTransitionGeneration === twitchSettingsTransitionGeneration;
       const stoppingTwitch = message.platform === "twitch" && !message.enabled;
       let twitchTransitionPersisted = false;
       if (stoppingTwitch) closeTwitchIntegrityLifecycle("Twitch disabled");
@@ -2087,21 +2102,42 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         }, message.platform === "twitch"
           ? () => {
               twitchTransitionPersisted = true;
-              if (message.enabled) reopenTwitchIntegrityLifecycle();
-              else closeTwitchIntegrityLifecycle("Twitch disabled");
+              if (message.enabled) {
+                if (twitchTransitionIsCurrent()) reopenTwitchIntegrityLifecycle();
+              } else {
+                closeTwitchIntegrityLifecycle("Twitch disabled");
+              }
             }
           : undefined);
       } catch (error) {
-        if (stoppingTwitch && !twitchTransitionPersisted) {
+        if (
+          stoppingTwitch
+          && !twitchTransitionPersisted
+          && twitchTransitionIsCurrent()
+        ) {
           reopenTwitchIntegrityLifecycle();
         }
         throw error;
       }
       if (message.platform === "twitch") {
-        if (message.enabled) await restoreTwitchIntegritySchedule();
+        if (message.enabled) {
+          if (!twitchTransitionIsCurrent()) return snapshot();
+          await restoreTwitchIntegritySchedule(twitchTransitionIsCurrent);
+          if (!twitchTransitionIsCurrent()) return snapshot();
+        }
         else await clearTwitchIntegrityAlarmBestEffort();
       }
-      if (message.enabled) await markPlatformsStarting([message.platform]);
+      if (message.enabled) {
+        await markPlatformsStarting(
+          [message.platform],
+          message.platform === "twitch"
+            ? twitchTransitionIsCurrent
+            : undefined,
+        );
+        if (message.platform === "twitch" && !twitchTransitionIsCurrent()) {
+          return snapshot();
+        }
+      }
       // Always scoped to the toggled platform. Nothing about this change can
       // affect the other one any more, so it is never dragged through this
       // platform's discovery.

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2117,6 +2117,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       const twitchTransitionIsCurrent = (): boolean =>
         !controllerShutdown
         && twitchTransitionGeneration === twitchSettingsTransitionGeneration;
+      const twitchLifecycleOpenBeforeTransition = message.platform === "twitch"
+        ? integrityLifecycleOpen
+        : undefined;
+      let twitchSettingsLoaded = false;
       const stoppingTwitch = message.platform === "twitch" && !message.enabled;
       if (stoppingTwitch) closeTwitchIntegrityLifecycle("Twitch disabled");
       try {
@@ -2136,12 +2140,17 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           : undefined,
         message.platform === "twitch"
           ? (settings) => {
+              twitchSettingsLoaded = true;
               lastPersistedTwitchEnabled = settings.platform.twitch.enabled;
             }
           : undefined);
       } catch (error) {
         if (message.platform === "twitch" && twitchTransitionIsCurrent()) {
-          reconcileTwitchIntegrityLifecycle(lastPersistedTwitchEnabled);
+          reconcileTwitchIntegrityLifecycle(
+            twitchSettingsLoaded
+              ? lastPersistedTwitchEnabled
+              : twitchLifecycleOpenBeforeTransition,
+          );
         }
         throw error;
       }

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -468,73 +468,85 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function runTwitchIntegrityRefresh(): Promise<void> {
-    await initialTwitchIntegrityLoad;
-    await withEventCollector(async (emit, events) => {
-      const settings = await deps.loadSettings();
-      let integrity: TwitchIntegrity | undefined;
-      try {
-        integrity = await deps.loadTwitchIntegrity?.();
-      } catch {
-        emit({
-          category: "diagnostic",
-          platform: "twitch",
-          level: "debug",
-          message: "Could not reload stored Twitch integrity before proactive refresh",
-        });
-      }
+    if (integrityRefreshAbort) return;
+    const abort = new AbortController();
+    integrityRefreshAbort = abort;
+    const ownsRefresh = (): boolean =>
+      integrityRefreshAbort === abort && !abort.signal.aborted;
+    const refreshStillEnabled = async (): Promise<boolean> => {
+      if (!ownsRefresh()) return false;
+      const currentSettings = await deps.loadSettings();
+      return ownsRefresh() && currentSettings.platform.twitch.enabled;
+    };
 
-      if (!settings.platform.twitch.enabled) {
-        integrityRefreshAbort?.abort(new Error("Twitch disabled"));
-        deps.cancelTwitchIntegrityAcquisition?.(new Error("Twitch disabled"));
-        await clearTwitchIntegrityAlarmBestEffort(emit);
-        await reportBestEffort(events);
-        return;
-      }
+    try {
+      await initialTwitchIntegrityLoad;
+      if (!ownsRefresh()) return;
+      await withEventCollector(async (emit, events) => {
+        try {
+          const settings = await deps.loadSettings();
+          if (!ownsRefresh()) return;
+          let integrity: TwitchIntegrity | undefined;
+          try {
+            integrity = await deps.loadTwitchIntegrity?.();
+          } catch {
+            emit({
+              category: "diagnostic",
+              platform: "twitch",
+              level: "debug",
+              message: "Could not reload stored Twitch integrity before proactive refresh",
+            });
+          }
+          if (!ownsRefresh()) return;
 
-      if (isValidTwitchIntegrity(integrity)) {
-        lastIntegrityToken = integrity.integrity;
-        setTwitchIntegrity(integrity);
-        if (twitchIntegrityRefreshTarget(integrity) > Date.now()) {
-          await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+          if (!settings.platform.twitch.enabled) {
+            cancelTwitchIntegrityWork("Twitch disabled");
+            await clearTwitchIntegrityAlarmBestEffort(emit);
+            return;
+          }
+
+          if (isValidTwitchIntegrity(integrity)) {
+            lastIntegrityToken = integrity.integrity;
+            setTwitchIntegrity(integrity);
+            if (twitchIntegrityRefreshTarget(integrity) > Date.now()) {
+              if (!await refreshStillEnabled()) return;
+              await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+              return;
+            }
+          }
+
+          if (!deps.ensureTwitchIntegrity || !await refreshStillEnabled()) return;
+
+          const ready = await deps.ensureTwitchIntegrity(emit, {
+            forceRefresh: true,
+            signal: abort.signal,
+          });
+          if (!ready && !abort.signal.aborted) {
+            emit({
+              category: "diagnostic",
+              platform: "twitch",
+              level: "warn",
+              message: "Could not refresh Twitch integrity; the next normal scheduler alarm will retry",
+            });
+          }
+        } catch {
+          if (!abort.signal.aborted) {
+            emit({
+              category: "diagnostic",
+              platform: "twitch",
+              level: "warn",
+              message: "Could not refresh Twitch integrity; the next normal scheduler alarm will retry",
+            });
+          }
+        } finally {
           await reportBestEffort(events);
-          return;
         }
+      });
+    } finally {
+      if (integrityRefreshAbort === abort) {
+        integrityRefreshAbort = undefined;
       }
-
-      if (!deps.ensureTwitchIntegrity || integrityRefreshAbort) {
-        await reportBestEffort(events);
-        return;
-      }
-
-      const abort = new AbortController();
-      integrityRefreshAbort = abort;
-      try {
-        const ready = await deps.ensureTwitchIntegrity(emit, {
-          forceRefresh: true,
-          signal: abort.signal,
-        });
-        if (!ready && !abort.signal.aborted) {
-          emit({
-            category: "diagnostic",
-            platform: "twitch",
-            level: "warn",
-            message: "Could not refresh Twitch integrity; the next normal scheduler alarm will retry",
-          });
-        }
-      } catch {
-        if (!abort.signal.aborted) {
-          emit({
-            category: "diagnostic",
-            platform: "twitch",
-            level: "warn",
-            message: "Could not refresh Twitch integrity; the next normal scheduler alarm will retry",
-          });
-        }
-      } finally {
-        if (integrityRefreshAbort === abort) integrityRefreshAbort = undefined;
-        await reportBestEffort(events);
-      }
-    });
+    }
   }
 
   // Fed by the background's webRequest listener with the outgoing headers of

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -351,6 +351,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   };
   let settingsMutation: Promise<unknown> = Promise.resolve();
   let integrityRefreshAbort: AbortController | undefined;
+  let integrityLifecycleGeneration = 0;
 
   // The last token handed to setTwitchIntegrity; used to skip re-persisting on
   // every page GQL call (the page sends integrity on most requests).
@@ -359,7 +360,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // Prime the in-memory integrity token from storage whenever the background
   // script (re)evaluates, so a claim right after a service-worker wake can use
   // the last captured token before any fresh page traffic is observed.
-  const initialTwitchIntegrityLoad = loadStoredTwitchIntegrity();
+  const initialTwitchIntegrityLoad = loadStoredTwitchIntegrity(integrityLifecycleGeneration);
 
   function integrityRefreshJitter(token: string): number {
     let hash = 2166136261;
@@ -437,10 +438,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
-  async function loadStoredTwitchIntegrity(): Promise<void> {
+  async function loadStoredTwitchIntegrity(lifecycleGeneration: number): Promise<void> {
     await withStateLock(() => withEventCollector(async (emit, events) => {
       try {
         const integrity = await deps.loadTwitchIntegrity?.();
+        if (integrityLifecycleGeneration !== lifecycleGeneration) return;
         if (isValidTwitchIntegrity(integrity)) {
           lastIntegrityToken = integrity.integrity;
           setTwitchIntegrity(integrity);
@@ -454,6 +456,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           });
         }
       } catch (error) {
+        if (integrityLifecycleGeneration !== lifecycleGeneration) return;
         // A missing/corrupt stored token is non-fatal: fresh page traffic will
         // re-capture one, and claims simply stay best-effort until then.
         emit({
@@ -471,8 +474,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     if (integrityRefreshAbort) return;
     const abort = new AbortController();
     integrityRefreshAbort = abort;
+    const lifecycleGeneration = integrityLifecycleGeneration;
     const ownsRefresh = (): boolean =>
-      integrityRefreshAbort === abort && !abort.signal.aborted;
+      integrityRefreshAbort === abort
+      && !abort.signal.aborted
+      && integrityLifecycleGeneration === lifecycleGeneration;
     const refreshStillEnabled = async (): Promise<boolean> => {
       if (!ownsRefresh()) return false;
       const currentSettings = await deps.loadSettings();
@@ -1399,6 +1405,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   function cancelTwitchIntegrityWork(reason: string): void {
     const error = new Error(reason);
+    integrityLifecycleGeneration += 1;
     integrityRefreshAbort?.abort(error);
     deps.cancelTwitchIntegrityAcquisition?.(error);
   }

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -32,6 +32,24 @@ export const WATCH_ALARM_NAME = "lurkloot.watch";
 export const TWITCH_INTEGRITY_ALARM_NAME = "lurkloot.twitch-integrity";
 export const TWITCH_INTEGRITY_REFRESH_LEAD_MS = 120_000;
 export const TWITCH_INTEGRITY_REFRESH_JITTER_MAX_MS = 30_000;
+
+interface BackgroundAlarmController {
+  tickAndHandOff(platforms?: Platform[], trigger?: TickTrigger): Promise<void>;
+  runWatchHeartbeat(): Promise<void>;
+  runTwitchIntegrityRefresh(): Promise<void>;
+}
+
+export function createBackgroundAlarmListener(controller: BackgroundAlarmController) {
+  return (alarm: { name: string }): void => {
+    if (alarm.name === ALARM_NAME) {
+      void controller.tickAndHandOff(undefined, "alarm");
+    } else if (alarm.name === WATCH_ALARM_NAME) {
+      void controller.runWatchHeartbeat();
+    } else if (alarm.name === TWITCH_INTEGRITY_ALARM_NAME) {
+      void controller.runTwitchIntegrityRefresh();
+    }
+  };
+}
 // Reward ids claimed during one tick, per platform. The post-claim handoff needs
 // the ids (not just the platforms) so it can tell a genuine successor from the
 // reward that was just claimed.
@@ -352,10 +370,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   let settingsMutation: Promise<unknown> = Promise.resolve();
   let integrityRefreshAbort: AbortController | undefined;
   let integrityLifecycleGeneration = 0;
-
-  // The last token handed to setTwitchIntegrity; used to skip re-persisting on
-  // every page GQL call (the page sends integrity on most requests).
-  let lastIntegrityToken: string | undefined;
+  let integrityLifecycleOpen = true;
+  let controllerShutdown = false;
+  let installedTwitchIntegrity: TwitchIntegrity | undefined;
+  let persistedIntegrityToken: string | undefined;
+  // A missing rejectedToken means there was no usable bundle when the refresh
+  // became due. Keeping the wrapper object distinguishes that from "not due."
+  let twitchIntegrityRefreshDue: { rejectedToken?: string } | undefined;
 
   // Prime the in-memory integrity token from storage whenever the background
   // script (re)evaluates, so a claim right after a service-worker wake can use
@@ -375,6 +396,39 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     return integrity.expiresAt
       - TWITCH_INTEGRITY_REFRESH_LEAD_MS
       - integrityRefreshJitter(integrity.integrity);
+  }
+
+  function installTwitchIntegrity(integrity: TwitchIntegrity, isNew = false, emit?: EventEmitter): void {
+    installedTwitchIntegrity = integrity;
+    setTwitchIntegrity(integrity, { isNew }, emit);
+  }
+
+  function currentInstalledTwitchIntegrity(): TwitchIntegrity | undefined {
+    return isValidTwitchIntegrity(installedTwitchIntegrity)
+      ? installedTwitchIntegrity
+      : undefined;
+  }
+
+  function reconcileStoredTwitchIntegrity(stored: TwitchIntegrity | undefined): TwitchIntegrity | undefined {
+    const current = currentInstalledTwitchIntegrity();
+    if (!isValidTwitchIntegrity(stored)) return current;
+    const storedSupersedesCurrent = !current
+      || (
+        stored.integrity !== current.integrity
+        && persistedIntegrityToken === current.integrity
+      );
+    persistedIntegrityToken = stored.integrity;
+    if (storedSupersedesCurrent) {
+      installTwitchIntegrity(stored);
+      return stored;
+    }
+    return current;
+  }
+
+  function markTwitchIntegrityRefreshDue(integrity?: TwitchIntegrity): void {
+    twitchIntegrityRefreshDue = {
+      ...(integrity ? { rejectedToken: integrity.integrity } : {}),
+    };
   }
 
   async function clearTwitchIntegrityAlarm(): Promise<void> {
@@ -405,10 +459,12 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   ): Promise<void> {
     const when = twitchIntegrityRefreshTarget(integrity);
     if (when <= Date.now()) {
+      markTwitchIntegrityRefreshDue(integrity);
       await clearTwitchIntegrityAlarm();
       return;
     }
     await deps.createAlarm(TWITCH_INTEGRITY_ALARM_NAME, { when });
+    twitchIntegrityRefreshDue = undefined;
     emit?.({
       category: "diagnostic",
       platform: "twitch",
@@ -442,11 +498,16 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     await withStateLock(() => withEventCollector(async (emit, events) => {
       try {
         const integrity = await deps.loadTwitchIntegrity?.();
-        if (integrityLifecycleGeneration !== lifecycleGeneration) return;
+        if (
+          integrityLifecycleGeneration !== lifecycleGeneration
+          || !integrityLifecycleOpen
+        ) return;
         if (isValidTwitchIntegrity(integrity)) {
-          lastIntegrityToken = integrity.integrity;
-          setTwitchIntegrity(integrity);
-          await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+          const current = reconcileStoredTwitchIntegrity(integrity);
+          await scheduleTwitchIntegrityRefreshBestEffort(
+            current!,
+            emit,
+          );
         } else if (integrity) {
           emit({
             category: "diagnostic",
@@ -456,7 +517,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           });
         }
       } catch (error) {
-        if (integrityLifecycleGeneration !== lifecycleGeneration) return;
+        if (
+          integrityLifecycleGeneration !== lifecycleGeneration
+          || !integrityLifecycleOpen
+        ) return;
         // A missing/corrupt stored token is non-fatal: fresh page traffic will
         // re-capture one, and claims simply stay best-effort until then.
         emit({
@@ -471,77 +535,100 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function runTwitchIntegrityRefresh(): Promise<void> {
-    if (integrityRefreshAbort) return;
+    if (!integrityLifecycleOpen || integrityRefreshAbort) return;
     const abort = new AbortController();
     integrityRefreshAbort = abort;
     const lifecycleGeneration = integrityLifecycleGeneration;
     const ownsRefresh = (): boolean =>
       integrityRefreshAbort === abort
       && !abort.signal.aborted
-      && integrityLifecycleGeneration === lifecycleGeneration;
-    const refreshStillEnabled = async (): Promise<boolean> => {
-      if (!ownsRefresh()) return false;
-      const currentSettings = await deps.loadSettings();
-      return ownsRefresh() && currentSettings.platform.twitch.enabled;
-    };
+      && integrityLifecycleGeneration === lifecycleGeneration
+      && integrityLifecycleOpen;
 
     try {
       await initialTwitchIntegrityLoad;
       if (!ownsRefresh()) return;
       await withEventCollector(async (emit, events) => {
+        let integrity: TwitchIntegrity | undefined;
+        let shouldAcquire = false;
         try {
-          const settings = await deps.loadSettings();
-          if (!ownsRefresh()) return;
-          let integrity: TwitchIntegrity | undefined;
-          try {
-            integrity = await deps.loadTwitchIntegrity?.();
-          } catch {
-            emit({
-              category: "diagnostic",
-              platform: "twitch",
-              level: "debug",
-              message: "Could not reload stored Twitch integrity before proactive refresh",
-            });
-          }
-          if (!ownsRefresh()) return;
-
-          if (!settings.platform.twitch.enabled) {
-            cancelTwitchIntegrityWork("Twitch disabled");
-            await clearTwitchIntegrityAlarmBestEffort(emit);
-            return;
-          }
-
-          if (isValidTwitchIntegrity(integrity)) {
-            lastIntegrityToken = integrity.integrity;
-            setTwitchIntegrity(integrity);
-            if (twitchIntegrityRefreshTarget(integrity) > Date.now()) {
-              if (!await refreshStillEnabled()) return;
-              await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+          await withSettingsLock(async () => {
+            if (!ownsRefresh()) return;
+            const settings = await deps.loadSettings();
+            if (!ownsRefresh()) return;
+            if (!settings.platform.twitch.enabled) {
+              closeTwitchIntegrityLifecycle("Twitch disabled");
+              await clearTwitchIntegrityAlarmBestEffort(emit);
               return;
             }
-          }
 
-          if (!deps.ensureTwitchIntegrity || !await refreshStillEnabled()) return;
+            await withStateLock(async () => {
+              if (!ownsRefresh()) return;
+              let stored: TwitchIntegrity | undefined;
+              try {
+                stored = await deps.loadTwitchIntegrity?.();
+              } catch {
+                emit({
+                  category: "diagnostic",
+                  platform: "twitch",
+                  level: "debug",
+                  message: "Could not reload stored Twitch integrity before proactive refresh",
+                });
+              }
+              if (!ownsRefresh()) return;
 
+              integrity = reconcileStoredTwitchIntegrity(stored);
+              if (integrity && twitchIntegrityRefreshTarget(integrity) > Date.now()) {
+                await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+                return;
+              }
+              markTwitchIntegrityRefreshDue(integrity);
+              shouldAcquire = true;
+            });
+          });
+
+          if (!shouldAcquire || !deps.ensureTwitchIntegrity || !ownsRefresh()) return;
+          const remainingMs = integrity
+            ? Math.max(0, integrity.expiresAt - Date.now())
+            : 0;
+          emit({
+            category: "diagnostic",
+            platform: "twitch",
+            level: "debug",
+            message: integrity
+              ? `Starting proactive Twitch integrity refresh with ${remainingMs}ms remaining`
+              : "Starting proactive Twitch integrity refresh with no valid token available",
+          });
           const ready = await deps.ensureTwitchIntegrity(emit, {
             forceRefresh: true,
+            reason: "proactive_refresh",
+            ...(integrity ? { rejectedToken: integrity.integrity } : {}),
+            onManagedPageContextOpen: () =>
+              recordTwitchIntegrityManagedTabOpen("proactive_integrity_refresh"),
             signal: abort.signal,
           });
           if (!ready && !abort.signal.aborted) {
             emit({
               category: "diagnostic",
               platform: "twitch",
-              level: "warn",
-              message: "Could not refresh Twitch integrity; the next normal scheduler alarm will retry",
+              level: "debug",
+              message: "Proactive Twitch integrity refresh was deferred; the next normal scheduler alarm will retry",
             });
           }
         } catch {
-          if (!abort.signal.aborted) {
+          if (abort.signal.aborted) {
             emit({
               category: "diagnostic",
               platform: "twitch",
-              level: "warn",
-              message: "Could not refresh Twitch integrity; the next normal scheduler alarm will retry",
+              level: "debug",
+              message: "Proactive Twitch integrity refresh was cancelled because Twitch stopped",
+            });
+          } else {
+            emit({
+              category: "diagnostic",
+              platform: "twitch",
+              level: "debug",
+              message: "Proactive Twitch integrity refresh was deferred; the next normal scheduler alarm will retry",
             });
           }
         } finally {
@@ -568,15 +655,53 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const integrity = integrityFromHeaders(headers);
     if (!integrity) return;
     await withStateLock(() => withEventCollector(async (emit, events) => {
-      const isNew = integrity.integrity !== lastIntegrityToken;
-      setTwitchIntegrity(integrity, { isNew }, emit);
+      const isNew = integrity.integrity !== installedTwitchIntegrity?.integrity;
+      installTwitchIntegrity(integrity, isNew, emit);
+      if (integrity.integrity !== persistedIntegrityToken && deps.saveTwitchIntegrity) {
+        try {
+          await deps.saveTwitchIntegrity(integrity);
+          persistedIntegrityToken = integrity.integrity;
+        } catch {
+          emit({
+            category: "diagnostic",
+            platform: "twitch",
+            level: "warn",
+            message: "Could not persist the captured Twitch integrity token",
+          });
+        }
+      }
       if (isNew) {
-        lastIntegrityToken = integrity.integrity;
-        await deps.saveTwitchIntegrity?.(integrity);
         await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
       }
       await reportBestEffort(events);
     }));
+  }
+
+  async function recordTwitchIntegrityManagedTabOpen(
+    reason: "integrity_readiness" | "proactive_integrity_refresh",
+  ): Promise<void> {
+    try {
+      await withStateLock(() => withEventCollector(async (emit, events) => {
+        if (!integrityLifecycleOpen) return;
+        const settings = await deps.loadSettings();
+        if (!integrityLifecycleOpen || !settings.criticalFailurePromptEnabled) return;
+        const state = await deps.loadState();
+        const transition = recordManagedTabOpen(state, "twitch", Date.now(), {
+          source: "page_context",
+          reason,
+        });
+        if (transition.event) emit(transition.event);
+        syncManagedTabBreakers(transition.state);
+        await persistAndReport(transition.state, events);
+      }));
+    } catch {
+      await reportBestEffort([{
+        category: "diagnostic",
+        platform: "twitch",
+        level: "warn",
+        message: "Could not account for a managed Twitch integrity page context",
+      }]);
+    }
   }
 
   async function persistAndReport(state: SchedulerState, events: readonly EngineEvent[] = []): Promise<void> {
@@ -740,16 +865,41 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     return run;
   }
 
-  async function updateStoredSettings(patch: SettingsPatch): Promise<S> {
+  async function updateStoredSettings(
+    patch: SettingsPatch,
+    afterPersist?: (settings: S) => void,
+  ): Promise<S> {
     return withSettingsLock(async () => {
       if (!deps.applySettingsPatch) {
         throw new Error("applySettingsPatch dependency is required to mutate settings");
       }
       const settings = deps.applySettingsPatch(await deps.loadSettings(), patch);
       await deps.saveSettings(settings);
+      afterPersist?.(settings);
       await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
       return settings;
     });
+  }
+
+  async function restoreTwitchIntegritySchedule(): Promise<void> {
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      if (!integrityLifecycleOpen) return;
+      let stored: TwitchIntegrity | undefined;
+      try {
+        stored = await deps.loadTwitchIntegrity?.();
+      } catch {
+        emit({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "debug",
+          message: "Could not reload stored Twitch integrity after Twitch was enabled",
+        });
+      }
+      if (!integrityLifecycleOpen) return;
+      const integrity = reconcileStoredTwitchIntegrity(stored);
+      if (integrity) await scheduleTwitchIntegrityRefreshBestEffort(integrity, emit);
+      await reportBestEffort(events);
+    }));
   }
 
   async function probeAuthHealth(
@@ -945,8 +1095,22 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const ensureTwitchIntegrity = deps.ensureTwitchIntegrity;
     if (!settings.platform.twitch.enabled || !ensureTwitchIntegrity) return true;
     return withEventCollector(async (emit, events) => {
+      const lifecycleGeneration = integrityLifecycleGeneration;
+      const due = twitchIntegrityRefreshDue;
       try {
-        const ready = await ensureTwitchIntegrity(emit, { signal });
+        const ready = await ensureTwitchIntegrity(emit, {
+          signal,
+          reason: due ? "proactive_refresh" : "readiness",
+          onManagedPageContextOpen: () => recordTwitchIntegrityManagedTabOpen(
+            due ? "proactive_integrity_refresh" : "integrity_readiness",
+          ),
+          ...(due
+            ? {
+                forceRefresh: true,
+                ...(due.rejectedToken ? { rejectedToken: due.rejectedToken } : {}),
+              }
+            : {}),
+        });
         if (!ready) {
           emit({
             category: "diagnostic",
@@ -956,6 +1120,29 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           });
         }
         return ready;
+      } catch {
+        signal.throwIfAborted();
+        const currentSettings = await deps.loadSettings();
+        if (
+          lifecycleGeneration !== integrityLifecycleGeneration
+          || !integrityLifecycleOpen
+          || !currentSettings.platform.twitch.enabled
+        ) {
+          emit({
+            category: "diagnostic",
+            platform: "twitch",
+            level: "debug",
+            message: "Twitch integrity acquisition was cancelled because Twitch stopped; continuing other platform work",
+          });
+          return false;
+        }
+        emit({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "warn",
+          message: "No valid Twitch integrity token; delaying authenticated Twitch work until the next normal scheduler alarm",
+        });
+        return false;
       } finally {
         await reportBestEffort(events);
       }
@@ -1403,23 +1590,33 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
-  function cancelTwitchIntegrityWork(reason: string): void {
+  function closeTwitchIntegrityLifecycle(reason: string): void {
     const error = new Error(reason);
-    integrityLifecycleGeneration += 1;
+    if (integrityLifecycleOpen) {
+      integrityLifecycleOpen = false;
+      integrityLifecycleGeneration += 1;
+    }
     integrityRefreshAbort?.abort(error);
     deps.cancelTwitchIntegrityAcquisition?.(error);
   }
 
+  function reopenTwitchIntegrityLifecycle(): void {
+    if (controllerShutdown || integrityLifecycleOpen) return;
+    integrityLifecycleOpen = true;
+    integrityLifecycleGeneration += 1;
+  }
+
   function shutdown(): void {
+    controllerShutdown = true;
     abortActiveTicks("Controller shutdown");
-    cancelTwitchIntegrityWork("Controller shutdown");
+    closeTwitchIntegrityLifecycle("Controller shutdown");
     void clearTwitchIntegrityAlarmBestEffort();
     abortClaimHandoffs();
   }
 
   async function prepareForHostReset(resetHostStorage?: () => Promise<void>): Promise<void> {
     abortActiveTicks("Host reset");
-    cancelTwitchIntegrityWork("Host reset");
+    closeTwitchIntegrityLifecycle("Host reset");
     await clearTwitchIntegrityAlarmBestEffort();
     abortClaimHandoffs();
     await withSettingsLock(() => withStateLock(() => withEventCollector(async (emit, events) => {
@@ -1442,7 +1639,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       }
       tablessWatchers.clear();
       registerManagedPageContextTabs({});
-      lastIntegrityToken = undefined;
+      installedTwitchIntegrity = undefined;
+      persistedIntegrityToken = undefined;
+      twitchIntegrityRefreshDue = undefined;
       setTwitchIntegrity(undefined);
       await resetHostStorage?.();
       await reportBestEffort(events);
@@ -1875,17 +2074,33 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     if (message.type === "setPlatformEnabled" || message.type === "setAutomation") {
       // Stopping must cancel any loop still refreshing in the background.
       if (!message.enabled) abortClaimHandoffs(message.platform);
-      if (message.platform === "twitch" && !message.enabled) {
-        cancelTwitchIntegrityWork("Twitch disabled");
-        await clearTwitchIntegrityAlarmBestEffort();
-      }
-      await updateStoredSettings({
-        platform: {
-          [message.platform]: {
-            enabled: message.enabled,
+      const stoppingTwitch = message.platform === "twitch" && !message.enabled;
+      let twitchTransitionPersisted = false;
+      if (stoppingTwitch) closeTwitchIntegrityLifecycle("Twitch disabled");
+      try {
+        await updateStoredSettings({
+          platform: {
+            [message.platform]: {
+              enabled: message.enabled,
+            },
           },
-        },
-      });
+        }, message.platform === "twitch"
+          ? () => {
+              twitchTransitionPersisted = true;
+              if (message.enabled) reopenTwitchIntegrityLifecycle();
+              else closeTwitchIntegrityLifecycle("Twitch disabled");
+            }
+          : undefined);
+      } catch (error) {
+        if (stoppingTwitch && !twitchTransitionPersisted) {
+          reopenTwitchIntegrityLifecycle();
+        }
+        throw error;
+      }
+      if (message.platform === "twitch") {
+        if (message.enabled) await restoreTwitchIntegritySchedule();
+        else await clearTwitchIntegrityAlarmBestEffort();
+      }
       if (message.enabled) await markPlatformsStarting([message.platform]);
       // Always scoped to the toggled platform. Nothing about this change can
       // affect the other one any more, so it is never dragged through this

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2188,11 +2188,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           : undefined);
       } catch (error) {
         if (message.platform === "twitch" && twitchTransitionIsCurrent()) {
-          reconcileTwitchIntegrityLifecycle(
-            twitchSettingsLoaded
-              ? lastPersistedTwitchEnabled
-              : twitchLifecycleOpenBeforeTransition,
-          );
+          const rollbackEnabled = twitchSettingsLoaded
+            ? lastPersistedTwitchEnabled
+            : twitchLifecycleOpenBeforeTransition;
+          reconcileTwitchIntegrityLifecycle(rollbackEnabled);
+          if (stoppingTwitch && rollbackEnabled === true) {
+            await restoreTwitchIntegritySchedule(twitchTransitionIsCurrent);
+          }
         }
         throw error;
       }

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -368,7 +368,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     kick: new Set<string>(),
   };
   let settingsMutation: Promise<unknown> = Promise.resolve();
+  let twitchIntegrityAlarmMutation: Promise<unknown> = Promise.resolve();
   let twitchSettingsTransitionGeneration = 0;
+  let lastPersistedTwitchEnabled: boolean | undefined;
   let integrityRefreshAbort: AbortController | undefined;
   let integrityLifecycleGeneration = 0;
   let integrityLifecycleOpen = true;
@@ -432,8 +434,16 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     };
   }
 
+  function withTwitchIntegrityAlarmLock<T>(operation: () => Promise<T>): Promise<T> {
+    const run = twitchIntegrityAlarmMutation.then(operation, operation);
+    twitchIntegrityAlarmMutation = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
   async function clearTwitchIntegrityAlarm(): Promise<void> {
-    await deps.clearAlarm?.(TWITCH_INTEGRITY_ALARM_NAME);
+    await withTwitchIntegrityAlarmLock(async () => {
+      await deps.clearAlarm?.(TWITCH_INTEGRITY_ALARM_NAME);
+    });
   }
 
   async function clearTwitchIntegrityAlarmBestEffort(emit?: EventEmitter): Promise<void> {
@@ -464,7 +474,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       await clearTwitchIntegrityAlarm();
       return;
     }
-    await deps.createAlarm(TWITCH_INTEGRITY_ALARM_NAME, { when });
+    await withTwitchIntegrityAlarmLock(async () => {
+      await deps.createAlarm(TWITCH_INTEGRITY_ALARM_NAME, { when });
+    });
     twitchIntegrityRefreshDue = undefined;
     emit?.({
       category: "diagnostic",
@@ -869,12 +881,15 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function updateStoredSettings(
     patch: SettingsPatch,
     afterPersist?: (settings: S) => void,
+    afterLoad?: (settings: S) => void,
   ): Promise<S> {
     return withSettingsLock(async () => {
       if (!deps.applySettingsPatch) {
         throw new Error("applySettingsPatch dependency is required to mutate settings");
       }
-      const settings = deps.applySettingsPatch(await deps.loadSettings(), patch);
+      const current = await deps.loadSettings();
+      afterLoad?.(current);
+      const settings = deps.applySettingsPatch(current, patch);
       await deps.saveSettings(settings);
       afterPersist?.(settings);
       await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
@@ -1611,8 +1626,14 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     integrityLifecycleGeneration += 1;
   }
 
+  function reconcileTwitchIntegrityLifecycle(enabled: boolean | undefined): void {
+    if (enabled === true) reopenTwitchIntegrityLifecycle();
+    else if (enabled === false) closeTwitchIntegrityLifecycle("Twitch disabled");
+  }
+
   function shutdown(): void {
     controllerShutdown = true;
+    twitchSettingsTransitionGeneration += 1;
     abortActiveTicks("Controller shutdown");
     closeTwitchIntegrityLifecycle("Controller shutdown");
     void clearTwitchIntegrityAlarmBestEffort();
@@ -1620,6 +1641,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function prepareForHostReset(resetHostStorage?: () => Promise<void>): Promise<void> {
+    twitchSettingsTransitionGeneration += 1;
     abortActiveTicks("Host reset");
     closeTwitchIntegrityLifecycle("Host reset");
     await clearTwitchIntegrityAlarmBestEffort();
@@ -1649,6 +1671,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       twitchIntegrityRefreshDue = undefined;
       setTwitchIntegrity(undefined);
       await resetHostStorage?.();
+      lastPersistedTwitchEnabled = undefined;
       await reportBestEffort(events);
     })));
   }
@@ -1732,6 +1755,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // snapshot back immediately; the popup re-polls getSnapshot on its own cadence
   // and picks the result up when the tick lands.
   function tickInBackground(platforms: Platform[] | undefined, trigger: TickTrigger): void {
+    if (controllerShutdown) return;
     const run = tickAndHandOff(platforms, trigger).catch((error) => {
       diagnosticEvent("warn", `Background tick (trigger=${trigger}) failed: ${error instanceof Error ? error.message : String(error)}`);
     });
@@ -1781,7 +1805,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       }
       if (!changed) return;
       if (!transitionIsCurrent()) return;
-      await persistAndReport({ ...state, sessions });
+      await saveOperationalState({ ...state, sessions });
+      if (!transitionIsCurrent()) {
+        await saveOperationalState(state);
+      }
     });
   }
 
@@ -2088,9 +2115,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         ? ++twitchSettingsTransitionGeneration
         : undefined;
       const twitchTransitionIsCurrent = (): boolean =>
-        twitchTransitionGeneration === twitchSettingsTransitionGeneration;
+        !controllerShutdown
+        && twitchTransitionGeneration === twitchSettingsTransitionGeneration;
       const stoppingTwitch = message.platform === "twitch" && !message.enabled;
-      let twitchTransitionPersisted = false;
       if (stoppingTwitch) closeTwitchIntegrityLifecycle("Twitch disabled");
       try {
         await updateStoredSettings({
@@ -2100,32 +2127,32 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
             },
           },
         }, message.platform === "twitch"
-          ? () => {
-              twitchTransitionPersisted = true;
-              if (message.enabled) {
-                if (twitchTransitionIsCurrent()) reopenTwitchIntegrityLifecycle();
-              } else {
-                closeTwitchIntegrityLifecycle("Twitch disabled");
+          ? (settings) => {
+              lastPersistedTwitchEnabled = settings.platform.twitch.enabled;
+              if (twitchTransitionIsCurrent()) {
+                reconcileTwitchIntegrityLifecycle(settings.platform.twitch.enabled);
               }
+            }
+          : undefined,
+        message.platform === "twitch"
+          ? (settings) => {
+              lastPersistedTwitchEnabled = settings.platform.twitch.enabled;
             }
           : undefined);
       } catch (error) {
-        if (
-          stoppingTwitch
-          && !twitchTransitionPersisted
-          && twitchTransitionIsCurrent()
-        ) {
-          reopenTwitchIntegrityLifecycle();
+        if (message.platform === "twitch" && twitchTransitionIsCurrent()) {
+          reconcileTwitchIntegrityLifecycle(lastPersistedTwitchEnabled);
         }
         throw error;
       }
       if (message.platform === "twitch") {
+        if (!twitchTransitionIsCurrent()) return snapshot();
         if (message.enabled) {
-          if (!twitchTransitionIsCurrent()) return snapshot();
           await restoreTwitchIntegritySchedule(twitchTransitionIsCurrent);
-          if (!twitchTransitionIsCurrent()) return snapshot();
+        } else {
+          await clearTwitchIntegrityAlarmBestEffort();
         }
-        else await clearTwitchIntegrityAlarmBestEffort();
+        if (!twitchTransitionIsCurrent()) return snapshot();
       }
       if (message.enabled) {
         await markPlatformsStarting(

--- a/packages/core/src/core/criticalHealth.ts
+++ b/packages/core/src/core/criticalHealth.ts
@@ -55,7 +55,10 @@ export interface CriticalHealthTransition {
 // A managed tab this extension opened. Only page contexts carry a PageContextOpenReason,
 // so the union keeps watch-tab opens from having to invent one.
 export type ManagedTabOpen =
-  | { source: "page_context"; reason: PageContextOpenReason }
+  | {
+      source: "page_context";
+      reason: PageContextOpenReason | "integrity_readiness" | "proactive_integrity_refresh";
+    }
   | { source: "watch_tab" };
 
 function breadcrumb(open: ManagedTabOpen): Omit<FailureRecord, "at" | "platform"> {

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -490,7 +490,7 @@ let twitchIntegrity: TwitchIntegrity | undefined;
 // Treat a token expiring within this window as already stale, so a claim never
 // ships with one that expires mid-flight (the captured token is replayed and
 // the round-trip plus Twitch-side clock skew can otherwise straddle expiry).
-const INTEGRITY_EXPIRY_SKEW_MS = 30_000;
+export const INTEGRITY_EXPIRY_SKEW_MS = 30_000;
 
 // Page context to open when no token has been captured: a logged-in twitch.tv
 // SPA route that immediately issues authenticated GQL carrying Client-Integrity,
@@ -545,8 +545,15 @@ function describeContextBoot(boot: TwitchContextBootTiming, now: number): string
   return `tab ready at ${since(boot.readyAt)}, first GQL at ${since(boot.firstGqlAt)}, ${now - boot.createdAt}ms since the tab was created`;
 }
 
+export function isValidTwitchIntegrity(
+  value: TwitchIntegrity | undefined,
+  now: number = Date.now(),
+): value is TwitchIntegrity {
+  return value != null && value.expiresAt > now + INTEGRITY_EXPIRY_SKEW_MS;
+}
+
 export function hasValidTwitchIntegrity(now: number = Date.now()): boolean {
-  return twitchIntegrity != null && twitchIntegrity.expiresAt > now + INTEGRITY_EXPIRY_SKEW_MS;
+  return isValidTwitchIntegrity(twitchIntegrity, now);
 }
 
 export function setTwitchIntegrity(value: TwitchIntegrity | undefined, options?: { isNew?: boolean }, emit: EventEmitter = ignoreEvent): void {
@@ -588,25 +595,27 @@ export function currentValidTwitchIntegrity(): TwitchIntegrity | undefined {
   return hasValidTwitchIntegrity() ? twitchIntegrity : undefined;
 }
 
-// A forced refresh boots a cold twitch.tv context and waits for Kasada's
-// proof-of-work, which is the single most expensive thing this module does
-// (~22s observed). It is wired into ~10 operations, several of which run
-// sequentially inside one discovery pass, so a broadly-rejecting session used to
-// stack that cost several times in one tick.
-//
-// Concurrent callers share the in-flight refresh rather than racing into
-// acquirePageContextTab, where the origin-keyed dedupe hands the later ones an
-// inherited context that requireFreshPageContext cannot make fresh — so they
-// would wait out the full timeout on a tab that was never going to mint for
-// them. Sequential callers are bounded by rejectedToken instead: once the first
-// refresh lands, the rest were rejected on a token that no longer exists.
-let inFlightForcedRefresh: Promise<boolean> | undefined;
+// Minting boots a twitch.tv context and may wait ~22s for Kasada's proof-of-work,
+// so every caller shares one owned acquisition. The owned abort cancels the
+// underlying page context; only the creator's signal owns that lifecycle, while
+// later joiners race their own signal without disturbing everyone else.
+interface TwitchIntegrityAcquisition {
+  promise: Promise<boolean>;
+  abort: AbortController;
+}
+
+let inFlightIntegrityAcquisition: TwitchIntegrityAcquisition | undefined;
+
+export function cancelTwitchIntegrityAcquisition(reason?: unknown): void {
+  inFlightIntegrityAcquisition?.abort.abort(reason);
+}
 
 // Test seam: this module's integrity state is process-global by design (the
 // webRequest listener feeds it from outside any call), so suites that exercise
 // the bounds need a way back to a known state.
 export function resetTwitchIntegrityRefreshBounds(): void {
-  inFlightForcedRefresh = undefined;
+  inFlightIntegrityAcquisition?.abort.abort();
+  inFlightIntegrityAcquisition = undefined;
 }
 
 function hasReplacementTwitchIntegrity(rejectedToken?: string): boolean {
@@ -676,7 +685,15 @@ export async function ensureTwitchIntegrityWithBrowser(
   const forceRefresh = request?.forceRefresh === true;
   if (!forceRefresh) {
     if (hasValidTwitchIntegrity()) return true;
-    return mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, undefined, false, request?.signal);
+    return startTwitchIntegrityAcquisition(
+      browserApi,
+      originUrl,
+      timeoutMs,
+      emit,
+      undefined,
+      false,
+      request?.signal,
+    );
   }
 
   // Another operation's refresh already replaced the token this caller was
@@ -687,18 +704,52 @@ export async function ensureTwitchIntegrityWithBrowser(
     return true;
   }
 
-  if (inFlightForcedRefresh) {
-    diagnostic(emit, "debug", "Joining the Twitch integrity refresh already in flight", "twitch");
-    return withAbortSignal(inFlightForcedRefresh, request?.signal);
+  const rejectedToken = request?.rejectedToken ?? twitchIntegrity?.integrity;
+  return startTwitchIntegrityAcquisition(
+    browserApi,
+    originUrl,
+    timeoutMs,
+    emit,
+    rejectedToken,
+    true,
+    request?.signal,
+  );
+}
+
+function startTwitchIntegrityAcquisition(
+  browserApi: BrowserTabApi,
+  originUrl: string,
+  timeoutMs: number,
+  emit: EventEmitter,
+  rejectedToken: string | undefined,
+  forceRefresh: boolean,
+  ownerSignal?: AbortSignal,
+): Promise<boolean> {
+  if (inFlightIntegrityAcquisition) {
+    diagnostic(emit, "debug", "Joining the Twitch integrity acquisition already in flight", "twitch");
+    return withAbortSignal(inFlightIntegrityAcquisition.promise, ownerSignal);
   }
 
-  const rejectedToken = request?.rejectedToken ?? twitchIntegrity?.integrity;
-  const refresh = mintTwitchIntegrity(browserApi, originUrl, timeoutMs, emit, rejectedToken, true, request?.signal)
-    .finally(() => {
-      inFlightForcedRefresh = undefined;
-    });
-  inFlightForcedRefresh = refresh;
-  return refresh;
+  const abort = new AbortController();
+  const abortFromOwner = () => abort.abort(ownerSignal?.reason);
+  ownerSignal?.addEventListener("abort", abortFromOwner, { once: true });
+
+  const promise = mintTwitchIntegrity(
+    browserApi,
+    originUrl,
+    timeoutMs,
+    emit,
+    rejectedToken,
+    forceRefresh,
+    abort.signal,
+  ).finally(() => {
+    ownerSignal?.removeEventListener("abort", abortFromOwner);
+    if (inFlightIntegrityAcquisition?.promise === promise) {
+      inFlightIntegrityAcquisition = undefined;
+    }
+  });
+  inFlightIntegrityAcquisition = { promise, abort };
+  return promise;
 }
 
 // The page-context boot itself, with no bounding logic: callers reach it through

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -458,6 +458,11 @@ export interface PageFetchOptions {
   };
   emit?: EventEmitter;
   openReason?: PageContextOpenReason;
+  // Integrity preparation must not create a user-facing activity entry, but the
+  // controller still needs to account for every extension-owned context it
+  // opens in the managed-tab churn breaker.
+  emitPageContextActivity?: boolean;
+  onManagedPageContextOpen?: () => void | Promise<void>;
   // Demands a context that is about to boot the SPA from scratch, because the
   // caller is waiting for the page to issue something (see ensureTwitchIntegrity-
   // WithBrowser). An already-loaded user tab is idle and would only time out, and
@@ -580,6 +585,8 @@ export function setTwitchIntegrity(value: TwitchIntegrity | undefined, options?:
 export interface TwitchIntegrityRequest {
   forceRefresh?: boolean;
   signal?: AbortSignal;
+  reason?: "readiness" | "proactive_refresh" | "rejection_recovery";
+  onManagedPageContextOpen?: () => void | Promise<void>;
   // The token the rejected request actually sent, captured before it was issued.
   // Without it a forced refresh cannot tell "this caller was rejected on a token
   // someone has already replaced" from "this caller was rejected on the token we
@@ -696,6 +703,8 @@ export async function ensureTwitchIntegrityWithBrowser(
 ): Promise<boolean> {
   request?.signal?.throwIfAborted();
   const forceRefresh = request?.forceRefresh === true;
+  const reason = request?.reason
+    ?? (forceRefresh ? "rejection_recovery" : "readiness");
   if (!forceRefresh) {
     if (hasValidTwitchIntegrity()) return true;
     return startTwitchIntegrityAcquisition(
@@ -705,6 +714,8 @@ export async function ensureTwitchIntegrityWithBrowser(
       emit,
       undefined,
       false,
+      reason,
+      request?.onManagedPageContextOpen,
       request?.signal,
     );
   }
@@ -725,6 +736,8 @@ export async function ensureTwitchIntegrityWithBrowser(
     emit,
     rejectedToken,
     true,
+    reason,
+    request?.onManagedPageContextOpen,
     request?.signal,
   );
 }
@@ -736,6 +749,8 @@ function startTwitchIntegrityAcquisition(
   emit: EventEmitter,
   rejectedToken: string | undefined,
   forceRefresh: boolean,
+  reason: NonNullable<TwitchIntegrityRequest["reason"]>,
+  onManagedPageContextOpen?: () => void | Promise<void>,
   ownerSignal?: AbortSignal,
 ): Promise<boolean> {
   if (inFlightIntegrityAcquisition) {
@@ -752,6 +767,8 @@ function startTwitchIntegrityAcquisition(
         emit,
         rejectedToken,
         true,
+        reason,
+        onManagedPageContextOpen,
         ownerSignal,
       );
     });
@@ -768,6 +785,8 @@ function startTwitchIntegrityAcquisition(
     emit,
     rejectedToken,
     forceRefresh,
+    reason,
+    onManagedPageContextOpen,
     abort.signal,
   ).finally(() => {
     ownerSignal?.removeEventListener("abort", abortFromOwner);
@@ -794,12 +813,16 @@ async function mintTwitchIntegrity(
   // a plain mint, which may inherit an idle tab that issues no request and can
   // only ever time out.
   forceRefresh: boolean,
+  reason: NonNullable<TwitchIntegrityRequest["reason"]>,
+  onManagedPageContextOpen?: () => void | Promise<void>,
   signal?: AbortSignal,
 ): Promise<boolean> {
   diagnostic(
     emit,
     "info",
-    forceRefresh
+    reason === "proactive_refresh"
+      ? "Proactively refreshing Twitch integrity through a twitch.tv page context"
+      : forceRefresh
       ? "Twitch rejected the current integrity token; using a twitch.tv page context to mint a replacement"
       : "No valid Twitch integrity token; using a twitch.tv page context to capture one",
     "twitch",
@@ -811,7 +834,19 @@ async function mintTwitchIntegrity(
       retainPageContext: { platform: "twitch" },
       emit,
       requireFreshPageContext: forceRefresh,
+      emitPageContextActivity: reason === "rejection_recovery",
+      onManagedPageContextOpen,
     }, signal);
+    if (reason !== "rejection_recovery" && pageContext.source === "created") {
+      diagnostic(
+        emit,
+        "debug",
+        reason === "proactive_refresh"
+          ? "Opened a managed twitch.tv page context for proactive integrity refresh"
+          : "Opened a managed twitch.tv page context for Twitch integrity readiness",
+        "twitch",
+      );
+    }
     // Which context we got decides whether waiting can work at all: only a
     // freshly created tab is guaranteed to boot the SPA and issue authenticated
     // GQL for the listener to read a token from. An inherited or already-idle tab
@@ -1347,13 +1382,20 @@ async function findOrCreatePageContextTab(
       ownedByExtension: true,
     };
     retainedPageContextTabs.set(retain.platform, retainedContext);
-    options?.emit?.({
-      category: "activity",
-      code: "page_context_opened",
-      level: "info",
-      platform: retain.platform,
-      data: { host: new URL(origin).host, reason: openReason },
-    });
+    try {
+      await options?.onManagedPageContextOpen?.();
+    } catch {
+      diagnostic(options?.emit ?? ignoreEvent, "warn", `Could not account for a managed page context opened on ${new URL(origin).host}`, retain.platform);
+    }
+    if (options?.emitPageContextActivity !== false) {
+      options?.emit?.({
+        category: "activity",
+        code: "page_context_opened",
+        level: "info",
+        platform: retain.platform,
+        data: { host: new URL(origin).host, reason: openReason },
+      });
+    }
     return {
       tabId: tab.id,
       createdByExtension: true,

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -514,6 +514,11 @@ export const INTEGRITY_REFRESH_TIMEOUT_MS = 30_000;
 // Resolvers waiting for the next captured token (see waitForIntegrityCapture).
 let integrityWaiters: Array<() => void> = [];
 
+// Test seam for proving terminal paths release their process-global callbacks.
+export function currentTwitchIntegrityWaiterCount(): number {
+  return integrityWaiters.length;
+}
+
 // Phase timings for the twitch.tv page context currently being booted to mint an
 // integrity token. A cold boot costs far more than the document load: the tab
 // reports `status === "complete"` as soon as the HTML shell lands, but the token
@@ -616,6 +621,7 @@ export function cancelTwitchIntegrityAcquisition(reason?: unknown): void {
 export function resetTwitchIntegrityRefreshBounds(): void {
   inFlightIntegrityAcquisition?.abort.abort();
   inFlightIntegrityAcquisition = undefined;
+  integrityWaiters = [];
 }
 
 function hasReplacementTwitchIntegrity(rejectedToken?: string): boolean {
@@ -637,11 +643,18 @@ function waitForIntegrityCapture(
   if (hasReplacementTwitchIntegrity(rejectedToken)) return Promise.resolve(true);
   return new Promise((resolve, reject) => {
     let settled = false;
+    const removeWaiter = () => {
+      integrityWaiters = integrityWaiters.filter((waiter) => waiter !== onCapture);
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      removeWaiter();
+    };
     const finish = () => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
+      cleanup();
       resolve(hasReplacementTwitchIntegrity(rejectedToken));
     };
     const onCapture = () => {
@@ -657,7 +670,7 @@ function waitForIntegrityCapture(
     const onAbort = () => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       reject(signal?.reason);
     };
     const timer = setTimeout(finish, timeoutMs);
@@ -727,7 +740,21 @@ function startTwitchIntegrityAcquisition(
 ): Promise<boolean> {
   if (inFlightIntegrityAcquisition) {
     diagnostic(emit, "debug", "Joining the Twitch integrity acquisition already in flight", "twitch");
-    return withAbortSignal(inFlightIntegrityAcquisition.promise, ownerSignal);
+    const joined = withAbortSignal(inFlightIntegrityAcquisition.promise, ownerSignal);
+    if (!forceRefresh) return joined;
+    return joined.then((captured) => {
+      ownerSignal?.throwIfAborted();
+      if (captured && hasReplacementTwitchIntegrity(rejectedToken)) return true;
+      return startTwitchIntegrityAcquisition(
+        browserApi,
+        originUrl,
+        timeoutMs,
+        emit,
+        rejectedToken,
+        true,
+        ownerSignal,
+      );
+    });
   }
 
   const abort = new AbortController();

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -864,7 +864,7 @@ async function mintTwitchIntegrity(
     const boot = twitchContextBoot?.tabId === pageContext.tabId ? twitchContextBoot : undefined;
     const phases = boot ? ` (${describeContextBoot(boot, settledAt)})` : "";
     if (!captured) {
-      diagnostic(emit, "warn", `Timed out waiting for a Twitch integrity token after ${settledAt - startedAt}ms from a ${source} page context${phases} (is twitch.tv logged in?)`, "twitch");
+      diagnostic(emit, reason === "proactive_refresh" ? "debug" : "warn", `Timed out waiting for a Twitch integrity token after ${settledAt - startedAt}ms from a ${source} page context${phases} (is twitch.tv logged in?)`, "twitch");
     } else {
       diagnostic(emit, "debug", `Waited ${settledAt - startedAt}ms for a Twitch integrity token from a ${source} page context${phases}`, "twitch");
     }
@@ -872,7 +872,7 @@ async function mintTwitchIntegrity(
   } catch (error) {
     signal?.throwIfAborted();
     const message = error instanceof Error ? error.message : String(error);
-    diagnostic(emit, "warn", `Could not open a twitch.tv tab to capture an integrity token: ${message}`, "twitch");
+    diagnostic(emit, reason === "proactive_refresh" ? "debug" : "warn", `Could not open a twitch.tv tab to capture an integrity token: ${message}`, "twitch");
     return false;
   } finally {
     if (pageContext) {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -996,6 +996,7 @@ export class TwitchAdapter implements PlatformAdapter {
       const rejectedToken = sentIntegrityToken(error);
       const refreshed = await this.ensureIntegrity({
         forceRefresh: true,
+        reason: "rejection_recovery",
         rejectedToken,
         signal,
       });
@@ -1051,6 +1052,7 @@ export class TwitchAdapter implements PlatformAdapter {
       const rejectedToken = sentIntegrityToken(error);
       if (!await this.ensureIntegrity({
         forceRefresh: true,
+        reason: "rejection_recovery",
         rejectedToken,
         signal,
       })) throw error;
@@ -1187,6 +1189,7 @@ export class TwitchAdapter implements PlatformAdapter {
       const rejectedToken = sentIntegrityToken(error);
       if (!await this.ensureIntegrity({
         forceRefresh: true,
+        reason: "rejection_recovery",
         rejectedToken,
         signal,
       })) throw error;
@@ -1333,7 +1336,11 @@ class TwitchWatcher implements TablessWatchController {
         // adapter's safe authenticated reads.
         if (!isIntegrityRejection(error)) throw error;
         this.log("debug", "Twitch viewer id lookup was rejected for integrity; refreshing the token and retrying once");
-        if (!await this.ensureIntegrity({ forceRefresh: true, rejectedToken: sentIntegrityToken(error) })) throw error;
+        if (!await this.ensureIntegrity({
+          forceRefresh: true,
+          reason: "rejection_recovery",
+          rejectedToken: sentIntegrityToken(error),
+        })) throw error;
         response = await currentUser();
       }
       this.viewerUserId = response.data?.currentUser?.id;

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -15,7 +15,7 @@ import {
   stopManagedPageContextTabs,
   stopWatchTab,
 } from "../src/core/tabs";
-import { ALARM_NAME, TWITCH_INTEGRITY_ALARM_NAME, WATCH_ALARM_NAME, createBackgroundController } from "@lurkloot/core/controller";
+import { createBackgroundAlarmListener, createBackgroundController } from "@lurkloot/core/controller";
 import { resolveCompatibility } from "@lurkloot/core";
 import { applySettingsPatch } from "@lurkloot/shared/settings";
 import { effectiveLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
@@ -255,15 +255,7 @@ export default defineBackground(() => {
     await controller.handleStartup();
   });
 
-  browser.alarms.onAlarm.addListener((alarm) => {
-    if (alarm.name === ALARM_NAME) {
-      void controller.tickAndHandOff(undefined, "alarm");
-    } else if (alarm.name === WATCH_ALARM_NAME) {
-      void controller.runWatchHeartbeat();
-    } else if (alarm.name === TWITCH_INTEGRITY_ALARM_NAME) {
-      void controller.runTwitchIntegrityRefresh();
-    }
-  });
+  browser.alarms.onAlarm.addListener(createBackgroundAlarmListener(controller));
 
   browser.tabs.onRemoved.addListener((tabId) => {
     void controller.handleTabRemoved(tabId);

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -3,6 +3,7 @@ import { loadSettings, loadState, loadTwitchIntegrity, resetStorage, saveSetting
 import type { CliCredentialBlob, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import {
   applyAdFocus,
+  cancelTwitchIntegrityAcquisition,
   currentValidTwitchIntegrity,
   ensureTwitchIntegrity,
   fetchJsonInPage,
@@ -14,7 +15,7 @@ import {
   stopManagedPageContextTabs,
   stopWatchTab,
 } from "../src/core/tabs";
-import { ALARM_NAME, WATCH_ALARM_NAME, createBackgroundController } from "@lurkloot/core/controller";
+import { ALARM_NAME, TWITCH_INTEGRITY_ALARM_NAME, WATCH_ALARM_NAME, createBackgroundController } from "@lurkloot/core/controller";
 import { resolveCompatibility } from "@lurkloot/core";
 import { applySettingsPatch } from "@lurkloot/shared/settings";
 import { effectiveLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
@@ -134,6 +135,9 @@ const controller = createBackgroundController<ExtensionSettings>({
   reportEvents,
   checkCredentialAvailability,
   createAlarm: (name, options) => browser.alarms.create(name, options),
+  clearAlarm: (name) => browser.alarms.clear(name),
+  ensureTwitchIntegrity: (emit, request) => ensureTwitchIntegrity(emit, request),
+  cancelTwitchIntegrityAcquisition,
   closeManagedTabs: async (tabs) => {
     await Promise.all(tabs.map(async ({ tabId, channelUrl }) => {
       try {
@@ -256,6 +260,8 @@ export default defineBackground(() => {
       void controller.tickAndHandOff(undefined, "alarm");
     } else if (alarm.name === WATCH_ALARM_NAME) {
       void controller.runWatchHeartbeat();
+    } else if (alarm.name === TWITCH_INTEGRITY_ALARM_NAME) {
+      void controller.runTwitchIntegrityRefresh();
     }
   });
 

--- a/packages/extension/src/core/tabs.ts
+++ b/packages/extension/src/core/tabs.ts
@@ -44,7 +44,7 @@ export function ensureTwitchIntegrity(emit?: EventEmitter, request?: TwitchInteg
   return ensureTwitchIntegrityWithBrowser(browser as BrowserTabApi, TWITCH_PAGE_CONTEXT_URL, undefined, emit, request);
 }
 
-export { currentValidTwitchIntegrity };
+export { cancelTwitchIntegrityAcquisition, currentValidTwitchIntegrity } from "@lurkloot/core/tabs";
 
 export function fetchTwitchInBackground<T>(url: string, init?: RequestInit): Promise<T> {
   return fetchTwitchInBackgroundWith<T>(browser as CookieApi, url, init);

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2658,7 +2658,11 @@ describe("TwitchAdapter integrity recovery", () => {
     await new TwitchAdapter(fetcher, ensureIntegrity, undefined, { currentIntegrity }).checkAuthHealth();
 
     expect(sent[0]).toBe("token-1");
-    expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true, rejectedToken: sent[0] });
+    expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
+      forceRefresh: true,
+      reason: "rejection_recovery",
+      rejectedToken: sent[0],
+    }));
   });
 
   it("sends the integrity trio together so the replayed token stays bound to its identity", async () => {
@@ -2703,7 +2707,10 @@ describe("TwitchAdapter integrity recovery", () => {
 
         expect(campaigns.map((campaign) => campaign.id)).toEqual(["campaign"]);
         expect(ensureIntegrity).toHaveBeenCalledOnce();
-        expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+        expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
+          forceRefresh: true,
+          reason: "rejection_recovery",
+        }));
         expect(attempts.get(target)).toBe(2);
       },
     );
@@ -2749,7 +2756,10 @@ describe("TwitchAdapter integrity recovery", () => {
       // (the second asks for reward campaigns). Each gets one refresh attempt
       // and, because the refresh failed, no retry at all.
       expect(ensureIntegrity).toHaveBeenCalledTimes(2);
-      expect(ensureIntegrity.mock.calls).toEqual([[{ forceRefresh: true }], [{ forceRefresh: true }]]);
+      expect(ensureIntegrity.mock.calls).toEqual([
+        [expect.objectContaining({ forceRefresh: true, reason: "rejection_recovery" })],
+        [expect.objectContaining({ forceRefresh: true, reason: "rejection_recovery" })],
+      ]);
       expect(dashboardAttempts).toBe(2);
       expect(events).toContainEqual(expect.objectContaining({
         level: "warn",
@@ -2815,7 +2825,10 @@ describe("TwitchAdapter integrity recovery", () => {
         .listCandidateChannels({ id: "campaign", slug: "game-slug" } as DropCampaign);
 
       expect(candidates.map((candidate) => candidate.username)).toEqual(["creator"]);
-      expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+      expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
+        forceRefresh: true,
+        reason: "rejection_recovery",
+      }));
       expect(attempts.get("DirectoryPage_Game")).toBe(2);
     });
 
@@ -2838,7 +2851,10 @@ describe("TwitchAdapter integrity recovery", () => {
       );
 
       expect(check.campaignMatches).toBe(true);
-      expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+      expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
+        forceRefresh: true,
+        reason: "rejection_recovery",
+      }));
       expect(attempts.get("DropsHighlightService_AvailableDrops")).toBe(2);
     });
 
@@ -2868,7 +2884,10 @@ describe("TwitchAdapter integrity recovery", () => {
         } as never);
 
         expect(progressed[0]?.rewards[0]?.watchedMinutes).toBe(42);
-        expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+        expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
+          forceRefresh: true,
+          reason: "rejection_recovery",
+        }));
         expect(attempts.get(target)).toBe(2);
       },
     );
@@ -2882,7 +2901,10 @@ describe("TwitchAdapter integrity recovery", () => {
       const health = await new TwitchAdapter(fetcher, ensureIntegrity).checkAuthHealth();
 
       expect(health.status).toBe("healthy");
-      expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+      expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
+        forceRefresh: true,
+        reason: "rejection_recovery",
+      }));
       expect(attempts.get("CurrentUser")).toBe(2);
     });
   });
@@ -2934,7 +2956,12 @@ describe("TwitchAdapter integrity recovery", () => {
       // Proactive fast path first, then an explicit forced refresh.
       expect(ensureIntegrity.mock.calls).toEqual([
         [{ signal: undefined }],
-        [{ forceRefresh: true, rejectedToken: undefined, signal: undefined }],
+        [{
+          forceRefresh: true,
+          reason: "rejection_recovery",
+          rejectedToken: undefined,
+          signal: undefined,
+        }],
       ]);
     });
 
@@ -2956,7 +2983,10 @@ describe("TwitchAdapter integrity recovery", () => {
       })).resolves.toBe(true);
 
       expect(attempts.get("ChannelPointsContext")).toBe(2);
-      expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+      expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
+        forceRefresh: true,
+        reason: "rejection_recovery",
+      }));
     });
 
     it("ensures integrity before the channel-points mutation and retries it exactly once", async () => {
@@ -2979,7 +3009,12 @@ describe("TwitchAdapter integrity recovery", () => {
       expect(attempts.get("ClaimCommunityPoints")).toBe(2);
       expect(ensureIntegrity.mock.calls).toEqual([
         [{ signal: undefined }],
-        [{ forceRefresh: true, rejectedToken: undefined, signal: undefined }],
+        [{
+          forceRefresh: true,
+          reason: "rejection_recovery",
+          rejectedToken: undefined,
+          signal: undefined,
+        }],
       ]);
     });
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ALARM_NAME, createBackgroundController, type CredentialAvailability } from "@lurkloot/core/controller";
+import {
+  ALARM_NAME,
+  createBackgroundController,
+  TWITCH_INTEGRITY_ALARM_NAME,
+  type CredentialAvailability,
+} from "@lurkloot/core/controller";
 import { resolveCompatibility } from "@lurkloot/core";
 import type { ChannelCandidate, DropCampaign, DropReward, ExtensionSettings, Platform, PlatformAuthHealth, SchedulerState } from "@lurkloot/shared/models";
 import type { DiagnosticEvent, EngineEvent, EventEmitter } from "@lurkloot/shared/events";
@@ -11,8 +16,19 @@ import { createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/k
 import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import type { TablessWatchController } from "@lurkloot/core/tablessWatch";
 import type { StopPageContextTabs } from "@lurkloot/core/scheduler";
-import { forgetManagedPageContextTabs, KickWafBlockedError, managedTabBreakerOpen, recordManagedPageContextFallback, registerManagedPageContextTabs, syncManagedTabBreakers } from "@lurkloot/core/tabs";
+import {
+  currentValidTwitchIntegrity,
+  forgetManagedPageContextTabs,
+  KickWafBlockedError,
+  managedTabBreakerOpen,
+  recordManagedPageContextFallback,
+  registerManagedPageContextTabs,
+  setTwitchIntegrity,
+  syncManagedTabBreakers,
+  type TwitchIntegrityRequest,
+} from "@lurkloot/core/tabs";
 import { TAB_CHURN_LIMIT } from "@lurkloot/core/criticalHealth";
+import type { IntegrityHeader, TwitchIntegrity } from "@lurkloot/core/twitchIntegrity";
 
 const reward = (status: DropReward["status"] = "in_progress"): DropReward => ({
   id: "reward",
@@ -48,6 +64,24 @@ function deferred<T>() {
     reject = nextReject;
   });
   return { promise, resolve, reject };
+}
+
+function integrityBundle(overrides: Partial<TwitchIntegrity> = {}): TwitchIntegrity {
+  return {
+    integrity: "test-integrity-token",
+    clientSessionId: "test-session",
+    deviceId: "test-device",
+    expiresAt: Date.now() + 30 * 60_000,
+    ...overrides,
+  };
+}
+
+function integrityHeaders(integrity: TwitchIntegrity): IntegrityHeader[] {
+  return [
+    { name: "Client-Integrity", value: integrity.integrity },
+    { name: "Client-Session-Id", value: integrity.clientSessionId },
+    { name: "X-Device-Id", value: integrity.deviceId },
+  ];
 }
 
 // `running: true` used to be what made a fixture farm; with the master switch
@@ -140,6 +174,18 @@ function harness(
     wait?: (ms: number, signal: AbortSignal) => Promise<void>;
     checkCredentialAvailability?: (platform: Platform) => Promise<CredentialAvailability>;
     authProbeTimeoutMs?: number;
+    loadTwitchIntegrity?: () => Promise<TwitchIntegrity | undefined>;
+    saveTwitchIntegrity?: (value: TwitchIntegrity) => Promise<void>;
+    createAlarm?: (
+      name: string,
+      options: { periodInMinutes: number } | { when: number },
+    ) => Promise<void>;
+    clearAlarm?: (name: string) => Promise<boolean>;
+    ensureTwitchIntegrity?: (
+      emit: EventEmitter,
+      request?: TwitchIntegrityRequest,
+    ) => Promise<boolean>;
+    cancelTwitchIntegrityAcquisition?: (reason?: unknown) => void;
   } = {},
 ) {
   let currentSettings = settings;
@@ -162,7 +208,13 @@ function harness(
     saveState: vi.fn(overrides.saveState ?? (async (next: SchedulerState) => {
       currentState = next;
     })),
-    createAlarm: vi.fn(async () => undefined),
+    createAlarm: vi.fn(overrides.createAlarm ?? (async (
+      _name: string,
+      _options: { periodInMinutes: number } | { when: number },
+    ) => undefined)),
+    clearAlarm: vi.fn(overrides.clearAlarm ?? (async () => true)),
+    ensureTwitchIntegrity: vi.fn(overrides.ensureTwitchIntegrity ?? (async () => true)),
+    cancelTwitchIntegrityAcquisition: vi.fn(overrides.cancelTwitchIntegrityAcquisition ?? (() => undefined)),
     createNotification: vi.fn(async () => undefined),
     closeManagedTabs: vi.fn(async () => undefined),
     applyAdFocus: vi.fn<(platform: Platform, tabId: number | undefined, adActive: boolean, emit: EventEmitter) => Promise<void>>(async () => undefined),
@@ -186,6 +238,12 @@ function harness(
     ...(overrides.authProbeTimeoutMs === undefined
       ? {}
       : { authProbeTimeoutMs: overrides.authProbeTimeoutMs }),
+    ...(overrides.loadTwitchIntegrity
+      ? { loadTwitchIntegrity: vi.fn(overrides.loadTwitchIntegrity) }
+      : {}),
+    ...(overrides.saveTwitchIntegrity
+      ? { saveTwitchIntegrity: vi.fn(overrides.saveTwitchIntegrity) }
+      : {}),
   };
 
   const controller = createBackgroundController(deps);
@@ -219,6 +277,190 @@ function harness(
 }
 
 describe("background controller", () => {
+  describe("Twitch integrity expiry scheduling", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-07-28T12:00:00.000Z"));
+      setTwitchIntegrity(undefined);
+    });
+
+    afterEach(() => {
+      setTwitchIntegrity(undefined);
+      vi.useRealTimers();
+    });
+
+    it("schedules integrity refresh from token expiry with stable bounded jitter", async () => {
+      const integrity = integrityBundle({
+        integrity: "stable-test-token",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+
+      await env.controller.settleBackgroundWork();
+
+      const calls = env.deps.createAlarm.mock.calls.filter(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      );
+      expect(calls).toHaveLength(1);
+      const when = (calls[0][1] as { when: number }).when;
+      expect(when).toBeLessThanOrEqual(integrity.expiresAt - 120_000);
+      expect(when).toBeGreaterThanOrEqual(integrity.expiresAt - 150_000);
+    });
+
+    it("ignores an expired stored token and reports why", async () => {
+      const integrity = integrityBundle({
+        integrity: "expired-test-token",
+        expiresAt: Date.now() - 1,
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+
+      await env.controller.settleBackgroundWork();
+
+      expect(env.deps.createAlarm.mock.calls.some(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )).toBe(false);
+      const events = env.reportEvents.mock.calls.flatMap(([batch]) => batch);
+      expect(events).toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        platform: "twitch",
+        level: "debug",
+        message: expect.stringContaining("expired"),
+      }));
+    });
+
+    it("persists a captured replacement and replaces its one-shot schedule", async () => {
+      const stored = integrityBundle({
+        integrity: "stored-test-token",
+        expiresAt: Date.now() + 25 * 60_000,
+      });
+      const replacement = integrityBundle({
+        integrity: "replacement-test-token",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const saveTwitchIntegrity = vi.fn(async () => undefined);
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => stored,
+        saveTwitchIntegrity,
+      });
+      await env.controller.settleBackgroundWork();
+
+      await env.controller.captureTwitchIntegrity(integrityHeaders(replacement));
+
+      expect(saveTwitchIntegrity).toHaveBeenCalledWith(replacement);
+      const calls = env.deps.createAlarm.mock.calls.filter(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      );
+      expect(calls).toHaveLength(2);
+      expect(calls[1][1]).not.toEqual(calls[0][1]);
+    });
+
+    it("uses the same refresh jitter for the same token", async () => {
+      const integrity = integrityBundle({
+        integrity: "same-token-stable-jitter",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const first = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+      await first.controller.settleBackgroundWork();
+      const second = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+      await second.controller.settleBackgroundWork();
+
+      const firstWhen = (first.deps.createAlarm.mock.calls.find(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )?.[1] as { when: number }).when;
+      const secondWhen = (second.deps.createAlarm.mock.calls.find(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )?.[1] as { when: number }).when;
+      expect(secondWhen).toBe(firstWhen);
+    });
+
+    it("rechecks stored integrity scheduling when the refresh handler runs", async () => {
+      const integrity = integrityBundle({
+        integrity: "refresh-handler-test-token",
+      });
+      const loadTwitchIntegrity = vi.fn(async () => integrity);
+      const env = harness(undefined, { loadTwitchIntegrity });
+      await env.controller.settleBackgroundWork();
+
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(loadTwitchIntegrity).toHaveBeenCalledTimes(2);
+      expect(env.deps.createAlarm.mock.calls.filter(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )).toHaveLength(2);
+    });
+
+    it("clears a prior alarm instead of creating an immediate refresh", async () => {
+      const integrity = integrityBundle({
+        expiresAt: Date.now() + 60_000,
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+
+      await env.controller.settleBackgroundWork();
+
+      expect(env.deps.clearAlarm).toHaveBeenCalledWith(TWITCH_INTEGRITY_ALARM_NAME);
+      expect(env.deps.createAlarm.mock.calls.some(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )).toBe(false);
+    });
+
+    it("retains a captured token when alarm creation fails", async () => {
+      const integrity = integrityBundle({
+        integrity: "retained-after-alarm-failure",
+      });
+      const saveTwitchIntegrity = vi.fn(async () => undefined);
+      const env = harness(undefined, {
+        saveTwitchIntegrity,
+        createAlarm: async (name) => {
+          if (name === TWITCH_INTEGRITY_ALARM_NAME) throw new Error("alarm unavailable");
+        },
+      });
+      await env.controller.settleBackgroundWork();
+
+      await expect(env.controller.captureTwitchIntegrity(integrityHeaders(integrity))).resolves.toBeUndefined();
+
+      expect(saveTwitchIntegrity).toHaveBeenCalledWith(integrity);
+      expect(currentValidTwitchIntegrity()).toEqual(integrity);
+      expect(env.reportEvents.mock.calls.flatMap(([batch]) => batch)).toContainEqual(
+        expect.objectContaining({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "warn",
+          message: expect.stringContaining("alarm unavailable"),
+        }),
+      );
+    });
+
+    it("never includes integrity token material in diagnostics", async () => {
+      const integrity = integrityBundle({
+        integrity: "highly-sensitive-integrity-token",
+      });
+      const env = harness(undefined, {
+        createAlarm: async (name) => {
+          if (name === TWITCH_INTEGRITY_ALARM_NAME) throw new Error("alarm unavailable");
+        },
+      });
+      await env.controller.settleBackgroundWork();
+
+      await env.controller.captureTwitchIntegrity(integrityHeaders(integrity));
+
+      const diagnostics = env.reportEvents.mock.calls
+        .flatMap(([batch]) => batch)
+        .filter((event): event is DiagnosticEvent => event.category === "diagnostic");
+      expect(diagnostics.length).toBeGreaterThan(0);
+      expect(diagnostics.every((event) => !event.message.includes(integrity.integrity))).toBe(true);
+    });
+  });
+
   it("retains Twitch discovery when each controller tick constructs a fresh adapter", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -364,6 +364,53 @@ describe("background controller", () => {
       expect(calls[1][1]).not.toEqual(calls[0][1]);
     });
 
+    it("installs and persists a fresh capture without scheduling after Twitch is disabled", async () => {
+      const integrity = integrityBundle({
+        integrity: "captured-while-disabled",
+      });
+      const saveTwitchIntegrity = vi.fn(async () => undefined);
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        saveTwitchIntegrity,
+      });
+      await env.controller.settleBackgroundWork();
+
+      await env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+
+      await env.controller.captureTwitchIntegrity(integrityHeaders(integrity));
+
+      expect(currentValidTwitchIntegrity()).toEqual(integrity);
+      expect(saveTwitchIntegrity).toHaveBeenCalledWith(integrity);
+      expect(env.deps.createAlarm).not.toHaveBeenCalled();
+    });
+
+    it("installs valid stored integrity without scheduling when Twitch starts disabled", async () => {
+      const integrity = integrityBundle({
+        integrity: "stored-while-disabled",
+      });
+      const env = harness({
+        ...farming(DEFAULT_SETTINGS),
+        platform: {
+          ...DEFAULT_SETTINGS.platform,
+          twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false },
+          kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
+        },
+      }, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+
+      await env.controller.settleBackgroundWork();
+
+      expect(currentValidTwitchIntegrity()).toEqual(integrity);
+      expect(env.deps.createAlarm).not.toHaveBeenCalled();
+    });
+
     it("uses the same refresh jitter for the same token", async () => {
       const integrity = integrityBundle({
         integrity: "same-token-stable-jitter",

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -647,7 +647,7 @@ describe("background controller", () => {
       await env.controller.runTwitchIntegrityRefresh();
       await env.controller.runTwitchIntegrityRefresh();
 
-      expect(env.deps.loadSettings).toHaveBeenCalledTimes(2);
+      expect(env.deps.loadSettings).toHaveBeenCalledTimes(4);
       expect(loadTwitchIntegrity).toHaveBeenCalledTimes(2);
     });
 
@@ -816,6 +816,76 @@ describe("background controller", () => {
       expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
       expect(env.deps.createAlarm).toHaveBeenCalledOnce();
     });
+
+    it.each([
+      ["settings", "disable", true],
+      ["settings", "reset", false],
+      ["settings", "shutdown", false],
+      ["integrity", "disable", true],
+      ["integrity", "reset", false],
+      ["integrity", "shutdown", true],
+    ] as const)(
+      "does not restart Twitch work when %s preflight resumes after %s",
+      async (pausedRead, cleanup, hasFutureToken) => {
+        const stored = hasFutureToken
+          ? integrityBundle({
+              integrity: `${pausedRead}-${cleanup}-future-token`,
+              expiresAt: Date.now() + 30 * 60_000,
+            })
+          : undefined;
+        const env = harness(undefined, {
+          loadTwitchIntegrity: async () => stored,
+          ensureTwitchIntegrity: async () => true,
+        });
+        await env.controller.settleBackgroundWork();
+        env.deps.createAlarm.mockClear();
+        env.deps.ensureTwitchIntegrity.mockClear();
+        env.deps.loadSettings.mockClear();
+        const loadTwitchIntegrity = env.deps.loadTwitchIntegrity!;
+        loadTwitchIntegrity.mockClear();
+        const settingsRead = deferred<ExtensionSettings>();
+        const integrityRead = deferred<TwitchIntegrity | undefined>();
+        if (pausedRead === "settings") {
+          env.deps.loadSettings.mockImplementationOnce(() => settingsRead.promise);
+        } else {
+          loadTwitchIntegrity.mockImplementationOnce(() => integrityRead.promise);
+        }
+
+        const refreshing = env.controller.runTwitchIntegrityRefresh();
+        if (pausedRead === "settings") {
+          await vi.waitFor(() => expect(env.deps.loadSettings).toHaveBeenCalledOnce());
+        } else {
+          await vi.waitFor(() => expect(loadTwitchIntegrity).toHaveBeenCalledOnce());
+        }
+
+        if (cleanup === "disable") {
+          await env.rawController.handleMessage({
+            type: "setPlatformEnabled",
+            platform: "twitch",
+            enabled: false,
+          });
+        } else if (cleanup === "reset") {
+          await env.controller.prepareForHostReset();
+        } else {
+          env.controller.shutdown();
+        }
+
+        if (pausedRead === "settings") {
+          settingsRead.resolve(farming(DEFAULT_SETTINGS));
+        } else {
+          integrityRead.resolve(stored);
+        }
+        await refreshing;
+        if (cleanup === "disable") {
+          await env.rawController.settleBackgroundWork();
+        }
+
+        expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+        expect(env.deps.createAlarm.mock.calls.some(
+          ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+        )).toBe(false);
+      },
+    );
 
     it("cancels acquisition and clears the alarm when Twitch is disabled", async () => {
       const acquisition = deferred<boolean>();

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -390,6 +390,94 @@ describe("background controller", () => {
       expect(env.deps.createAlarm).not.toHaveBeenCalled();
     });
 
+    it("restores capture scheduling when a concurrent disable save fails", async () => {
+      const integrity = integrityBundle({
+        integrity: "captured-during-failed-disable",
+      });
+      const captureSave = deferred<void>();
+      const capturePersisted = deferred<void>();
+      const disableSave = deferred<void>();
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        saveTwitchIntegrity: async () => {
+          await captureSave.promise;
+          capturePersisted.resolve();
+        },
+        saveSettings: async () => {
+          await disableSave.promise;
+          throw new Error("settings storage unavailable");
+        },
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+
+      const capturing = env.controller.captureTwitchIntegrity(integrityHeaders(integrity));
+      await vi.waitFor(() => expect(env.deps.saveTwitchIntegrity).toHaveBeenCalledOnce());
+      const disabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      await vi.waitFor(() => expect(env.deps.saveSettings).toHaveBeenCalledOnce());
+
+      captureSave.resolve();
+      await capturePersisted.promise;
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      disableSave.resolve();
+
+      await expect(disabling).rejects.toThrow("settings storage unavailable");
+      await capturing;
+
+      expect(env.settings.platform.twitch.enabled).toBe(true);
+      expect(currentValidTwitchIntegrity()).toEqual(integrity);
+      expect(env.deps.createAlarm).toHaveBeenCalledWith(
+        TWITCH_INTEGRITY_ALARM_NAME,
+        expect.objectContaining({ when: expect.any(Number) }),
+      );
+    });
+
+    it("keeps a successful disable authoritative over a capture waiting for persistence", async () => {
+      const integrity = integrityBundle({
+        integrity: "captured-during-successful-disable",
+      });
+      const captureSave = deferred<void>();
+      const capturePersisted = deferred<void>();
+      const disableSave = deferred<void>();
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        saveTwitchIntegrity: async () => {
+          await captureSave.promise;
+          capturePersisted.resolve();
+        },
+        saveSettings: async () => disableSave.promise,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+      env.deps.clearAlarm.mockClear();
+
+      const capturing = env.controller.captureTwitchIntegrity(integrityHeaders(integrity));
+      await vi.waitFor(() => expect(env.deps.saveTwitchIntegrity).toHaveBeenCalledOnce());
+      const disabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      await vi.waitFor(() => expect(env.deps.saveSettings).toHaveBeenCalledOnce());
+
+      captureSave.resolve();
+      await capturePersisted.promise;
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      disableSave.resolve();
+      await Promise.all([capturing, disabling]);
+
+      expect(env.settings.platform.twitch.enabled).toBe(false);
+      expect(currentValidTwitchIntegrity()).toEqual(integrity);
+      expect(env.deps.createAlarm.mock.calls.some(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )).toBe(false);
+      expect(env.deps.clearAlarm).toHaveBeenCalledWith(TWITCH_INTEGRITY_ALARM_NAME);
+    });
+
     it("installs valid stored integrity without scheduling when Twitch starts disabled", async () => {
       const integrity = integrityBundle({
         integrity: "stored-while-disabled",

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -736,6 +736,61 @@ describe("background controller", () => {
       await env.rawController.settleBackgroundWork();
     });
 
+    it("does not let a stale Twitch enable reopen integrity or start farming after disable supersedes it", async () => {
+      const enableSave = deferred<void>();
+      const disableSave = deferred<void>();
+      let saveCount = 0;
+      let exposeStoredIntegrity = false;
+      const stored = integrityBundle({
+        integrity: "stale-enable-schedule",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const env = harness(notFarming(DEFAULT_SETTINGS), {
+        saveSettings: async () => {
+          saveCount += 1;
+          await (saveCount === 1 ? enableSave.promise : disableSave.promise);
+        },
+        loadTwitchIntegrity: async () => exposeStoredIntegrity ? stored : undefined,
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+      env.deps.ensureTwitchIntegrity.mockClear();
+      vi.mocked(env.twitch.discoverCampaigns).mockClear();
+      env.deps.cancelTwitchIntegrityAcquisition.mockClear();
+      exposeStoredIntegrity = true;
+
+      const enabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: true,
+      });
+      await vi.waitFor(() => expect(env.deps.saveSettings).toHaveBeenCalledOnce());
+
+      const disabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      expect(env.deps.cancelTwitchIntegrityAcquisition).toHaveBeenCalledOnce();
+
+      enableSave.resolve();
+      await vi.waitFor(() => expect(env.deps.saveSettings).toHaveBeenCalledTimes(2));
+      await enabling;
+      await env.rawController.settleBackgroundWork();
+
+      disableSave.resolve();
+      await disabling;
+      await env.rawController.settleBackgroundWork();
+
+      expect(env.settings.platform.twitch.enabled).toBe(false);
+      expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+      expect(env.deps.createAlarm.mock.calls.some(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )).toBe(false);
+      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    });
+
     it("recreates the refresh schedule from a valid stored token when Twitch is re-enabled", async () => {
       const integrity = integrityBundle({
         integrity: "reschedule-after-enable",

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -817,6 +817,50 @@ describe("background controller", () => {
       expect(env.deps.createAlarm).toHaveBeenCalledOnce();
     });
 
+    it.each(["disable", "reset", "shutdown"] as const)(
+      "does not schedule from a pending startup token load after %s cleanup",
+      async (cleanup) => {
+        const stored = integrityBundle({
+          integrity: `startup-${cleanup}-future-token`,
+          expiresAt: Date.now() + 30 * 60_000,
+        });
+        const integrityRead = deferred<TwitchIntegrity | undefined>();
+        const env = harness(undefined, {
+          loadTwitchIntegrity: async () => integrityRead.promise,
+          ensureTwitchIntegrity: async () => true,
+        });
+        await vi.waitFor(() => expect(env.deps.loadTwitchIntegrity).toHaveBeenCalledOnce());
+        env.deps.createAlarm.mockClear();
+        env.deps.clearAlarm.mockClear();
+        env.deps.ensureTwitchIntegrity.mockClear();
+
+        let cleanupFinished: Promise<void> | undefined;
+        if (cleanup === "disable") {
+          await env.rawController.handleMessage({
+            type: "setPlatformEnabled",
+            platform: "twitch",
+            enabled: false,
+          });
+        } else if (cleanup === "reset") {
+          cleanupFinished = env.controller.prepareForHostReset();
+          await vi.waitFor(() => expect(env.deps.clearAlarm).toHaveBeenCalledWith(
+            TWITCH_INTEGRITY_ALARM_NAME,
+          ));
+        } else {
+          env.controller.shutdown();
+        }
+
+        integrityRead.resolve(stored);
+        await cleanupFinished;
+        await env.rawController.settleBackgroundWork();
+
+        expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+        expect(env.deps.createAlarm.mock.calls.some(
+          ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+        )).toBe(false);
+      },
+    );
+
     it.each([
       ["settings", "disable", true],
       ["settings", "reset", false],

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -791,6 +791,265 @@ describe("background controller", () => {
       expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
     });
 
+    it("clears an enable alarm creation that finishes after disable supersedes it", async () => {
+      const alarmCreate = deferred<void>();
+      let alarmScheduled = false;
+      let exposeStoredIntegrity = false;
+      const stored = integrityBundle({
+        integrity: "alarm-create-completion-race",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const env = harness(notFarming(DEFAULT_SETTINGS), {
+        loadTwitchIntegrity: async () => exposeStoredIntegrity ? stored : undefined,
+        createAlarm: async (name) => {
+          if (name !== TWITCH_INTEGRITY_ALARM_NAME) return;
+          await alarmCreate.promise;
+          alarmScheduled = true;
+        },
+        clearAlarm: async (name) => {
+          if (name === TWITCH_INTEGRITY_ALARM_NAME) alarmScheduled = false;
+          return true;
+        },
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+      env.deps.clearAlarm.mockClear();
+      env.deps.saveSettings.mockClear();
+      exposeStoredIntegrity = true;
+
+      const enabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: true,
+      });
+      await vi.waitFor(() => expect(env.deps.createAlarm).toHaveBeenCalledWith(
+        TWITCH_INTEGRITY_ALARM_NAME,
+        expect.objectContaining({ when: expect.any(Number) }),
+      ));
+
+      const disabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      await vi.waitFor(() => expect(env.settings.platform.twitch.enabled).toBe(false));
+
+      alarmCreate.resolve();
+      await Promise.all([enabling, disabling]);
+      await env.rawController.settleBackgroundWork();
+
+      expect(alarmScheduled).toBe(false);
+    });
+
+    it("compensates a starting-state save that finishes after disable supersedes it", async () => {
+      const startingSave = deferred<void>();
+      const disabledSave = deferred<void>();
+      const env = harness(notFarming(DEFAULT_SETTINGS), {
+        ensureTwitchIntegrity: async () => true,
+      });
+      let persistedState = structuredClone(env.state);
+      env.deps.loadState.mockImplementation(async () => persistedState);
+      env.deps.saveState.mockImplementation(async (next: SchedulerState) => {
+        if (next.sessions.twitch.message === "Starting automation") {
+          await startingSave.promise;
+        } else if (next.sessions.twitch.reasonCode === "automation_disabled") {
+          await disabledSave.promise;
+        }
+        persistedState = next;
+      });
+
+      const enabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: true,
+      });
+      await vi.waitFor(() => expect(env.deps.saveState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessions: expect.objectContaining({
+            twitch: expect.objectContaining({ message: "Starting automation" }),
+          }),
+        }),
+      ));
+
+      const disabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      await vi.waitFor(() => expect(env.settings.platform.twitch.enabled).toBe(false));
+
+      startingSave.resolve();
+      await vi.waitFor(() => expect(env.deps.saveState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessions: expect.objectContaining({
+            twitch: expect.objectContaining({ reasonCode: "automation_disabled" }),
+          }),
+        }),
+      ));
+      const stateBeforeDisableTickLands = structuredClone(persistedState);
+
+      disabledSave.resolve();
+      await Promise.all([enabling, disabling]);
+      await env.rawController.settleBackgroundWork();
+
+      expect(stateBeforeDisableTickLands.sessions.twitch.message).not.toBe("Starting automation");
+    });
+
+    it.each(["reset", "shutdown"] as const)(
+      "does not resume a pending Twitch enable after %s supersedes it",
+      async (cleanup) => {
+        const enableSave = deferred<void>();
+        const env = harness(notFarming(DEFAULT_SETTINGS), {
+          saveSettings: async () => enableSave.promise,
+          loadTwitchIntegrity: async () => undefined,
+          ensureTwitchIntegrity: async () => true,
+        });
+        await env.controller.settleBackgroundWork();
+        env.deps.ensureTwitchIntegrity.mockClear();
+        vi.mocked(env.twitch.discoverCampaigns).mockClear();
+        env.deps.createAlarm.mockClear();
+
+        const enabling = env.rawController.handleMessage({
+          type: "setPlatformEnabled",
+          platform: "twitch",
+          enabled: true,
+        });
+        await vi.waitFor(() => expect(env.deps.saveSettings).toHaveBeenCalledOnce());
+
+        let cleanupFinished: Promise<void>;
+        if (cleanup === "reset") {
+          cleanupFinished = env.controller.prepareForHostReset();
+          await vi.waitFor(() => expect(env.deps.clearAlarm).toHaveBeenCalledWith(
+            TWITCH_INTEGRITY_ALARM_NAME,
+          ));
+        } else {
+          env.controller.shutdown();
+          cleanupFinished = Promise.resolve();
+        }
+
+        enableSave.resolve();
+        await Promise.all([enabling, cleanupFinished]);
+        await env.rawController.settleBackgroundWork();
+
+        expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+        expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+        expect(env.state.sessions.twitch.message).not.toBe("Starting automation");
+        expect(env.deps.createAlarm.mock.calls.some(
+          ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+        )).toBe(false);
+      },
+    );
+
+    it("does not admit a new platform-toggle tick after shutdown", async () => {
+      const env = harness(notFarming(DEFAULT_SETTINGS), {
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.ensureTwitchIntegrity.mockClear();
+      vi.mocked(env.twitch.discoverCampaigns).mockClear();
+
+      env.controller.shutdown();
+      await env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: true,
+      });
+      await env.rawController.settleBackgroundWork();
+
+      expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.state.sessions.twitch.message).not.toBe("Starting automation");
+    });
+
+    it("preserves a newer enable schedule when an older disable clear finishes last", async () => {
+      const alarmClear = deferred<void>();
+      let holdAlarmClear = false;
+      let alarmScheduled = false;
+      const stored = integrityBundle({
+        integrity: "disable-clear-completion-race",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => stored,
+        createAlarm: async (name) => {
+          if (name === TWITCH_INTEGRITY_ALARM_NAME) alarmScheduled = true;
+        },
+        clearAlarm: async (name) => {
+          if (name === TWITCH_INTEGRITY_ALARM_NAME) {
+            if (holdAlarmClear) await alarmClear.promise;
+            alarmScheduled = false;
+          }
+          return true;
+        },
+      });
+      await env.controller.settleBackgroundWork();
+      expect(alarmScheduled).toBe(true);
+      env.deps.saveSettings.mockClear();
+      env.deps.createAlarm.mockClear();
+      env.deps.clearAlarm.mockClear();
+      holdAlarmClear = true;
+
+      const disabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      await vi.waitFor(() => expect(env.deps.clearAlarm).toHaveBeenCalledWith(
+        TWITCH_INTEGRITY_ALARM_NAME,
+      ));
+
+      const enabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: true,
+      });
+      await vi.waitFor(() => expect(env.deps.saveSettings).toHaveBeenCalledTimes(2));
+
+      alarmClear.resolve();
+      await Promise.all([disabling, enabling]);
+      await env.rawController.settleBackgroundWork();
+
+      expect(env.settings.platform.twitch.enabled).toBe(true);
+      expect(alarmScheduled).toBe(true);
+    });
+
+    it("reconciles lifecycle to persisted enabled state when overlapping disable and enable saves both fail", async () => {
+      const disableSave = deferred<void>();
+      let saveCount = 0;
+      const env = harness(undefined, {
+        saveSettings: async () => {
+          saveCount += 1;
+          if (saveCount === 1) await disableSave.promise;
+          throw new Error("settings storage unavailable");
+        },
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.ensureTwitchIntegrity.mockClear();
+
+      const disabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      await vi.waitFor(() => expect(env.deps.saveSettings).toHaveBeenCalledOnce());
+      const enabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: true,
+      });
+
+      disableSave.resolve();
+      await expect(disabling).rejects.toThrow("settings storage unavailable");
+      await expect(enabling).rejects.toThrow("settings storage unavailable");
+      expect(env.settings.platform.twitch.enabled).toBe(true);
+
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce();
+    });
+
     it("recreates the refresh schedule from a valid stored token when Twitch is re-enabled", async () => {
       const integrity = integrityBundle({
         integrity: "reschedule-after-enable",

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -461,6 +461,435 @@ describe("background controller", () => {
     });
   });
 
+  describe("Twitch integrity readiness", () => {
+    beforeEach(() => {
+      setTwitchIntegrity(undefined);
+    });
+
+    afterEach(() => {
+      setTwitchIntegrity(undefined);
+    });
+
+    it("acquires integrity before Twitch auth and scheduler work", async () => {
+      const order: string[] = [];
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async () => {
+          order.push("integrity");
+          return true;
+        },
+      });
+      vi.mocked(env.twitch.checkAuthHealth).mockImplementation(async () => {
+        order.push("auth");
+        return { status: "healthy", checkedAt: "2026-07-28T12:00:00.000Z" };
+      });
+      vi.mocked(env.twitch.discoverCampaigns).mockImplementation(async () => {
+        order.push("scheduler");
+        return [campaign("twitch")];
+      });
+
+      await env.controller.tick(["twitch"], "manual_tick");
+
+      expect(order).toEqual(["integrity", "auth", "scheduler"]);
+    });
+
+    it("continues the same Twitch tick after successful acquisition", async () => {
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async () => true,
+      });
+
+      await env.controller.tick(["twitch"], "manual_tick");
+
+      expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce();
+      expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
+      expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+      expect(env.state.sessions.twitch.status).toBe("watching");
+    });
+
+    it("skips Twitch auth and scheduler work when acquisition returns false", async () => {
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async () => false,
+      });
+
+      await env.controller.tick(["twitch"], "manual_tick");
+
+      expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
+      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.deps.createAdapter).not.toHaveBeenCalled();
+      expect(env.deps.createAdapters).not.toHaveBeenCalled();
+    });
+
+    it("warns that a failed acquisition waits for the next normal scheduler alarm", async () => {
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async () => false,
+      });
+
+      await env.controller.tick(["twitch"], "manual_tick");
+
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(
+        expect.objectContaining({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "warn",
+          message: expect.stringContaining("next normal scheduler alarm"),
+        }),
+      );
+      expect(env.deps.createAlarm.mock.calls.some(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )).toBe(false);
+    });
+
+    it("does not treat acquisition failure as an interruption or unhealthy auth", async () => {
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async () => false,
+      });
+      const before = structuredClone(env.state.authHealth.twitch);
+
+      await env.controller.tick(["twitch"], "manual_tick");
+
+      const events = env.reportEvents.mock.calls.flatMap(([batch]) => batch);
+      expect(events).not.toContainEqual(expect.objectContaining({
+        category: "activity",
+        code: "interruption",
+      }));
+      expect(env.state.authHealth.twitch).toEqual(before);
+      expect(env.deps.saveState).not.toHaveBeenCalled();
+    });
+
+    it("continues Kick auth and scheduler work when Twitch acquisition fails", async () => {
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async () => false,
+      });
+
+      await env.controller.tick(undefined, "manual_tick");
+
+      expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
+      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce();
+      expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+      expect(env.state.sessions.kick.status).toBe("watching");
+    });
+
+    it("exits silently when shutdown aborts integrity acquisition", async () => {
+      let acquisitionSignal: AbortSignal | undefined;
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async (_emit, request) => new Promise<boolean>((_resolve, reject) => {
+          acquisitionSignal = request?.signal;
+          request?.signal?.addEventListener("abort", () => reject(request.signal?.reason), { once: true });
+        }),
+      });
+
+      const ticking = env.controller.tick(["twitch"], "manual_tick");
+      await vi.waitFor(() => expect(acquisitionSignal).toBeDefined());
+      env.reportEvents.mockClear();
+
+      env.controller.shutdown();
+
+      await expect(ticking).resolves.toEqual({});
+      expect(acquisitionSignal?.aborted).toBe(true);
+      expect(env.deps.cancelTwitchIntegrityAcquisition).toHaveBeenCalled();
+      expect(env.deps.clearAlarm).toHaveBeenCalledWith(TWITCH_INTEGRITY_ALARM_NAME);
+      const events = env.reportEvents.mock.calls.flatMap(([batch]) => batch);
+      expect(events).not.toContainEqual(expect.objectContaining({
+        category: "activity",
+        code: "interruption",
+      }));
+      expect(events).not.toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        level: "error",
+      }));
+    });
+
+    it("returns from Twitch enablement before detached acquisition resolves", async () => {
+      const acquisition = deferred<boolean>();
+      const env = harness(notFarming(DEFAULT_SETTINGS), {
+        ensureTwitchIntegrity: async () => acquisition.promise,
+      });
+      let acquisitionSettled = false;
+      acquisition.promise.finally(() => {
+        acquisitionSettled = true;
+      });
+
+      const snapshot = asSnapshot(await env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: true,
+      }));
+
+      await vi.waitFor(() => expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce());
+      expect(acquisitionSettled).toBe(false);
+      expect(snapshot.settings.platform.twitch.enabled).toBe(true);
+      expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
+
+      acquisition.resolve(false);
+      await env.rawController.settleBackgroundWork();
+    });
+  });
+
+  describe("Twitch integrity refresh alarm", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-07-28T12:00:00.000Z"));
+      setTwitchIntegrity(undefined);
+    });
+
+    afterEach(() => {
+      setTwitchIntegrity(undefined);
+      vi.useRealTimers();
+    });
+
+    it("reloads current settings and stored integrity on every invocation", async () => {
+      const loadTwitchIntegrity = vi.fn(async () => integrityBundle());
+      const env = harness(undefined, { loadTwitchIntegrity });
+      await env.controller.settleBackgroundWork();
+      env.deps.loadSettings.mockClear();
+      loadTwitchIntegrity.mockClear();
+
+      await env.controller.runTwitchIntegrityRefresh();
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(env.deps.loadSettings).toHaveBeenCalledTimes(2);
+      expect(loadTwitchIntegrity).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears the refresh alarm without minting when Twitch is disabled", async () => {
+      const loadTwitchIntegrity = vi.fn(async () => integrityBundle());
+      const env = harness({
+        ...farming(DEFAULT_SETTINGS),
+        platform: {
+          ...DEFAULT_SETTINGS.platform,
+          twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false },
+          kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
+        },
+      }, { loadTwitchIntegrity });
+      await env.controller.settleBackgroundWork();
+      env.deps.clearAlarm.mockClear();
+      env.deps.createAlarm.mockClear();
+      loadTwitchIntegrity.mockClear();
+
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(loadTwitchIntegrity).toHaveBeenCalledOnce();
+      expect(env.deps.clearAlarm).toHaveBeenCalledWith(TWITCH_INTEGRITY_ALARM_NAME);
+      expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+      expect(env.deps.createAlarm).not.toHaveBeenCalled();
+    });
+
+    it("reschedules a naturally captured newer token without minting", async () => {
+      const newer = integrityBundle({
+        integrity: "naturally-captured-newer-token",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => newer,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+      env.deps.ensureTwitchIntegrity.mockClear();
+
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+      expect(env.deps.createAlarm).toHaveBeenCalledOnce();
+      expect(env.deps.createAlarm).toHaveBeenCalledWith(
+        TWITCH_INTEGRITY_ALARM_NAME,
+        expect.objectContaining({ when: expect.any(Number) }),
+      );
+    });
+
+    it.each([
+      ["missing", false],
+      ["inside the refresh window", true],
+    ])("forces one fresh-context acquisition when the stored token is %s", async (_label, hasNearExpiryToken) => {
+      const integrity = hasNearExpiryToken
+        ? integrityBundle({ expiresAt: Date.now() + 90_000 })
+        : undefined;
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+      env.deps.clearAlarm.mockClear();
+      env.deps.ensureTwitchIntegrity.mockClear();
+
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce();
+      expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          forceRefresh: true,
+          signal: expect.any(AbortSignal),
+        }),
+      );
+      expect(env.deps.createAlarm).not.toHaveBeenCalled();
+    });
+
+    it("relies on captured-token persistence to schedule after successful acquisition", async () => {
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce();
+      expect(env.deps.createAlarm).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["returns false", async () => false],
+      ["throws", async () => {
+        throw new Error("page context failed");
+      }],
+    ])("does not create a retry alarm when acquisition %s", async (_label, ensureTwitchIntegrity) => {
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+
+      await expect(env.controller.runTwitchIntegrityRefresh()).resolves.toBeUndefined();
+
+      expect(env.deps.createAlarm).not.toHaveBeenCalled();
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(
+        expect.objectContaining({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "warn",
+          message: expect.stringContaining("next normal scheduler alarm"),
+        }),
+      );
+    });
+
+    it("shares one underlying acquisition between concurrent alarm and tick calls", async () => {
+      const acquisition = deferred<boolean>();
+      let underlyingAcquisitions = 0;
+      let inFlight: Promise<boolean> | undefined;
+      const ensureTwitchIntegrity = vi.fn(async () => {
+        if (!inFlight) {
+          underlyingAcquisitions += 1;
+          inFlight = acquisition.promise.finally(() => {
+            inFlight = undefined;
+          });
+        }
+        return inFlight;
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity,
+      });
+      await env.controller.settleBackgroundWork();
+
+      const refreshing = env.controller.runTwitchIntegrityRefresh();
+      await vi.waitFor(() => expect(underlyingAcquisitions).toBe(1));
+      const ticking = env.controller.tick(["twitch"], "manual_tick");
+      await vi.waitFor(() => expect(ensureTwitchIntegrity).toHaveBeenCalledTimes(2));
+
+      expect(underlyingAcquisitions).toBe(1);
+      acquisition.resolve(true);
+      await Promise.all([refreshing, ticking]);
+      expect(underlyingAcquisitions).toBe(1);
+    });
+
+    it("revalidates the stored token when a late alarm runs", async () => {
+      let stored = integrityBundle({
+        integrity: "original-near-expiry-token",
+        expiresAt: Date.now() + 90_000,
+      });
+      const loadTwitchIntegrity = vi.fn(async () => stored);
+      const env = harness(undefined, { loadTwitchIntegrity });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+      env.deps.ensureTwitchIntegrity.mockClear();
+      stored = integrityBundle({
+        integrity: "replacement-captured-while-asleep",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(loadTwitchIntegrity).toHaveBeenCalledTimes(2);
+      expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+      expect(env.deps.createAlarm).toHaveBeenCalledOnce();
+    });
+
+    it("cancels acquisition and clears the alarm when Twitch is disabled", async () => {
+      const acquisition = deferred<boolean>();
+      let acquisitionSignal: AbortSignal | undefined;
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity: async (_emit, request) => {
+          acquisitionSignal = request?.signal;
+          return acquisition.promise;
+        },
+      });
+      await env.controller.settleBackgroundWork();
+      const refreshing = env.controller.runTwitchIntegrityRefresh();
+      await vi.waitFor(() => expect(acquisitionSignal).toBeDefined());
+
+      await env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+
+      expect(acquisitionSignal?.aborted).toBe(true);
+      expect(env.deps.cancelTwitchIntegrityAcquisition).toHaveBeenCalled();
+      expect(env.deps.clearAlarm).toHaveBeenCalledWith(TWITCH_INTEGRITY_ALARM_NAME);
+      acquisition.resolve(false);
+      await refreshing;
+      await env.rawController.settleBackgroundWork();
+    });
+
+    it("does not abort in-flight Kick work when Twitch is disabled", async () => {
+      const kickDiscovery = deferred<DropCampaign[]>();
+      let kickSignal: AbortSignal | undefined;
+      const env = harness(undefined);
+      vi.mocked(env.kick.discoverCampaigns).mockImplementation(async ({ signal } = {}) => {
+        kickSignal = signal;
+        return kickDiscovery.promise;
+      });
+      const ticking = env.controller.tick(["kick"], "manual_tick");
+      await vi.waitFor(() => expect(kickSignal).toBeDefined());
+
+      await env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+
+      expect(kickSignal?.aborted).toBe(false);
+      kickDiscovery.resolve([campaign("kick")]);
+      await ticking;
+      await env.rawController.settleBackgroundWork();
+    });
+
+    it("cancels an owned refresh during host reset", async () => {
+      let acquisitionSignal: AbortSignal | undefined;
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity: async (_emit, request) => new Promise<boolean>((_resolve, reject) => {
+          acquisitionSignal = request?.signal;
+          request?.signal?.addEventListener("abort", () => reject(request.signal?.reason), { once: true });
+        }),
+      });
+      await env.controller.settleBackgroundWork();
+      const refreshing = env.controller.runTwitchIntegrityRefresh();
+      await vi.waitFor(() => expect(acquisitionSignal).toBeDefined());
+
+      await env.controller.prepareForHostReset();
+      await refreshing;
+
+      expect(acquisitionSignal?.aborted).toBe(true);
+      expect(env.deps.cancelTwitchIntegrityAcquisition).toHaveBeenCalled();
+      expect(env.deps.clearAlarm).toHaveBeenCalledWith(TWITCH_INTEGRITY_ALARM_NAME);
+    });
+  });
+
   it("retains Twitch discovery when each controller tick constructs a fresh adapter", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1050,6 +1050,29 @@ describe("background controller", () => {
       expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce();
     });
 
+    it("restores lifecycle admission when a current disable fails on its first settings load", async () => {
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.ensureTwitchIntegrity.mockClear();
+      env.deps.loadSettings.mockRejectedValueOnce(
+        new Error("settings storage unavailable"),
+      );
+
+      await expect(env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      })).rejects.toThrow("settings storage unavailable");
+      expect(env.settings.platform.twitch.enabled).toBe(true);
+
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce();
+    });
+
     it("recreates the refresh schedule from a valid stored token when Twitch is re-enabled", async () => {
       const integrity = integrityBundle({
         integrity: "reschedule-after-enable",

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -17,14 +17,18 @@ import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import type { TablessWatchController } from "@lurkloot/core/tablessWatch";
 import type { StopPageContextTabs } from "@lurkloot/core/scheduler";
 import {
+  cancelTwitchIntegrityAcquisition,
   currentValidTwitchIntegrity,
+  ensureTwitchIntegrityWithBrowser,
   forgetManagedPageContextTabs,
   KickWafBlockedError,
   managedTabBreakerOpen,
   recordManagedPageContextFallback,
   registerManagedPageContextTabs,
+  resetTwitchIntegrityRefreshBounds,
   setTwitchIntegrity,
   syncManagedTabBreakers,
+  type BrowserTabApi,
   type TwitchIntegrityRequest,
 } from "@lurkloot/core/tabs";
 import { TAB_CHURN_LIMIT } from "@lurkloot/core/criticalHealth";
@@ -176,6 +180,7 @@ function harness(
     authProbeTimeoutMs?: number;
     loadTwitchIntegrity?: () => Promise<TwitchIntegrity | undefined>;
     saveTwitchIntegrity?: (value: TwitchIntegrity) => Promise<void>;
+    saveSettings?: (value: ExtensionSettings) => Promise<void>;
     createAlarm?: (
       name: string,
       options: { periodInMinutes: number } | { when: number },
@@ -202,6 +207,7 @@ function harness(
   const deps = {
     loadSettings: vi.fn(async () => currentSettings),
     saveSettings: vi.fn(async (next: ExtensionSettings) => {
+      await overrides.saveSettings?.(next);
       currentSettings = next;
     }),
     loadState: vi.fn(async () => currentState),
@@ -413,6 +419,64 @@ describe("background controller", () => {
       )).toBe(false);
     });
 
+    it("forces the next normal tick to replace a valid token whose refresh target is already due", async () => {
+      const integrity = integrityBundle({
+        integrity: "due-on-next-normal-tick",
+        expiresAt: Date.now() + 60_000,
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.ensureTwitchIntegrity.mockClear();
+
+      await env.controller.tick(["twitch"], "alarm");
+
+      expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          forceRefresh: true,
+          rejectedToken: integrity.integrity,
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+
+    it("retries a failed integrity write when the same token is captured again", async () => {
+      const integrity = integrityBundle({
+        integrity: "retry-persistence-without-exposing-me",
+      });
+      const saveTwitchIntegrity = vi.fn()
+        .mockRejectedValueOnce(new Error("storage unavailable"))
+        .mockResolvedValueOnce(undefined);
+      const env = harness(undefined, { saveTwitchIntegrity });
+      await env.controller.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+
+      await expect(env.controller.captureTwitchIntegrity(integrityHeaders(integrity))).resolves.toBeUndefined();
+
+      expect(currentValidTwitchIntegrity()).toEqual(integrity);
+      expect(env.deps.createAlarm).toHaveBeenCalledWith(
+        TWITCH_INTEGRITY_ALARM_NAME,
+        expect.objectContaining({ when: expect.any(Number) }),
+      );
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(
+        expect.objectContaining({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "warn",
+          message: "Could not persist the captured Twitch integrity token",
+        }),
+      );
+
+      await expect(env.controller.captureTwitchIntegrity(integrityHeaders(integrity))).resolves.toBeUndefined();
+      expect(saveTwitchIntegrity).toHaveBeenCalledTimes(2);
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events).every(
+        (event) => event.category !== "diagnostic" || !event.message.includes(integrity.integrity),
+      )).toBe(true);
+    });
+
     it("retains a captured token when alarm creation fails", async () => {
       const integrity = integrityBundle({
         integrity: "retained-after-alarm-failure",
@@ -569,6 +633,54 @@ describe("background controller", () => {
       expect(env.state.sessions.kick.status).toBe("watching");
     });
 
+    it("accounts an initial readiness context without labelling it as a proactive refresh", async () => {
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async (_emit, request) => {
+          await request?.onManagedPageContextOpen?.();
+          return false;
+        },
+      });
+
+      await env.controller.tick(["twitch"], "manual_tick");
+
+      expect(env.state.criticalHealth?.twitch?.records).toContainEqual(
+        expect.objectContaining({
+          kind: "context_open",
+          code: "integrity_readiness",
+        }),
+      );
+      expect(env.state.criticalHealth?.twitch?.records).not.toContainEqual(
+        expect.objectContaining({
+          kind: "context_open",
+          code: "proactive_integrity_refresh",
+        }),
+      );
+    });
+
+    it("continues Kick when disabling Twitch cancels the acquisition awaited by an all-platform tick", async () => {
+      const acquisition = deferred<boolean>();
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async () => acquisition.promise,
+        cancelTwitchIntegrityAcquisition: (reason) => acquisition.reject(reason),
+      });
+      const ticking = env.controller.tick(undefined, "alarm");
+      await vi.waitFor(() => expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce());
+
+      await env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+
+      await expect(ticking).resolves.toEqual({});
+      expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
+      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce();
+      expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+      expect(env.state.sessions.kick.status).toBe("watching");
+      await env.rawController.settleBackgroundWork();
+    });
+
     it("exits silently when shutdown aborts integrity acquisition", async () => {
       let acquisitionSignal: AbortSignal | undefined;
       const env = harness(undefined, {
@@ -623,6 +735,37 @@ describe("background controller", () => {
       acquisition.resolve(false);
       await env.rawController.settleBackgroundWork();
     });
+
+    it("recreates the refresh schedule from a valid stored token when Twitch is re-enabled", async () => {
+      const integrity = integrityBundle({
+        integrity: "reschedule-after-enable",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+      await env.controller.settleBackgroundWork();
+
+      await env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      await env.rawController.settleBackgroundWork();
+      env.deps.createAlarm.mockClear();
+
+      await env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: true,
+      });
+
+      expect(env.deps.createAlarm).toHaveBeenCalledWith(
+        TWITCH_INTEGRITY_ALARM_NAME,
+        expect.objectContaining({ when: expect.any(Number) }),
+      );
+      await env.rawController.settleBackgroundWork();
+    });
   });
 
   describe("Twitch integrity refresh alarm", () => {
@@ -647,7 +790,7 @@ describe("background controller", () => {
       await env.controller.runTwitchIntegrityRefresh();
       await env.controller.runTwitchIntegrityRefresh();
 
-      expect(env.deps.loadSettings).toHaveBeenCalledTimes(4);
+      expect(env.deps.loadSettings).toHaveBeenCalledTimes(2);
       expect(loadTwitchIntegrity).toHaveBeenCalledTimes(2);
     });
 
@@ -668,7 +811,7 @@ describe("background controller", () => {
 
       await env.controller.runTwitchIntegrityRefresh();
 
-      expect(loadTwitchIntegrity).toHaveBeenCalledOnce();
+      expect(loadTwitchIntegrity).not.toHaveBeenCalled();
       expect(env.deps.clearAlarm).toHaveBeenCalledWith(TWITCH_INTEGRITY_ALARM_NAME);
       expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
       expect(env.deps.createAlarm).not.toHaveBeenCalled();
@@ -759,40 +902,69 @@ describe("background controller", () => {
         expect.objectContaining({
           category: "diagnostic",
           platform: "twitch",
-          level: "warn",
+          level: "debug",
           message: expect.stringContaining("next normal scheduler alarm"),
         }),
       );
     });
 
-    it("shares one underlying acquisition between concurrent alarm and tick calls", async () => {
-      const acquisition = deferred<boolean>();
-      let underlyingAcquisitions = 0;
-      let inFlight: Promise<boolean> | undefined;
-      const ensureTwitchIntegrity = vi.fn(async () => {
-        if (!inFlight) {
-          underlyingAcquisitions += 1;
-          inFlight = acquisition.promise.finally(() => {
-            inFlight = undefined;
-          });
-        }
-        return inFlight;
-      });
+    it("uses the real tabs single-flight while keeping proactive managed opens diagnostic-only and churn-accounted", async () => {
+      const browser = {
+        tabs: {
+          get: vi.fn(),
+          update: vi.fn(async () => undefined),
+          remove: vi.fn(async () => undefined),
+          query: vi.fn(async () => []),
+          create: vi.fn(async () => ({ id: 93 })),
+        },
+      } satisfies BrowserTabApi;
+      registerManagedPageContextTabs({});
+      resetTwitchIntegrityRefreshBounds();
+      setTwitchIntegrity(undefined);
       const env = harness(undefined, {
         loadTwitchIntegrity: async () => undefined,
-        ensureTwitchIntegrity,
+        ensureTwitchIntegrity: (emit, request) => ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          5_000,
+          emit,
+          request,
+        ),
+        cancelTwitchIntegrityAcquisition,
       });
       await env.controller.settleBackgroundWork();
 
       const refreshing = env.controller.runTwitchIntegrityRefresh();
-      await vi.waitFor(() => expect(underlyingAcquisitions).toBe(1));
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
       const ticking = env.controller.tick(["twitch"], "manual_tick");
-      await vi.waitFor(() => expect(ensureTwitchIntegrity).toHaveBeenCalledTimes(2));
-
-      expect(underlyingAcquisitions).toBe(1);
-      acquisition.resolve(true);
+      await vi.waitFor(() => expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledTimes(2));
+      setTwitchIntegrity(integrityBundle({
+        integrity: "real-composition-replacement",
+      }), { isNew: true });
       await Promise.all([refreshing, ticking]);
-      expect(underlyingAcquisitions).toBe(1);
+
+      const reported = env.reportEvents.mock.calls.flatMap(([events]) => events);
+      const emittedActivity = reported.some((event) =>
+        event.category === "activity" && event.code === "page_context_opened");
+      const proactiveDiagnostic = reported.some((event) =>
+        event.category === "diagnostic"
+        && event.platform === "twitch"
+        && event.message.includes("proactive"));
+      const managedTabOpens = env.state.criticalHealth?.twitch?.managedTabOpens.length;
+      const recordedProactiveOpen = env.state.criticalHealth?.twitch?.records.some((record) =>
+        record.kind === "context_open" && record.code === "proactive_integrity_refresh");
+      resetTwitchIntegrityRefreshBounds();
+      setTwitchIntegrity(undefined);
+
+      expect(browser.tabs.create).toHaveBeenCalledOnce();
+      expect(emittedActivity).toBe(false);
+      expect(proactiveDiagnostic).toBe(true);
+      expect(reported).not.toContainEqual(expect.objectContaining({
+        category: "activity",
+        code: "page_context_opened",
+      }));
+      expect(managedTabOpens).toBeGreaterThanOrEqual(1);
+      expect(recordedProactiveOpen).toBe(true);
     });
 
     it("revalidates the stored token when a late alarm runs", async () => {
@@ -815,6 +987,111 @@ describe("background controller", () => {
       expect(loadTwitchIntegrity).toHaveBeenCalledTimes(2);
       expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
       expect(env.deps.createAlarm).toHaveBeenCalledOnce();
+    });
+
+    it("does not let alarm preflight overwrite a fresh capture waiting for persistence", async () => {
+      const oldIntegrity = integrityBundle({
+        integrity: "stored-before-capture",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const replacement = integrityBundle({
+        integrity: "captured-before-storage-finishes",
+        expiresAt: Date.now() + 40 * 60_000,
+      });
+      const capturedReplacement = {
+        ...replacement,
+        expiresAt: Date.now() + 30 * 60_000,
+      };
+      let stored = oldIntegrity;
+      const saveGate = deferred<void>();
+      const loadTwitchIntegrity = vi.fn(async () => stored);
+      const env = harness(undefined, {
+        loadTwitchIntegrity,
+        saveTwitchIntegrity: async (value) => {
+          await saveGate.promise;
+          stored = value;
+        },
+      });
+      await env.controller.settleBackgroundWork();
+      loadTwitchIntegrity.mockClear();
+      env.deps.createAlarm.mockClear();
+
+      const capturing = env.controller.captureTwitchIntegrity(integrityHeaders(replacement));
+      await vi.waitFor(() => expect(env.deps.saveTwitchIntegrity).toHaveBeenCalledOnce());
+      const refreshing = env.controller.runTwitchIntegrityRefresh();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      const preflightWaitedForCapture = loadTwitchIntegrity.mock.calls.length === 0;
+      const memoryStayedFreshWhileSaving = currentValidTwitchIntegrity()?.integrity === replacement.integrity;
+
+      saveGate.resolve();
+      await Promise.all([capturing, refreshing]);
+
+      expect(preflightWaitedForCapture).toBe(true);
+      expect(memoryStayedFreshWhileSaving).toBe(true);
+      expect(stored).toEqual(capturedReplacement);
+      expect(currentValidTwitchIntegrity()).toEqual(capturedReplacement);
+      const integrityAlarmCalls = env.deps.createAlarm.mock.calls.filter(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      );
+      expect(integrityAlarmCalls.length).toBeGreaterThan(0);
+      expect(new Set(integrityAlarmCalls.map(([, options]) => JSON.stringify(options))).size).toBe(1);
+    });
+
+    it("forces the next normal tick after a proactive refresh is deferred", async () => {
+      const integrity = integrityBundle({
+        integrity: "deferred-proactive-token",
+        expiresAt: Date.now() + 90_000,
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+        ensureTwitchIntegrity: async () => false,
+      });
+      await env.controller.settleBackgroundWork();
+
+      await env.controller.runTwitchIntegrityRefresh();
+      env.deps.ensureTwitchIntegrity.mockClear();
+      await env.controller.tick(["twitch"], "alarm");
+
+      expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          forceRefresh: true,
+          rejectedToken: integrity.integrity,
+        }),
+      );
+    });
+
+    it("reports proactive start timing before a debug-level deferral", async () => {
+      const integrity = integrityBundle({
+        integrity: "timed-proactive-token",
+        expiresAt: Date.now() + 90_000,
+      });
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+        ensureTwitchIntegrity: async () => false,
+      });
+      await env.controller.settleBackgroundWork();
+      env.reportEvents.mockClear();
+
+      await env.controller.runTwitchIntegrityRefresh();
+
+      const diagnostics = env.reportEvents.mock.calls
+        .flatMap(([events]) => events)
+        .filter((event): event is DiagnosticEvent => event.category === "diagnostic");
+      const started = diagnostics.findIndex((event) =>
+        event.level === "debug"
+        && event.message.includes("Starting proactive Twitch integrity refresh")
+        && event.message.includes("90000ms remaining"));
+      const deferred = diagnostics.findIndex((event) =>
+        event.level === "debug"
+        && event.message.includes("next normal scheduler alarm"));
+      expect(started).toBeGreaterThanOrEqual(0);
+      expect(deferred).toBeGreaterThan(started);
+      expect(diagnostics).not.toContainEqual(expect.objectContaining({
+        level: "warn",
+        message: expect.stringContaining("Could not refresh Twitch integrity"),
+      }));
     });
 
     it.each(["disable", "reset", "shutdown"] as const)(
@@ -902,14 +1179,15 @@ describe("background controller", () => {
           await vi.waitFor(() => expect(loadTwitchIntegrity).toHaveBeenCalledOnce());
         }
 
+        let cleanupFinished: Promise<unknown> | undefined;
         if (cleanup === "disable") {
-          await env.rawController.handleMessage({
+          cleanupFinished = env.rawController.handleMessage({
             type: "setPlatformEnabled",
             platform: "twitch",
             enabled: false,
           });
         } else if (cleanup === "reset") {
-          await env.controller.prepareForHostReset();
+          cleanupFinished = env.controller.prepareForHostReset();
         } else {
           env.controller.shutdown();
         }
@@ -919,7 +1197,7 @@ describe("background controller", () => {
         } else {
           integrityRead.resolve(stored);
         }
-        await refreshing;
+        await Promise.all([refreshing, cleanupFinished]);
         if (cleanup === "disable") {
           await env.rawController.settleBackgroundWork();
         }
@@ -932,16 +1210,16 @@ describe("background controller", () => {
     );
 
     it("cancels acquisition and clears the alarm when Twitch is disabled", async () => {
-      const acquisition = deferred<boolean>();
       let acquisitionSignal: AbortSignal | undefined;
       const env = harness(undefined, {
         loadTwitchIntegrity: async () => undefined,
-        ensureTwitchIntegrity: async (_emit, request) => {
+        ensureTwitchIntegrity: async (_emit, request) => new Promise<boolean>((_resolve, reject) => {
           acquisitionSignal = request?.signal;
-          return acquisition.promise;
-        },
+          request?.signal?.addEventListener("abort", () => reject(request.signal?.reason), { once: true });
+        }),
       });
       await env.controller.settleBackgroundWork();
+      env.reportEvents.mockClear();
       const refreshing = env.controller.runTwitchIntegrityRefresh();
       await vi.waitFor(() => expect(acquisitionSignal).toBeDefined());
 
@@ -954,9 +1232,81 @@ describe("background controller", () => {
       expect(acquisitionSignal?.aborted).toBe(true);
       expect(env.deps.cancelTwitchIntegrityAcquisition).toHaveBeenCalled();
       expect(env.deps.clearAlarm).toHaveBeenCalledWith(TWITCH_INTEGRITY_ALARM_NAME);
-      acquisition.resolve(false);
       await refreshing;
       await env.rawController.settleBackgroundWork();
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(
+        expect.objectContaining({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "debug",
+          message: expect.stringContaining("cancelled because Twitch stopped"),
+        }),
+      );
+    });
+
+    it("does not admit an alarm queued while the Twitch disable write is pending", async () => {
+      const settingsSave = deferred<void>();
+      const env = harness(undefined, {
+        saveSettings: async () => settingsSave.promise,
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.ensureTwitchIntegrity.mockClear();
+
+      const disabling = env.rawController.handleMessage({
+        type: "setPlatformEnabled",
+        platform: "twitch",
+        enabled: false,
+      });
+      await vi.waitFor(() => expect(env.deps.saveSettings).toHaveBeenCalledOnce());
+      const queuedAlarm = env.controller.runTwitchIntegrityRefresh();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      const admittedBeforeDisablePersisted = env.deps.ensureTwitchIntegrity.mock.calls.length > 0;
+
+      settingsSave.resolve();
+      await Promise.all([disabling, queuedAlarm]);
+      await env.rawController.settleBackgroundWork();
+      expect(admittedBeforeDisablePersisted).toBe(false);
+      expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+    });
+
+    it("does not admit a fresh queued alarm after reset cleanup starts", async () => {
+      const alarmClear = deferred<boolean>();
+      const env = harness(undefined, {
+        clearAlarm: async () => alarmClear.promise,
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.ensureTwitchIntegrity.mockClear();
+
+      const resetting = env.controller.prepareForHostReset();
+      await vi.waitFor(() => expect(env.deps.clearAlarm).toHaveBeenCalledOnce());
+      const queuedAlarm = env.controller.runTwitchIntegrityRefresh();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      const admittedAfterResetStarted = env.deps.ensureTwitchIntegrity.mock.calls.length > 0;
+
+      alarmClear.resolve(true);
+      await Promise.all([resetting, queuedAlarm]);
+      expect(admittedAfterResetStarted).toBe(false);
+      expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
+    });
+
+    it("does not admit a fresh queued alarm after shutdown", async () => {
+      const env = harness(undefined, {
+        loadTwitchIntegrity: async () => undefined,
+        ensureTwitchIntegrity: async () => true,
+      });
+      await env.controller.settleBackgroundWork();
+      env.deps.ensureTwitchIntegrity.mockClear();
+
+      env.controller.shutdown();
+      await env.controller.runTwitchIntegrityRefresh();
+
+      expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
     });
 
     it("does not abort in-flight Kick work when Twitch is disabled", async () => {

--- a/packages/extension/tests/backgroundEntrypoint.test.ts
+++ b/packages/extension/tests/backgroundEntrypoint.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import * as controllerModule from "@lurkloot/core/controller";
+import { describe, expect, it, vi } from "vitest";
 
 describe("background integrity alarm wiring", () => {
   const source = readFileSync(
@@ -18,9 +19,36 @@ describe("background integrity alarm wiring", () => {
     expect(source).toContain("cancelTwitchIntegrityAcquisition,");
   });
 
-  it("dispatches only the integrity alarm to the controller refresh", () => {
-    expect(alarmListener).toContain("} else if (alarm.name === TWITCH_INTEGRITY_ALARM_NAME) {");
-    expect(alarmListener).toContain("void controller.runTwitchIntegrityRefresh();");
-    expect(alarmListener).not.toMatch(/else\s*\{/);
+  it("registers the behavioral named-alarm dispatcher", () => {
+    expect(alarmListener).toContain(
+      "browser.alarms.onAlarm.addListener(createBackgroundAlarmListener(controller));",
+    );
+  });
+
+  it("behaviorally dispatches named alarms and ignores unrelated alarms", () => {
+    const createBackgroundAlarmListener = (
+      controllerModule as typeof controllerModule & {
+        createBackgroundAlarmListener?: (controller: {
+          tickAndHandOff(): Promise<void>;
+          runWatchHeartbeat(): Promise<void>;
+          runTwitchIntegrityRefresh(): Promise<void>;
+        }) => (alarm: { name: string }) => void;
+      }
+    ).createBackgroundAlarmListener;
+    expect(createBackgroundAlarmListener).toBeTypeOf("function");
+    if (!createBackgroundAlarmListener) return;
+    const controller = {
+      tickAndHandOff: vi.fn(async () => undefined),
+      runWatchHeartbeat: vi.fn(async () => undefined),
+      runTwitchIntegrityRefresh: vi.fn(async () => undefined),
+    };
+    const listener = createBackgroundAlarmListener(controller);
+
+    listener({ name: "lurkloot.twitch-integrity" });
+    listener({ name: "unrelated.alarm" });
+
+    expect(controller.runTwitchIntegrityRefresh).toHaveBeenCalledOnce();
+    expect(controller.tickAndHandOff).not.toHaveBeenCalled();
+    expect(controller.runWatchHeartbeat).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/tests/backgroundEntrypoint.test.ts
+++ b/packages/extension/tests/backgroundEntrypoint.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("background integrity alarm wiring", () => {
+  const source = readFileSync(
+    new URL("../entrypoints/background.ts", import.meta.url),
+    "utf8",
+  );
+  const alarmListener = source.slice(
+    source.indexOf("browser.alarms.onAlarm.addListener"),
+    source.indexOf("browser.tabs.onRemoved.addListener"),
+  );
+
+  it("injects the one-shot alarm and integrity lifecycle dependencies", () => {
+    expect(source).toContain("createAlarm: (name, options) => browser.alarms.create(name, options),");
+    expect(source).toContain("clearAlarm: (name) => browser.alarms.clear(name),");
+    expect(source).toContain("ensureTwitchIntegrity: (emit, request) => ensureTwitchIntegrity(emit, request),");
+    expect(source).toContain("cancelTwitchIntegrityAcquisition,");
+  });
+
+  it("dispatches only the integrity alarm to the controller refresh", () => {
+    expect(alarmListener).toContain("} else if (alarm.name === TWITCH_INTEGRITY_ALARM_NAME) {");
+    expect(alarmListener).toContain("void controller.runTwitchIntegrityRefresh();");
+    expect(alarmListener).not.toMatch(/else\s*\{/);
+  });
+});

--- a/packages/extension/tests/tablessWatch.test.ts
+++ b/packages/extension/tests/tablessWatch.test.ts
@@ -533,7 +533,10 @@ describe("adapter-created twitch watcher diagnostics", () => {
     expect(result).toMatchObject({ ok: true });
     expect(currentUserCalls).toBe(2);
     expect(ensureIntegrity).toHaveBeenCalledOnce();
-    expect(ensureIntegrity).toHaveBeenCalledWith({ forceRefresh: true });
+    expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
+      forceRefresh: true,
+      reason: "rejection_recovery",
+    }));
     // The heartbeat itself is never replayed by integrity recovery.
     expect(sendEventsCalls).toBe(1);
   });

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -7,6 +7,7 @@ import {
   applyAdFocusWithBrowser,
   cancelTwitchIntegrityAcquisition,
   currentManagedPageContextTabs,
+  currentTwitchIntegrityWaiterCount,
   ensureTwitchIntegrityWithBrowser,
   fetchJsonInPageWithBrowser,
   fetchKickInBackgroundWith,
@@ -1261,6 +1262,55 @@ describe("twitch integrity refresh", () => {
       expect(browser.tabs.create).toHaveBeenCalledTimes(1);
     });
 
+    it("preserves fresh-context and rejected-token guarantees when a forced caller joins an ordinary acquisition", async () => {
+      const browser = browserMock();
+      browser.tabs.query.mockResolvedValue([{ id: 3 }]);
+      browser.tabs.create.mockResolvedValue({ id: 56 });
+      const rejected = {
+        integrity: "rejected-token",
+        clientSessionId: "page-session",
+        deviceId: "page-device",
+        expiresAt: Date.now() + 60_000,
+      };
+      const replacement = {
+        ...rejected,
+        integrity: "replacement-token",
+      };
+
+      const ordinary = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+      );
+      await vi.waitFor(() => expect(browser.tabs.query).toHaveBeenCalledOnce());
+      let forcedSettled = false;
+      const forced = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+        undefined,
+        { forceRefresh: true, rejectedToken: rejected.integrity },
+      ).then((result) => {
+        forcedSettled = true;
+        return result;
+      });
+
+      setTwitchIntegrity(rejected, { isNew: true });
+      await expect(ordinary).resolves.toBe(true);
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+      expect(forcedSettled).toBe(false);
+      expect(browser.tabs.create).toHaveBeenCalledWith({
+        url: "https://www.twitch.tv/drops/inventory",
+        pinned: false,
+        active: false,
+      });
+
+      setTwitchIntegrity(replacement, { isNew: true });
+
+      await expect(forced).resolves.toBe(true);
+      expect(browser.tabs.remove).not.toHaveBeenCalledWith(3);
+    });
+
     it("cancels the shared acquisition, removes its new context, and rejects every caller", async () => {
       const browser = browserMock();
       browser.tabs.create.mockResolvedValue({ id: 52 });
@@ -1283,6 +1333,41 @@ describe("twitch integrity refresh", () => {
       await expect(first).rejects.toBe(reason);
       await expect(second).rejects.toBe(reason);
       expect(browser.tabs.remove).toHaveBeenCalledWith(52);
+    });
+
+    it("removes its waiter after every cancellation", async () => {
+      const browser = browserMock();
+      let nextTabId = 60;
+      browser.tabs.create.mockImplementation(async () => ({ id: nextTabId++ }));
+
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const reason = new DOMException(`Host reset ${attempt}`, "AbortError");
+        const pending = ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          5_000,
+        );
+        await vi.waitFor(() => expect(currentTwitchIntegrityWaiterCount()).toBe(1));
+
+        cancelTwitchIntegrityAcquisition(reason);
+
+        await expect(pending).rejects.toBe(reason);
+        expect(currentTwitchIntegrityWaiterCount()).toBe(0);
+      }
+    });
+
+    it("removes its waiter after every timeout", async () => {
+      const browser = browserMock();
+      browser.tabs.query.mockResolvedValue([{ id: 3 }]);
+
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await expect(ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          5,
+        )).resolves.toBe(false);
+        expect(currentTwitchIntegrityWaiterCount()).toBe(0);
+      }
     });
 
     it("starts a new acquisition after cancellation settles", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -5,12 +5,14 @@ import { activityDiagnostic } from "@lurkloot/core/activityDiagnostics";
 import {
   AD_FOCUS_MAX_HOLD_MS,
   applyAdFocusWithBrowser,
+  cancelTwitchIntegrityAcquisition,
   currentManagedPageContextTabs,
   ensureTwitchIntegrityWithBrowser,
   fetchJsonInPageWithBrowser,
   fetchKickInBackgroundWith,
   fetchTwitchInBackgroundWith,
   hasValidTwitchIntegrity,
+  isValidTwitchIntegrity,
   KickWafBlockedError,
   noteTwitchGqlRequest,
   openPinnedMutedTabWithBrowser,
@@ -1142,6 +1144,35 @@ describe("twitch integrity refresh", () => {
     });
   });
 
+  describe("isValidTwitchIntegrity", () => {
+    const now = 1_000_000;
+
+    it("accepts a token outside the 30-second expiry skew", () => {
+      expect(isValidTwitchIntegrity({
+        integrity: "valid-token",
+        expiresAt: now + 30_001,
+      }, now)).toBe(true);
+    });
+
+    it("rejects a missing token", () => {
+      expect(isValidTwitchIntegrity(undefined, now)).toBe(false);
+    });
+
+    it("rejects an expired token", () => {
+      expect(isValidTwitchIntegrity({
+        integrity: "expired-token",
+        expiresAt: now,
+      }, now)).toBe(false);
+    });
+
+    it("rejects a token at the 30-second expiry skew boundary", () => {
+      expect(isValidTwitchIntegrity({
+        integrity: "inside-skew-token",
+        expiresAt: now + 30_000,
+      }, now)).toBe(false);
+    });
+  });
+
   describe("ensureTwitchIntegrityWithBrowser", () => {
     it("fast-returns without touching tabs when a valid token already exists", async () => {
       const browser = browserMock();
@@ -1206,6 +1237,108 @@ describe("twitch integrity refresh", () => {
         active: false,
       });
       await expect(pending).resolves.toBe(false);
+    });
+
+    it("shares one page-context mint between concurrent ordinary acquisitions", async () => {
+      const browser = browserMock();
+      browser.tabs.create.mockResolvedValue({ id: 51 });
+
+      const first = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+      );
+      const second = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+      );
+
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledTimes(1));
+      setTwitchIntegrity(fresh(), { isNew: true });
+
+      await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+      expect(browser.tabs.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels the shared acquisition, removes its new context, and rejects every caller", async () => {
+      const browser = browserMock();
+      browser.tabs.create.mockResolvedValue({ id: 52 });
+      const reason = new DOMException("Host reset", "AbortError");
+
+      const first = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+      );
+      const second = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+      );
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledTimes(1));
+
+      cancelTwitchIntegrityAcquisition(reason);
+
+      await expect(first).rejects.toBe(reason);
+      await expect(second).rejects.toBe(reason);
+      expect(browser.tabs.remove).toHaveBeenCalledWith(52);
+    });
+
+    it("starts a new acquisition after cancellation settles", async () => {
+      const browser = browserMock();
+      browser.tabs.create
+        .mockResolvedValueOnce({ id: 53 })
+        .mockResolvedValueOnce({ id: 54 });
+      const reason = new DOMException("Host reset", "AbortError");
+
+      const cancelled = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+      );
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledTimes(1));
+      cancelTwitchIntegrityAcquisition(reason);
+      await expect(cancelled).rejects.toBe(reason);
+
+      const restarted = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+      );
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledTimes(2));
+      setTwitchIntegrity(fresh(), { isNew: true });
+
+      await expect(restarted).resolves.toBe(true);
+      expect(browser.tabs.remove).toHaveBeenCalledWith(53);
+    });
+
+    it("aborts only a joined caller without cancelling the shared acquisition", async () => {
+      const browser = browserMock();
+      browser.tabs.create.mockResolvedValue({ id: 55 });
+      const joinerAbort = new AbortController();
+      const reason = new DOMException("Caller stopped", "AbortError");
+
+      const owner = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+      );
+      const joined = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+        undefined,
+        { signal: joinerAbort.signal },
+      );
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledTimes(1));
+
+      joinerAbort.abort(reason);
+
+      await expect(joined).rejects.toBe(reason);
+      expect(browser.tabs.remove).not.toHaveBeenCalled();
+      setTwitchIntegrity(fresh(), { isNew: true });
+      await expect(owner).resolves.toBe(true);
     });
 
     it("resolves false and warns when no token is captured before the timeout", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -27,6 +27,7 @@ import {
   setTwitchIntegrity,
   stopManagedPageContextTabsWithBrowser,
   stopWatchTabWithBrowser,
+  type TwitchIntegrityRequest,
 } from "@lurkloot/core/tabs";
 import { isSafeFetchError } from "@lurkloot/core/fetchError";
 
@@ -1309,6 +1310,87 @@ describe("twitch integrity refresh", () => {
 
       await expect(forced).resolves.toBe(true);
       expect(browser.tabs.remove).not.toHaveBeenCalledWith(3);
+    });
+
+    it("keeps proactive managed-context creation diagnostic-only and reports it for churn accounting", async () => {
+      const browser = browserMock();
+      browser.tabs.create.mockResolvedValue({ id: 57 });
+      const events: EngineEvent[] = [];
+      const managedOpen = vi.fn(async () => undefined);
+      const pending = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+        (event) => events.push(event),
+        {
+          forceRefresh: true,
+          reason: "proactive_refresh",
+          onManagedPageContextOpen: managedOpen,
+        } as TwitchIntegrityRequest,
+      );
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+      setTwitchIntegrity({
+        integrity: "proactive-replacement",
+        clientSessionId: "page-session",
+        deviceId: "page-device",
+        expiresAt: Date.now() + 60_000,
+      }, { isNew: true });
+
+      await expect(pending).resolves.toBe(true);
+
+      expect(managedOpen).toHaveBeenCalledOnce();
+      expect(events).not.toContainEqual(expect.objectContaining({
+        category: "activity",
+        code: "page_context_opened",
+      }));
+      expect(events).toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        platform: "twitch",
+        level: "debug",
+        message: expect.stringContaining("proactive"),
+      }));
+      expect(events).not.toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        message: expect.stringContaining("rejected"),
+      }));
+    });
+
+    it("keeps initial readiness context creation diagnostic-only", async () => {
+      const browser = browserMock();
+      browser.tabs.create.mockResolvedValue({ id: 58 });
+      const events: EngineEvent[] = [];
+      const managedOpen = vi.fn(async () => undefined);
+      const pending = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        5_000,
+        (event) => events.push(event),
+        {
+          reason: "readiness",
+          onManagedPageContextOpen: managedOpen,
+        },
+      );
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+      setTwitchIntegrity({
+        integrity: "readiness-token",
+        clientSessionId: "page-session",
+        deviceId: "page-device",
+        expiresAt: Date.now() + 60_000,
+      }, { isNew: true });
+
+      await expect(pending).resolves.toBe(true);
+
+      expect(managedOpen).toHaveBeenCalledOnce();
+      expect(events).not.toContainEqual(expect.objectContaining({
+        category: "activity",
+        code: "page_context_opened",
+      }));
+      expect(events).toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        platform: "twitch",
+        level: "debug",
+        message: expect.stringContaining("readiness"),
+      }));
     });
 
     it("cancels the shared acquisition, removes its new context, and rejects every caller", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1508,19 +1508,63 @@ describe("twitch integrity refresh", () => {
       await expect(owner).resolves.toBe(true);
     });
 
-    it("resolves false and warns when no token is captured before the timeout", async () => {
-      const browser = browserMock();
-      browser.tabs.query.mockResolvedValue([{ id: 3 }]);
-      const events: EngineEvent[] = [];
+    it.each([
+      { reason: "proactive_refresh", forceRefresh: true, level: "debug" },
+      { reason: "readiness", forceRefresh: false, level: "warn" },
+    ] as const)(
+      "resolves false and logs a $reason timeout at $level level",
+      async ({ reason, forceRefresh, level }) => {
+        const browser = browserMock();
+        browser.tabs.query.mockResolvedValue([{ id: 3 }]);
+        browser.tabs.create.mockResolvedValue({ id: 59 });
+        const events: EngineEvent[] = [];
 
-      const ok = await ensureTwitchIntegrityWithBrowser(browser, "https://www.twitch.tv/drops/inventory", 50, (event) => events.push(event));
+        const ok = await ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          50,
+          (event) => events.push(event),
+          { reason, forceRefresh },
+        );
 
-      expect(ok).toBe(false);
-      expect(events).toContainEqual(expect.objectContaining({
-        level: "warn",
-        message: expect.stringContaining("Timed out waiting for a Twitch integrity token"),
-      }));
-    });
+        const timeouts = events.filter((event) =>
+          event.category === "diagnostic"
+          && event.message.includes("Timed out waiting for a Twitch integrity token"));
+        expect(ok).toBe(false);
+        expect(timeouts).toEqual([
+          expect.objectContaining({ level }),
+        ]);
+      },
+    );
+
+    it.each([
+      { reason: "proactive_refresh", forceRefresh: true, level: "debug" },
+      { reason: "readiness", forceRefresh: false, level: "warn" },
+    ] as const)(
+      "returns false and logs a $reason page-open failure at $level level",
+      async ({ reason, forceRefresh, level }) => {
+        const browser = browserMock();
+        browser.tabs.query.mockResolvedValue([]);
+        browser.tabs.create.mockRejectedValue(new Error("tab open denied"));
+        const events: EngineEvent[] = [];
+
+        const ok = await ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          50,
+          (event) => events.push(event),
+          { reason, forceRefresh },
+        );
+
+        const openFailures = events.filter((event) =>
+          event.category === "diagnostic"
+          && event.message.includes("Could not open a twitch.tv tab"));
+        expect(ok).toBe(false);
+        expect(openFailures).toEqual([
+          expect.objectContaining({ level }),
+        ]);
+      },
+    );
 
     // Which page context answered decides whether the wait could ever succeed:
     // only a freshly created tab is guaranteed to boot the SPA and issue the


### PR DESCRIPTION
## Summary

- proactively warm Twitch Client-Integrity tokens before expiry using a dedicated one-shot alarm
- gate authenticated Twitch farming on one bounded token acquisition while keeping Kick independent
- unify integrity acquisition behind a cancellable single flight and preserve rejected-token semantics
- keep preparation diagnostics-only, with no popup or user-facing preparation state
- make enable, disable, reset, shutdown, capture, startup, and alarm scheduling concurrency-safe

## Why

Cold Twitch page contexts can take long enough to mint an integrity token that authenticated work times out or stacks repeated refresh attempts. Keeping a valid token warm avoids paying that cost on the farming critical path while retaining bounded fallback behavior.

## Validation

- `pnpm verify`
- 1,170 extension tests
- 132 CLI tests
- all workspace typechecks
- Astro site build
- Chromium and Firefox extension builds
- independent final review: 0 critical, 0 important, 0 minor findings

Closes #298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proactive Twitch integrity token refresh before tokens expire.
  * Twitch activity now waits for integrity readiness and skips Twitch work when readiness fails.
  * Coordinated concurrent token requests to avoid duplicate browser operations.
  * Added lifecycle handling for enablement changes, shutdown, and reset.

* **Bug Fixes**
  * Improved recovery after rejected Twitch integrity tokens.
  * Added cancellation and cleanup for interrupted refreshes.
  * Prevented stale alarms and tokens from triggering unnecessary refreshes.

* **Documentation**
  * Added detailed implementation and design specifications for Twitch integrity warming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->