### PR TITLE
perf(scheduler): run Twitch and Kick independently

### DIFF
--- a/docs/superpowers/plans/2026-07-29-current-watch-fast-path.md
+++ b/docs/superpowers/plans/2026-07-29-current-watch-fast-path.md
@@ -1,0 +1,120 @@
+# Current Watch Fast Path Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a steady-state Twitch scheduler tick validate the current watch once instead of scanning every eligible campaign and candidate first.
+
+**Architecture:** Derive the highest-priority campaign and active reward locally from the refreshed campaign inventory. When they match the current session, call the existing watch-retention validation before global channel selection and reuse its result. Fall back to the existing full selection path whenever the current target is no longer preferred or validation says it must switch.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace.
+
+## Global Constraints
+
+- Keep platform behavior behind `PlatformAdapter`.
+- Keep `@lurkloot/core` free of WXT and browser globals.
+- Diagnostics are English literals and platform-scoped.
+- Preserve current campaign priority, channel exclusion, retry, playback, and fallback behavior.
+- Use deterministic tests with mocked adapters.
+
+---
+
+### Task 1: Add a steady-state retention decision
+
+**Files:**
+- Modify: `packages/core/src/core/scheduler.ts`
+- Test: `packages/extension/tests/scheduler.test.ts`
+
+**Interfaces:**
+- Consumes: `sortCampaigns`, `isEligible`, `activeReward`, `shouldKeepWatching`.
+- Produces: an internal fast-path result that contains a retained `WatchDecision` and retention health counters.
+
+- [ ] **Step 1: Write the failing steady-state test**
+
+Create a watching session whose campaign/reward remains the first locally ranked target. Give `listCandidateChannels` many candidates and assert it is never called, while `checkChannel` is called exactly once for the current channel and the resulting reason is `keeping_current_watch`.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- scheduler.test.ts
+```
+
+Expected: the new assertion fails because `chooseCampaignDecision` currently calls `listCandidateChannels` before `shouldKeepWatching`.
+
+- [ ] **Step 3: Implement the minimal fast path**
+
+Add an internal helper that:
+
+```ts
+type CurrentWatchFastPath = {
+  decision: WatchDecision;
+  keep: Awaited<ReturnType<typeof shouldKeepWatching>>;
+};
+```
+
+It must return `undefined` unless the session is watching, has a channel, and its campaign/reward IDs match the first eligible sorted campaign and that campaign's active reward. For a match, construct a current-target decision, call `shouldKeepWatching` once, and return only when `keep.keep` is true.
+
+- [ ] **Step 4: Integrate before global selection**
+
+Call the helper before `chooseCampaignDecision`. On a retained result, skip global selection, reuse its validation result, and emit:
+
+```text
+Campaign selection fast path retained current watch in <N>ms (1 candidate checked)
+```
+
+Otherwise run the existing global selection and retention flow unchanged.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- scheduler.test.ts
+```
+
+Expected: all scheduler and workspace extension tests pass.
+
+### Task 2: Prove reselection behavior remains intact
+
+**Files:**
+- Test: `packages/extension/tests/scheduler.test.ts`
+
+**Interfaces:**
+- Consumes: the fast path from Task 1.
+- Produces: regression coverage for priority and completed-reward invalidation.
+
+- [ ] **Step 1: Write failing/regression tests**
+
+Add cases asserting:
+
+- A newly higher-priority campaign bypasses the fast path and performs full candidate selection.
+- A completed or claimable current reward bypasses the fast path and selects the next reward.
+- A failed current-channel validation falls through to full selection without reusing the failed retention result.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- scheduler.test.ts
+```
+
+Expected: all new cases pass after the minimal implementation, or reveal a concrete fast-path gap to fix.
+
+- [ ] **Step 3: Run full verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, all package typechecks/tests, site build, and Chromium/Firefox extension builds pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-07-29-current-watch-fast-path.md packages/core/src/core/scheduler.ts packages/extension/tests/scheduler.test.ts
+git commit -m "perf(scheduler): retain current watch before reselection"
+```

--- a/docs/superpowers/plans/2026-07-29-diagnostics-polish.md
+++ b/docs/superpowers/plans/2026-07-29-diagnostics-polish.md
@@ -1,0 +1,498 @@
+# Diagnostics Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make diagnostics unambiguous across controller restarts, eliminate redundant integrity-alarm scheduling lines, label Twitch selection timings, and report material platform-lock contention.
+
+**Architecture:** The controller owns one run ID and applies it at the reporting choke point, so all diagnostic producers inherit it without duplicating logic. Alarm deduplication stays behind a host-provided read-only alarm adapter, Twitch selection owns its campaign context, and lock-wait timing is measured at the existing platform-lock boundary.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace, WXT browser extension APIs
+
+## Global Constraints
+
+- `controllerRunId` is opaque, unique per background-controller instance, and attached to every diagnostic from that instance.
+- `globalTickId` and `platformTickId` remain per-run counters.
+- One unscoped run-boundary diagnostic precedes the controller's first reported diagnostic.
+- Diagnostics outside ticks carry no tick IDs.
+- An integrity alarm within 1,000 milliseconds of the desired target is unchanged and unlogged.
+- Alarm lookup failures are best-effort and never block scheduling.
+- Compatibility remains once per controller run.
+- Platform lock waits below 50 milliseconds remain silent.
+- Core stays browser-free; browser alarm access remains in the extension host.
+- Diagnostic copy remains English literals; no locale keys are added.
+
+---
+
+### Task 1: Correlate every diagnostic with a controller run
+
+**Files:**
+- Modify: `packages/shared/src/events.ts:59-79`
+- Modify: `packages/core/src/background/controller.ts:75-110`
+- Modify: `packages/core/src/background/controller.ts:820-850`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/extension/tests/activityStorage.test.ts`
+
+**Interfaces:**
+- Produces: `DiagnosticEvent.controllerRunId?: string`
+- Produces: controller-local `controllerRunId: string`
+- Consumes: existing `reportBestEffort(events)` reporting choke point
+
+- [ ] **Step 1: Write failing run-correlation tests**
+
+Add a controller test that emits both a non-tick request diagnostic and a tick:
+
+```ts
+it("announces one controller run and correlates all of its diagnostics", async () => {
+  const env = harness(farming(DEFAULT_SETTINGS));
+
+  await env.controller.handleMessage({
+    type: "setAutomation",
+    platform: "twitch",
+    enabled: true,
+  });
+  await env.controller.settleBackgroundWork();
+
+  const diagnostics = env.reportEvents.mock.calls
+    .flatMap(([events]) => events)
+    .filter((event): event is DiagnosticEvent => event.category === "diagnostic");
+  const boundaries = diagnostics.filter((event) =>
+    event.message.startsWith("Background controller run "));
+  const runId = boundaries[0]?.controllerRunId;
+
+  expect(boundaries).toHaveLength(1);
+  expect(runId).toEqual(expect.any(String));
+  expect(diagnostics.every((event) => event.controllerRunId === runId)).toBe(true);
+  expect(diagnostics.find((event) =>
+    event.message === "User requested Twitch automation enable")).not.toHaveProperty("globalTickId");
+});
+```
+
+Add a second test that constructs two harnesses, runs one Twitch tick in each,
+and asserts both display `Tick #1` while their full `controllerRunId` values
+differ.
+
+Extend activity storage round-trip coverage with a diagnostic containing
+`controllerRunId`, `globalTickId`, and `platformTickId`, then assert all three
+survive `append` and `load`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/backgroundController.test.ts tests/activityStorage.test.ts
+```
+
+Expected: FAIL because there is no run field or boundary event.
+
+- [ ] **Step 3: Add the shared field and run ID generator**
+
+Extend `DiagnosticEvent`:
+
+```ts
+controllerRunId?: string;
+```
+
+Create one ID when `createBackgroundController` runs:
+
+```ts
+const controllerRunId = typeof crypto !== "undefined" && "randomUUID" in crypto
+  ? crypto.randomUUID()
+  : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+const controllerRunLabel = controllerRunId.slice(0, 8);
+```
+
+- [ ] **Step 4: Announce and decorate at the reporting choke point**
+
+Keep a single announcement promise and report it before the first non-empty
+diagnostic batch. Decorate diagnostics only:
+
+```ts
+const correlateControllerRun = (events: readonly EngineEvent[]): EngineEvent[] =>
+  events.map((event) =>
+    event.category === "diagnostic"
+      ? { ...event, controllerRunId }
+      : event);
+```
+
+The boundary event is:
+
+```ts
+{
+  category: "diagnostic",
+  level: "debug",
+  message: `Background controller run ${controllerRunLabel} started`,
+  controllerRunId,
+}
+```
+
+Call `deps.reportEvents` directly for the boundary to avoid recursively invoking
+`reportBestEffort`; then report the decorated batch. Activity-only batches do
+not create a boundary until a diagnostic is actually reported.
+
+- [ ] **Step 5: Run focused tests and typechecks**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/backgroundController.test.ts tests/activityStorage.test.ts
+pnpm --filter @lurkloot/shared --filter @lurkloot/core --filter @lurkloot/extension typecheck
+git diff --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/events.ts packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/activityStorage.test.ts
+git commit -m "feat(core): correlate diagnostics by controller run"
+```
+
+### Task 2: Avoid redundant integrity alarm scheduling
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts:170-210`
+- Modify: `packages/core/src/background/controller.ts:490-535`
+- Modify: `packages/extension/entrypoints/background.ts:130-142`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/extension/tests/backgroundEntrypoint.test.ts`
+
+**Interfaces:**
+- Produces: `BackgroundControllerDeps.getAlarm?(name: string): Promise<{ scheduledTime: number } | undefined>`
+- Consumes: browser `alarms.get(name)` through the extension host
+
+- [ ] **Step 1: Write failing alarm-deduplication tests**
+
+Add controller tests using an integrity token whose calculated refresh target is
+captured from the first `createAlarm` call:
+
+```ts
+it("does not recreate or relog an unchanged Twitch integrity alarm", async () => {
+  const integrity = integrityBundle({
+    integrity: "unchanged-alarm-token",
+    expiresAt: Date.now() + 30 * 60_000,
+  });
+  const first = harness(undefined, {
+    loadTwitchIntegrity: async () => integrity,
+  });
+  await first.controller.settleBackgroundWork();
+  const scheduledTime = (first.deps.createAlarm.mock.calls.find(
+    ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+  )?.[1] as { when: number }).when;
+
+  const second = harness(undefined, {
+    loadTwitchIntegrity: async () => integrity,
+    getAlarm: async () => ({ scheduledTime }),
+  });
+  await second.controller.settleBackgroundWork();
+
+  expect(second.deps.createAlarm).not.toHaveBeenCalledWith(
+    TWITCH_INTEGRITY_ALARM_NAME,
+    expect.anything(),
+  );
+  expect(allDiagnostics(second)).not.toContainEqual(expect.objectContaining({
+    message: expect.stringContaining("Scheduled proactive Twitch integrity refresh"),
+  }));
+});
+```
+
+Add companion tests where `getAlarm` returns a target more than 1,000ms away and
+where it rejects. Both must call `createAlarm` and emit the scheduled target.
+
+Update the entrypoint source test to require:
+
+```ts
+getAlarm: async (name) => {
+  const alarm = await browser.alarms.get(name);
+  return alarm ? { scheduledTime: alarm.scheduledTime } : undefined;
+},
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/backgroundController.test.ts tests/backgroundEntrypoint.test.ts
+```
+
+Expected: FAIL because `getAlarm` is not part of the dependency contract and
+every schedule recreates/logs the alarm.
+
+- [ ] **Step 3: Add the dependency and source-level comparison**
+
+Add the optional dependency:
+
+```ts
+getAlarm?(name: string): Promise<{ scheduledTime: number } | undefined>;
+```
+
+Before `createAlarm`, perform a best-effort lookup:
+
+```ts
+let existing: { scheduledTime: number } | undefined;
+try {
+  existing = await deps.getAlarm?.(TWITCH_INTEGRITY_ALARM_NAME);
+} catch {
+  existing = undefined;
+}
+if (existing && Math.abs(existing.scheduledTime - when) <= 1_000) {
+  twitchIntegrityRefreshDue = undefined;
+  return;
+}
+```
+
+Then preserve the existing create/log path.
+
+- [ ] **Step 4: Wire browser and headless hosts**
+
+The extension maps `browser.alarms.get` to the browser-free shape. The CLI omits
+the optional dependency.
+
+- [ ] **Step 5: Run focused tests and typechecks**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/backgroundController.test.ts tests/backgroundEntrypoint.test.ts
+pnpm --filter @lurkloot/core --filter @lurkloot/extension --filter @lurkloot/cli typecheck
+git diff --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/entrypoints/background.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/backgroundEntrypoint.test.ts
+git commit -m "perf(twitch): skip unchanged integrity alarms"
+```
+
+### Task 3: Label Twitch channel-selection diagnostics
+
+**Files:**
+- Modify: `packages/core/src/platforms/twitch/index.ts:980-1060`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Consumes: `campaign?: DropCampaign` already passed to `selectCandidateChannel`
+- Produces: a shared local selection-context label used by both success and no-winner diagnostics
+
+- [ ] **Step 1: Write failing selection-context tests**
+
+Extend the existing selection diagnostics tests:
+
+```ts
+expect(events).toContainEqual(expect.objectContaining({
+  category: "diagnostic",
+  message: expect.stringMatching(
+    /^Twitch channel selection for "Campaign One" \(campaign campaign-1\) finished in \d+ms/,
+  ),
+}));
+```
+
+Call selection without a campaign and assert:
+
+```ts
+message: expect.stringMatching(
+  /^Twitch idle channel selection finished in \d+ms/,
+)
+```
+
+Cover both a selected winner and an empty result so the two existing emit sites
+cannot drift.
+
+- [ ] **Step 2: Run the adapter tests to verify RED**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/adapters.test.ts
+```
+
+Expected: FAIL because both diagnostics currently begin only with
+`Twitch channel selection finished`.
+
+- [ ] **Step 3: Build one context label**
+
+At the beginning of selection:
+
+```ts
+const selectionLabel = campaign
+  ? `for "${campaign.name}" (campaign ${campaign.id})`
+  : "idle";
+```
+
+Use one local `reportSelectionFinished()` helper for both emit sites so each
+message begins:
+
+```ts
+`Twitch ${selectionLabel} channel selection finished in ...`
+```
+
+Keep all request, cache, fallback, and candidate counters unchanged.
+
+- [ ] **Step 4: Run focused tests and typecheck**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/adapters.test.ts
+pnpm --filter @lurkloot/core --filter @lurkloot/extension typecheck
+git diff --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/platforms/twitch/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "feat(twitch): label channel selection diagnostics"
+```
+
+### Task 4: Measure material platform-lock contention
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts:1120-1220`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: `tickContext?: TickDiagnosticContext` already accepted by `refreshAuthHealth`
+- Produces: structured `data.waitMs` on lock-wait diagnostics
+
+- [ ] **Step 1: Write failing contention tests**
+
+Use fake timers and hold the Twitch platform lock with a deferred scheduler
+refresh. Start a second Twitch tick, advance 75ms, release the first tick, and
+assert:
+
+```ts
+expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+  category: "diagnostic",
+  platform: "twitch",
+  globalTickId: 2,
+  platformTickId: 2,
+  message: "Tick #2 waited 75ms for Twitch platform work",
+  data: { waitMs: 75 },
+}));
+```
+
+Add an uncontended tick assertion:
+
+```ts
+expect(allDiagnostics(env).some((event) =>
+  event.message.includes("waited") && event.message.includes("platform work"),
+)).toBe(false);
+```
+
+- [ ] **Step 2: Run the controller tests to verify RED**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/backgroundController.test.ts
+```
+
+Expected: FAIL because platform-lock acquisition time is not measured.
+
+- [ ] **Step 3: Return acquisition timing from auth refresh**
+
+Measure around `beginAuthRefresh`:
+
+```ts
+const lockStartedAt = Date.now();
+const generations = await beginAuthRefresh(platforms);
+const lockWaitMs = Date.now() - lockStartedAt;
+```
+
+When `tickContext` exists and `lockWaitMs >= 50`, emit one correlated diagnostic
+per requested platform:
+
+```ts
+diagnosticEvent(
+  "debug",
+  `Tick #${tickContext.platformTickId} waited ${lockWaitMs}ms for ${platformLabel} platform work`,
+  platform,
+  tickContext,
+  { waitMs: lockWaitMs },
+);
+```
+
+Extend `diagnosticEvent` with an optional `data` argument and preserve all
+existing call sites.
+
+- [ ] **Step 4: Run focused tests and typechecks**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/backgroundController.test.ts tests/activityStorage.test.ts
+pnpm --filter @lurkloot/shared --filter @lurkloot/core --filter @lurkloot/extension typecheck
+git diff --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(core): report platform lock contention"
+```
+
+### Task 5: Verify and update the existing pull request
+
+**Files:**
+- Verify only: entire workspace and browser builds
+
+**Interfaces:**
+- Consumes: Tasks 1-4
+- Produces: verified Chrome and Firefox extension builds on the existing issue branch
+
+- [ ] **Step 1: Search the final diagnostic producers**
+
+Run:
+
+```bash
+rg -n "Background controller run|controllerRunId|Scheduled proactive Twitch integrity refresh|channel selection finished|platform work" packages
+```
+
+Expected: run correlation is centralized, the alarm line remains only on the
+actual scheduling path, both selection outcomes use the shared reporter, and
+lock-wait copy exists only in the controller.
+
+- [ ] **Step 2: Run full verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: tooling tests, all workspace typechecks, extension and CLI tests, site
+tests/build, and Chromium/Firefox production builds pass.
+
+- [ ] **Step 3: Inspect final state**
+
+Run:
+
+```bash
+git status --short
+git diff --check
+git log --oneline -8
+```
+
+Expected: clean worktree and the four implementation commits above the design
+and plan commits.
+
+- [ ] **Step 4: Push without force**
+
+Run:
+
+```bash
+git push origin perf/scheduler-platform-concurrency
+```
+
+Expected: the existing pull request branch advances normally.

--- a/docs/superpowers/plans/2026-07-29-dual-tick-identifiers.md
+++ b/docs/superpowers/plans/2026-07-29-dual-tick-identifiers.md
@@ -1,0 +1,245 @@
+# Dual Tick Identifiers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every scheduler tick a globally unique ID and a continuous platform-local ID while keeping current filtered diagnostic messages concise.
+
+**Architecture:** Extend `DiagnosticEvent` with optional structured tick correlation fields. The background controller allocates both IDs synchronously, uses the platform-local ID in lifecycle messages, and decorates every diagnostic collected or emitted during that tick with the same pair.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace, WXT extension
+
+## Global Constraints
+
+- `globalTickId` is unique across Twitch and Kick ticks within one controller lifetime.
+- `platformTickId` is sequential independently for Twitch and Kick.
+- Both counters reset with the in-memory controller.
+- Current lifecycle messages display only `platformTickId`.
+- All diagnostics produced inside a tick carry both identifiers; diagnostics outside ticks omit them.
+- Activity event contracts, persisted scheduler state, settings, permissions, and locale catalogs remain unchanged.
+- Diagnostic messages remain English literals.
+
+---
+
+### Task 1: Define and populate structured tick correlation
+
+**Files:**
+- Modify: `packages/shared/src/events.ts:59-77`
+- Modify: `packages/core/src/background/controller.ts:789-814`
+- Modify: `packages/core/src/background/controller.ts:1263-1437`
+- Test: `packages/extension/tests/backgroundController.test.ts:3620-3690`
+
+**Interfaces:**
+- Produces: `DiagnosticEvent.globalTickId?: number`
+- Produces: `DiagnosticEvent.platformTickId?: number`
+- Produces: per-tick context `{ globalTickId: number; platformTickId: number }`
+- Consumes: existing `Platform`, `DiagnosticEvent`, `EngineEvent`, `reportBestEffort`, and tick event collection
+
+- [ ] **Step 1: Write failing controller tests**
+
+Add a test that runs Twitch, Kick, then Twitch ticks and groups lifecycle
+diagnostics by platform:
+
+```ts
+it("assigns global and platform-local identifiers to interleaved platform ticks", async () => {
+  const env = harness(farming(DEFAULT_SETTINGS));
+
+  await env.controller.tick(["twitch"], "manual_tick");
+  await env.controller.tick(["kick"], "manual_tick");
+  await env.controller.tick(["twitch"], "manual_tick");
+
+  const starts = env.reportEvents.mock.calls
+    .flatMap(([events]) => events)
+    .filter((event): event is DiagnosticEvent =>
+      event.category === "diagnostic" && event.message.includes("started (trigger=manual_tick"));
+
+  expect(starts.map(({ platform, globalTickId, platformTickId, message }) => ({
+    platform,
+    globalTickId,
+    platformTickId,
+    message,
+  }))).toEqual([
+    {
+      platform: "twitch",
+      globalTickId: 1,
+      platformTickId: 1,
+      message: "Tick #1 started (trigger=manual_tick, platforms=twitch)",
+    },
+    {
+      platform: "kick",
+      globalTickId: 2,
+      platformTickId: 1,
+      message: "Tick #1 started (trigger=manual_tick, platforms=kick)",
+    },
+    {
+      platform: "twitch",
+      globalTickId: 3,
+      platformTickId: 2,
+      message: "Tick #2 started (trigger=manual_tick, platforms=twitch)",
+    },
+  ]);
+});
+```
+
+Extend the existing lifecycle test to select one tick's start, auth timing,
+campaign refresh, and finish diagnostics and assert that all carry
+`globalTickId: 1` and `platformTickId: 1`. Add a diagnostic emitted outside a
+tick through an existing controller action and assert both fields are absent.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/backgroundController.test.ts
+```
+
+Expected: FAIL because `DiagnosticEvent` has no tick fields, the global counter
+appears in the Twitch message after a Kick tick, and collected scheduler
+diagnostics have no correlation metadata.
+
+- [ ] **Step 3: Extend the shared diagnostic contract**
+
+Add the optional fields to `DiagnosticEvent`:
+
+```ts
+export type DiagnosticEvent = {
+  category: "diagnostic";
+  level: LogLevel;
+  platform?: Platform;
+  message: string;
+  globalTickId?: number;
+  platformTickId?: number;
+  // existing fields remain unchanged
+};
+```
+
+- [ ] **Step 4: Allocate both identifiers in the controller**
+
+Replace the single counter with:
+
+```ts
+let globalTickSequence = 0;
+const platformTickSequence: Record<Platform, number> = {
+  twitch: 0,
+  kick: 0,
+};
+```
+
+At the beginning of `tickPlatform`, synchronously allocate:
+
+```ts
+const tickContext = {
+  globalTickId: ++globalTickSequence,
+  platformTickId: ++platformTickSequence[platform],
+};
+```
+
+Pass this context into `runTick`. Format lifecycle messages with
+`tickContext.platformTickId`.
+
+- [ ] **Step 5: Decorate immediate and collected tick diagnostics**
+
+Allow `diagnosticEvent` to receive optional tick metadata:
+
+```ts
+function diagnosticEvent(
+  level: "debug" | "info" | "warn",
+  message: string,
+  platform?: Platform,
+  tickContext?: Pick<DiagnosticEvent, "globalTickId" | "platformTickId">,
+): void {
+  void reportBestEffort([{
+    category: "diagnostic",
+    level,
+    message,
+    platform,
+    ...tickContext,
+  }]);
+}
+```
+
+Before reporting a tick's collected events, decorate only diagnostics:
+
+```ts
+function correlateTickDiagnostics(
+  events: readonly EngineEvent[],
+  tickContext: Pick<DiagnosticEvent, "globalTickId" | "platformTickId">,
+): EngineEvent[] {
+  return events.map((event) =>
+    event.category === "diagnostic" ? { ...event, ...tickContext } : event);
+}
+```
+
+Use the correlated array in both the success and scheduler-error
+`persistPlatformAndReport` paths. Pass the context to the immediate start,
+authentication timing, and finish diagnostics.
+
+- [ ] **Step 6: Run focused tests and typechecks**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/backgroundController.test.ts tests/activityStorage.test.ts tests/activityLogView.test.tsx
+pnpm --filter @lurkloot/shared --filter @lurkloot/core --filter @lurkloot/extension typecheck
+git diff --check
+```
+
+Expected: all tests and typechecks pass; no whitespace errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/shared/src/events.ts packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(core): add dual tick diagnostic identifiers"
+```
+
+### Task 2: Verify delivery
+
+**Files:**
+- Verify only: all workspace packages and browser builds
+
+**Interfaces:**
+- Consumes: completed dual identifier implementation from Task 1
+- Produces: verified Chrome and Firefox extension builds
+
+- [ ] **Step 1: Search for stale global-only tick formatting**
+
+Run:
+
+```bash
+rg -n "tickSequence|Tick #\\$\\{tickId\\}" packages/core packages/extension
+```
+
+Expected: no stale single-counter declaration or lifecycle interpolation.
+
+- [ ] **Step 2: Run full verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, workspace typechecks, extension and CLI tests, site
+build, and both Chromium and Firefox production builds pass.
+
+- [ ] **Step 3: Check final branch state**
+
+Run:
+
+```bash
+git status --short
+git diff --check
+git log --oneline -3
+```
+
+Expected: clean worktree, no diff errors, and the feature commit at `HEAD`.
+
+- [ ] **Step 4: Push the existing issue branch**
+
+```bash
+git push origin perf/scheduler-platform-concurrency
+```
+
+Expected: the existing pull request branch updates without a force push.
+

--- a/docs/superpowers/plans/2026-07-29-platform-automation-presentation.md
+++ b/docs/superpowers/plans/2026-07-29-platform-automation-presentation.md
@@ -1,0 +1,211 @@
+# Per-Platform Automation Presentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make each Twitch and Kick automation card render a badge and detail from one canonical per-platform lifecycle state.
+
+**Architecture:** Extend the pure `automationPresentation` resolver to consume the platform session alongside effective settings, pending state, auth health, and manual-close pause. The popup will render only the resolver's canonical detail for non-running states and will admit a scheduler status message for `running` only when it is compatible with the settled enabled state.
+
+**Tech Stack:** TypeScript, React, Vitest, pnpm, WXT
+
+## Global Constraints
+
+- Resolve Twitch and Kick independently.
+- Keep diagnostic and scheduler messages as English literals; do not add diagnostic locale keys.
+- User-facing transition copy must use existing locale keys.
+- Badge, detail, tone, actions, and operational styling must derive from one `AutomationPresentation`.
+- Do not display `Automation disabled`, `Platform disabled`, or `Starting automation` under a `Running` badge.
+
+---
+
+### Task 1: Canonical Per-Platform Presentation Resolver
+
+**Files:**
+- Modify: `packages/popup-ui/src/automationStatus.ts`
+- Modify: `packages/extension/tests/popupAutomationStatus.test.ts`
+
+**Interfaces:**
+- Consumes: `PlatformSession` from `@lurkloot/shared/models`
+- Produces: `automationPresentation({ platform, enabled, pending, authHealth, session, manualClosePaused }): AutomationPresentation`
+- Produces: `AutomationPresentation.statusMessage?: string`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Add literal behavior tests covering:
+
+```ts
+expect(automationPresentation({
+  platform: "twitch",
+  enabled: true,
+  pending: false,
+  authHealth: HEALTHY,
+  session: { platform: "twitch", status: "idle", offlineChecks: 0, message: "Starting automation" },
+})).toMatchObject({
+  state: "starting",
+  badgeKey: "automationStarting",
+  detailKey: "startingAutomation",
+});
+```
+
+Also assert that an enabled healthy session with `message: "Automation disabled"`
+returns `state: "running"` without exposing that message, while an ordinary
+settled running message remains available as `statusMessage`.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/popupAutomationStatus.test.ts
+```
+
+Expected: FAIL because `automationPresentation` does not consume `session` and
+does not guard contradictory status messages.
+
+- [ ] **Step 3: Implement the minimal resolver change**
+
+Import `PlatformSession`, add `session` to the resolver arguments, recognize the
+enabled startup marker before auth-health resolution, and add a helper that
+returns a running `statusMessage` only when it is not one of:
+
+```ts
+new Set(["Starting automation", "Automation disabled", "Platform disabled"])
+```
+
+Return that safe message on the `running` presentation.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/popupAutomationStatus.test.ts
+```
+
+Expected: all presentation tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/popup-ui/src/automationStatus.ts packages/extension/tests/popupAutomationStatus.test.ts
+git commit -m "fix(popup): unify platform automation presentation"
+```
+
+### Task 2: Render Only the Canonical Presentation
+
+**Files:**
+- Modify: `packages/popup-ui/src/Popup.tsx`
+- Modify: `packages/popup-ui/src/automation.tsx`
+- Modify: `packages/extension/tests/popupAutomation.test.tsx`
+
+**Interfaces:**
+- Consumes: `AutomationPresentation.statusMessage`
+- Removes: `AutomationHeroProps.statusMessage`
+
+- [ ] **Step 1: Write a failing rendered-card test**
+
+Render an enabled Twitch card from a snapshot whose auth is healthy and whose
+session still says `Automation disabled`. Assert:
+
+```ts
+expect(screen.getByText("Running")).toBeTruthy();
+expect(screen.queryByText("Automation disabled")).toBeNull();
+```
+
+Render the persisted startup-marker case and assert the card contains both the
+`Starting` badge and localized `Starting automation...` detail.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/popupAutomation.test.tsx
+```
+
+Expected: FAIL because `AutomationHero` still renders the independently passed
+raw session message.
+
+- [ ] **Step 3: Wire the session into each platform resolver**
+
+In `Popup.tsx`, pass:
+
+```ts
+session: snapshot.state.sessions[id]
+```
+
+for each platform. Stop passing `session.message` separately to
+`AutomationHero`.
+
+- [ ] **Step 4: Render the presentation's safe running detail**
+
+Remove `statusMessage` from `AutomationHeroProps` and use
+`presentation.statusMessage` in the settled running branch, falling back to
+`waitingEligibleStream`.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/popupAutomationStatus.test.ts tests/popupAutomation.test.tsx
+```
+
+Expected: all automation presentation and rendered-card tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/popup-ui/src/Popup.tsx packages/popup-ui/src/automation.tsx packages/extension/tests/popupAutomation.test.tsx
+git commit -m "fix(popup): render canonical automation state"
+```
+
+### Task 3: Verify and Rebuild
+
+**Files:**
+- No source changes expected
+
+**Interfaces:**
+- Produces: verified Chromium build at `packages/extension/.output/chrome-mv3`
+
+- [ ] **Step 1: Run repository verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, workspace typechecks, CLI tests, extension tests, site
+build, Chromium build, and Firefox build all pass.
+
+- [ ] **Step 2: Validate the rendered target flow**
+
+The flow under test is: enable Twitch or Kick automation -> observe the
+per-platform startup state -> observe the settled running state -> confirm the
+badge and detail never contradict each other.
+
+Use the Browser plugin when available. If it is unavailable, record that fact
+and use the repository's existing popup test harness or Playwright without
+installing dependencies.
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors and only intended files changed.
+
+- [ ] **Step 4: Push the verified commits**
+
+Run:
+
+```bash
+git push origin HEAD
+```
+
+Expected: PR #305 receives the canonical presentation changes.

--- a/docs/superpowers/plans/2026-07-29-scheduler-platform-concurrency.md
+++ b/docs/superpowers/plans/2026-07-29-scheduler-platform-concurrency.md
@@ -1,0 +1,689 @@
+# Scheduler Platform Concurrency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run Twitch and Kick scheduler work independently for every trigger and route recurring work through separate platform alarms without losing concurrent state updates.
+
+**Architecture:** Long-running work is serialized only against other work for the same platform. Each completed operation commits its explicitly owned platform slice through a short storage queue that reloads and merges the latest `SchedulerState`, while all-platform callers fan out with settled aggregation.
+
+**Tech Stack:** TypeScript 7, pnpm workspaces, Vitest, WXT WebExtension APIs.
+
+## Global Constraints
+
+- Keep one persisted `SchedulerState` blob; do not introduce a state migration.
+- Both platforms continue using `settings.pollIntervalMinutes`.
+- Network, tab, notification, and watcher work must never run inside the storage commit queue.
+- Same-platform state writers must remain ordered.
+- One platform failure must not cancel or roll back the sibling platform.
+- Diagnostic messages remain English literals; activity events retain structured codes and data.
+- `@lurkloot/core` must remain browser-free.
+- Use two-space indentation, double quotes, semicolons, explicit type imports, and ES modules.
+
+---
+
+### Task 1: Platform State Slice Merge
+
+**Files:**
+- Create: `packages/core/src/background/platformState.ts`
+- Create: `packages/extension/tests/platformState.test.ts`
+
+**Interfaces:**
+- Produces: `mergePlatformState(destination: SchedulerState, source: SchedulerState, platform: Platform): SchedulerState`
+- Produces: `withPlatformRecordEntry<T>(destination, source, platform)` as a private helper that preserves or deletes optional entries correctly.
+
+- [ ] **Step 1: Write failing merge tests**
+
+Create tests that construct distinguishable Twitch, Kick, and global values and prove that merging Twitch:
+
+```ts
+const merged = mergePlatformState(destination, source, "twitch");
+
+expect(merged.sessions.twitch).toEqual(source.sessions.twitch);
+expect(merged.sessions.kick).toEqual(destination.sessions.kick);
+expect(merged.campaigns.twitch).toEqual(source.campaigns.twitch);
+expect(merged.campaigns.kick).toEqual(destination.campaigns.kick);
+expect(merged.installedAt).toBe(destination.installedAt);
+expect(merged.lastTickAt).toBe(source.lastTickAt);
+```
+
+Add a second test where `source.managedWatchTabs.twitch`,
+`source.managedPageContextTabs.twitch`, `source.manualWatch.twitch`,
+`source.manualClosePause.twitch`, `source.gamification.twitch`,
+`source.criticalHealth.twitch`, and
+`source.deadlineInfeasibleRewardIds.twitch` are absent. Assert that the merged
+records remove Twitch while preserving Kick.
+
+- [ ] **Step 2: Run the tests and verify the missing module failure**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- platformState.test.ts
+```
+
+Expected: FAIL because `@lurkloot/core/background/platformState` is not exported.
+
+- [ ] **Step 3: Implement the merge boundary**
+
+Implement `platformState.ts` with an optional-record helper and explicit field
+list:
+
+```ts
+function mergeOptionalEntry<T>(
+  destination: Partial<Record<Platform, T>> | undefined,
+  source: Partial<Record<Platform, T>> | undefined,
+  platform: Platform,
+): Partial<Record<Platform, T>> {
+  const merged = { ...destination };
+  const value = source?.[platform];
+  if (value === undefined) delete merged[platform];
+  else merged[platform] = value;
+  return merged;
+}
+
+export function mergePlatformState(
+  destination: SchedulerState,
+  source: SchedulerState,
+  platform: Platform,
+): SchedulerState {
+  return {
+    ...destination,
+    sessions: { ...destination.sessions, [platform]: source.sessions[platform] },
+    authHealth: { ...destination.authHealth, [platform]: source.authHealth[platform] },
+    campaigns: { ...destination.campaigns, [platform]: source.campaigns[platform] },
+    criticalHealth: mergeOptionalEntry(destination.criticalHealth, source.criticalHealth, platform),
+    managedWatchTabs: mergeOptionalEntry(destination.managedWatchTabs, source.managedWatchTabs, platform),
+    managedPageContextTabs: mergeOptionalEntry(destination.managedPageContextTabs, source.managedPageContextTabs, platform),
+    manualWatch: mergeOptionalEntry(destination.manualWatch, source.manualWatch, platform),
+    manualClosePause: mergeOptionalEntry(destination.manualClosePause, source.manualClosePause, platform),
+    gamification: mergeOptionalEntry(destination.gamification, source.gamification, platform),
+    deadlineInfeasibleRewardIds: mergeOptionalEntry(
+      destination.deadlineInfeasibleRewardIds,
+      source.deadlineInfeasibleRewardIds,
+      platform,
+    ),
+    lastTickAt: newestTimestamp(destination.lastTickAt, source.lastTickAt),
+  };
+}
+```
+
+Export the module through `packages/core/package.json` using
+`"./background/platformState": "./src/background/platformState.ts"`.
+Implement `newestTimestamp` by parsing both defined ISO values and returning
+the value with the larger finite timestamp, falling back to the defined value
+when only one parses.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- platformState.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/background/platformState.ts packages/core/package.json packages/extension/tests/platformState.test.ts
+git commit -m "refactor(controller): add platform state merge boundary"
+```
+
+### Task 2: Platform-scoped Tab Registries
+
+**Files:**
+- Modify: `packages/core/src/core/tabs.ts`
+- Modify: `packages/core/src/core/scheduler.ts`
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/extension/tests/tabs.test.ts`
+- Modify: `packages/extension/tests/scheduler.test.ts`
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+- Modify: `packages/extension/tests/criticalHealth.test.ts`
+
+**Interfaces:**
+- Produces: `registerManagedPageContextTabs(contexts, platforms?: readonly Platform[]): void`
+- Produces: `syncManagedTabBreakers(state, platforms?: readonly Platform[]): void`
+- Keeps: omitted `platforms` means whole-registry synchronization for reset and test cleanup.
+
+- [ ] **Step 1: Write failing scoped-registry tests**
+
+Seed both platforms, then synchronize only Twitch:
+
+```ts
+registerManagedPageContextTabs({
+  twitch: twitchContext,
+  kick: kickContext,
+});
+registerManagedPageContextTabs({}, ["twitch"]);
+expect(currentManagedPageContextTabs()).toEqual({ kick: kickContext });
+
+syncManagedTabBreakers({
+  criticalHealth: {
+    twitch: { ...openHealth, breakerOpen: false },
+    kick: { ...openHealth, breakerOpen: true },
+  },
+});
+syncManagedTabBreakers({}, ["twitch"]);
+expect(managedTabBreakerOpen("twitch")).toBe(false);
+expect(managedTabBreakerOpen("kick")).toBe(true);
+```
+
+Also add a scheduler test proving a Twitch-only tick does not remove a
+registered Kick retained context or Kick breaker.
+
+- [ ] **Step 2: Verify tests fail**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tabs.test.ts scheduler.test.ts criticalHealth.test.ts
+```
+
+Expected: FAIL because both current functions clear or synchronize all
+platforms.
+
+- [ ] **Step 3: Implement scoped synchronization**
+
+Use one normalized target list:
+
+```ts
+const ALL_PLATFORMS: readonly Platform[] = ["twitch", "kick"];
+
+export function registerManagedPageContextTabs(
+  contexts: SchedulerManagedPageContexts,
+  platforms: readonly Platform[] = ALL_PLATFORMS,
+): void {
+  for (const platform of platforms) {
+    retainedPageContextTabs.delete(platform);
+    const context = contexts[platform];
+    if (context) retainedPageContextTabs.set(platform, context);
+  }
+}
+```
+
+Apply the same target-list pattern to `syncManagedTabBreakers`. Update
+single-platform scheduler/controller call sites to pass `[platform]`; retain
+whole-registry calls only for reset and test cleanup.
+
+- [ ] **Step 4: Run scoped-registry tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tabs.test.ts scheduler.test.ts criticalHealth.test.ts backgroundController.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/core/tabs.ts packages/core/src/core/scheduler.ts packages/core/src/background/controller.ts packages/extension/tests/tabs.test.ts packages/extension/tests/scheduler.test.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/criticalHealth.test.ts
+git commit -m "refactor(tabs): scope state mirrors by platform"
+```
+
+### Task 3: Make the Scheduler Single-platform
+
+**Files:**
+- Modify: `packages/core/src/core/scheduler.ts`
+- Modify: `packages/extension/tests/scheduler.test.ts`
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/cli/src/runtime/run.ts`
+
+**Interfaces:**
+- Changes: `SchedulerTickOptions.platforms?: Platform[]` to `SchedulerTickOptions.platform: Platform`
+- Keeps: `runSchedulerTick(state, settings, adapters, options): Promise<SchedulerTickResult>`
+
+- [ ] **Step 1: Update tests to require one platform**
+
+Change scheduler test calls to pass `platform: "twitch"` or
+`platform: "kick"`. Add a test with spies on both adapters:
+
+```ts
+await runSchedulerTick(state, settings, adapters, { platform: "kick" });
+
+expect(kick.discoverCampaigns).toHaveBeenCalledOnce();
+expect(twitch.discoverCampaigns).not.toHaveBeenCalled();
+expect(result.decisions.every((decision) => decision.platform === "kick")).toBe(true);
+```
+
+- [ ] **Step 2: Run the focused scheduler suite and verify type/test failures**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- scheduler.test.ts
+pnpm --filter @lurkloot/core typecheck
+```
+
+Expected: FAIL until the scheduler option and call sites are changed.
+
+- [ ] **Step 3: Remove the platform loop**
+
+Replace:
+
+```ts
+const platforms = options.platforms ?? PLATFORMS;
+for (const platform of platforms) {
+  // platform body
+}
+```
+
+with one scoped body:
+
+```ts
+const { platform } = options;
+registerManagedPageContextTabs(state.managedPageContextTabs ?? {}, [platform]);
+syncManagedTabBreakers(
+  settings.criticalFailurePromptEnabled ? nextState : {},
+  [platform],
+);
+// Existing loop body executes once for platform.
+```
+
+Update breaker resynchronization inside `applyObservation` to pass
+`[platform]`. Remove the scheduler-local `PLATFORMS` constant if unused.
+Temporarily adapt controller calls by iterating the requested platform list
+sequentially; Task 4 replaces that compatibility bridge with concurrent
+controller operations.
+
+- [ ] **Step 4: Run scheduler and type checks**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- scheduler.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/core/scheduler.ts packages/core/src/background/controller.ts packages/cli/src/runtime/run.ts packages/extension/tests/scheduler.test.ts
+git commit -m "refactor(scheduler): run one platform per tick"
+```
+
+### Task 4: Per-platform Operation Queues and Short Commits
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: `mergePlatformState(destination, source, platform)`
+- Produces: private `withPlatformLock<T>(platform, operation): Promise<T>`
+- Produces: private `commitPlatformState(platform, source): Promise<SchedulerState>`
+- Changes: `runTick` becomes `runPlatformTick(platform, tickId, tickStartedAt, signal): Promise<string[]>`
+
+- [ ] **Step 1: Write failing overlap and merge tests**
+
+Use deferred adapter promises to prove Kick starts and commits while Twitch is
+still pending:
+
+```ts
+const twitchDiscovery = deferred<DropCampaign[]>();
+env.twitch.discoverCampaigns = vi.fn(() => twitchDiscovery.promise);
+
+const ticking = env.controller.tick(undefined, "manual_tick");
+await vi.waitFor(() => expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce());
+await vi.waitFor(() => expect(env.state.lastTickAt).toBeDefined());
+expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+
+twitchDiscovery.resolve([]);
+await ticking;
+```
+
+Add a concurrent completion test where Twitch and Kick each mutate campaigns
+and sessions. Assert both final slices survive. Add a failure test where Twitch
+throws after Kick succeeds; assert Kick state persists and the Twitch
+interruption includes `platform: "twitch"`.
+
+Retain and update the existing same-platform writer tests: telemetry racing a
+Twitch tick must still show ordered load/save behavior for Twitch, while Kick
+may interleave.
+
+- [ ] **Step 2: Run the focused tests and verify serialization failures**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+```
+
+Expected: FAIL because the global `stateMutation` holds Twitch work ahead of
+Kick.
+
+- [ ] **Step 3: Add operation and commit queues**
+
+Replace the module-global state queue with controller-local queues:
+
+```ts
+const platformMutations: Record<Platform, Promise<unknown>> = {
+  twitch: Promise.resolve(),
+  kick: Promise.resolve(),
+};
+let stateCommit: Promise<unknown> = Promise.resolve();
+
+function withPlatformLock<T>(platform: Platform, operation: () => Promise<T>): Promise<T> {
+  const run = platformMutations[platform].then(operation, operation);
+  platformMutations[platform] = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+function withStateCommit<T>(operation: () => Promise<T>): Promise<T> {
+  const run = stateCommit.then(operation, operation);
+  stateCommit = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+async function commitPlatformState(platform: Platform, source: SchedulerState): Promise<SchedulerState> {
+  return withStateCommit(async () => {
+    const latest = await deps.loadState();
+    const merged = mergePlatformState(latest, source, platform);
+    await deps.saveState(merged);
+    return merged;
+  });
+}
+```
+
+Move auth preparation, adapter creation, `runSchedulerTick`, notification
+generation, ad focus, watcher reconciliation, critical-health event handling,
+and commit into `withPlatformLock(platform, ...)`. Ensure the commit queue wraps
+only the final load/merge/save.
+
+- [ ] **Step 4: Fan out platform ticks with settled aggregation**
+
+Normalize targets and start them together:
+
+```ts
+const requested = platforms ?? PLATFORMS;
+const settled = await Promise.allSettled(
+  requested.map((platform) => runPlatformTick(platform, tickId, tickStartedAt, signal)),
+);
+for (let index = 0; index < settled.length; index += 1) {
+  const result = settled[index];
+  const platform = requested[index];
+  if (result.status === "fulfilled" && result.value.length > 0) {
+    claimedRewards[platform] = result.value;
+  } else if (result.status === "rejected") {
+    await reportPlatformTickFailure(platform, result.reason);
+  }
+}
+```
+
+Give each platform its own event collector. Do not share `events`,
+`nextWaitingClaimRewardIds`, or claimed arrays between concurrent operations.
+Update `waitingClaimRewardIds` only for the completed platform.
+
+- [ ] **Step 5: Convert single-platform writers**
+
+Change telemetry, tab removal, manual resume, auth-health changes, heartbeats,
+and other handlers that own one platform to use that platform queue and
+`commitPlatformState`. For tab removal, resolve affected platforms first and
+acquire those queues in stable Twitch-then-Kick order. Whole-host reset acquires
+both platform queues in that order, then uses the commit queue for replacement.
+
+- [ ] **Step 6: Run controller tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+pnpm typecheck
+```
+
+Expected: PASS, including overlap, independent failure, merge, and
+same-platform ordering tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "perf(controller): run platform ticks concurrently"
+```
+
+### Task 5: Separate Twitch and Kick Scheduler Alarms
+
+**Files:**
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+- Modify: `packages/extension/tests/backgroundEntrypoint.test.ts`
+- Modify: `packages/extension/tests/credentialObserver.test.ts`
+
+**Interfaces:**
+- Produces: `TWITCH_ALARM_NAME = "lurkloot.tick.twitch"`
+- Produces: `KICK_ALARM_NAME = "lurkloot.tick.kick"`
+- Keeps: `ALARM_NAME = "lurkloot.tick"` as a legacy cleanup constant.
+
+- [ ] **Step 1: Write failing alarm tests**
+
+Assert setup creates both scoped alarms and clears the legacy alarm:
+
+```ts
+await env.controller.ensureAlarm();
+
+expect(env.deps.createAlarm).toHaveBeenCalledWith(
+  TWITCH_ALARM_NAME,
+  { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes },
+);
+expect(env.deps.createAlarm).toHaveBeenCalledWith(
+  KICK_ALARM_NAME,
+  { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes },
+);
+expect(env.deps.clearAlarm).toHaveBeenCalledWith(ALARM_NAME);
+```
+
+Update the alarm-listener test to deliver each name and assert:
+
+```ts
+listener({ name: TWITCH_ALARM_NAME });
+expect(controller.tickAndHandOff).toHaveBeenCalledWith(["twitch"], "alarm");
+
+listener({ name: KICK_ALARM_NAME });
+expect(controller.tickAndHandOff).toHaveBeenCalledWith(["kick"], "alarm");
+```
+
+Assert the legacy alarm does not trigger scheduler work.
+
+- [ ] **Step 2: Verify alarm tests fail**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts backgroundEntrypoint.test.ts credentialObserver.test.ts
+```
+
+Expected: FAIL because only `lurkloot.tick` exists.
+
+- [ ] **Step 3: Implement alarm creation, routing, and cleanup**
+
+Add the constants and route names explicitly in
+`createBackgroundAlarmListener`. Extract one helper used by ensure/startup and
+poll-interval changes:
+
+```ts
+async function ensureSchedulerAlarms(periodInMinutes: number): Promise<void> {
+  await deps.clearAlarm?.(ALARM_NAME);
+  await Promise.all([
+    deps.createAlarm?.(TWITCH_ALARM_NAME, { periodInMinutes }),
+    deps.createAlarm?.(KICK_ALARM_NAME, { periodInMinutes }),
+  ]);
+}
+```
+
+Do not alter `WATCH_ALARM_NAME` or `TWITCH_INTEGRITY_ALARM_NAME`.
+
+- [ ] **Step 4: Run alarm and type tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts backgroundEntrypoint.test.ts credentialObserver.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/backgroundEntrypoint.test.ts packages/extension/tests/credentialObserver.test.ts
+git commit -m "perf(controller): schedule platforms independently"
+```
+
+### Task 6: Cross-trigger Concurrency and Lifecycle Safety
+
+**Files:**
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+- Modify: `packages/cli/tests/runtime.test.ts`
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/cli/src/runtime/run.ts`
+
+**Interfaces:**
+- Keeps: `tick(platforms?: Platform[], trigger?: TickTrigger)`
+- Keeps: `tickAndHandOff(platforms?: Platform[], trigger?: TickTrigger)`
+- Keeps: `settleBackgroundWork(): Promise<void>`
+
+- [ ] **Step 1: Add trigger and lifecycle tests**
+
+Cover startup/manual all-platform fan-out by holding Twitch discovery and
+asserting Kick completes. Add CLI coverage proving the default one-shot call
+starts both adapters before either is released.
+
+Add shutdown/reset coverage:
+
+```ts
+const twitchTick = env.controller.tick(["twitch"]);
+const kickTick = env.controller.tick(["kick"]);
+await vi.waitFor(() => {
+  expect(env.twitch.discoverCampaigns).toHaveBeenCalled();
+  expect(env.kick.discoverCampaigns).toHaveBeenCalled();
+});
+await env.controller.prepareForHostReset();
+await expect(Promise.all([twitchTick, kickTick])).resolves.toBeDefined();
+```
+
+Add a concurrent-claim test asserting Twitch and Kick claimed IDs each start
+only their own post-claim handoff.
+
+- [ ] **Step 2: Run tests and inspect failures**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+pnpm --filter @lurkloot/cli test -- runtime.test.ts
+```
+
+Expected: any failures identify remaining shared abort, background-work, or
+handoff assumptions.
+
+- [ ] **Step 3: Make lifecycle tracking platform-safe**
+
+Keep active abort controllers associated with their platform:
+
+```ts
+const activeTicks = new Map<AbortController, Platform>();
+```
+
+Abort only matching platform work on a platform toggle; abort all entries on
+shutdown/reset. Ensure `backgroundWork` draining includes every concurrently
+started platform promise and any handoffs appended while it drains.
+
+Keep `claimHandoffs` keyed by platform and launch successful platform handoffs
+with settled aggregation so a Twitch handoff cannot delay Kick:
+
+```ts
+await Promise.allSettled(
+  (Object.keys(claimed) as Platform[]).map((platform) =>
+    runClaimHandoff(platform, claimed[platform] ?? [])),
+);
+```
+
+- [ ] **Step 4: Run lifecycle, CLI, and type tests**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts
+pnpm --filter @lurkloot/cli test
+pnpm typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts packages/cli/src/runtime/run.ts packages/cli/tests/runtime.test.ts
+git commit -m "fix(controller): isolate platform tick lifecycles"
+```
+
+### Task 7: Full Verification and Documentation Check
+
+**Files:**
+- Modify only files required by failures found during verification.
+
+**Interfaces:**
+- Verifies all interfaces introduced by Tasks 1–6.
+
+- [ ] **Step 1: Run formatting and static checks**
+
+Run:
+
+```bash
+git diff --check origin/develop...
+pnpm typecheck
+```
+
+Expected: no whitespace errors and all workspace typechecks pass.
+
+- [ ] **Step 2: Run all tests**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: all CLI, extension, and site tests pass.
+
+- [ ] **Step 3: Run repository verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: scripts, typechecks, extension tests, site build, Chromium build, and
+Firefox build all pass.
+
+- [ ] **Step 4: Inspect final diff and architecture boundary**
+
+Run:
+
+```bash
+git diff --stat origin/develop...
+git diff --check origin/develop...
+pnpm --filter @lurkloot/extension test -- coreBoundary.test.ts
+```
+
+Expected: changes remain scoped to controller/scheduler/tab coordination,
+alarms, tests, and the approved docs; the core boundary test passes.
+
+- [ ] **Step 5: Commit verification fixes if needed**
+
+If verification required code changes, inspect `git diff --name-only`, stage
+only the listed controller/scheduler/tab/test files that were edited, and
+commit:
+
+```bash
+git add packages/core/src/background/controller.ts packages/core/src/core/scheduler.ts packages/core/src/core/tabs.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/scheduler.test.ts packages/extension/tests/tabs.test.ts
+git commit -m "fix(controller): address platform concurrency verification"
+```
+
+If no files changed, do not create an empty commit.

--- a/docs/superpowers/plans/2026-07-29-scheduler-platform-concurrency.md
+++ b/docs/superpowers/plans/2026-07-29-scheduler-platform-concurrency.md
@@ -29,7 +29,7 @@
 
 **Interfaces:**
 - Produces: `mergePlatformState(destination: SchedulerState, source: SchedulerState, platform: Platform): SchedulerState`
-- Produces: `withPlatformRecordEntry<T>(destination, source, platform)` as a private helper that preserves or deletes optional entries correctly.
+- Produces: `mergeOptionalEntry<T>(destination, source, platform)` as a private helper that preserves or deletes optional entries correctly.
 
 - [ ] **Step 1: Write failing merge tests**
 
@@ -43,7 +43,7 @@ expect(merged.sessions.kick).toEqual(destination.sessions.kick);
 expect(merged.campaigns.twitch).toEqual(source.campaigns.twitch);
 expect(merged.campaigns.kick).toEqual(destination.campaigns.kick);
 expect(merged.installedAt).toBe(destination.installedAt);
-expect(merged.lastTickAt).toBe(source.lastTickAt);
+expect(merged.lastTickAt).toBe("2026-07-29T12:00:00.000Z");
 ```
 
 Add a second test where `source.managedWatchTabs.twitch`,
@@ -52,6 +52,9 @@ Add a second test where `source.managedWatchTabs.twitch`,
 `source.criticalHealth.twitch`, and
 `source.deadlineInfeasibleRewardIds.twitch` are absent. Assert that the merged
 records remove Twitch while preserving Kick.
+Set the destination timestamp to `2026-07-29T12:00:00.000Z` and the source
+timestamp to `2026-07-29T11:00:00.000Z` so the assertion proves a late commit
+cannot move `lastTickAt` backwards.
 
 - [ ] **Step 2: Run the tests and verify the missing module failure**
 

--- a/docs/superpowers/plans/2026-07-29-scheduler-platform-concurrency.md
+++ b/docs/superpowers/plans/2026-07-29-scheduler-platform-concurrency.md
@@ -226,7 +226,7 @@ git add packages/core/src/core/tabs.ts packages/core/src/core/scheduler.ts packa
 git commit -m "refactor(tabs): scope state mirrors by platform"
 ```
 
-### Task 3: Make the Scheduler Single-platform
+### Task 3: Enforce Single-platform Controller Calls
 
 **Files:**
 - Modify: `packages/core/src/core/scheduler.ts`
@@ -235,16 +235,16 @@ git commit -m "refactor(tabs): scope state mirrors by platform"
 - Modify: `packages/cli/src/runtime/run.ts`
 
 **Interfaces:**
-- Changes: `SchedulerTickOptions.platforms?: Platform[]` to `SchedulerTickOptions.platform: Platform`
+- Keeps: `SchedulerTickOptions.platforms?: Platform[]` for direct engine consumers and focused tests.
 - Keeps: `runSchedulerTick(state, settings, adapters, options): Promise<SchedulerTickResult>`
+- Enforces: controller calls always pass a one-element `platforms` array.
 
-- [ ] **Step 1: Update tests to require one platform**
+- [ ] **Step 1: Add tests for one-platform controller invocation**
 
-Change scheduler test calls to pass `platform: "twitch"` or
-`platform: "kick"`. Add a test with spies on both adapters:
+Add a test with spies on both adapters:
 
 ```ts
-await runSchedulerTick(state, settings, adapters, { platform: "kick" });
+await runSchedulerTick(state, settings, adapters, { platforms: ["kick"] });
 
 expect(kick.discoverCampaigns).toHaveBeenCalledOnce();
 expect(twitch.discoverCampaigns).not.toHaveBeenCalled();
@@ -260,36 +260,16 @@ pnpm --filter @lurkloot/extension test -- scheduler.test.ts
 pnpm --filter @lurkloot/core typecheck
 ```
 
-Expected: FAIL until the scheduler option and call sites are changed.
+Expected: PASS for the compatibility surface; the controller concurrency test
+in Task 4 fails until controller calls are split.
 
-- [ ] **Step 3: Remove the platform loop**
+- [ ] **Step 3: Preserve the scheduler compatibility bridge**
 
-Replace:
-
-```ts
-const platforms = options.platforms ?? PLATFORMS;
-for (const platform of platforms) {
-  // platform body
-}
-```
-
-with one scoped body:
-
-```ts
-const { platform } = options;
-registerManagedPageContextTabs(state.managedPageContextTabs ?? {}, [platform]);
-syncManagedTabBreakers(
-  settings.criticalFailurePromptEnabled ? nextState : {},
-  [platform],
-);
-// Existing loop body executes once for platform.
-```
-
-Update breaker resynchronization inside `applyObservation` to pass
-`[platform]`. Remove the scheduler-local `PLATFORMS` constant if unused.
-Temporarily adapt controller calls by iterating the requested platform list
-sequentially; Task 4 replaces that compatibility bridge with concurrent
-controller operations.
+Keep the existing scheduler loop for direct callers. Scope retained contexts
+and breaker synchronization to `options.platforms ?? PLATFORMS`, and update
+breaker resynchronization inside `applyObservation` to pass `[platform]`.
+Task 4 makes every controller call pass a single platform and fans out
+multi-platform requests concurrently.
 
 - [ ] **Step 4: Run scheduler and type checks**
 

--- a/docs/superpowers/plans/2026-07-29-unified-campaign-refresh.md
+++ b/docs/superpowers/plans/2026-07-29-unified-campaign-refresh.md
@@ -1,0 +1,439 @@
+# Unified Campaign Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the scheduler's sequential discovery/progress pipeline with one adapter-owned refresh operation that avoids Twitch's duplicate inventory request and runs Kick's independent campaign/progress requests concurrently.
+
+**Architecture:** Each `PlatformAdapter` will expose `refreshCampaigns(session?, options?)`, returning a fully reconciled `DropCampaign[]`. Twitch will carry its discovery inventory through reconciliation and perform only active-session-specific follow-up work; Kick will fetch campaign definitions and account progress concurrently while preserving its existing progress soft-failure behavior.
+
+**Tech Stack:** TypeScript, pnpm workspace, Vitest, WXT WebExtension, browser-free `@lurkloot/core`.
+
+## Global Constraints
+
+- Core must not import WXT or browser globals.
+- Platform request planning and parsing must remain behind `PlatformAdapter`.
+- Diagnostics are English literals and must not be added to locale catalogs.
+- Authentication failures and abort signals must retain their current propagation semantics.
+- No settings, persisted-state schemas, permissions, or locale catalogs change.
+- Use two-space indentation, double quotes, semicolons, explicit imports, and type-only imports where applicable.
+
+---
+
+### Task 1: Twitch Single-Inventory Refresh
+
+**Files:**
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Produces: `TwitchAdapter.refreshCampaigns(session?: WatchSession, options?: AdapterOperationOptions): Promise<DropCampaign[]>`
+- Internal helper: `discoverCampaignSnapshot(options?): Promise<DropCampaign[]>`
+- Preserves temporarily: existing `discoverCampaigns` and `readProgress` methods until Task 3 migrates the shared interface.
+
+- [ ] **Step 1: Write a failing test proving a non-watching refresh fetches inventory once**
+
+Add a focused adapter test whose fetcher counts `Inventory` operations while returning valid inventory, dashboard, and detail responses:
+
+```ts
+it("refreshes Twitch campaigns with one inventory request", async () => {
+  let inventoryCalls = 0;
+  const adapter = new TwitchAdapter(jsonFetcher((_url, init) => {
+    const body = JSON.parse(String(init?.body)) as
+      | Record<string, unknown>
+      | Array<Record<string, unknown>>;
+    if (Array.isArray(body)) {
+      return body.map((entry) =>
+        twitchCampaignDetails(String((entry.variables as { dropID?: string }).dropID)));
+    }
+    if (body.operationName === "Inventory") {
+      inventoryCalls += 1;
+      return twitchInventory(["campaign"]);
+    }
+    return twitchDashboard(["campaign"]);
+  }));
+
+  await adapter.refreshCampaigns();
+
+  expect(inventoryCalls).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing method fails**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/adapters.test.ts -t "refreshes Twitch campaigns with one inventory request"
+```
+
+Expected: FAIL because `refreshCampaigns` does not exist.
+
+- [ ] **Step 3: Refactor Twitch discovery to return its inventory snapshot**
+
+Extract the current `discoverCampaigns` body into:
+
+```ts
+private async discoverCampaignSnapshot(
+  { signal }: AdapterOperationOptions = {},
+): Promise<DropCampaign[]> {
+  // Existing discovery logic already merges the fetched inventory into the
+  // returned campaigns.
+}
+```
+
+Keep the temporary compatibility wrapper:
+
+```ts
+async discoverCampaigns(options: AdapterOperationOptions = {}): Promise<DropCampaign[]> {
+  return this.discoverCampaignSnapshot(options);
+}
+```
+
+- [ ] **Step 4: Implement Twitch `refreshCampaigns` without a second inventory read**
+
+```ts
+async refreshCampaigns(
+  session?: WatchSession,
+  options: AdapterOperationOptions = {},
+): Promise<DropCampaign[]> {
+  const campaigns = await this.discoverCampaignSnapshot(options);
+  if (!session?.channel || session.status !== "watching") return campaigns;
+  return this.mergeCurrentSessionProgress(campaigns, session.channel, options.signal);
+}
+```
+
+Keep `readProgress` unchanged until Task 3 so existing callers remain valid during this independently testable commit.
+
+- [ ] **Step 5: Add and run an active-session regression test**
+
+Add a test that supplies a watching session, verifies one `Inventory` request, and verifies the current-session operation still runs:
+
+```ts
+expect(inventoryCalls).toBe(1);
+expect(currentDropCalls).toBe(1);
+```
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/adapters.test.ts
+pnpm --filter @lurkloot/core --filter @lurkloot/extension typecheck
+```
+
+Expected: all adapter tests and both typechecks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/platforms/twitch/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "perf(twitch): reuse discovery inventory during refresh"
+```
+
+---
+
+### Task 2: Concurrent Kick Refresh
+
+**Files:**
+- Modify: `packages/core/src/platforms/kick/index.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Produces: `KickAdapter.refreshCampaigns(session?: WatchSession, options?: AdapterOperationOptions): Promise<DropCampaign[]>`
+- Internal helpers:
+  - `fetchCampaignData(signal?: AbortSignal): Promise<unknown>`
+  - `fetchProgressData(signal?: AbortSignal): Promise<unknown>`
+  - `mergeProgress(campaigns: DropCampaign[], data: unknown): DropCampaign[]`
+  - `reportProgressFallback(error: unknown): void`
+- Preserves temporarily: existing `discoverCampaigns` and `readProgress` methods until Task 3.
+
+- [ ] **Step 1: Write a failing concurrency test**
+
+Use two deferred promises so neither endpoint can finish before both have started:
+
+```ts
+it("starts Kick campaign and progress requests concurrently", async () => {
+  let campaignStarted = false;
+  let progressStarted = false;
+  const adapter = new KickAdapter(jsonFetcher(async (url) => {
+    if (url.endsWith("/drops/campaigns")) {
+      campaignStarted = true;
+      await vi.waitFor(() => expect(progressStarted).toBe(true));
+      return {
+        data: [{
+          id: 1,
+          name: "Kick Campaign",
+          status: "active",
+          category: { id: 99, name: "Game" },
+          rewards: [{ id: 10, name: "Reward", required_minutes: 60 }],
+        }],
+      };
+    }
+    progressStarted = true;
+    await vi.waitFor(() => expect(campaignStarted).toBe(true));
+    return {
+      data: [{
+        id: 1,
+        status: "in progress",
+        rewards: [{ id: 10, progress: 0.5, required_units: 60 }],
+      }],
+    };
+  }));
+
+  await adapter.refreshCampaigns();
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing method fails**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/adapters.test.ts -t "starts Kick campaign and progress requests concurrently"
+```
+
+Expected: FAIL because `refreshCampaigns` does not exist.
+
+- [ ] **Step 3: Implement concurrent Kick refresh with asymmetric failure handling**
+
+Start both requests immediately, but convert only the progress promise into a settled result:
+
+```ts
+async refreshCampaigns(
+  _session?: WatchSession,
+  { signal }: AdapterOperationOptions = {},
+): Promise<DropCampaign[]> {
+  const progressPromise = this.fetchProgressData(signal).then(
+    (value) => ({ status: "fulfilled" as const, value }),
+    (reason) => ({ status: "rejected" as const, reason }),
+  );
+  const [campaignData, progressResult] = await Promise.all([
+    this.fetchCampaignData(signal),
+    progressPromise,
+  ]);
+  const campaigns = parseKickCampaigns(campaignData);
+  if (progressResult.status === "fulfilled") {
+    return this.mergeProgress(campaigns, progressResult.value);
+  }
+  signal?.throwIfAborted();
+  if (authHealthFromError(progressResult.reason)) throw progressResult.reason;
+  this.reportProgressFallback(progressResult.reason);
+  return campaigns;
+}
+```
+
+Extract private request/merge/report helpers from the existing two public methods; do not duplicate endpoint headers or warning text.
+
+- [ ] **Step 4: Add failure-semantics tests**
+
+Add tests proving:
+
+```ts
+await expect(adapterWithProgressNetworkFailure.refreshCampaigns())
+  .resolves.toEqual(parsedCampaigns);
+await expect(adapterWithProgressAuthFailure.refreshCampaigns())
+  .rejects.toMatchObject({ kind: "credentials" });
+await expect(adapterWithCampaignFailure.refreshCampaigns())
+  .rejects.toThrow();
+```
+
+Also assert the existing warning is emitted for a non-authentication progress failure.
+
+- [ ] **Step 5: Run focused verification**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/adapters.test.ts
+pnpm --filter @lurkloot/core --filter @lurkloot/extension typecheck
+```
+
+Expected: all adapter tests and both typechecks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/platforms/kick/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "perf(kick): refresh campaigns and progress concurrently"
+```
+
+---
+
+### Task 3: Migrate the Scheduler Contract
+
+**Files:**
+- Modify: `packages/core/src/platforms/adapter.ts`
+- Modify: `packages/core/src/core/scheduler.ts`
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Modify: `packages/core/src/platforms/kick/index.ts`
+- Modify: `packages/extension/tests/scheduler.test.ts`
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+- Modify: `packages/cli/tests/run.test.ts`
+- Test: `packages/extension/tests/scheduler.test.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/cli/tests/run.test.ts`
+
+**Interfaces:**
+- Consumes: both concrete adapters' `refreshCampaigns` methods from Tasks 1 and 2.
+- Produces:
+
+```ts
+interface PlatformAdapter {
+  refreshCampaigns(
+    session?: WatchSession,
+    options?: AdapterOperationOptions,
+  ): Promise<DropCampaign[]>;
+}
+```
+
+- Removes: `PlatformAdapter.discoverCampaigns` and `PlatformAdapter.readProgress`.
+
+- [ ] **Step 1: Write a failing scheduler test for the unified call**
+
+Change the scheduler test adapter to expose a `refreshCampaigns` spy and assert:
+
+```ts
+expect(adapter.refreshCampaigns).toHaveBeenCalledOnce();
+expect(adapter.refreshCampaigns).toHaveBeenCalledWith(
+  previousSession,
+  expect.objectContaining({ signal: expect.any(AbortSignal) }),
+);
+```
+
+Assert the event batch contains:
+
+```ts
+expect.objectContaining({
+  category: "diagnostic",
+  message: expect.stringMatching(/^Campaign refresh finished in \d+ms \(1 campaign\)$/),
+});
+```
+
+and does not contain the old discovery/progress timing messages.
+
+- [ ] **Step 2: Run the scheduler test and verify it fails against the old contract**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run tests/scheduler.test.ts -t "refresh"
+```
+
+Expected: FAIL because the scheduler still calls `discoverCampaigns` and `readProgress`.
+
+- [ ] **Step 3: Replace the shared adapter contract and scheduler pipeline**
+
+In `adapter.ts`, replace the two methods with the exact `refreshCampaigns` signature above.
+
+In `scheduler.ts`, replace the two timed calls with:
+
+```ts
+const refreshStartedAt = Date.now();
+campaigns = await adapter.refreshCampaigns(previous, { signal: options.signal });
+emitDiagnostic(
+  emit,
+  platform,
+  "debug",
+  `Campaign refresh finished in ${Date.now() - refreshStartedAt}ms (${countLabel(campaigns.length, "campaign")})`,
+);
+campaigns = preserveClaimedRewards(campaigns, state.campaigns[platform]);
+```
+
+Keep the existing error fallback, state update, health observation, claim, and selection blocks unchanged.
+
+- [ ] **Step 4: Remove the obsolete public methods and migrate deterministic adapters**
+
+Delete public `discoverCampaigns` and `readProgress` from Twitch and Kick after their private helpers have no callers.
+
+Replace test/CLI adapter stubs:
+
+```ts
+refreshCampaigns: vi.fn(async () => campaigns),
+```
+
+or:
+
+```ts
+refreshCampaigns: async () => [],
+```
+
+Remove old spy assertions and update diagnostic expectations to the single refresh message.
+
+- [ ] **Step 5: Run contract and scheduler verification**
+
+Run:
+
+```bash
+pnpm --dir packages/extension exec vitest run \
+  tests/scheduler.test.ts \
+  tests/backgroundController.test.ts \
+  tests/adapters.test.ts
+pnpm --dir packages/cli exec vitest run tests/run.test.ts
+pnpm typecheck
+```
+
+Expected: all selected tests and workspace typechecks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  packages/core/src/platforms/adapter.ts \
+  packages/core/src/core/scheduler.ts \
+  packages/core/src/platforms/twitch/index.ts \
+  packages/core/src/platforms/kick/index.ts \
+  packages/extension/tests/scheduler.test.ts \
+  packages/extension/tests/backgroundController.test.ts \
+  packages/cli/tests/run.test.ts
+git commit -m "refactor(core): unify campaign refresh"
+```
+
+---
+
+### Task 4: Full Regression Verification and Delivery
+
+**Files:**
+- Verify only unless a regression requires a focused correction.
+
+**Interfaces:**
+- Consumes: unified `PlatformAdapter.refreshCampaigns` contract.
+- Produces: verified Chromium and Firefox extension builds on the existing PR branch.
+
+- [ ] **Step 1: Confirm removed APIs are gone**
+
+Run:
+
+```bash
+rg -n "discoverCampaigns|readProgress|Campaign discovery finished|Campaign progress refresh finished" \
+  packages/core packages/extension packages/cli
+```
+
+Expected: no production or stale test-adapter references; fixture prose is acceptable only if it describes external platform concepts.
+
+- [ ] **Step 2: Run full verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: script tests, workspace typechecks, CLI/extension/site tests, site build, Chromium build, and Firefox build all exit successfully.
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run:
+
+```bash
+git diff origin/develop...HEAD --check
+git status --short
+```
+
+Expected: no whitespace errors and a clean worktree after commits.
+
+- [ ] **Step 4: Push the existing branch**
+
+```bash
+git push origin perf/scheduler-platform-concurrency
+```
+
+Expected: the existing draft PR updates without creating another branch or PR.

--- a/docs/superpowers/specs/2026-07-29-diagnostics-polish-design.md
+++ b/docs/superpowers/specs/2026-07-29-diagnostics-polish-design.md
@@ -1,0 +1,119 @@
+# Diagnostics Polish Design
+
+## Goal
+
+Make diagnostics easier to correlate across background-controller restarts,
+remove genuinely redundant integrity scheduling lines, identify the campaign
+behind channel-selection timings, and expose material platform-lock contention.
+
+## Controller Run Identity
+
+Each background-controller instance will generate one opaque
+`controllerRunId`. Every diagnostic emitted by that controller will carry the
+ID as structured metadata.
+
+Before the controller reports its first diagnostic, it will report one
+unscoped boundary:
+
+```text
+Background controller run a1b2c3d4 started
+```
+
+The message uses a short display prefix while `controllerRunId` retains the
+complete value. Unscoped events appear in both current platform-filtered views,
+so Twitch and Kick exports can explain tick counter resets.
+
+`globalTickId` and `platformTickId` remain numeric and reset for each controller
+run. Their stable correlation key is therefore:
+
+```text
+(controllerRunId, globalTickId)
+```
+
+Diagnostics outside scheduler ticks carry `controllerRunId` but omit both tick
+IDs.
+
+## Compatibility Context
+
+The compatibility profile remains an event emitted once per controller run.
+This is intentional rather than redundant: it records which adapter behavior
+was active for that run. Existing within-run fingerprint suppression remains.
+The explicit controller boundary makes repeated profiles across runs
+interpretable.
+
+Compatibility warnings retain their current severity and structured metadata.
+
+## Integrity Alarm Deduplication
+
+The controller dependency contract will gain a read-only alarm lookup that
+returns the current scheduled time for a named alarm. The extension host will
+implement it with the browser alarms API; headless hosts may omit it.
+
+Before recreating the proactive Twitch integrity alarm, the controller will
+compare the existing scheduled time with the desired target. If they match
+within 1,000 milliseconds, scheduling becomes a no-op and no diagnostic is
+emitted.
+
+If the target differs or cannot be read, the controller preserves current
+behavior: create/replace the alarm and emit the new target. Lookup failures are
+best-effort and must not block integrity handling.
+
+## Channel-Selection Context
+
+Every `Twitch channel selection finished` diagnostic will include the campaign
+ID and name when campaign-specific selection is running. Idle-watchlist
+selection, which has no campaign, will explicitly identify itself as idle
+selection.
+
+The existing timing and request/fallback counters remain unchanged.
+
+## Platform-Lock Contention
+
+Authentication refresh already acquires the platform state lock before probing
+credentials. The controller will measure the time spent acquiring this lock.
+When the wait is at least 50 milliseconds, it will emit:
+
+```text
+Tick #N waited Xms for Twitch platform work
+```
+
+The event carries the run and tick identifiers plus structured `waitMs`.
+Uncontended and negligible waits remain silent. This measures the actual lock
+boundary instead of inferring queue time from total tick duration.
+
+## Data Contracts
+
+`DiagnosticEvent` gains:
+
+```ts
+controllerRunId?: string;
+```
+
+The existing optional `globalTickId` and `platformTickId` fields remain.
+Persisted history accepts the new optional field without a migration because
+activity records are structurally stored and older records remain valid.
+
+The alarm dependency gains a read-only shape equivalent to:
+
+```ts
+getAlarm?(name: string): Promise<{ scheduledTime: number } | undefined>;
+```
+
+Core remains browser-free; browser API access stays in the extension host.
+
+## Testing
+
+Tests will prove:
+
+- One run boundary precedes the first diagnostic from a controller.
+- All diagnostics in that controller share its full `controllerRunId`.
+- Tick IDs reset in a new controller while the run ID changes.
+- Non-tick diagnostics have a run ID and no tick IDs.
+- An unchanged integrity alarm is neither recreated nor logged.
+- A changed or unavailable alarm is scheduled and logged normally.
+- Twitch campaign and idle channel-selection timings identify their context.
+- A lock wait of at least 50 milliseconds is measured and correlated.
+- Uncontended ticks emit no wait line.
+
+Full repository verification and Chromium/Firefox production builds remain the
+delivery gate.

--- a/docs/superpowers/specs/2026-07-29-dual-tick-identifiers-design.md
+++ b/docs/superpowers/specs/2026-07-29-dual-tick-identifiers-design.md
@@ -1,0 +1,63 @@
+# Dual Tick Identifiers Design
+
+## Goal
+
+Keep tick diagnostics easy to follow in the current platform-filtered views
+without losing the globally unique ordering needed by a future combined Twitch
+and Kick diagnostics view.
+
+## Identifier Model
+
+The controller will assign every platform tick two monotonically increasing,
+in-memory identifiers:
+
+- `globalTickId`: unique across all Twitch and Kick ticks created by the
+  controller instance.
+- `platformTickId`: sequential within the tick's platform.
+
+Both sequences reset when the extension background controller restarts, matching
+the existing global tick counter behavior. They are diagnostic correlation
+identifiers, not persisted scheduler state.
+
+## Diagnostic Contract
+
+`DiagnosticEvent` will expose optional numeric `globalTickId` and
+`platformTickId` fields. Every diagnostic produced as part of a scheduler tick,
+including the immediate start, authentication timing, and finish events, will
+carry both identifiers.
+
+Diagnostics outside a scheduler tick will omit the fields. Activity events are
+unchanged; their automatically generated English diagnostic counterparts receive
+tick identifiers when they are emitted inside a tick.
+
+## Display Behavior
+
+Existing platform-filtered diagnostics will render `platformTickId` in the
+English lifecycle message:
+
+```text
+Tick #4 started (trigger=alarm, platforms=twitch)
+```
+
+The global identifier remains structured metadata and is not added to today's
+message, avoiding extra noise. A future combined view can use `globalTickId` for
+unique correlation and true interleaved ordering, and can optionally render both
+identifiers.
+
+## Concurrency
+
+JavaScript increments both counters synchronously before the tick first awaits,
+so concurrent Twitch and Kick ticks cannot receive the same global identifier.
+Each platform maintains an independent local counter.
+
+## Testing
+
+Controller tests will prove that:
+
+- Interleaved Twitch and Kick ticks receive unique, increasing global IDs.
+- Twitch and Kick each receive continuous platform-local IDs.
+- Lifecycle messages use the platform-local ID.
+- Start, authentication timing, scheduler diagnostics, and finish events from
+  one tick carry the same identifier pair.
+- Diagnostics emitted outside a scheduler tick remain uncorrelated.
+

--- a/docs/superpowers/specs/2026-07-29-platform-automation-presentation-design.md
+++ b/docs/superpowers/specs/2026-07-29-platform-automation-presentation-design.md
@@ -1,0 +1,87 @@
+# Per-Platform Automation Presentation Design
+
+## Problem
+
+The popup currently derives an automation card from multiple independent
+sources. The toggle uses pending or persisted settings, the badge primarily
+uses authentication health, and the detail may use the scheduler session's
+raw English message. These sources can advance at different times and produce
+contradictory combinations such as:
+
+- `Starting automation...` followed by `Starting automation`
+- a `Running` badge paired with `Automation disabled`
+
+Twitch and Kick also transition independently, so the presentation must not
+infer one platform's state from the other.
+
+## Design
+
+The popup will build one canonical `AutomationPresentation` for each platform.
+The presentation will be the only source for the automation card's badge,
+detail, tone, operational styling, action, and transition status.
+
+The canonical lifecycle states are:
+
+- `paused`
+- `starting`
+- `running`
+- `stopping`
+- `checking`
+- `needs_sign_in`
+- `blocked`
+- `unavailable`
+- `paused_tab_closed`
+
+The presentation resolver will receive the platform's effective enabled
+setting, local pending transition, authentication health, scheduler session,
+and manual-close pause state. It will rank those inputs explicitly:
+
+1. A local stop transition is `stopping`.
+2. A local start transition, or an enabled session carrying the controller's
+   startup marker, is `starting`.
+3. A disabled platform is `paused`.
+4. A manual-close pause is `paused_tab_closed`.
+5. Authentication problems map to their existing user-actionable states.
+6. A healthy enabled platform is `running`.
+
+Both badge and detail will come from the selected presentation state. Raw
+`session.message` may supply the running detail only when it is compatible
+with an enabled, settled session. Transitional or contradictory scheduler
+messages such as `Starting automation` and `Automation disabled` will never be
+rendered as running detail.
+
+Scheduler messages remain English diagnostic/state data. This change will not
+localize them or add diagnostic locale keys. User-facing transition copy will
+continue to use locale catalog keys.
+
+## Platform Isolation
+
+The popup will resolve Twitch and Kick separately from their respective
+settings, auth health, session, and pending transition. Starting or stopping
+one platform must not alter the other platform's presentation.
+
+## Consistency Invariants
+
+- `starting` always renders the `Starting` badge and localized
+  `Starting automation...` detail.
+- `running` never renders `Automation disabled`, `Platform disabled`, or
+  `Starting automation` as its detail.
+- A checked toggle cannot render a `paused` presentation unless the user is in
+  an explicit manual-close pause state.
+- An unchecked toggle cannot render `running`.
+- Badge, detail, styling, and actions always come from the same presentation.
+
+## Testing
+
+Focused popup presentation tests will cover:
+
+- the local pending start state;
+- the persisted startup marker after the runtime request completes;
+- stale `Automation disabled` session data with enabled settings and healthy
+  authentication;
+- normal settled running detail;
+- independent Twitch and Kick presentations;
+- existing authentication and manual-close states.
+
+The implementation will then run the full repository verification suite and
+rebuild the Chromium extension for manual testing.

--- a/docs/superpowers/specs/2026-07-29-scheduler-platform-concurrency-design.md
+++ b/docs/superpowers/specs/2026-07-29-scheduler-platform-concurrency-design.md
@@ -1,0 +1,228 @@
+# Scheduler Platform Concurrency Design
+
+## Summary
+
+Twitch and Kick scheduler work currently shares three serialization points:
+
+1. `runSchedulerTick` loops over both platforms in one invocation.
+2. `createBackgroundController` holds one process-global state lock across
+   load, network and tab work, and persistence.
+3. `tabs.ts` mirrors persisted page-context and breaker state through
+   whole-state module registries.
+
+As a result, slow Twitch discovery, integrity acquisition, or tab work delays
+Kick even though the two platforms have no operational dependency.
+
+This change makes every multi-platform refresh fan out into independent
+per-platform operations, regardless of whether it was triggered by an alarm,
+startup, installation, settings, or a manual action. It also replaces the
+single scheduler alarm with platform-specific Twitch and Kick alarms.
+
+## Goals
+
+- Twitch network and tab work never blocks Kick network and tab work, and vice
+  versa.
+- All triggers that target both platforms start both platform operations
+  independently.
+- Same-platform operations remain ordered so telemetry, tab removal, auth
+  changes, heartbeats, and scheduler work cannot overwrite one another.
+- Concurrent platform completions merge into the existing persisted
+  `SchedulerState` blob without lost updates.
+- A failure on one platform is reported and persisted without cancelling or
+  rolling back the other platform.
+- Upgraded installations remove the legacy `lurkloot.tick` alarm.
+- The extension and CLI continue to share the same controller and state model.
+
+## Non-goals
+
+- Splitting `SchedulerState` into separate storage keys or files.
+- Giving Twitch and Kick separate polling interval settings.
+- Parallelizing operations within one platform.
+- Changing campaign selection, claiming, heartbeat cadence, or farming
+  eligibility.
+- Adding credentials, cookies, or permissions.
+
+## Chosen Approach
+
+Each platform operation owns one platform slice of scheduler state. Long work
+runs under a per-platform operation queue, while persistence uses a separate,
+short commit queue:
+
+1. Acquire the target platform's operation queue.
+2. Load settings and the latest state.
+3. Run auth preparation and one single-platform scheduler tick outside the
+   persistence queue.
+4. Acquire the commit queue only long enough to reload the latest persisted
+   state, merge the completed platform slice, and save.
+5. Release the commit queue, then finish reporting and any platform-scoped
+   handoff work.
+
+The commit queue is not an execution lock. It protects only the physical
+read-modify-write of the one storage blob. Slow discovery, integrity proof of
+work, page-context waits, tab operations, notifications, and watcher
+reconciliation never run inside it.
+
+This preserves the current storage format while preventing stale full-state
+saves. Splitting storage would provide stronger physical isolation but would
+require a migration and wider host API changes. Optimistic revision retries
+were rejected because browser storage does not provide an atomic
+compare-and-swap primitive.
+
+## State Ownership and Merging
+
+Introduce explicit helpers that copy or merge the fields owned by one
+`Platform`:
+
+- `sessions[platform]`
+- `authHealth[platform]`
+- `criticalHealth[platform]`
+- `managedWatchTabs[platform]`
+- `managedPageContextTabs[platform]`
+- `manualWatch[platform]`
+- `manualClosePause[platform]`
+- `gamification[platform]`
+- `campaigns[platform]`
+- `deadlineInfeasibleRewardIds[platform]`
+
+Optional records must support both setting and deleting their platform entry.
+The merge helper must preserve the other platform and every global field from
+the freshly reloaded destination state.
+
+`installedAt` remains globally owned. `lastTickAt` remains a compatibility
+field and is updated to the newest successfully committed platform completion
+time. It is not used as a lock or platform freshness boundary.
+
+Handlers that mutate exactly one platform use that platform's operation queue
+and commit through the same slice merge. Whole-host operations such as factory
+reset acquire both platform queues in stable Twitch-then-Kick order before
+replacing global state. Stable ordering prevents deadlocks.
+
+Settings retain their existing settings mutation queue because settings are a
+separate persisted object. A settings change may dispatch independent
+platform ticks after its settings write completes.
+
+## Scheduler Execution
+
+`runSchedulerTick` becomes a single-platform operation. Its public input
+identifies one `platform`, and its result contains the updated full working
+snapshot plus decisions and events for that platform only. Keeping a full
+working snapshot minimizes churn inside scheduler logic; only the explicit
+platform slice is allowed through the persistence boundary.
+
+Controller methods accepting `Platform[] | undefined` normalize the target
+list and fan out one operation per platform. Multi-platform calls use settled
+aggregation:
+
+- both operations begin without waiting for the other;
+- each operation owns its own event collector and claimed-reward result;
+- one rejection does not cancel its sibling;
+- after both settle, failures are reported with platform context;
+- callers receive the union of successful per-platform claimed reward IDs.
+
+Twitch integrity preparation and auth refresh move inside the Twitch operation.
+Kick auth refresh runs independently. A Twitch integrity timeout or setup
+failure therefore excludes only Twitch and cannot delay Kick.
+
+Same-platform preemption introduced by issue #299 is retained. Aborting a
+Twitch tick does not abort Kick. Controller shutdown and host reset abort both.
+
+## Side Registries
+
+Whole-state mirror functions in `tabs.ts` become platform-scoped:
+
+- retained managed page contexts are registered, read, or cleared by platform;
+- managed-tab breaker synchronization updates only the requested platform;
+- an in-flight page-context entry is associated with its platform rather than
+  relying only on the origin key.
+
+The in-flight page-context registry may still deduplicate requests for the same
+platform origin, but a Twitch registration cannot clear or replace Kick state.
+Kick registration cannot touch Twitch integrity state. Twitch integrity remains
+an explicitly Twitch-owned registry and lifecycle.
+
+Whole-registry reset helpers remain available only for controller shutdown,
+test cleanup, and factory reset after both platform queues have been acquired.
+
+## Alarm Model
+
+Define:
+
+- `TWITCH_ALARM_NAME = "lurkloot.tick.twitch"`
+- `KICK_ALARM_NAME = "lurkloot.tick.kick"`
+- legacy `ALARM_NAME = "lurkloot.tick"` only for upgrade cleanup
+
+`ensureAlarm`, installation setup, startup setup, and poll-interval changes
+create both platform alarms with the existing `pollIntervalMinutes`. They also
+clear the legacy alarm. Alarm creation is independent of whether a platform is
+currently enabled, matching the existing periodic reconciliation behavior;
+the scoped tick exits cheaply when its platform is disabled.
+
+The alarm listener routes each name to
+`tickAndHandOff([platform], "alarm")`. Watch-heartbeat and Twitch-integrity
+alarms keep their current names and behavior.
+
+Startup, installation, manual refresh, settings changes, platform toggles, and
+critical-failure dismissal continue using their current target selection, but
+any target list containing both platforms fans out concurrently.
+
+## Events, Notifications, and Failures
+
+Each platform operation collects and persists its own events. Lifecycle
+comparison, notification generation, ad focus, tabless watcher reconciliation,
+critical-health transitions, and claimed-reward observation use the
+single-platform before/after snapshots.
+
+If scheduler work fails:
+
+- its partial platform slice is discarded;
+- partial claim IDs are discarded;
+- operational activity from the failed attempt is cleared;
+- a platform-scoped interruption and English diagnostic are persisted;
+- the sibling platform continues and may commit successfully.
+
+If the short commit itself fails, the platform operation reports the storage
+failure through the existing caller path. The commit queue remains usable for
+later operations.
+
+Post-claim handoffs remain one per platform. Handoffs spawned by concurrently
+successful ticks may run concurrently with one another but remain serialized
+against other work for their own platform.
+
+## Testing
+
+Focused deterministic tests will cover:
+
+1. Deferred Twitch discovery does not prevent Kick discovery or completion.
+2. Deferred Kick discovery does not prevent Twitch completion.
+3. A Twitch failure persists a Twitch interruption while Kick state commits.
+4. Concurrent platform commits preserve both slices and unrelated global
+   fields.
+5. Same-platform telemetry, tab removal, heartbeat, auth, and tick mutations
+   remain ordered without lost updates.
+6. A scoped page-context or breaker synchronization leaves the sibling
+   platform registry unchanged.
+7. A Kick tick cannot replace or clear Twitch integrity.
+8. Both platform alarms are created with the configured interval.
+9. The legacy alarm is cleared during initialization and interval changes.
+10. Each alarm routes only its platform.
+11. Startup and manual all-platform triggers overlap both platform operations.
+12. Post-claim handoffs still receive claimed IDs from concurrent successful
+    ticks.
+13. Controller shutdown and factory reset safely abort or drain both platform
+    queues.
+
+The implementation will run focused Vitest files during development, followed
+by `pnpm typecheck`, `pnpm test`, and the repository's broader verification
+appropriate to the final change.
+
+## Rollout and Compatibility
+
+No persisted-state migration is required. Existing `SchedulerState` values
+remain valid. On first initialization after upgrade, the controller clears the
+legacy combined alarm and creates the two scoped alarms. Repeating this setup is
+idempotent.
+
+The CLI has no browser alarm host, but its default all-platform run uses the
+same concurrent fan-out. Public controller methods retain platform-list inputs
+where practical so existing extension and CLI call sites need only alarm-name
+updates.

--- a/docs/superpowers/specs/2026-07-29-scheduler-platform-concurrency-design.md
+++ b/docs/superpowers/specs/2026-07-29-scheduler-platform-concurrency-design.md
@@ -103,11 +103,12 @@ platform ticks after its settings write completes.
 
 ## Scheduler Execution
 
-`runSchedulerTick` becomes a single-platform operation. Its public input
-identifies one `platform`, and its result contains the updated full working
-snapshot plus decisions and events for that platform only. Keeping a full
-working snapshot minimizes churn inside scheduler logic; only the explicit
-platform slice is allowed through the persistence boundary.
+The controller invokes `runSchedulerTick` with exactly one platform per
+operation. The scheduler retains its existing `platforms?: Platform[]`
+compatibility surface for direct engine consumers and focused tests, but the
+controller is the concurrency boundary and never sends more than one platform.
+Keeping a full working snapshot minimizes churn inside scheduler logic; only
+the explicit platform slice is allowed through the persistence boundary.
 
 Controller methods accepting `Platform[] | undefined` normalize the target
 list and fan out one operation per platform. Multi-platform calls use settled

--- a/docs/superpowers/specs/2026-07-29-unified-campaign-refresh-design.md
+++ b/docs/superpowers/specs/2026-07-29-unified-campaign-refresh-design.md
@@ -1,0 +1,92 @@
+# Unified Campaign Refresh Design
+
+## Goal
+
+Replace the scheduler's fixed `discoverCampaigns` then `readProgress` sequence
+with one adapter-owned campaign refresh operation. Each platform will choose the
+most efficient request plan while returning the same fully reconciled
+`DropCampaign[]` snapshot the scheduler consumes today.
+
+## Adapter Contract
+
+`PlatformAdapter` will expose:
+
+```ts
+refreshCampaigns(
+  session?: WatchSession,
+  options?: AdapterOperationOptions,
+): Promise<DropCampaign[]>;
+```
+
+The scheduler will call this method once per enabled platform and will no longer
+coordinate discovery and progress reconciliation as separate operations.
+Platform-specific request ordering, concurrency, parsing, and partial-failure
+behavior remain inside the adapter.
+
+The existing `discoverCampaigns` and `readProgress` methods will be removed
+rather than retained as competing scheduler contracts. Internal adapter helpers
+may keep those names where they still clarify platform-specific phases.
+
+## Twitch Data Flow
+
+Twitch refresh will:
+
+1. Fetch inventory and the drops dashboard concurrently.
+2. Fetch campaign details in the existing bounded GraphQL batches.
+3. Merge the inventory progress already obtained during discovery into the
+   detailed campaigns.
+4. If an active Twitch watch session exists, perform only the additional
+   current-session reconciliation needed for that session.
+
+It will not issue a second inventory request immediately after discovery.
+Existing retained campaign-detail behavior, authentication failures, integrity
+retry behavior, and malformed-response fallbacks remain unchanged.
+
+## Kick Data Flow
+
+Kick refresh will fetch `/drops/campaigns` and `/drops/progress` concurrently,
+then parse the campaign definitions and merge the progress response.
+
+If campaign discovery fails, the refresh fails as it does today. If the progress
+request fails with a non-authentication error, Kick returns the parsed campaigns
+with their last-known/default progress and emits the existing warning.
+Authentication failures and cancellation continue to propagate.
+
+## Scheduler Behavior
+
+The scheduler will measure one platform refresh and emit:
+
+```text
+Campaign refresh finished in Nms (X campaigns)
+```
+
+Platform adapters will retain their detailed phase diagnostics, including
+Twitch campaign-detail batching and Kick progress fallback warnings. All later
+scheduler behavior—claiming, eligibility filtering, campaign selection,
+critical-health observation, and state persistence—continues to operate on the
+returned campaign array without semantic changes.
+
+## Compatibility and Migration
+
+All first-party adapters and deterministic test adapters will migrate to the new
+method in the same change. Core remains browser-free. No shared persisted state,
+settings schema, browser permissions, or locale catalogs change.
+
+The CLI receives the optimization automatically because it uses the same core
+adapters.
+
+## Testing
+
+Tests will prove:
+
+- The scheduler invokes one refresh operation instead of a discover/read pair.
+- Twitch performs only one inventory request per non-watching refresh.
+- Twitch still performs active-session reconciliation without repeating the
+  base inventory request.
+- Kick begins campaigns and progress requests concurrently.
+- Kick preserves campaigns when progress fails non-fatally.
+- Kick propagates authentication failures and cancellation.
+- Existing claim, selection, diagnostics scoping, and platform isolation tests
+  remain green.
+
+Full verification will run workspace checks plus Chromium and Firefox builds.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -203,9 +203,9 @@ const authCommand: CommandModule = {
   handler: () => { /* a subcommand always runs; see demandCommand above */ },
 };
 
-async function discoverPlatform(platform: Platform, adapter: { discoverCampaigns(): Promise<DropCampaign[]> }, logger: ReturnType<typeof createLogger>): Promise<void> {
+async function discoverPlatform(platform: Platform, adapter: { refreshCampaigns(): Promise<DropCampaign[]> }, logger: ReturnType<typeof createLogger>): Promise<void> {
   try {
-    const campaigns = await adapter.discoverCampaigns();
+    const campaigns = await adapter.refreshCampaigns();
     logger.info(`discovered ${campaigns.length} campaign(s)`, platform);
     for (const campaign of campaigns.slice(0, 20)) {
       for (const line of formatDiscoveredCampaign(campaign)) logger.info(line, platform);

--- a/packages/cli/tests/bootstrap.test.ts
+++ b/packages/cli/tests/bootstrap.test.ts
@@ -99,6 +99,14 @@ describe.each(transports)("%s transport bootstrap", (_name, createTransport) => 
     const transport = await createTransport();
 
     expect(transport.adapters.twitch.platform).toBe("twitch");
+    const createAdapter = transport.createAdapter;
+    transport.createAdapter = (platform, emit, settings) => {
+      const created = createAdapter(platform, emit, settings);
+      if (platform === "twitch") {
+        created.adapter.discoverCampaigns = async () => [];
+      }
+      return created;
+    };
     await runLoop({
       settings: {
         ...DEFAULT_CLI_SETTINGS,

--- a/packages/cli/tests/bootstrap.test.ts
+++ b/packages/cli/tests/bootstrap.test.ts
@@ -103,7 +103,7 @@ describe.each(transports)("%s transport bootstrap", (_name, createTransport) => 
     transport.createAdapter = (platform, emit, settings) => {
       const created = createAdapter(platform, emit, settings);
       if (platform === "twitch") {
-        created.adapter.discoverCampaigns = async () => [];
+        created.adapter.refreshCampaigns = async () => [];
       }
       return created;
     };

--- a/packages/cli/tests/impersonate.test.ts
+++ b/packages/cli/tests/impersonate.test.ts
@@ -83,7 +83,7 @@ describe("impersonate transport", () => {
     });
     const handle = await createImpersonateTransport({ kick: { sessionToken: "sess-token" } }, ENABLED, { initClient: async () => client });
 
-    const campaigns = await handle.adapters.kick.discoverCampaigns();
+    const campaigns = await handle.adapters.kick.refreshCampaigns();
     expect(campaigns).toEqual([]);
     expect(captured?.method).toBe("get");
     expect(captured?.options.ja3).toBe(CHROME_JA3);
@@ -98,7 +98,7 @@ describe("impersonate transport", () => {
   it("surfaces a Cloudflare 403 as KickWafBlockedError", async () => {
     const client = fakeClient(() => Promise.resolve({ status: 403, data: "blocked" }));
     const handle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
-    await expect(handle.adapters.kick.discoverCampaigns()).rejects.toBeInstanceOf(KickWafBlockedError);
+    await expect(handle.adapters.kick.refreshCampaigns()).rejects.toBeInstanceOf(KickWafBlockedError);
     await handle.dispose();
   });
 
@@ -169,8 +169,8 @@ describe("impersonate transport", () => {
     const client = fakeClient(() => Promise.resolve({ status: 200, data: {} }));
     const handle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
 
-    const first = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.discoverCampaigns();
-    const second = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.discoverCampaigns();
+    const first = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.refreshCampaigns();
+    const second = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.refreshCampaigns();
 
     expect(first.map((campaign) => campaign.id)).toEqual(["retained"]);
     expect(second.map((campaign) => campaign.id)).toEqual(["retained"]);
@@ -196,11 +196,11 @@ describe("impersonate transport", () => {
     const firstHandle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
     const secondHandle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
 
-    expect((await firstHandle.adapters.twitch.discoverCampaigns()).map((campaign) => campaign.id))
+    expect((await firstHandle.adapters.twitch.refreshCampaigns()).map((campaign) => campaign.id))
       .toEqual(["retained"]);
     seedFirstHandle = false;
 
-    await expect(secondHandle.adapters.twitch.discoverCampaigns()).resolves.toEqual([]);
+    await expect(secondHandle.adapters.twitch.refreshCampaigns()).resolves.toEqual([]);
     await firstHandle.dispose();
     await secondHandle.dispose();
   });

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -19,8 +19,7 @@ function fakeAdapter(platform: Platform, health: PlatformAuthHealth): PlatformAd
   return {
     platform,
     checkAuthHealth: async () => health,
-    discoverCampaigns: async () => [],
-    readProgress: async (campaigns: DropCampaign[]) => campaigns,
+    refreshCampaigns: async () => [],
     listCandidateChannels: async () => [],
     checkChannel: async (candidate: ChannelCandidate): Promise<ChannelCheck> => ({ live: false, categoryMatches: false, candidate }),
     claimReward: async () => false,

--- a/packages/cli/tests/transport.test.ts
+++ b/packages/cli/tests/transport.test.ts
@@ -126,8 +126,8 @@ describe("createTransport", () => {
     }));
     const handle = await createTransport("http", {}, "/tmp/auth", ENABLED);
 
-    const first = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.discoverCampaigns();
-    const second = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.discoverCampaigns();
+    const first = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.refreshCampaigns();
+    const second = await handle.createAdapters(() => {}, DEFAULT_ENGINE_SETTINGS).adapters.twitch.refreshCampaigns();
 
     expect(first.map((campaign) => campaign.id)).toEqual(["retained"]);
     expect(second.map((campaign) => campaign.id)).toEqual(["retained"]);
@@ -152,11 +152,11 @@ describe("createTransport", () => {
     const firstHandle = await createTransport("http", {}, "/tmp/auth", ENABLED);
     const secondHandle = await createTransport("http", {}, "/tmp/auth", ENABLED);
 
-    expect((await firstHandle.adapters.twitch.discoverCampaigns()).map((campaign) => campaign.id))
+    expect((await firstHandle.adapters.twitch.refreshCampaigns()).map((campaign) => campaign.id))
       .toEqual(["retained"]);
     seedFirstHandle = false;
 
-    await expect(secondHandle.adapters.twitch.discoverCampaigns()).resolves.toEqual([]);
+    await expect(secondHandle.adapters.twitch.refreshCampaigns()).resolves.toEqual([]);
     await firstHandle.dispose();
     await secondHandle.dispose();
   });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,8 @@
     "./kick": "./src/platforms/kick/index.ts",
     "./kick/parser": "./src/platforms/kick/parser.ts",
     "./kick/watch": "./src/platforms/kick/watch.ts",
-    "./controller": "./src/background/controller.ts"
+    "./controller": "./src/background/controller.ts",
+    "./background/platformState": "./src/background/platformState.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -23,6 +23,7 @@ import type { PlatformAdapter } from "../platforms/adapter";
 import type { TablessWatchController, WatchContext } from "../core/tablessWatch";
 import { applyPlatformAuthHealth } from "../core/authHealth";
 import { withActivityDiagnostics } from "../core/activityDiagnostics";
+import { mergePlatformState } from "./platformState";
 
 export const ALARM_NAME = "lurkloot.tick";
 // A separate, fixed 1-minute alarm drives tabless watch heartbeats independently
@@ -147,20 +148,6 @@ function emitHostCallbackError(
   });
 }
 
-// One in-flight state mutation at a time. Each handler's load→modify→persist
-// runs inside this lock so a save built on a stale snapshot can't clobber
-// another handler's concurrent write (telemetry arrives every ~5s while ticks
-// and heartbeats fire on alarms). NOT reentrant: a locked section must never
-// call another locked section (see runWatchHeartbeat, which calls tick() only
-// after its locked closure returns).
-let stateMutation: Promise<unknown> = Promise.resolve();
-function withStateLock<T>(operation: () => Promise<T>): Promise<T> {
-  const run = stateMutation.then(operation, operation);
-  // Keep the chain alive regardless of outcome without leaking rejections.
-  stateMutation = run.then(() => undefined, () => undefined);
-  return run;
-}
-
 // Generic over the host's settings type `S`, which must satisfy the engine
 // contract (EngineSettings). The extension parametrizes it with its fuller
 // ExtensionSettings (load/save round-trip the host-only fields); the CLI uses the
@@ -219,6 +206,37 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
 }
 
 export function createBackgroundController<S extends EngineSettings = EngineSettings>(deps: BackgroundControllerDeps<S>) {
+  const platformMutations: Record<Platform, Promise<unknown>> = {
+    twitch: Promise.resolve(),
+    kick: Promise.resolve(),
+  };
+  let stateCommit: Promise<unknown> = Promise.resolve();
+
+  function withPlatformLock<T>(platform: Platform, operation: () => Promise<T>): Promise<T> {
+    const run = platformMutations[platform].then(operation, operation);
+    platformMutations[platform] = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  function withStateLock<T>(
+    operation: () => Promise<T>,
+    platforms: readonly Platform[] = PLATFORMS,
+  ): Promise<T> {
+    const targets = PLATFORMS.filter((platform) => platforms.includes(platform));
+    const acquire = (index: number): Promise<T> => {
+      const platform = targets[index];
+      if (!platform) return operation();
+      return withPlatformLock(platform, () => acquire(index + 1));
+    };
+    return acquire(0);
+  }
+
+  function withStateCommit<T>(operation: () => Promise<T>): Promise<T> {
+    const run = stateCommit.then(operation, operation);
+    stateCommit = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
   const reportedCompatibility = new Map<Platform, string>();
   const reportedCompatibilityWarnings = new Set<string>();
   const authRefreshGeneration: Record<Platform, number> = {
@@ -764,7 +782,23 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     await reportBestEffort(events);
   }
 
+  async function persistPlatformAndReport(
+    platform: Platform,
+    state: SchedulerState,
+    events: readonly EngineEvent[] = [],
+  ): Promise<void> {
+    await withStateCommit(async () => {
+      const latest = await deps.loadState();
+      await saveOperationalStateDirect(mergePlatformState(latest, state, platform));
+    });
+    await reportBestEffort(events);
+  }
+
   async function saveOperationalState(state: SchedulerState): Promise<void> {
+    await withStateCommit(() => saveOperationalStateDirect(state));
+  }
+
+  async function saveOperationalStateDirect(state: SchedulerState): Promise<void> {
     const { events: _legacyEvents, ...operationalState } = state as SchedulerState & { events?: unknown };
     await deps.saveState(operationalState);
   }
@@ -1220,20 +1254,41 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   const activeTicks = new Set<AbortController>();
 
   async function tick(platforms?: Platform[], trigger: TickTrigger = "unknown"): Promise<ClaimedRewards> {
+    const requestedPlatforms = platforms ?? PLATFORMS;
+    const settled = await Promise.allSettled(requestedPlatforms.map((platform) =>
+      tickPlatform(platform, trigger)));
+    const failures = settled.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : []);
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(failures, "Platform scheduler ticks failed");
+    }
+    return settled.reduce<ClaimedRewards>((claimed, result) => {
+      if (result.status !== "fulfilled") return claimed;
+      const [platform, rewards] = result.value;
+      if (rewards.length > 0) claimed[platform] = rewards;
+      return claimed;
+    }, {});
+  }
+
+  async function tickPlatform(
+    platform: Platform,
+    trigger: TickTrigger,
+  ): Promise<readonly [Platform, string[]]> {
     const abort = new AbortController();
     activeTicks.add(abort);
     const tickId = ++tickSequence;
     const tickStartedAt = Date.now();
-    const scope = platforms ? platforms.join("+") : "all";
-    diagnosticEvent("debug", `Tick #${tickId} started (trigger=${trigger}, platforms=${scope})`);
+    diagnosticEvent("debug", `Tick #${tickId} started (trigger=${trigger}, platforms=${platform})`);
     try {
-      return await runTick(tickId, tickStartedAt, platforms, abort.signal);
+      const claimed = await runTick(tickId, tickStartedAt, [platform], abort.signal);
+      return [platform, claimed[platform] ?? []];
     } catch (error) {
-      if (abort.signal.aborted) return {};
+      if (abort.signal.aborted) return [platform, []];
       throw error;
     } finally {
       activeTicks.delete(abort);
-      diagnosticEvent("debug", `Tick #${tickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${scope})`);
+      diagnosticEvent("debug", `Tick #${tickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${platform})`);
     }
   }
 
@@ -1287,6 +1342,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const schedulerPlatforms = requestedPlatforms.filter((platform) =>
       !excludedPlatforms.has(platform));
     if (schedulerPlatforms.length === 0) return claimedRewards;
+    const platform = schedulerPlatforms[0];
     await withStateLock(() => withEventCollector(async (emit, events) => {
       signal.throwIfAborted();
       const settings = await deps.loadSettings();
@@ -1297,9 +1353,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       };
       let nextState: SchedulerState;
       try {
-        const adapters = excludedPlatforms.size > 0
-          ? createSelectedAdapters(settings, emit, schedulerPlatforms)
-          : createAdapters(settings, emit);
+        const adapters = createSelectedAdapters(settings, emit, schedulerPlatforms);
         // Observed here rather than returned by the scheduler: the controller
         // already sees every emitted event, and the post-claim handoff only
         // needs to know which platforms claimed.
@@ -1351,19 +1405,17 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         clearOperationalEvents(events);
         if (signal.aborted) return;
         const detail = error instanceof Error ? error.message : "Scheduler tick failed";
-        emit({ category: "activity", code: "interruption", level: "error", data: { reason: "platform_error", detail } });
-        emit({ category: "diagnostic", level: "error", message: detail });
-        await persistAndReport(state, events);
+        emit({ category: "activity", code: "interruption", level: "error", platform, data: { reason: "platform_error", detail } });
+        emit({ category: "diagnostic", level: "error", platform, message: detail });
+        await persistPlatformAndReport(platform, state, events);
         return;
       }
-      await persistAndReport(nextState, events);
-      for (const platform of PLATFORMS) {
-        waitingClaimRewardIds[platform].clear();
-        for (const rewardId of nextWaitingClaimRewardIds[platform]) {
-          waitingClaimRewardIds[platform].add(rewardId);
-        }
+      await persistPlatformAndReport(platform, nextState, events);
+      waitingClaimRewardIds[platform].clear();
+      for (const rewardId of nextWaitingClaimRewardIds[platform]) {
+        waitingClaimRewardIds[platform].add(rewardId);
       }
-    }));
+    }), schedulerPlatforms);
     return claimedRewards;
   }
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -846,6 +846,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     message: string,
     platform?: Platform,
     tickContext?: TickDiagnosticContext,
+    data?: DiagnosticEvent["data"],
   ): void {
     void reportBestEffort([{
       category: "diagnostic",
@@ -853,6 +854,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       message,
       platform,
       ...tickContext,
+      ...(data === undefined ? {} : { data }),
     }]);
   }
 
@@ -1209,7 +1211,20 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     tickContext?: TickDiagnosticContext,
   ): Promise<void> {
     signal?.throwIfAborted();
+    const lockStartedAt = Date.now();
     const generations = await beginAuthRefresh(platforms);
+    const lockWaitMs = Date.now() - lockStartedAt;
+    if (tickContext && lockWaitMs >= 50) {
+      for (const platform of platforms) {
+        diagnosticEvent(
+          "debug",
+          `Tick #${tickContext.platformTickId} waited ${lockWaitMs}ms for ${platformLabel(platform)} platform work`,
+          platform,
+          tickContext,
+          { waitMs: lockWaitMs },
+        );
+      }
+    }
     const settings = loadedSettings ?? await deps.loadSettings();
     const enabled = platforms.filter((platform) => settings.platform[platform].enabled);
     const results = await Promise.allSettled(enabled.map(async (platform) => {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1299,7 +1299,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     activePlatformTicks[platform] += 1;
     const tickId = ++tickSequence;
     const tickStartedAt = Date.now();
-    diagnosticEvent("debug", `Tick #${tickId} started (trigger=${trigger}, platforms=${platform})`);
+    diagnosticEvent("debug", `Tick #${tickId} started (trigger=${trigger}, platforms=${platform})`, platform);
     try {
       const claimed = await runTick(tickId, tickStartedAt, [platform], abort.signal);
       return [platform, claimed[platform] ?? []];
@@ -1309,7 +1309,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     } finally {
       activeTicks.delete(abort);
       activePlatformTicks[platform] -= 1;
-      diagnosticEvent("debug", `Tick #${tickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${platform})`);
+      diagnosticEvent("debug", `Tick #${tickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${platform})`, platform);
     }
   }
 
@@ -1333,7 +1333,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         const authStartedAt = Date.now();
         try {
           await refreshAuthHealth(authPlatforms, settings, false, signal);
-          diagnosticEvent("debug", `Tick #${tickId} refreshed auth health in ${Date.now() - authStartedAt}ms`);
+          for (const platform of authPlatforms) {
+            diagnosticEvent("debug", `Tick #${tickId} refreshed auth health in ${Date.now() - authStartedAt}ms`, platform);
+          }
         } catch (error) {
           const failures = flattenedRefreshFailures(error);
           const setupFailures = failures.filter((failure): failure is AuthProbeSetupError =>
@@ -1878,7 +1880,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const run = tickAndHandOff(platforms, trigger)
       .then(() => onCompleted?.())
       .catch((error) => {
-        diagnosticEvent("warn", `Background tick (trigger=${trigger}) failed: ${error instanceof Error ? error.message : String(error)}`);
+        const platform = platforms?.length === 1 ? platforms[0] : undefined;
+        diagnosticEvent("warn", `Background tick (trigger=${trigger}) failed: ${error instanceof Error ? error.message : String(error)}`, platform);
       });
     backgroundWork = backgroundWork.then(() => run, () => run);
   }

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1105,7 +1105,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         generations[platform] = authRefreshGeneration[platform];
       }
       return generations;
-    });
+    }, platforms);
   }
 
   function unavailableAfterAdapterSetup(): PlatformAuthHealth {
@@ -1923,8 +1923,18 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // the handoff's own inner ticks cannot recurse into another handoff.
   async function tickAndHandOff(platforms?: Platform[], trigger: TickTrigger = "unknown"): Promise<void> {
     const claimed = await tick(platforms, trigger);
-    await Promise.allSettled((Object.keys(claimed) as Platform[]).map((platform) =>
+    const handoffPlatforms = Object.keys(claimed) as Platform[];
+    const results = await Promise.allSettled(handoffPlatforms.map((platform) =>
       runClaimHandoff(platform, claimed[platform] ?? [])));
+    for (let index = 0; index < results.length; index += 1) {
+      const result = results[index];
+      if (result.status !== "rejected") continue;
+      diagnosticEvent(
+        "warn",
+        `Post-claim handoff failed: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+        handoffPlatforms[index],
+      );
+    }
   }
 
   // Transmits one heartbeat for a freshly-selected tabless target instead of

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -746,7 +746,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           reason,
         });
         if (transition.event) emit(transition.event);
-        syncManagedTabBreakers(transition.state);
+        syncManagedTabBreakers(transition.state, ["twitch"]);
         await persistAndReport(transition.state, events);
       }));
     } catch {
@@ -1343,7 +1343,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           }
           // Keep the registry that gates page-context creation in step with the
           // state we are about to persist, so the very next fetch is suppressed.
-          syncManagedTabBreakers(nextState);
+          syncManagedTabBreakers(nextState, schedulerPlatforms);
         }
       } catch (error) {
         // The tick was rolled back, so any partial claim set is not actionable.
@@ -2280,7 +2280,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         if (transition.event) emit(transition.event);
         // Closing the breaker here is what lets farming resume immediately
         // instead of waiting for the next tick to sync the registry.
-        syncManagedTabBreakers(transition.state);
+        syncManagedTabBreakers(transition.state, [message.platform]);
         await persistAndReport(transition.state, events);
       }));
       await tickAndHandOff(undefined, "critical_failure_dismissed");

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -180,6 +180,7 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
     name: string,
     options: { periodInMinutes: number } | { when: number },
   ): Promise<void>;
+  getAlarm?(name: string): Promise<{ scheduledTime: number } | undefined>;
   clearAlarm?(name: string): Promise<boolean>;
   ensureTwitchIntegrity?(
     emit: EventEmitter,
@@ -517,9 +518,21 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       await clearTwitchIntegrityAlarm();
       return;
     }
-    await withTwitchIntegrityAlarmLock(async () => {
+    const scheduled = await withTwitchIntegrityAlarmLock(async () => {
+      let existing: { scheduledTime: number } | undefined;
+      try {
+        existing = await deps.getAlarm?.(TWITCH_INTEGRITY_ALARM_NAME);
+      } catch {
+        existing = undefined;
+      }
+      if (existing && Math.abs(existing.scheduledTime - when) <= 1_000) {
+        twitchIntegrityRefreshDue = undefined;
+        return false;
+      }
       await deps.createAlarm(TWITCH_INTEGRITY_ALARM_NAME, { when });
+      return true;
     });
+    if (!scheduled) return;
     twitchIntegrityRefreshDue = undefined;
     emit?.({
       category: "diagnostic",

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -26,6 +26,8 @@ import { withActivityDiagnostics } from "../core/activityDiagnostics";
 import { mergePlatformState } from "./platformState";
 
 export const ALARM_NAME = "lurkloot.tick";
+export const TWITCH_ALARM_NAME = "lurkloot.tick.twitch";
+export const KICK_ALARM_NAME = "lurkloot.tick.kick";
 // A separate, fixed 1-minute alarm drives tabless watch heartbeats independently
 // of the (heavier, configurable) discovery tick. chrome.alarms clamps to a
 // 1-minute minimum, close enough to TwitchDropsMiner's 59s send cadence.
@@ -42,8 +44,10 @@ interface BackgroundAlarmController {
 
 export function createBackgroundAlarmListener(controller: BackgroundAlarmController) {
   return (alarm: { name: string }): void => {
-    if (alarm.name === ALARM_NAME) {
-      void controller.tickAndHandOff(undefined, "alarm");
+    if (alarm.name === TWITCH_ALARM_NAME) {
+      void controller.tickAndHandOff(["twitch"], "alarm");
+    } else if (alarm.name === KICK_ALARM_NAME) {
+      void controller.tickAndHandOff(["kick"], "alarm");
     } else if (alarm.name === WATCH_ALARM_NAME) {
       void controller.runWatchHeartbeat();
     } else if (alarm.name === TWITCH_INTEGRITY_ALARM_NAME) {
@@ -848,13 +852,21 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   async function ensureAlarm(): Promise<void> {
     const settings = await deps.loadSettings();
-    await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
+    await ensureSchedulerAlarms(settings.pollIntervalMinutes);
     await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
     if (settings.autoStartDropFarming && isFarmingActive(settings)) {
       await tick(undefined, "install");
     } else {
       await refreshAuthHealth(PLATFORMS, settings);
     }
+  }
+
+  async function ensureSchedulerAlarms(periodInMinutes: number): Promise<void> {
+    await deps.clearAlarm?.(ALARM_NAME);
+    await Promise.all([
+      deps.createAlarm(TWITCH_ALARM_NAME, { periodInMinutes }),
+      deps.createAlarm(KICK_ALARM_NAME, { periodInMinutes }),
+    ]);
   }
 
   async function ensureInstalledAt(installedAt = new Date().toISOString()): Promise<void> {
@@ -892,7 +904,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     // no loop running against them.
     abortClaimHandoffs();
     const settings = await deps.loadSettings();
-    await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
+    await ensureSchedulerAlarms(settings.pollIntervalMinutes);
     await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
     // A restart kills any in-memory watchers; start clean and let tick() rebuild.
     tablessWatchers.clear();
@@ -968,7 +980,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       const settings = deps.applySettingsPatch(current, patch);
       await deps.saveSettings(settings);
       afterPersist?.(settings);
-      await deps.createAlarm(ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes });
+      await ensureSchedulerAlarms(settings.pollIntervalMinutes);
       return settings;
     });
   }

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -787,6 +787,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   async function recordTwitchIntegrityManagedTabOpen(
     reason: "integrity_readiness" | "proactive_integrity_refresh",
+    tickContext?: TickDiagnosticContext,
   ): Promise<void> {
     try {
       await withStateLock(() => withEventCollector(async (emit, events) => {
@@ -800,7 +801,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         });
         if (transition.event) emit(transition.event);
         syncManagedTabBreakers(transition.state, ["twitch"]);
-        await persistAndReport(transition.state, events);
+        await persistAndReport(
+          transition.state,
+          tickContext ? correlateTickDiagnostics(events, tickContext) : events,
+        );
       }));
     } catch {
       await reportBestEffort([{
@@ -808,6 +812,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         platform: "twitch",
         level: "warn",
         message: "Could not account for a managed Twitch integrity page context",
+        ...tickContext,
       }]);
     }
   }
@@ -822,11 +827,18 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     state: SchedulerState,
     events: readonly EngineEvent[] = [],
   ): Promise<void> {
+    await persistPlatformState(platform, state);
+    await reportBestEffort(events);
+  }
+
+  async function persistPlatformState(
+    platform: Platform,
+    state: SchedulerState,
+  ): Promise<void> {
     await withStateCommit(async () => {
       const latest = await deps.loadState();
       await saveOperationalStateDirect(mergePlatformState(latest, state, platform));
     });
-    await reportBestEffort(events);
   }
 
   async function saveOperationalState(state: SchedulerState): Promise<void> {
@@ -1309,6 +1321,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           reason: due ? "proactive_refresh" : "readiness",
           onManagedPageContextOpen: () => recordTwitchIntegrityManagedTabOpen(
             due ? "proactive_integrity_refresh" : "integrity_readiness",
+            tickContext,
           ),
           ...(due
             ? {
@@ -1521,7 +1534,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         for (const event of lifecycleEvents) emit(event);
         await emitNotifications(settings, state, result.state, result.events);
         signal.throwIfAborted();
-        await applyAdFocusForState(result.state, emit);
+        await applyAdFocusForState(result.state, emit, schedulerPlatforms);
         signal.throwIfAborted();
         await reconcileTablessWatchers(result.state, settings, adapters, emit, schedulerPlatforms);
         signal.throwIfAborted();
@@ -1735,83 +1748,87 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function runWatchHeartbeat(): Promise<void> {
     const settings = await deps.loadSettings();
     if (!isFarmingActive(settings)) return;
-    const fallbackPlatforms = await withStateLock<Platform[]>(() => withEventCollector(async (emit, events) => {
+
+    const heartbeatResults = await Promise.allSettled(PLATFORMS.map((platform) =>
+      runPlatformWatchHeartbeat(platform, settings)));
+    const fallbackPlatforms = heartbeatResults.flatMap((result) =>
+      result.status === "fulfilled" && result.value ? [result.value] : []);
+    const fallbackResults = await Promise.allSettled(fallbackPlatforms.map((platform) =>
+      tick([platform], "tabless_fallback")));
+    const failures = [...heartbeatResults, ...fallbackResults].flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : []);
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(failures, "Platform watch heartbeats failed");
+    }
+  }
+
+  async function runPlatformWatchHeartbeat(
+    platform: Platform,
+    settings: S,
+  ): Promise<Platform | undefined> {
+    return withStateLock(() => withEventCollector(async (emit, events) => {
       let nextState = await deps.loadState();
-      registerManagedPageContextTabs(nextState.managedPageContextTabs ?? {});
+      registerManagedPageContextTabs(nextState.managedPageContextTabs ?? {}, [platform]);
       // After a service-worker restart the in-memory watcher map is empty, so
-      // rebuild it from persisted tabless sessions before the size check below.
+      // rebuild this platform's watcher from its persisted tabless session.
       // Otherwise the 1-minute watch alarm would do nothing until the next
       // (possibly distant) discovery tick re-armed the watchers, stalling Twitch
-      // tabless farming. Done inside the state lock so it cannot race tick()'s
-      // own reconcile over the shared watcher map (the discovery and watch alarms
-      // both fire on a ~1-minute cadence). reconcileTablessWatchers only calls
+      // tabless farming. Done inside the platform lock so it cannot race tick()'s
+      // own reconcile for the same watcher (the discovery and watch alarms both
+      // fire on a ~1-minute cadence). reconcileTablessWatchers only calls
       // watcher.start() on a fresh start/channel switch and never re-acquires the
       // lock, so holding it here is safe (no reentrancy).
-      await reconcileTablessWatchers(nextState, settings, createAdapters(settings, emit), emit);
-      if (tablessWatchers.size === 0) {
+      await reconcileTablessWatchers(
+        nextState,
+        settings,
+        createSelectedAdapters(settings, emit, [platform]),
+        emit,
+        [platform],
+      );
+      const watcher = tablessWatchers.get(platform);
+      if (!watcher) {
         await reportBestEffort(events);
-        return [];
+        return undefined;
       }
 
-      let changed = false;
-      const fallbacks: Platform[] = [];
-
-      for (const [platform, watcher] of [...tablessWatchers]) {
-        const session = nextState.sessions[platform];
-        if (
-          nextState.authHealth[platform].status !== "healthy"
-          || session.status !== "watching"
-          || session.watchMode !== "tabless"
-        ) {
-          try {
-            await watcher.stop();
-          } catch (error) {
-            emitHostCallbackError(emit, platform, error, "Could not stop the tabless watcher");
-          } finally {
-            drainWatcherEvents(watcher, emit);
-            tablessWatchers.delete(platform);
-          }
-          continue;
-        }
-
-        let ok = false;
-        let message: string | undefined;
+      const session = nextState.sessions[platform];
+      let ok = false;
+      let message: string | undefined;
+      drainWatcherEvents(watcher, emit);
+      try {
+        const result = await watcher.tick(tablessWatchContext());
+        ok = result.ok;
+        message = result.message;
+      } catch (error) {
+        message = error instanceof Error ? error.message : "Tabless heartbeat failed";
+      } finally {
         drainWatcherEvents(watcher, emit);
-        try {
-          const result = await watcher.tick(tablessWatchContext());
-          ok = result.ok;
-          message = result.message;
-        } catch (error) {
-          message = error instanceof Error ? error.message : "Tabless heartbeat failed";
-        } finally {
-          drainWatcherEvents(watcher, emit);
-        }
+      }
 
-        const previousChecks = session.heartbeatChecks ?? 0;
-        const heartbeatChecks = ok ? 0 : previousChecks + 1;
-        nextState = {
-          ...nextState,
-          sessions: {
-            ...nextState.sessions,
-            [platform]: {
-              ...session,
-              lastHeartbeatAt: new Date().toISOString(),
-              lastHeartbeatOk: ok,
-              heartbeatChecks,
-            },
+      const previousChecks = session.heartbeatChecks ?? 0;
+      const heartbeatChecks = ok ? 0 : previousChecks + 1;
+      nextState = {
+        ...nextState,
+        sessions: {
+          ...nextState.sessions,
+          [platform]: {
+            ...session,
+            lastHeartbeatAt: new Date().toISOString(),
+            lastHeartbeatOk: ok,
+            heartbeatChecks,
           },
-        };
-        changed = true;
+        },
+      };
 
-        if (ok && previousChecks > 0) {
-          emit({ category: "diagnostic", platform, level: "info", message: "Tabless watch heartbeat recovered" });
-        } else if (!ok && previousChecks === 0) {
-          emit({ category: "diagnostic", platform, level: "warn", message: message ?? "Tabless watch heartbeat failed" });
-        }
-        if (!ok && heartbeatChecks >= settings.tablessFallbackFailureLimit && !fallbacks.includes(platform)) {
-          fallbacks.push(platform);
-          emit({ category: "diagnostic", platform, level: "warn", message: "Tabless watch heartbeat keeps failing; falling back to a watch tab" });
-        }
+      if (ok && previousChecks > 0) {
+        emit({ category: "diagnostic", platform, level: "info", message: "Tabless watch heartbeat recovered" });
+      } else if (!ok && previousChecks === 0) {
+        emit({ category: "diagnostic", platform, level: "warn", message: message ?? "Tabless watch heartbeat failed" });
+      }
+      const fallback = !ok && heartbeatChecks >= settings.tablessFallbackFailureLimit;
+      if (fallback) {
+        emit({ category: "diagnostic", platform, level: "warn", message: "Tabless watch heartbeat keeps failing; falling back to a watch tab" });
       }
 
       nextState = {
@@ -1819,16 +1836,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         managedPageContextTabs: currentManagedPageContextTabs(),
       };
 
-      if (changed) await persistAndReport(nextState, events);
-      else await reportBestEffort(events);
-      return fallbacks;
-    }));
-
-    // chooseTablessWatch now sees heartbeatChecks past the tabless fallback limit and opens a tab.
-    // Run outside the lock: tick() acquires the lock itself.
-    for (const platform of fallbackPlatforms) {
-      await tick([platform], "tabless_fallback");
-    }
+      await persistPlatformAndReport(platform, nextState, events);
+      return fallback ? platform : undefined;
+    }), [platform]);
   }
 
   // Aborts every in-flight handoff. Called when farming stops, when a settings
@@ -2146,7 +2156,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
       if (!isManagedWatchTab) {
         if (senderTabId != null) {
-          await persistAndReport(recordManualWatchTelemetry(state, settings, message, senderTabId), events);
+          await persistPlatformAndReport(
+            message.platform,
+            recordManualWatchTelemetry(state, settings, message, senderTabId),
+            events,
+          );
         }
         return;
       }
@@ -2179,7 +2193,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         : [];
       for (const event of playbackDiagnostics) emit(event);
 
-      await saveOperationalState(nextState);
+      await persistPlatformState(message.platform, nextState);
       try {
         if (deps.applyAdFocus && session.status === "watching" && session.tabId === senderTabId) {
           await deps.applyAdFocus(message.platform, session.tabId, Boolean(message.telemetry.adActive), emit);
@@ -2189,7 +2203,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       } finally {
         await reportBestEffort(events);
       }
-    }));
+    }), [message.platform]);
   }
 
   function recordManualWatchTelemetry(
@@ -2218,9 +2232,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     return { ...state, manualWatch };
   }
 
-  async function applyAdFocusForState(state: SchedulerState, emit: EventEmitter): Promise<void> {
+  async function applyAdFocusForState(
+    state: SchedulerState,
+    emit: EventEmitter,
+    platforms: readonly Platform[] = PLATFORMS,
+  ): Promise<void> {
     if (!deps.applyAdFocus) return;
-    for (const platform of ["twitch", "kick"] as Platform[]) {
+    for (const platform of platforms) {
       const session = state.sessions[platform];
       const watching = session.status === "watching" && session.tabId != null;
       try {
@@ -2248,9 +2266,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function claimRewardNow(
     message: Extract<CoreRuntimeMessage, { type: "claimReward" }>,
   ): Promise<RuntimeSnapshot<S>> {
-    // Hold the state lock across the whole load→persist so a concurrent tick or
-    // telemetry write can't clobber the claimed-reward update. snapshot() runs
-    // after the lock so it reflects the committed state.
+    // Hold the owning platform lock across the whole load→persist so a concurrent
+    // same-platform tick or telemetry write can't clobber the claimed-reward
+    // update. The short commit merges this slice with any sibling-platform write.
     let claimedManually = false;
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
@@ -2265,7 +2283,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           level: "warn",
           message: "Reward claim skipped because the campaign or reward is no longer available",
         });
-        await persistAndReport(state, events);
+        await persistPlatformAndReport(message.platform, state, events);
         return;
       }
 
@@ -2276,7 +2294,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           level: "warn",
           message: `${reward.name} is not ready to claim`,
         });
-        await persistAndReport(state, events);
+        await persistPlatformAndReport(message.platform, state, events);
         return;
       }
 
@@ -2333,11 +2351,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           level: "error",
           message: error instanceof Error ? error.message : `Claim failed for ${reward.name}`,
         });
-        await persistAndReport(state, events);
+        await persistPlatformAndReport(message.platform, state, events);
         return;
       }
-      await persistAndReport(stateWithCampaigns, events);
-    }));
+      await persistPlatformAndReport(message.platform, stateWithCampaigns, events);
+    }), [message.platform]);
     // Outside the lock: runClaimHandoff ticks, which takes the lock itself.
     if (claimedManually) await runClaimHandoff(message.platform, [message.rewardId]);
     return snapshot();

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -75,6 +75,10 @@ export type TickTrigger =
   | "tabless_fallback"
   | "claim_handoff"
   | "unknown";
+type TickDiagnosticContext = Required<Pick<
+  DiagnosticEvent,
+  "globalTickId" | "platformTickId"
+>>;
 export type CredentialAvailability =
   | { status: "available" }
   | { status: "missing" }
@@ -92,6 +96,15 @@ function isNothingLeftToFarm(reasonCode: WatchReasonCode | undefined): boolean {
 // still transmits.
 const RECENT_HEARTBEAT_MS = 30_000;
 const PLATFORMS: Platform[] = ["twitch", "kick"];
+
+function correlateTickDiagnostics(
+  events: readonly EngineEvent[],
+  tickContext: TickDiagnosticContext,
+): EngineEvent[] {
+  return events.map((event) =>
+    event.category === "diagnostic" ? { ...event, ...tickContext } : event);
+}
+
 // Must stay strictly greater than INTEGRITY_REFRESH_TIMEOUT_MS. A Twitch probe
 // runs through gqlWithIntegrityRetry, so a rejection makes it wait on a page
 // context minting a token; when this deadline was the shorter of the two (10s
@@ -810,8 +823,19 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // Reports a single diagnostic immediately rather than collecting it into a
   // tick's event batch. Tick lifecycle lines must land as they happen: batching
   // them would defeat the point of timing a tick that is still running.
-  function diagnosticEvent(level: "debug" | "info" | "warn", message: string, platform?: Platform): void {
-    void reportBestEffort([{ category: "diagnostic", level, message, platform }]);
+  function diagnosticEvent(
+    level: "debug" | "info" | "warn",
+    message: string,
+    platform?: Platform,
+    tickContext?: TickDiagnosticContext,
+  ): void {
+    void reportBestEffort([{
+      category: "diagnostic",
+      level,
+      message,
+      platform,
+      ...tickContext,
+    }]);
   }
 
   async function reportBestEffort(events: readonly EngineEvent[]): Promise<void> {
@@ -1085,6 +1109,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     health: PlatformAuthHealth,
     probeEvents: readonly EngineEvent[] = [],
     generation: number,
+    tickContext?: TickDiagnosticContext,
   ): Promise<boolean> {
     return withStateLock(() => withEventCollector(async (emit, events) => {
       if (authRefreshGeneration[platform] !== generation) return false;
@@ -1095,7 +1120,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         if (transition.event) emit(transition.event);
         await saveOperationalStateDirect(transition.state);
       });
-      await reportBestEffort(events);
+      await reportBestEffort(tickContext
+        ? correlateTickDiagnostics(events, tickContext)
+        : events);
       return true;
     }), [platform]);
   }
@@ -1140,6 +1167,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     loadedSettings?: S,
     reportCompatibility = false,
     signal?: AbortSignal,
+    tickContext?: TickDiagnosticContext,
   ): Promise<void> {
     signal?.throwIfAborted();
     const generations = await beginAuthRefresh(platforms);
@@ -1168,7 +1196,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       signal?.throwIfAborted();
       let accepted: boolean;
       try {
-        accepted = await persistAuthHealth(platform, result.health, result.events, generation);
+        accepted = await persistAuthHealth(
+          platform,
+          result.health,
+          result.events,
+          generation,
+          tickContext,
+        );
       } catch (error) {
         if (result.setupFailure) {
           throw new AggregateError(
@@ -1183,7 +1217,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     throwRefreshFailures(results);
   }
 
-  async function reportAuthSetupFailures(failures: readonly AuthProbeSetupError[]): Promise<void> {
+  async function reportAuthSetupFailures(
+    failures: readonly AuthProbeSetupError[],
+    tickContext?: TickDiagnosticContext,
+  ): Promise<void> {
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const state = await deps.loadState();
       for (const failure of failures) {
@@ -1195,13 +1232,17 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           data: { reason: "platform_error", detail: failure.message },
         });
       }
-      await persistAndReport(state, events);
+      await persistAndReport(
+        state,
+        tickContext ? correlateTickDiagnostics(events, tickContext) : events,
+      );
     }));
   }
 
   async function prepareTwitchIntegrity(
     settings: S,
     signal: AbortSignal,
+    tickContext: TickDiagnosticContext,
   ): Promise<boolean> {
     const ensureTwitchIntegrity = deps.ensureTwitchIntegrity;
     if (!settings.platform.twitch.enabled || !ensureTwitchIntegrity) return true;
@@ -1255,7 +1296,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         });
         return false;
       } finally {
-        await reportBestEffort(events);
+        await reportBestEffort(correlateTickDiagnostics(events, tickContext));
       }
     });
   }
@@ -1263,7 +1304,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // Every tick is bracketed by a start/finish diagnostic carrying its trigger and
   // elapsed time. A tick that succeeds otherwise emits nothing about itself, which
   // makes a slow one indistinguishable from an idle gap in an exported log.
-  let tickSequence = 0;
+  let globalTickSequence = 0;
+  const platformTickSequence: Record<Platform, number> = {
+    twitch: 0,
+    kick: 0,
+  };
   // Chain of detached ticks, drained by settleBackgroundWork().
   let backgroundWork: Promise<unknown> = Promise.resolve();
   const activeTicks = new Set<AbortController>();
@@ -1297,11 +1342,19 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const abort = new AbortController();
     activeTicks.add(abort);
     activePlatformTicks[platform] += 1;
-    const tickId = ++tickSequence;
+    const tickContext: TickDiagnosticContext = {
+      globalTickId: ++globalTickSequence,
+      platformTickId: ++platformTickSequence[platform],
+    };
     const tickStartedAt = Date.now();
-    diagnosticEvent("debug", `Tick #${tickId} started (trigger=${trigger}, platforms=${platform})`, platform);
+    diagnosticEvent(
+      "debug",
+      `Tick #${tickContext.platformTickId} started (trigger=${trigger}, platforms=${platform})`,
+      platform,
+      tickContext,
+    );
     try {
-      const claimed = await runTick(tickId, tickStartedAt, [platform], abort.signal);
+      const claimed = await runTick(tickContext, [platform], abort.signal);
       return [platform, claimed[platform] ?? []];
     } catch (error) {
       if (abort.signal.aborted) return [platform, []];
@@ -1309,13 +1362,17 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     } finally {
       activeTicks.delete(abort);
       activePlatformTicks[platform] -= 1;
-      diagnosticEvent("debug", `Tick #${tickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${platform})`, platform);
+      diagnosticEvent(
+        "debug",
+        `Tick #${tickContext.platformTickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${platform})`,
+        platform,
+        tickContext,
+      );
     }
   }
 
   async function runTick(
-    tickId: number,
-    tickStartedAt: number,
+    tickContext: TickDiagnosticContext,
     platforms: Platform[] | undefined,
     signal: AbortSignal,
   ): Promise<ClaimedRewards> {
@@ -1325,16 +1382,27 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const excludedPlatforms = new Set<Platform>();
     if (isFarmingActive(settings)) {
       if (requestedPlatforms.includes("twitch")) {
-        const twitchReady = await prepareTwitchIntegrity(settings, signal);
+        const twitchReady = await prepareTwitchIntegrity(settings, signal, tickContext);
         if (!twitchReady) excludedPlatforms.add("twitch");
       }
       const authPlatforms = requestedPlatforms.filter((platform) => !excludedPlatforms.has(platform));
       if (authPlatforms.length > 0) {
         const authStartedAt = Date.now();
         try {
-          await refreshAuthHealth(authPlatforms, settings, false, signal);
+          await refreshAuthHealth(
+            authPlatforms,
+            settings,
+            false,
+            signal,
+            tickContext,
+          );
           for (const platform of authPlatforms) {
-            diagnosticEvent("debug", `Tick #${tickId} refreshed auth health in ${Date.now() - authStartedAt}ms`, platform);
+            diagnosticEvent(
+              "debug",
+              `Tick #${tickContext.platformTickId} refreshed auth health in ${Date.now() - authStartedAt}ms`,
+              platform,
+              tickContext,
+            );
           }
         } catch (error) {
           const failures = flattenedRefreshFailures(error);
@@ -1344,7 +1412,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           for (const failure of setupFailures) excludedPlatforms.add(failure.platform);
           let reportingFailure: unknown;
           try {
-            await reportAuthSetupFailures(setupFailures);
+            await reportAuthSetupFailures(setupFailures, tickContext);
           } catch (failure) {
             reportingFailure = failure;
           }
@@ -1430,10 +1498,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         const detail = error instanceof Error ? error.message : "Scheduler tick failed";
         emit({ category: "activity", code: "interruption", level: "error", platform, data: { reason: "platform_error", detail } });
         emit({ category: "diagnostic", level: "error", platform, message: detail });
-        await persistPlatformAndReport(platform, state, events);
+        await persistPlatformAndReport(platform, state, correlateTickDiagnostics(events, tickContext));
         return;
       }
-      await persistPlatformAndReport(platform, nextState, events);
+      await persistPlatformAndReport(platform, nextState, correlateTickDiagnostics(events, tickContext));
       waitingClaimRewardIds[platform].clear();
       for (const rewardId of nextWaitingClaimRewardIds[platform]) {
         waitingClaimRewardIds[platform].add(rewardId);

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1089,12 +1089,15 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     return withStateLock(() => withEventCollector(async (emit, events) => {
       if (authRefreshGeneration[platform] !== generation) return false;
       events.push(...probeEvents);
-      const state = await deps.loadState();
-      const transition = applyPlatformAuthHealth(state, platform, health);
-      if (transition.event) emit(transition.event);
-      await persistAndReport(transition.state, events);
+      await withStateCommit(async () => {
+        const state = await deps.loadState();
+        const transition = applyPlatformAuthHealth(state, platform, health);
+        if (transition.event) emit(transition.event);
+        await saveOperationalStateDirect(transition.state);
+      });
+      await reportBestEffort(events);
       return true;
-    }));
+    }), [platform]);
   }
 
   async function beginAuthRefresh(platforms: readonly Platform[]): Promise<Partial<Record<Platform, number>>> {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1267,6 +1267,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // Chain of detached ticks, drained by settleBackgroundWork().
   let backgroundWork: Promise<unknown> = Promise.resolve();
   const activeTicks = new Set<AbortController>();
+  const activePlatformTicks: Record<Platform, number> = {
+    twitch: 0,
+    kick: 0,
+  };
 
   async function tick(platforms?: Platform[], trigger: TickTrigger = "unknown"): Promise<ClaimedRewards> {
     const requestedPlatforms = platforms ?? PLATFORMS;
@@ -1292,6 +1296,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   ): Promise<readonly [Platform, string[]]> {
     const abort = new AbortController();
     activeTicks.add(abort);
+    activePlatformTicks[platform] += 1;
     const tickId = ++tickSequence;
     const tickStartedAt = Date.now();
     diagnosticEvent("debug", `Tick #${tickId} started (trigger=${trigger}, platforms=${platform})`);
@@ -1303,6 +1308,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       throw error;
     } finally {
       activeTicks.delete(abort);
+      activePlatformTicks[platform] -= 1;
       diagnosticEvent("debug", `Tick #${tickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${platform})`);
     }
   }
@@ -1863,11 +1869,17 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // Runs a tick without holding the caller open for it. A user action gets its
   // snapshot back immediately; the popup re-polls getSnapshot on its own cadence
   // and picks the result up when the tick lands.
-  function tickInBackground(platforms: Platform[] | undefined, trigger: TickTrigger): void {
+  function tickInBackground(
+    platforms: Platform[] | undefined,
+    trigger: TickTrigger,
+    onCompleted?: () => void,
+  ): void {
     if (controllerShutdown) return;
-    const run = tickAndHandOff(platforms, trigger).catch((error) => {
-      diagnosticEvent("warn", `Background tick (trigger=${trigger}) failed: ${error instanceof Error ? error.message : String(error)}`);
-    });
+    const run = tickAndHandOff(platforms, trigger)
+      .then(() => onCompleted?.())
+      .catch((error) => {
+        diagnosticEvent("warn", `Background tick (trigger=${trigger}) failed: ${error instanceof Error ? error.message : String(error)}`);
+      });
     backgroundWork = backgroundWork.then(() => run, () => run);
   }
 
@@ -2227,6 +2239,16 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     // is no master switch to flip alongside the platform flag. Both are kept:
     // they are separate wire messages with existing callers.
     if (message.type === "setPlatformEnabled" || message.type === "setAutomation") {
+      const platformLabel = message.platform === "twitch" ? "Twitch" : "Kick";
+      const action = message.enabled ? "enable" : "disable";
+      diagnosticEvent("info", `User requested ${platformLabel} automation ${action}`, message.platform);
+      if (activePlatformTicks[message.platform] > 0) {
+        diagnosticEvent(
+          "info",
+          `${platformLabel} automation ${action} queued behind an active tick`,
+          message.platform,
+        );
+      }
       // Stopping must cancel any loop still refreshing in the background.
       if (!message.enabled) abortClaimHandoffs(message.platform);
       const twitchTransitionGeneration = message.platform === "twitch"
@@ -2297,7 +2319,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       // Always scoped to the toggled platform. Nothing about this change can
       // affect the other one any more, so it is never dragged through this
       // platform's discovery.
-      tickInBackground([message.platform], message.type === "setAutomation" ? "automation_toggle" : "platform_toggle");
+      tickInBackground(
+        [message.platform],
+        message.type === "setAutomation" ? "automation_toggle" : "platform_toggle",
+        () => diagnosticEvent("info", `${platformLabel} automation ${action} completed`, message.platform),
+      );
       return snapshot();
     }
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -223,6 +223,11 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
 }
 
 export function createBackgroundController<S extends EngineSettings = EngineSettings>(deps: BackgroundControllerDeps<S>) {
+  const controllerRunId = typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  const controllerRunLabel = controllerRunId.slice(0, 8);
+  let controllerRunAnnouncement: Promise<void> | undefined;
   const platformMutations: Record<Platform, Promise<unknown>> = {
     twitch: Promise.resolve(),
     kick: Promise.resolve(),
@@ -840,8 +845,29 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   async function reportBestEffort(events: readonly EngineEvent[]): Promise<void> {
     if (events.length === 0 || !deps.reportEvents) return;
+    const correlateControllerRun = (events: readonly EngineEvent[]): EngineEvent[] =>
+      events.map((event) =>
+        event.category === "diagnostic"
+          ? { ...event, controllerRunId }
+          : event);
+    const correlatedEvents = correlateControllerRun(events);
+    if (correlatedEvents.some((event) => event.category === "diagnostic")) {
+      controllerRunAnnouncement ??= (async () => {
+        try {
+          await deps.reportEvents?.([{
+            category: "diagnostic",
+            level: "debug",
+            message: `Background controller run ${controllerRunLabel} started`,
+            controllerRunId,
+          }]);
+        } catch {
+          // Host event persistence/output is best-effort.
+        }
+      })();
+      await controllerRunAnnouncement;
+    }
     try {
-      await deps.reportEvents(events);
+      await deps.reportEvents(correlatedEvents);
     } catch {
       // Host event persistence/output is best-effort.
     }

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1901,10 +1901,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   // The persisted session still describes the platform as it was *before* the
-  // toggle ("Automation disabled"), and nothing rewrites it until the tick
-  // finishes. Detaching the tick alone would not fix that: the popup polls the
-  // stored state, so a slow tick leaves it rendering a status that contradicts
-  // the switch the user just flipped. Stamp the transition up front instead.
+  // toggle, and nothing rewrites it until the tick finishes. Detaching the tick
+  // alone would not fix that: the popup polls stored state, so a slow tick can
+  // leave it rendering a lifecycle that contradicts the switch the user just
+  // flipped. Persist the typed transition up front instead.
   async function markPlatformsStarting(
     platforms: readonly Platform[],
     transitionIsCurrent: () => boolean = () => true,
@@ -1921,7 +1921,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         if (session.status === "watching") continue;
         sessions[platform] = {
           ...session,
-          status: "idle",
+          status: "starting",
           message: "Starting automation",
           reasonCode: "no_existing_session",
         };

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1923,9 +1923,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // the handoff's own inner ticks cannot recurse into another handoff.
   async function tickAndHandOff(platforms?: Platform[], trigger: TickTrigger = "unknown"): Promise<void> {
     const claimed = await tick(platforms, trigger);
-    for (const platform of Object.keys(claimed) as Platform[]) {
-      await runClaimHandoff(platform, claimed[platform] ?? []);
-    }
+    await Promise.allSettled((Object.keys(claimed) as Platform[]).map((platform) =>
+      runClaimHandoff(platform, claimed[platform] ?? [])));
   }
 
   // Transmits one heartbeat for a freshly-selected tabless target instead of

--- a/packages/core/src/background/platformState.ts
+++ b/packages/core/src/background/platformState.ts
@@ -1,0 +1,84 @@
+import type { Platform, SchedulerState } from "@lurkloot/shared/models";
+
+function mergeOptionalEntry<T>(
+  destination: Partial<Record<Platform, T>> | undefined,
+  source: Partial<Record<Platform, T>> | undefined,
+  platform: Platform,
+): Partial<Record<Platform, T>> {
+  const merged = { ...destination };
+  const value = source?.[platform];
+  if (value === undefined) delete merged[platform];
+  else merged[platform] = value;
+  return merged;
+}
+
+function newestTimestamp(
+  destination: string | undefined,
+  source: string | undefined,
+): string | undefined {
+  if (!destination) return source;
+  if (!source) return destination;
+  const destinationTime = Date.parse(destination);
+  const sourceTime = Date.parse(source);
+  if (!Number.isFinite(destinationTime)) return source;
+  if (!Number.isFinite(sourceTime)) return destination;
+  return sourceTime > destinationTime ? source : destination;
+}
+
+export function mergePlatformState(
+  destination: SchedulerState,
+  source: SchedulerState,
+  platform: Platform,
+): SchedulerState {
+  return {
+    ...destination,
+    sessions: {
+      ...destination.sessions,
+      [platform]: source.sessions[platform],
+    },
+    authHealth: {
+      ...destination.authHealth,
+      [platform]: source.authHealth[platform],
+    },
+    campaigns: {
+      ...destination.campaigns,
+      [platform]: source.campaigns[platform],
+    },
+    criticalHealth: mergeOptionalEntry(
+      destination.criticalHealth,
+      source.criticalHealth,
+      platform,
+    ),
+    managedWatchTabs: mergeOptionalEntry(
+      destination.managedWatchTabs,
+      source.managedWatchTabs,
+      platform,
+    ),
+    managedPageContextTabs: mergeOptionalEntry(
+      destination.managedPageContextTabs,
+      source.managedPageContextTabs,
+      platform,
+    ),
+    manualWatch: mergeOptionalEntry(
+      destination.manualWatch,
+      source.manualWatch,
+      platform,
+    ),
+    manualClosePause: mergeOptionalEntry(
+      destination.manualClosePause,
+      source.manualClosePause,
+      platform,
+    ),
+    gamification: mergeOptionalEntry(
+      destination.gamification,
+      source.gamification,
+      platform,
+    ),
+    deadlineInfeasibleRewardIds: mergeOptionalEntry(
+      destination.deadlineInfeasibleRewardIds,
+      source.deadlineInfeasibleRewardIds,
+      platform,
+    ),
+    lastTickAt: newestTimestamp(destination.lastTickAt, source.lastTickAt),
+  };
+}

--- a/packages/core/src/core/criticalHealth.ts
+++ b/packages/core/src/core/criticalHealth.ts
@@ -21,7 +21,7 @@ export const COOLDOWN_MS = FAILING_WINDOW_MS;
 export interface CriticalHealthObservation {
   at: number;
   // The tick ended in error. The scheduler sets this for platform backoff, for a
-  // discovery/readProgress failure, and for any error thrown later in the farming
+  // campaign refresh failure, and for any error thrown later in the farming
   // work (which is also what leaves the session in status "error"). A tick that
   // reached no conclusion at all — platform disabled, authentication unhealthy —
   // is NOT failing: it reports a neutral observation instead, so the pruning

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -205,15 +205,23 @@ export async function chooseCampaignDecision(
   settings: EngineSettings,
   adapter: Pick<PlatformAdapter, "listCandidateChannels" | "checkChannel">,
   signal?: AbortSignal,
+  reportMetrics?: (metrics: { campaignsChecked: number; candidatesChecked: number }) => void,
 ): Promise<WatchDecision> {
   const sorted = sortCampaigns(campaigns.filter((campaign) => isEligible(campaign, settings)), settings);
   const noCampaignReason = noEligibleCampaignReason(campaigns, settings);
   const waitingForSubscription = onlyWaitingSubscriptionCampaigns(campaigns, settings);
   const subscriptionOnly = onlySubscriptionCampaigns(campaigns, settings);
+  let campaignsChecked = 0;
+  let candidatesChecked = 0;
+  const finish = (decision: WatchDecision): WatchDecision => {
+    reportMetrics?.({ campaignsChecked, candidatesChecked });
+    return decision;
+  };
 
   for (const campaign of sorted) {
     const reward = activeReward(campaign, settings);
     if (!reward) continue;
+    campaignsChecked += 1;
 
     const excludedChannels = settings.platform[platform].excludedChannels ?? [];
     signal?.throwIfAborted();
@@ -224,9 +232,11 @@ export async function chooseCampaignDecision(
         return (right.viewerCount ?? 0) - (left.viewerCount ?? 0);
       });
 
-    const channel = await firstValidCandidate(candidates, campaign, adapter, signal);
+    const channel = await firstValidCandidate(candidates, campaign, adapter, signal, () => {
+      candidatesChecked += 1;
+    });
     if (channel) {
-      return {
+      return finish({
         platform,
         action: "watch",
         campaign,
@@ -234,41 +244,43 @@ export async function chooseCampaignDecision(
         channel,
         reason: "Eligible campaign selected",
         reasonCode: "eligible_campaign",
-      };
+      });
     }
   }
 
   if (subscriptionOnly) {
-    return {
+    return finish({
       platform,
       action: "idle",
       reason: noCampaignReason,
       reasonCode: "campaign_ineligible",
-    };
+    });
   }
 
   const fallbackCandidates = settings.platform[platform].idleWatchlistChannels
     .map((username) => username.trim().toLowerCase())
     .filter(Boolean)
     .map((username) => fallbackChannel(platform, username));
-  const fallback = await firstValidCandidate(fallbackCandidates, undefined, adapter, signal);
+  const fallback = await firstValidCandidate(fallbackCandidates, undefined, adapter, signal, () => {
+    candidatesChecked += 1;
+  });
 
   if (fallback) {
-    return {
+    return finish({
       platform,
       action: "fallback",
       channel: fallback,
       reason: `${noCampaignReason}; Idle Watchlist channel selected`,
       reasonCode: "idle_watchlist_selected",
-    };
+    });
   }
 
-  return {
+  return finish({
     platform,
     action: "idle",
     reason: `${noCampaignReason} and no Idle Watchlist channels`,
     reasonCode: waitingForSubscription ? "campaign_ineligible" : "no_eligible_channel",
-  };
+  });
 }
 
 function noEligibleCampaignReason(campaigns: DropCampaign[], settings: EngineSettings): string {
@@ -343,9 +355,11 @@ async function firstValidCandidate(
   campaign: DropCampaign | undefined,
   adapter: Pick<PlatformAdapter, "checkChannel">,
   signal?: AbortSignal,
+  onCheck?: () => void,
 ): Promise<ChannelCandidate | undefined> {
   for (const candidate of candidates) {
     signal?.throwIfAborted();
+    onCheck?.();
     const check = await adapter.checkChannel(candidate, { campaign, signal });
     if (check.live && check.categoryMatches && check.campaignMatches !== false) {
       return channelFromCheck(candidate, check);
@@ -712,9 +726,23 @@ export async function runSchedulerTick(
       let campaigns: DropCampaign[];
       let discoveryFailed = false;
       try {
+        const discoveryStartedAt = Date.now();
         const discovered = await adapter.discoverCampaigns({ signal: options.signal });
+        emitDiagnostic(
+          emit,
+          platform,
+          "debug",
+          `Campaign discovery finished in ${Date.now() - discoveryStartedAt}ms (${countLabel(discovered.length, "campaign")})`,
+        );
         options.signal?.throwIfAborted();
+        const progressStartedAt = Date.now();
         campaigns = await adapter.readProgress(discovered, previous, { signal: options.signal });
+        emitDiagnostic(
+          emit,
+          platform,
+          "debug",
+          `Campaign progress refresh finished in ${Date.now() - progressStartedAt}ms (${countLabel(campaigns.length, "campaign")})`,
+        );
         campaigns = preserveClaimedRewards(campaigns, state.campaigns[platform]);
       } catch (error) {
         options.signal?.throwIfAborted();
@@ -835,7 +863,24 @@ export async function runSchedulerTick(
         }
       }
 
-      let decision = await chooseCampaignDecision(platform, campaigns, settings, adapter, options.signal);
+      const selectionStartedAt = Date.now();
+      let selectionMetrics = { campaignsChecked: 0, candidatesChecked: 0 };
+      let decision = await chooseCampaignDecision(
+        platform,
+        campaigns,
+        settings,
+        adapter,
+        options.signal,
+        (metrics) => {
+          selectionMetrics = metrics;
+        },
+      );
+      emitDiagnostic(
+        emit,
+        platform,
+        "debug",
+        `Campaign selection finished in ${Date.now() - selectionStartedAt}ms (${countLabel(selectionMetrics.campaignsChecked, "campaign")} checked, ${countLabel(selectionMetrics.candidatesChecked, "candidate")} checked)`,
+      );
       const shouldKeep = await shouldKeepWatching(previous, decision, campaigns, settings, adapter, options.signal);
       // The single site where a stop reason is decided for an existing watch, so
       // the precondition-break arm is set here rather than at every consumer.
@@ -1427,4 +1472,8 @@ function emitDiagnostic(
   message: string,
 ): void {
   emit({ category: "diagnostic", platform, level, message });
+}
+
+function countLabel(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
 }

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -715,6 +715,7 @@ export async function runSchedulerTick(
         const discovered = await adapter.discoverCampaigns({ signal: options.signal });
         options.signal?.throwIfAborted();
         campaigns = await adapter.readProgress(discovered, previous, { signal: options.signal });
+        campaigns = preserveClaimedRewards(campaigns, state.campaigns[platform]);
       } catch (error) {
         options.signal?.throwIfAborted();
         if (authHealthFromError(error)) throw error;
@@ -1159,6 +1160,35 @@ async function claimReadyRewards(
   for (const rewardId of stillWaitingRewardIds) previouslyWaitingRewardIds.add(rewardId);
 
   return { campaigns: updated, events };
+}
+
+function preserveClaimedRewards(
+  campaigns: DropCampaign[],
+  previousCampaigns: readonly DropCampaign[],
+): DropCampaign[] {
+  const previouslyClaimed = new Map<string, DropReward>();
+  for (const campaign of previousCampaigns) {
+    for (const reward of campaign.rewards) {
+      if (reward.status === "claimed" && reward.claimId) {
+        previouslyClaimed.set(reward.claimId, reward);
+      }
+    }
+  }
+
+  return campaigns.map((campaign) => {
+    let changed = false;
+    const rewards = campaign.rewards.map<DropReward>((reward) => {
+      const previous = reward.claimId ? previouslyClaimed.get(reward.claimId) : undefined;
+      if (!previous || previous.id !== reward.id) return reward;
+      changed = true;
+      return {
+        ...reward,
+        status: "claimed",
+        watchedMinutes: Math.max(reward.watchedMinutes, reward.requiredMinutes),
+      };
+    });
+    return changed ? reconcileCampaignAfterClaims(campaign, rewards) : campaign;
+  });
 }
 
 function isRewardRelevantNow(reward: DropReward): boolean {

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -753,22 +753,13 @@ export async function runSchedulerTick(
       let campaigns: DropCampaign[];
       let discoveryFailed = false;
       try {
-        const discoveryStartedAt = Date.now();
-        const discovered = await adapter.discoverCampaigns({ signal: options.signal });
+        const refreshStartedAt = Date.now();
+        campaigns = await adapter.refreshCampaigns(previous, { signal: options.signal });
         emitDiagnostic(
           emit,
           platform,
           "debug",
-          `Campaign discovery finished in ${Date.now() - discoveryStartedAt}ms (${countLabel(discovered.length, "campaign")})`,
-        );
-        options.signal?.throwIfAborted();
-        const progressStartedAt = Date.now();
-        campaigns = await adapter.readProgress(discovered, previous, { signal: options.signal });
-        emitDiagnostic(
-          emit,
-          platform,
-          "debug",
-          `Campaign progress refresh finished in ${Date.now() - progressStartedAt}ms (${countLabel(campaigns.length, "campaign")})`,
+          `Campaign refresh finished in ${Date.now() - refreshStartedAt}ms (${countLabel(campaigns.length, "campaign")})`,
         );
         campaigns = preserveClaimedRewards(campaigns, state.campaigns[platform]);
       } catch (error) {

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -451,7 +451,8 @@ export async function runSchedulerTick(
 ): Promise<SchedulerTickResult> {
   options.signal?.throwIfAborted();
   const stopPageContextTabs = options.stopPageContextTabs ?? forgetManagedPageContextTabs;
-  registerManagedPageContextTabs(state.managedPageContextTabs ?? {});
+  const platforms = options.platforms ?? PLATFORMS;
+  registerManagedPageContextTabs(state.managedPageContextTabs ?? {}, platforms);
   let nextState: SchedulerState = {
     ...state,
     campaigns: { ...state.campaigns },
@@ -524,9 +525,11 @@ export async function runSchedulerTick(
   // Otherwise a breaker latched before the switch was flipped would keep blocking
   // page-context creation forever: observations no longer run to release it, and
   // the popup no longer renders the panel that would dismiss it.
-  syncManagedTabBreakers(settings.criticalFailurePromptEnabled ? nextState : {});
+  syncManagedTabBreakers(
+    settings.criticalFailurePromptEnabled ? nextState : {},
+    platforms,
+  );
 
-  const platforms = options.platforms ?? PLATFORMS;
   for (const platform of platforms) {
     options.signal?.throwIfAborted();
     const previous = nextState.sessions[platform];
@@ -545,7 +548,7 @@ export async function runSchedulerTick(
       if (!settings.criticalFailurePromptEnabled) return;
       const transition = observeCriticalHealth(nextState, platform, observation);
       nextState = transition.state;
-      syncManagedTabBreakers(nextState);
+      syncManagedTabBreakers(nextState, [platform]);
       // This runs inside a `finally`, so a throwing listener here would replace
       // the in-flight error and abort the remaining platforms. Health reporting
       // is never worth that.

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -864,24 +864,45 @@ export async function runSchedulerTick(
       }
 
       const selectionStartedAt = Date.now();
-      let selectionMetrics = { campaignsChecked: 0, candidatesChecked: 0 };
-      let decision = await chooseCampaignDecision(
-        platform,
+      const currentWatch = await evaluatePreferredCurrentWatch(
+        previous,
         campaigns,
         settings,
         adapter,
         options.signal,
-        (metrics) => {
-          selectionMetrics = metrics;
-        },
       );
-      emitDiagnostic(
-        emit,
-        platform,
-        "debug",
-        `Campaign selection finished in ${Date.now() - selectionStartedAt}ms (${countLabel(selectionMetrics.campaignsChecked, "campaign")} checked, ${countLabel(selectionMetrics.candidatesChecked, "candidate")} checked)`,
-      );
-      const shouldKeep = await shouldKeepWatching(previous, decision, campaigns, settings, adapter, options.signal);
+      let decision: WatchDecision;
+      let shouldKeep: Awaited<ReturnType<typeof shouldKeepWatching>>;
+      if (currentWatch?.keep.keep) {
+        decision = currentWatch.decision;
+        shouldKeep = currentWatch.keep;
+        emitDiagnostic(
+          emit,
+          platform,
+          "debug",
+          `Campaign selection fast path retained current watch in ${Date.now() - selectionStartedAt}ms (1 candidate checked)`,
+        );
+      } else {
+        let selectionMetrics = { campaignsChecked: 0, candidatesChecked: 0 };
+        decision = await chooseCampaignDecision(
+          platform,
+          campaigns,
+          settings,
+          adapter,
+          options.signal,
+          (metrics) => {
+            selectionMetrics = metrics;
+          },
+        );
+        emitDiagnostic(
+          emit,
+          platform,
+          "debug",
+          `Campaign selection finished in ${Date.now() - selectionStartedAt}ms (${countLabel(selectionMetrics.campaignsChecked, "campaign")} checked, ${countLabel(selectionMetrics.candidatesChecked, "candidate")} checked)`,
+        );
+        shouldKeep = currentWatch?.keep
+          ?? await shouldKeepWatching(previous, decision, campaigns, settings, adapter, options.signal);
+      }
       // The single site where a stop reason is decided for an existing watch, so
       // the precondition-break arm is set here rather than at every consumer.
       if (!shouldKeep.keep && previous.status === "watching" && ACCRUAL_PRECONDITION_BREAK_REASONS.has(shouldKeep.reasonCode)) {
@@ -1270,6 +1291,40 @@ function canClaimReward(reward: DropReward): boolean {
   return Number.isNaN(claimUntil) || Date.now() < claimUntil;
 }
 
+async function evaluatePreferredCurrentWatch(
+  previous: WatchSession,
+  campaigns: readonly DropCampaign[],
+  settings: EngineSettings,
+  adapter: Pick<PlatformAdapter, "checkChannel">,
+  signal?: AbortSignal,
+): Promise<{
+  decision: WatchDecision;
+  keep: Awaited<ReturnType<typeof shouldKeepWatching>>;
+} | undefined> {
+  if (previous.status !== "watching" || !previous.channel || !previous.campaignId || !previous.rewardId) {
+    return undefined;
+  }
+  const preferredCampaign = sortCampaigns(
+    campaigns.filter((campaign) => isEligible(campaign, settings)),
+    settings,
+  ).find((campaign) => activeReward(campaign, settings));
+  const preferredReward = preferredCampaign ? activeReward(preferredCampaign, settings) : undefined;
+  if (preferredCampaign?.id !== previous.campaignId || preferredReward?.id !== previous.rewardId) {
+    return undefined;
+  }
+  const decision: WatchDecision = {
+    platform: previous.platform,
+    action: "watch",
+    campaign: preferredCampaign,
+    reward: preferredReward,
+    channel: previous.channel,
+    reason: "Current campaign remains highest priority",
+    reasonCode: "keeping_current_watch",
+  };
+  const keep = await shouldKeepWatching(previous, decision, campaigns, settings, adapter, signal);
+  return { decision, keep };
+}
+
 async function shouldKeepWatching(
   previous: WatchSession,
   nextDecision: WatchDecision,
@@ -1281,9 +1336,8 @@ async function shouldKeepWatching(
   if (!previous.channel || previous.status !== "watching") {
     return { keep: false, offlineChecks: 0, playbackChecks: 0, reason: "No existing watch session", reasonCode: "no_existing_session" };
   }
-  const previousReward = campaigns
-    .find((campaign) => campaign.id === previous.campaignId)
-    ?.rewards.find((reward) => reward.id === previous.rewardId);
+  const previousCampaign = campaigns.find((campaign) => campaign.id === previous.campaignId);
+  const previousReward = previousCampaign?.rewards.find((reward) => reward.id === previous.rewardId);
   if (previousReward?.status === "claimable" || previousReward?.status === "claimed") {
     return {
       keep: false,
@@ -1346,7 +1400,7 @@ async function shouldKeepWatching(
     return { keep: false, offlineChecks: 0, playbackChecks: 0, reason: "Higher priority Idle Watchlist channel available", reasonCode: "higher_priority_idle_watchlist" };
   }
 
-  const check = await adapter.checkChannel(previous.channel, { signal });
+  const check = await adapter.checkChannel(previous.channel, { campaign: previousCampaign, signal });
   const offlineChecks = check.live ? 0 : previous.offlineChecks + 1;
   if (offlineChecks >= settings.offlineRetryLimit) {
     return { keep: false, offlineChecks, playbackChecks: 0, reason: check.reason ?? "Channel offline retry limit reached", reasonCode: "channel_offline" };
@@ -1354,6 +1408,9 @@ async function shouldKeepWatching(
 
   if (!check.categoryMatches) {
     return { keep: false, offlineChecks, playbackChecks: 0, reason: check.reason ?? "Channel category no longer matches", reasonCode: "channel_mismatch" };
+  }
+  if (check.campaignMatches === false) {
+    return { keep: false, offlineChecks, playbackChecks: 0, reason: check.reason ?? "Channel no longer offers the current campaign", reasonCode: "campaign_ineligible" };
   }
 
   const playbackChecks = nextPlaybackChecks(previous, isTabless);

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -203,7 +203,7 @@ export async function chooseCampaignDecision(
   platform: Platform,
   campaigns: DropCampaign[],
   settings: EngineSettings,
-  adapter: Pick<PlatformAdapter, "listCandidateChannels" | "checkChannel">,
+  adapter: Pick<PlatformAdapter, "listCandidateChannels" | "selectCandidateChannel" | "checkChannel">,
   signal?: AbortSignal,
   reportMetrics?: (metrics: { campaignsChecked: number; candidatesChecked: number }) => void,
 ): Promise<WatchDecision> {
@@ -213,6 +213,7 @@ export async function chooseCampaignDecision(
   const subscriptionOnly = onlySubscriptionCampaigns(campaigns, settings);
   let campaignsChecked = 0;
   let candidatesChecked = 0;
+  const generalCandidatesByCategory = new Map<string, ChannelCandidate[]>();
   const finish = (decision: WatchDecision): WatchDecision => {
     reportMetrics?.({ campaignsChecked, candidatesChecked });
     return decision;
@@ -225,8 +226,29 @@ export async function chooseCampaignDecision(
 
     const excludedChannels = settings.platform[platform].excludedChannels ?? [];
     signal?.throwIfAborted();
-    const candidates = (await adapter.listCandidateChannels(campaign, { signal }))
-      .filter((candidate) => !excludedChannels.includes(candidate.username.toLowerCase()))
+    const reusableDirectoryKey = campaign.allowedChannels?.length
+      ? undefined
+      : campaign.categoryId ?? campaign.slug;
+    let listedCandidates = reusableDirectoryKey
+      ? generalCandidatesByCategory.get(reusableDirectoryKey)
+      : undefined;
+    if (!listedCandidates) {
+      listedCandidates = await adapter.listCandidateChannels(campaign, { signal });
+      if (reusableDirectoryKey && listedCandidates.length > 0) {
+        generalCandidatesByCategory.set(reusableDirectoryKey, listedCandidates);
+      }
+    }
+    const candidates = [...new Map(
+      listedCandidates
+        .filter((candidate) => !excludedChannels.includes(candidate.username.toLowerCase()))
+        .map((candidate) => ({
+          ...candidate,
+          campaignId: campaign.id,
+          categoryId: campaign.categoryId ?? candidate.categoryId,
+          categoryName: campaign.gameName ?? candidate.categoryName,
+        }))
+        .map((candidate) => [candidate.username.toLowerCase(), candidate] as const),
+    ).values()]
       .sort((left, right) => {
         if (left.isAclMatch !== right.isAclMatch) return left.isAclMatch ? -1 : 1;
         return (right.viewerCount ?? 0) - (left.viewerCount ?? 0);
@@ -353,10 +375,15 @@ function onlySubscriptionCampaigns(campaigns: DropCampaign[], settings: EngineSe
 async function firstValidCandidate(
   candidates: ChannelCandidate[],
   campaign: DropCampaign | undefined,
-  adapter: Pick<PlatformAdapter, "checkChannel">,
+  adapter: Pick<PlatformAdapter, "selectCandidateChannel" | "checkChannel">,
   signal?: AbortSignal,
   onCheck?: () => void,
 ): Promise<ChannelCandidate | undefined> {
+  if (adapter.selectCandidateChannel) {
+    const selection = await adapter.selectCandidateChannel(candidates, campaign, { signal });
+    for (let index = 0; index < selection.checked; index += 1) onCheck?.();
+    return selection.channel;
+  }
   for (const candidate of candidates) {
     signal?.throwIfAborted();
     onCheck?.();

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -60,6 +60,7 @@ interface PageContextEntry {
 
 const pageContextTabs = new Map<string, PageContextEntry>();
 const retainedPageContextTabs = new Map<Platform, ManagedPageContextTab>();
+const ALL_PLATFORMS: readonly Platform[] = ["twitch", "kick"];
 // Mirrors SchedulerState.criticalHealth[platform].breakerOpen. The page-context
 // call sites are several layers deep and have no access to scheduler state, so
 // the scheduler (and the controller, whenever it records an open) pushes the
@@ -69,8 +70,9 @@ const openManagedTabBreakers = new Set<Platform>();
 
 export function syncManagedTabBreakers(
   state: { criticalHealth?: Partial<Record<Platform, { breakerOpen?: boolean }>> },
+  platforms: readonly Platform[] = ALL_PLATFORMS,
 ): void {
-  for (const platform of ["twitch", "kick"] as const) {
+  for (const platform of platforms) {
     if (state.criticalHealth?.[platform]?.breakerOpen) openManagedTabBreakers.add(platform);
     else openManagedTabBreakers.delete(platform);
   }
@@ -1504,10 +1506,14 @@ async function waitForPageContextReady(
   }
 }
 
-export function registerManagedPageContextTabs(contexts: SchedulerManagedPageContexts): void {
-  retainedPageContextTabs.clear();
-  for (const context of Object.values(contexts)) {
-    if (context) retainedPageContextTabs.set(context.platform, context);
+export function registerManagedPageContextTabs(
+  contexts: SchedulerManagedPageContexts,
+  platforms: readonly Platform[] = ALL_PLATFORMS,
+): void {
+  for (const platform of platforms) {
+    retainedPageContextTabs.delete(platform);
+    const context = contexts[platform];
+    if (context) retainedPageContextTabs.set(platform, context);
   }
 }
 

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -909,8 +909,9 @@ function twitchGqlErrorEnvelope(
 }
 
 function isUsableTwitchGql(value: unknown): boolean {
-  const entry = Array.isArray(value) ? (value.length === 1 ? value[0] : undefined) : value;
-  return entry != null && typeof entry === "object" && !Array.isArray(entry);
+  const entries = Array.isArray(value) ? value : [value];
+  return entries.length > 0
+    && entries.every((entry) => entry != null && typeof entry === "object" && !Array.isArray(entry));
 }
 
 export async function fetchTwitchInBackgroundWith<T>(api: CookieApi, url: string, init?: RequestInit): Promise<T> {

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -457,6 +457,7 @@ export interface PageFetchOptions {
   retainPageContext?: {
     platform: Platform;
     managedContext?: ManagedPageContextTab;
+    retainCreatedPageContext?: boolean;
   };
   emit?: EventEmitter;
   openReason?: PageContextOpenReason;
@@ -833,7 +834,10 @@ async function mintTwitchIntegrity(
   let pageContext: PageContextTab | undefined;
   try {
     pageContext = await acquirePageContextTab(browserApi, originUrl, origin, {
-      retainPageContext: { platform: "twitch" },
+      retainPageContext: {
+        platform: "twitch",
+        retainCreatedPageContext: false,
+      },
       emit,
       requireFreshPageContext: forceRefresh,
       emitPageContextActivity: reason === "rejection_recovery",
@@ -1376,7 +1380,14 @@ async function findOrCreatePageContextTab(
     }
     throw error;
   }
-  if (retain) {
+  try {
+    await options?.onManagedPageContextOpen?.();
+  } catch {
+    if (contextPlatform) {
+      diagnostic(options?.emit ?? ignoreEvent, "warn", `Could not account for a managed page context opened on ${new URL(origin).host}`, contextPlatform);
+    }
+  }
+  if (retain && retain.retainCreatedPageContext !== false) {
     const retainedContext: ManagedPageContextTab = {
       platform: retain.platform,
       tabId: tab.id,
@@ -1385,11 +1396,6 @@ async function findOrCreatePageContextTab(
       ownedByExtension: true,
     };
     retainedPageContextTabs.set(retain.platform, retainedContext);
-    try {
-      await options?.onManagedPageContextOpen?.();
-    } catch {
-      diagnostic(options?.emit ?? ignoreEvent, "warn", `Could not account for a managed page context opened on ${new URL(origin).host}`, retain.platform);
-    }
     if (options?.emitPageContextActivity !== false) {
       options?.emit?.({
         category: "activity",

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -38,6 +38,11 @@ export interface AdapterOperationOptions {
   signal?: AbortSignal;
 }
 
+export interface CandidateChannelSelection {
+  channel?: ChannelCandidate;
+  checked: number;
+}
+
 // A gamification challenge that was just claimed. Account-level, so unlike
 // channel points it is not tied to a channel or a watch session.
 export interface ClaimedChallenge {
@@ -53,6 +58,11 @@ export interface PlatformAdapter {
   discoverCampaigns(options?: AdapterOperationOptions): Promise<DropCampaign[]>;
   readProgress(campaigns: DropCampaign[], session?: WatchSession, options?: AdapterOperationOptions): Promise<DropCampaign[]>;
   listCandidateChannels(campaign: DropCampaign, options?: AdapterOperationOptions): Promise<ChannelCandidate[]>;
+  selectCandidateChannel?(
+    candidates: ChannelCandidate[],
+    campaign?: DropCampaign,
+    options?: AdapterOperationOptions,
+  ): Promise<CandidateChannelSelection>;
   checkChannel(channel: ChannelCandidate, options?: AdapterOperationOptions & { campaign?: DropCampaign }): Promise<ChannelCheck>;
   claimReward(campaign: DropCampaign, reward: DropReward, options?: AdapterOperationOptions): Promise<boolean>;
   // Whether a "claimable" reward can actually be claimed right now. Twitch only

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -55,8 +55,7 @@ export interface PlatformAdapter {
   platform: Platform;
   readonly compatibility?: ResolvedCompatibility[Platform];
   checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth>;
-  discoverCampaigns(options?: AdapterOperationOptions): Promise<DropCampaign[]>;
-  readProgress(campaigns: DropCampaign[], session?: WatchSession, options?: AdapterOperationOptions): Promise<DropCampaign[]>;
+  refreshCampaigns(session?: WatchSession, options?: AdapterOperationOptions): Promise<DropCampaign[]>;
   listCandidateChannels(campaign: DropCampaign, options?: AdapterOperationOptions): Promise<ChannelCandidate[]>;
   selectCandidateChannel?(
     candidates: ChannelCandidate[],

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -272,8 +272,33 @@ export class KickAdapter implements PlatformAdapter {
   }
 
   async discoverCampaigns({ signal }: AdapterOperationOptions = {}): Promise<DropCampaign[]> {
-    const data = await this.fetcher.fetchJson<unknown>("https://web.kick.com/api/v1/drops/campaigns", { signal }, this.emit);
-    return parseKickCampaigns(data as Parameters<typeof parseKickCampaigns>[0]);
+    return parseKickCampaigns(
+      await this.fetchCampaignData(signal) as Parameters<typeof parseKickCampaigns>[0],
+    );
+  }
+
+  async refreshCampaigns(
+    _session?: WatchSession,
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<DropCampaign[]> {
+    const progressPromise = this.fetchProgressData(signal).then(
+      (value) => ({ status: "fulfilled" as const, value }),
+      (reason: unknown) => ({ status: "rejected" as const, reason }),
+    );
+    const [campaignData, progressResult] = await Promise.all([
+      this.fetchCampaignData(signal),
+      progressPromise,
+    ]);
+    const campaigns = parseKickCampaigns(
+      campaignData as Parameters<typeof parseKickCampaigns>[0],
+    );
+    if (progressResult.status === "fulfilled") {
+      return this.mergeProgress(campaigns, progressResult.value);
+    }
+    signal?.throwIfAborted();
+    if (authHealthFromError(progressResult.reason)) throw progressResult.reason;
+    this.reportProgressFallback(progressResult.reason);
+    return campaigns;
   }
 
   async readProgress(
@@ -282,23 +307,52 @@ export class KickAdapter implements PlatformAdapter {
     { signal }: AdapterOperationOptions = {},
   ): Promise<DropCampaign[]> {
     try {
-      // Kick's WAF rejects authed drops endpoints that omit X-Client-Token with
-      // "Request blocked by security policy." — the reference sends it on
-      // /drops/progress and /drops/claim (references/kickautodrops/core/kick.py:
-      // 131, 67). pageFetchJson adds the Bearer from session_token on top.
-      const data = await this.fetcher.fetchJson<unknown>("https://web.kick.com/api/v1/drops/progress", {
-        headers: { "X-Client-Token": KICK_CLIENT_TOKEN },
-        signal,
-      }, this.emit);
-      const progress = mergeKickProgress(campaigns, data as Parameters<typeof mergeKickProgress>[1]);
-      return this.claimCapability.reconcileProgress?.(progress, affirmativelyLinkedCampaignIds(data)) ?? progress;
+      return this.mergeProgress(campaigns, await this.fetchProgressData(signal));
     } catch (error) {
       signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
-      const message = error instanceof Error ? error.message : String(error);
-      diagnostic(this.emit, "warn", `Could not read Kick drop progress; using last-known progress: ${message}`, "kick");
+      this.reportProgressFallback(error);
       return campaigns;
     }
+  }
+
+  private fetchCampaignData(signal?: AbortSignal): Promise<unknown> {
+    return this.fetcher.fetchJson<unknown>(
+      "https://web.kick.com/api/v1/drops/campaigns",
+      { signal },
+      this.emit,
+    );
+  }
+
+  private fetchProgressData(signal?: AbortSignal): Promise<unknown> {
+    // Kick's WAF rejects authed drops endpoints that omit X-Client-Token with
+    // "Request blocked by security policy." — the reference sends it on
+    // /drops/progress and /drops/claim (references/kickautodrops/core/kick.py:
+    // 131, 67). pageFetchJson adds the Bearer from session_token on top.
+    return this.fetcher.fetchJson<unknown>(
+      "https://web.kick.com/api/v1/drops/progress",
+      {
+        headers: { "X-Client-Token": KICK_CLIENT_TOKEN },
+        signal,
+      },
+      this.emit,
+    );
+  }
+
+  private mergeProgress(campaigns: DropCampaign[], data: unknown): DropCampaign[] {
+    const progress = mergeKickProgress(
+      campaigns,
+      data as Parameters<typeof mergeKickProgress>[1],
+    );
+    return this.claimCapability.reconcileProgress?.(
+      progress,
+      affirmativelyLinkedCampaignIds(data),
+    ) ?? progress;
+  }
+
+  private reportProgressFallback(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    diagnostic(this.emit, "warn", `Could not read Kick drop progress; using last-known progress: ${message}`, "kick");
   }
 
   async searchCategories(query: string): Promise<CategorySelection[]> {

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -271,12 +271,6 @@ export class KickAdapter implements PlatformAdapter {
     );
   }
 
-  async discoverCampaigns({ signal }: AdapterOperationOptions = {}): Promise<DropCampaign[]> {
-    return parseKickCampaigns(
-      await this.fetchCampaignData(signal) as Parameters<typeof parseKickCampaigns>[0],
-    );
-  }
-
   async refreshCampaigns(
     _session?: WatchSession,
     { signal }: AdapterOperationOptions = {},
@@ -299,21 +293,6 @@ export class KickAdapter implements PlatformAdapter {
     if (authHealthFromError(progressResult.reason)) throw progressResult.reason;
     this.reportProgressFallback(progressResult.reason);
     return campaigns;
-  }
-
-  async readProgress(
-    campaigns: DropCampaign[],
-    _session?: WatchSession,
-    { signal }: AdapterOperationOptions = {},
-  ): Promise<DropCampaign[]> {
-    try {
-      return this.mergeProgress(campaigns, await this.fetchProgressData(signal));
-    } catch (error) {
-      signal?.throwIfAborted();
-      if (authHealthFromError(error)) throw error;
-      this.reportProgressFallback(error);
-      return campaigns;
-    }
   }
 
   private fetchCampaignData(signal?: AbortSignal): Promise<unknown> {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -995,10 +995,26 @@ export class TwitchAdapter implements PlatformAdapter {
       const target = streamCandidates[index];
       if (target) checks[target.index] = check;
     });
+    const availabilityResult = campaign
+      ? await this.batchCampaignAvailability(
+          checks.flatMap((check) =>
+            check?.live && check.categoryMatches && check.candidate.channelId
+              ? [{
+                  channelId: check.candidate.channelId,
+                  channelLogin: check.candidate.username,
+                }]
+              : []),
+          campaign.id,
+          signal,
+        )
+      : {
+          matches: new Map<string, boolean | undefined>(),
+          batchRequests: 0,
+          singleFallbacks: 0,
+          cacheHits: 0,
+        };
 
     let checked = 0;
-    let availabilityChecks = 0;
-    let availabilityCacheHits = 0;
     let winnerFallbacks = 0;
     for (const check of checks) {
       if (!check) continue;
@@ -1013,22 +1029,13 @@ export class TwitchAdapter implements PlatformAdapter {
         selectedCandidate = confirmed.candidate;
         campaignMatches = confirmed.campaignMatches;
       } else if (campaign && check.candidate.channelId) {
-        const metrics = { checks: 0, cacheHits: 0 };
-        campaignMatches = await this.checkCampaignAvailability(
-          check.candidate.channelId,
-          campaign.id,
-          check.candidate.username,
-          signal,
-          metrics,
-        );
-        availabilityChecks += metrics.checks;
-        availabilityCacheHits += metrics.cacheHits;
+        campaignMatches = availabilityResult.matches.get(check.candidate.channelId);
       }
       if (campaignMatches === false) continue;
       diagnostic(
         this.emit,
         "debug",
-        `Twitch channel selection finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityChecks} AvailableDrops lookups, ${availabilityCacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
+        `Twitch channel selection finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
         "twitch",
       );
       return {
@@ -1042,10 +1049,183 @@ export class TwitchAdapter implements PlatformAdapter {
     diagnostic(
       this.emit,
       "debug",
-      `Twitch channel selection finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityChecks} AvailableDrops lookups, ${availabilityCacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
+      `Twitch channel selection finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
       "twitch",
     );
     return { checked: candidates.length };
+  }
+
+  private async batchCampaignAvailability(
+    candidates: readonly { channelId: string; channelLogin: string }[],
+    campaignId: string,
+    signal?: AbortSignal,
+  ): Promise<{
+    matches: Map<string, boolean | undefined>;
+    batchRequests: number;
+    singleFallbacks: number;
+    cacheHits: number;
+  }> {
+    const matches = new Map<string, boolean | undefined>();
+    const uncached: Array<{ channelId: string; channelLogin: string }> = [];
+    let cacheHits = 0;
+    for (const candidate of candidates) {
+      if (matches.has(candidate.channelId)) continue;
+      const cached = this.availableCampaignsByChannel.get(candidate.channelId);
+      if (cached && cached.expiresAt > Date.now()) {
+        cacheHits += 1;
+        matches.set(candidate.channelId, cached.campaignIds.has(campaignId));
+        continue;
+      }
+      if (cached) this.availableCampaignsByChannel.delete(candidate.channelId);
+      uncached.push(candidate);
+    }
+    if (uncached.length === 1) {
+      const candidate = uncached[0];
+      const metrics = { checks: 0, cacheHits: 0 };
+      matches.set(
+        candidate.channelId,
+        await this.checkCampaignAvailability(
+          candidate.channelId,
+          campaignId,
+          candidate.channelLogin,
+          signal,
+          metrics,
+        ),
+      );
+      return {
+        matches,
+        batchRequests: 0,
+        singleFallbacks: metrics.checks,
+        cacheHits: cacheHits + metrics.cacheHits,
+      };
+    }
+    const chunks = Array.from(
+      { length: Math.ceil(uncached.length / GQL_BATCH_OPERATION_LIMIT) },
+      (_, index) => uncached.slice(
+        index * GQL_BATCH_OPERATION_LIMIT,
+        (index + 1) * GQL_BATCH_OPERATION_LIMIT,
+      ),
+    );
+    const results = new Array<{
+      matches: Map<string, boolean | undefined>;
+      singleFallbacks: number;
+    }>(chunks.length);
+    let nextChunk = 0;
+    await Promise.all(Array.from(
+      { length: Math.min(GQL_BATCH_CONCURRENCY, chunks.length) },
+      async () => {
+        for (;;) {
+          const chunkIndex = nextChunk;
+          nextChunk += 1;
+          const chunk = chunks[chunkIndex];
+          if (!chunk) return;
+          signal?.throwIfAborted();
+          results[chunkIndex] = await this.batchCampaignAvailabilityChunk(
+            chunk,
+            campaignId,
+            signal,
+          );
+        }
+      },
+    ));
+    for (const result of results) {
+      for (const [channelId, match] of result.matches) matches.set(channelId, match);
+    }
+    return {
+      matches,
+      batchRequests: chunks.length,
+      singleFallbacks: results.reduce((total, result) => total + result.singleFallbacks, 0),
+      cacheHits,
+    };
+  }
+
+  private async batchCampaignAvailabilityChunk(
+    candidates: readonly { channelId: string; channelLogin: string }[],
+    campaignId: string,
+    signal?: AbortSignal,
+  ): Promise<{
+    matches: Map<string, boolean | undefined>;
+    singleFallbacks: number;
+  }> {
+    const matches = new Map<string, boolean | undefined>();
+    const fallback = async (
+      candidate: { channelId: string; channelLogin: string },
+    ): Promise<void> => {
+      matches.set(
+        candidate.channelId,
+        await this.checkCampaignAvailability(
+          candidate.channelId,
+          campaignId,
+          candidate.channelLogin,
+          signal,
+        ),
+      );
+    };
+    const integrity = this.options.currentIntegrity?.();
+    let raw: unknown;
+    try {
+      raw = await this.fetcher.fetchJson<unknown>(
+        "https://gql.twitch.tv/gql",
+        {
+          method: "POST",
+          headers: {
+            "Accept": "*/*",
+            "Accept-Language": "en-US",
+            "Content-Type": "text/plain; charset=UTF-8",
+            "Client-ID": this.options.clientId ?? TWITCH_CLIENT_ID,
+            ...(this.options.userAgent ? { "User-Agent": this.options.userAgent } : {}),
+            ...(integrity
+              ? {
+                  "Client-Integrity": integrity.integrity,
+                  ...(integrity.deviceId ? { "X-Device-Id": integrity.deviceId } : {}),
+                  ...(integrity.clientSessionId ? { "Client-Session-Id": integrity.clientSessionId } : {}),
+                }
+              : {}),
+          },
+          ...(signal ? { signal } : {}),
+          body: JSON.stringify(candidates.map((candidate) => ({
+            operationName: "DropsHighlightService_AvailableDrops",
+            variables: { channelID: candidate.channelId },
+            extensions: {
+              persistedQuery: {
+                version: 1,
+                sha256Hash: TWITCH_QUERIES.availableDropsHash,
+              },
+            },
+          }))),
+        },
+        this.emit,
+      );
+    } catch (error) {
+      signal?.throwIfAborted();
+      if (authHealthFromError(error)) throw error;
+      for (const candidate of candidates) await fallback(candidate);
+      return { matches, singleFallbacks: candidates.length };
+    }
+    if (twitchPageFetchError(raw)) {
+      for (const candidate of candidates) await fallback(candidate);
+      return { matches, singleFallbacks: candidates.length };
+    }
+    const responses = Array.isArray(raw) ? raw : candidates.length === 1 ? [raw] : [];
+    let singleFallbacks = 0;
+    for (const [index, candidate] of candidates.entries()) {
+      const response = normalizeTwitchGqlResponse<TwitchAvailableDropsData>(responses[index]);
+      const campaigns = response?.data?.channel?.viewerDropCampaigns;
+      if (!Array.isArray(campaigns) || response?.errors?.length || response?.error) {
+        singleFallbacks += 1;
+        await fallback(candidate);
+        continue;
+      }
+      const campaignIds = new Set(
+        campaigns.map((campaign) => campaign.id).filter((id): id is string => Boolean(id)),
+      );
+      this.availableCampaignsByChannel.set(candidate.channelId, {
+        campaignIds,
+        expiresAt: Date.now() + CHANNEL_CAMPAIGN_CACHE_TTL_MS,
+      });
+      matches.set(candidate.channelId, campaignIds.has(campaignId));
+    }
+    return { matches, singleFallbacks };
   }
 
   private async batchStreamInfoChecks(

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -603,7 +603,9 @@ export class TwitchAdapter implements PlatformAdapter {
     );
   }
 
-  async discoverCampaigns({ signal }: AdapterOperationOptions = {}): Promise<DropCampaign[]> {
+  private async discoverCampaignSnapshot(
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<DropCampaign[]> {
     let [inventory, dashboardResult] = await Promise.all([
       this.fetchInventory({ signal }),
       this.fetchDashboard(TWITCH_QUERIES.dashboard.variables, signal),
@@ -753,6 +755,19 @@ export class TwitchAdapter implements PlatformAdapter {
       dashboardResponded,
     );
     return [...mergedDetails, ...inventoryOnly];
+  }
+
+  async discoverCampaigns(options: AdapterOperationOptions = {}): Promise<DropCampaign[]> {
+    return this.discoverCampaignSnapshot(options);
+  }
+
+  async refreshCampaigns(
+    session?: WatchSession,
+    options: AdapterOperationOptions = {},
+  ): Promise<DropCampaign[]> {
+    const campaigns = await this.discoverCampaignSnapshot(options);
+    if (!session?.channel || session.status !== "watching") return campaigns;
+    return this.mergeCurrentSessionProgress(campaigns, session.channel, options.signal);
   }
 
   async readProgress(

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -5,7 +5,7 @@ import { authHealthFromError, SafeFetchError } from "../../core/fetchError";
 import type { TwitchIntegrityRequest } from "../../core/tabs";
 import type { TwitchIntegrity } from "../../core/twitchIntegrity";
 import { PendingWatcherDiagnostics, type HeartbeatResult, type TablessWatchController, type WatchContext } from "../../core/tablessWatch";
-import { diagnostic, ignoreEvent, unavailableWatchTabPort, type AdapterOperationOptions, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
+import { diagnostic, ignoreEvent, unavailableWatchTabPort, type AdapterOperationOptions, type CandidateChannelSelection, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { campaignHasClaimableReward, mergeTwitchCampaignProgress, parseTwitchCampaigns, twitchCandidatesFromCampaign, withCampaignStatus } from "./parser";
 import type { ResolvedCompatibility, TwitchIdentity } from "../../compatibility/types";
 import { createTwitchHeartbeat } from "./heartbeat/factory";
@@ -24,6 +24,8 @@ const CURRENT_USER_QUERY = "query CurrentUser { currentUser { id } }";
 const TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 const CHANNEL_CAMPAIGN_CACHE_TTL_MS = 60_000;
 const DISCOVERY_DETAIL_PRUNE_LIMIT = 32;
+const GQL_BATCH_OPERATION_LIMIT = 20;
+const GQL_BATCH_CONCURRENCY = 2;
 // How long a discovery result stays usable when Twitch stops answering. Long
 // enough to ride out an outage of many ticks, short enough that a campaign
 // Twitch quietly stopped serving does not linger for a whole session.
@@ -137,7 +139,7 @@ const TWITCH_INLINE_QUERIES: Partial<Record<string, string>> = {
           node {
             title
             viewersCount
-            broadcaster { login displayName profileImageURL }
+            broadcaster { id login displayName profileImageURL }
           }
         }
       }
@@ -255,6 +257,7 @@ interface TwitchDirectoryData {
           title?: string;
           viewersCount?: number;
           broadcaster?: {
+            id?: string;
             login?: string;
             displayName?: string;
             profileImageURL?: string;
@@ -601,18 +604,23 @@ export class TwitchAdapter implements PlatformAdapter {
   }
 
   async discoverCampaigns({ signal }: AdapterOperationOptions = {}): Promise<DropCampaign[]> {
-    let inventory = await this.fetchInventory({ signal });
-    let dashboardResult = await this.fetchDashboard(TWITCH_QUERIES.dashboard.variables, signal);
+    let [inventory, dashboardResult] = await Promise.all([
+      this.fetchInventory({ signal }),
+      this.fetchDashboard(TWITCH_QUERIES.dashboard.variables, signal),
+    ]);
     let inventoryCampaigns = this.inventoryCapability.parse(inventory);
     let dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
 
     if (inventoryCampaigns.length === 0 && dashboardCampaigns.length === 0) {
       try {
-        inventory = await this.fetchInventory({
-          variables: { fetchRewardCampaigns: true },
-          signal,
-        });
-        const fallbackDashboardResult = await this.fetchDashboard({ fetchRewardCampaigns: true }, signal);
+        const [fallbackInventory, fallbackDashboardResult] = await Promise.all([
+          this.fetchInventory({
+            variables: { fetchRewardCampaigns: true },
+            signal,
+          }),
+          this.fetchDashboard({ fetchRewardCampaigns: true }, signal),
+        ]);
+        inventory = fallbackInventory;
         inventoryCampaigns = this.inventoryCapability.parse(inventory);
         if (fallbackDashboardResult.ok || !dashboardResult.ok) {
           dashboardResult = fallbackDashboardResult;
@@ -672,13 +680,14 @@ export class TwitchAdapter implements PlatformAdapter {
       );
     }
 
-    const details = await Promise.allSettled(
-      discoverableCampaignIds.map((dropID) =>
-        this.gqlWithIntegrityRetry<TwitchCampaignDetailsData>("DropCampaignDetails", TWITCH_QUERIES.campaignDetailsHash, {
-          channelLogin: userLogin,
-          dropID,
-        }, undefined, undefined, this.emit, signal),
-      ),
+    const detailsStartedAt = Date.now();
+    const detailFetch = await this.fetchCampaignDetails(discoverableCampaignIds, userLogin, signal);
+    const details = detailFetch.results;
+    diagnostic(
+      this.emit,
+      "debug",
+      `Twitch campaign details finished in ${Date.now() - detailsStartedAt}ms (${discoverableCampaignIds.length} operations: ${detailFetch.batchRequests} batch requests, ${detailFetch.singleFallbacks} single fallbacks)`,
+      "twitch",
     );
     signal?.throwIfAborted();
     for (const result of details) {
@@ -757,6 +766,154 @@ export class TwitchAdapter implements PlatformAdapter {
     return this.mergeCurrentSessionProgress(inventoryProgress, session.channel, signal);
   }
 
+  private async fetchCampaignDetails(
+    dropIds: readonly string[],
+    channelLogin: string,
+    signal?: AbortSignal,
+  ): Promise<{
+    results: PromiseSettledResult<TwitchGqlResponse<TwitchCampaignDetailsData>>[];
+    batchRequests: number;
+    singleFallbacks: number;
+  }> {
+    const chunks = Array.from(
+      { length: Math.ceil(dropIds.length / GQL_BATCH_OPERATION_LIMIT) },
+      (_, index) => dropIds.slice(
+        index * GQL_BATCH_OPERATION_LIMIT,
+        (index + 1) * GQL_BATCH_OPERATION_LIMIT,
+      ),
+    );
+    const results = new Array<{
+      results: PromiseSettledResult<TwitchGqlResponse<TwitchCampaignDetailsData>>[];
+      singleFallbacks: number;
+    }>(chunks.length);
+    let nextChunk = 0;
+    const workers = Array.from(
+      { length: Math.min(GQL_BATCH_CONCURRENCY, chunks.length) },
+      async () => {
+        for (;;) {
+          const chunkIndex = nextChunk;
+          nextChunk += 1;
+          const chunk = chunks[chunkIndex];
+          if (!chunk) return;
+          signal?.throwIfAborted();
+          results[chunkIndex] = await this.fetchCampaignDetailsChunk(chunk, channelLogin, signal);
+        }
+      },
+    );
+    await Promise.all(workers);
+    return {
+      results: results.flatMap((result) => result.results),
+      batchRequests: chunks.length,
+      singleFallbacks: results.reduce((total, result) => total + result.singleFallbacks, 0),
+    };
+  }
+
+  private async fetchCampaignDetailsChunk(
+    dropIds: readonly string[],
+    channelLogin: string,
+    signal?: AbortSignal,
+  ): Promise<{
+    results: PromiseSettledResult<TwitchGqlResponse<TwitchCampaignDetailsData>>[];
+    singleFallbacks: number;
+  }> {
+    const fallback = async () => {
+      const results: PromiseSettledResult<TwitchGqlResponse<TwitchCampaignDetailsData>>[] = [];
+      for (const dropID of dropIds) {
+        try {
+          const value = await this.gqlWithIntegrityRetry<TwitchCampaignDetailsData>(
+            "DropCampaignDetails",
+            TWITCH_QUERIES.campaignDetailsHash,
+            { channelLogin, dropID },
+            undefined,
+            undefined,
+            this.emit,
+            signal,
+          );
+          results.push({ status: "fulfilled", value });
+        } catch (reason) {
+          results.push({ status: "rejected", reason });
+        }
+      }
+      return { results, singleFallbacks: dropIds.length };
+    };
+    const integrity = this.options.currentIntegrity?.();
+    let raw: unknown;
+    try {
+      raw = await this.fetcher.fetchJson<unknown>(
+        "https://gql.twitch.tv/gql",
+        {
+          method: "POST",
+          headers: {
+            "Accept": "*/*",
+            "Accept-Language": "en-US",
+            "Content-Type": "text/plain; charset=UTF-8",
+            "Client-ID": this.options.clientId ?? TWITCH_CLIENT_ID,
+            ...(this.options.userAgent ? { "User-Agent": this.options.userAgent } : {}),
+            ...(integrity
+              ? {
+                  "Client-Integrity": integrity.integrity,
+                  ...(integrity.deviceId ? { "X-Device-Id": integrity.deviceId } : {}),
+                  ...(integrity.clientSessionId ? { "Client-Session-Id": integrity.clientSessionId } : {}),
+                }
+              : {}),
+          },
+          ...(signal ? { signal } : {}),
+          body: JSON.stringify(dropIds.map((dropID) => ({
+            operationName: "DropCampaignDetails",
+            variables: { channelLogin, dropID },
+            extensions: {
+              persistedQuery: {
+                version: 1,
+                sha256Hash: TWITCH_QUERIES.campaignDetailsHash,
+              },
+            },
+          }))),
+        },
+        this.emit,
+      );
+    } catch (error) {
+      signal?.throwIfAborted();
+      if (authHealthFromError(error)) throw error;
+      return fallback();
+    }
+    if (twitchPageFetchError(raw)) return fallback();
+    const responses = Array.isArray(raw) ? raw : dropIds.length === 1 ? [raw] : [];
+    if (responses.length !== dropIds.length) return fallback();
+
+    let singleFallbacks = 0;
+    const results: PromiseSettledResult<TwitchGqlResponse<TwitchCampaignDetailsData>>[] = [];
+    for (let index = 0; index < responses.length; index += 1) {
+      const value = responses[index];
+      const response = normalizeTwitchGqlResponse<TwitchCampaignDetailsData>(value);
+      if (
+        response
+        && Object.prototype.hasOwnProperty.call(response, "data")
+        && !response.error
+        && !(response.message && response.data === undefined)
+        && !response.errors?.length
+      ) {
+        results.push({ status: "fulfilled", value: response });
+        continue;
+      }
+      singleFallbacks += 1;
+      try {
+        const fallbackResponse = await this.gqlWithIntegrityRetry<TwitchCampaignDetailsData>(
+          "DropCampaignDetails",
+          TWITCH_QUERIES.campaignDetailsHash,
+          { channelLogin, dropID: dropIds[index] },
+          undefined,
+          undefined,
+          this.emit,
+          signal,
+        );
+        results.push({ status: "fulfilled", value: fallbackResponse });
+      } catch (reason) {
+        results.push({ status: "rejected", reason });
+      }
+    }
+    return { results, singleFallbacks };
+  }
+
   async listCandidateChannels(
     campaign: DropCampaign,
     { signal }: AdapterOperationOptions = {},
@@ -800,9 +957,195 @@ export class TwitchAdapter implements PlatformAdapter {
           viewerCount: edge.node?.viewersCount,
           title: edge.node?.title,
           live: true,
+          channelId: broadcaster.id,
         };
       })
       .filter((candidate): candidate is ChannelCandidate => Boolean(candidate));
+  }
+
+  async selectCandidateChannel(
+    candidates: ChannelCandidate[],
+    campaign?: DropCampaign,
+    { signal }: AdapterOperationOptions = {},
+  ): Promise<CandidateChannelSelection> {
+    if (candidates.length === 0) return { checked: 0 };
+    const startedAt = Date.now();
+    const checks = new Array<ChannelCheck | undefined>(candidates.length);
+    const streamCandidates: Array<{ candidate: ChannelCandidate; index: number }> = [];
+    let trustedDirectoryCandidates = 0;
+    for (let index = 0; index < candidates.length; index += 1) {
+      const candidate = candidates[index];
+      if (candidate.live === true && candidate.isAclMatch === false) {
+        trustedDirectoryCandidates += 1;
+        checks[index] = {
+          live: true,
+          categoryMatches: !campaign?.categoryId || candidate.categoryId === campaign.categoryId,
+          candidate,
+        };
+      } else {
+        streamCandidates.push({ candidate, index });
+      }
+    }
+    const streamCheckResult = await this.batchStreamInfoChecks(
+      streamCandidates.map(({ candidate }) => candidate),
+      campaign,
+      signal,
+    );
+    streamCheckResult.checks.forEach((check, index) => {
+      const target = streamCandidates[index];
+      if (target) checks[target.index] = check;
+    });
+
+    let checked = 0;
+    let availabilityChecks = 0;
+    let availabilityCacheHits = 0;
+    let winnerFallbacks = 0;
+    for (const check of checks) {
+      if (!check) continue;
+      checked += 1;
+      if (!check.live || !check.categoryMatches) continue;
+      let campaignMatches: boolean | undefined;
+      let selectedCandidate = check.candidate;
+      if (campaign && !check.candidate.channelId) {
+        winnerFallbacks += 1;
+        const confirmed = await this.checkChannel(check.candidate, { campaign, signal });
+        if (!confirmed.live || !confirmed.categoryMatches || confirmed.campaignMatches === false) continue;
+        selectedCandidate = confirmed.candidate;
+        campaignMatches = confirmed.campaignMatches;
+      } else if (campaign && check.candidate.channelId) {
+        const metrics = { checks: 0, cacheHits: 0 };
+        campaignMatches = await this.checkCampaignAvailability(
+          check.candidate.channelId,
+          campaign.id,
+          check.candidate.username,
+          signal,
+          metrics,
+        );
+        availabilityChecks += metrics.checks;
+        availabilityCacheHits += metrics.cacheHits;
+      }
+      if (campaignMatches === false) continue;
+      diagnostic(
+        this.emit,
+        "debug",
+        `Twitch channel selection finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityChecks} AvailableDrops lookups, ${availabilityCacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
+        "twitch",
+      );
+      return {
+        checked: candidates.length,
+        channel: {
+          ...selectedCandidate,
+          live: true,
+        },
+      };
+    }
+    diagnostic(
+      this.emit,
+      "debug",
+      `Twitch channel selection finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityChecks} AvailableDrops lookups, ${availabilityCacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
+      "twitch",
+    );
+    return { checked: candidates.length };
+  }
+
+  private async batchStreamInfoChecks(
+    candidates: readonly ChannelCandidate[],
+    campaign: DropCampaign | undefined,
+    signal?: AbortSignal,
+  ): Promise<{ checks: ChannelCheck[]; singleFallbacks: number }> {
+    if (candidates.length === 0) return { checks: [], singleFallbacks: 0 };
+    const chunks = Array.from(
+      { length: Math.ceil(candidates.length / GQL_BATCH_OPERATION_LIMIT) },
+      (_, index) => candidates.slice(
+        index * GQL_BATCH_OPERATION_LIMIT,
+        (index + 1) * GQL_BATCH_OPERATION_LIMIT,
+      ),
+    );
+    const results = new Array<{ checks: ChannelCheck[]; singleFallbacks: number }>(chunks.length);
+    let nextChunk = 0;
+    await Promise.all(Array.from(
+      { length: Math.min(GQL_BATCH_CONCURRENCY, chunks.length) },
+      async () => {
+        for (;;) {
+          const chunkIndex = nextChunk;
+          nextChunk += 1;
+          const chunk = chunks[chunkIndex];
+          if (!chunk) return;
+          signal?.throwIfAborted();
+          results[chunkIndex] = await this.batchStreamInfoChunk(chunk, campaign, signal);
+        }
+      },
+    ));
+    return {
+      checks: results.flatMap((result) => result.checks),
+      singleFallbacks: results.reduce((total, result) => total + result.singleFallbacks, 0),
+    };
+  }
+
+  private async batchStreamInfoChunk(
+    candidates: readonly ChannelCandidate[],
+    campaign: DropCampaign | undefined,
+    signal?: AbortSignal,
+  ): Promise<{ checks: ChannelCheck[]; singleFallbacks: number }> {
+    let raw: unknown;
+    try {
+      raw = await this.fetcher.fetchJson<unknown>(
+        "https://gql.twitch.tv/gql",
+        {
+          method: "POST",
+          credentials: "omit",
+          headers: {
+            "Accept": "*/*",
+            "Accept-Language": "en-US",
+            "Content-Type": "text/plain; charset=UTF-8",
+            "Client-ID": this.options.clientId ?? TWITCH_CLIENT_ID,
+            ...(this.options.userAgent ? { "User-Agent": this.options.userAgent } : {}),
+          },
+          ...(signal ? { signal } : {}),
+          body: JSON.stringify(candidates.map((candidate) => ({
+            operationName: "StreamInfo",
+            variables: { channel: candidate.username },
+            query: STREAM_INFO_QUERY,
+          }))),
+        },
+        this.emit,
+      );
+    } catch (error) {
+      signal?.throwIfAborted();
+      const checks: ChannelCheck[] = [];
+      for (const candidate of candidates) {
+        checks.push(await this.checkChannel(candidate, { signal }));
+      }
+      return { checks, singleFallbacks: candidates.length };
+    }
+    const responses = Array.isArray(raw) ? raw : candidates.length === 1 ? [raw] : [];
+    const checks: ChannelCheck[] = [];
+    let singleFallbacks = 0;
+    for (const [index, candidate] of candidates.entries()) {
+      const response = normalizeTwitchGqlResponse<TwitchStreamInfoData>(responses[index]);
+      if (!response?.data?.user || response.errors?.length || response.error) {
+        singleFallbacks += 1;
+        checks.push(await this.checkChannel(candidate, { signal }));
+        continue;
+      }
+      const stream = response.data.user.stream;
+      const categoryId = stream?.game?.id;
+      checks.push({
+        live: Boolean(stream),
+        categoryMatches: !campaign?.categoryId || categoryId === campaign.categoryId,
+        candidate: {
+          ...candidate,
+          displayName: response.data.user.displayName ?? candidate.displayName,
+          categoryId: categoryId ?? candidate.categoryId,
+          categoryName: stream?.game?.name ?? candidate.categoryName,
+          viewerCount: stream?.viewersCount ?? candidate.viewerCount,
+          channelId: response.data.user.id ?? candidate.channelId,
+          broadcastId: stream?.id ?? candidate.broadcastId,
+          live: Boolean(stream),
+        },
+      });
+    }
+    return { checks, singleFallbacks };
   }
 
   async checkChannel(
@@ -859,14 +1202,17 @@ export class TwitchAdapter implements PlatformAdapter {
     campaignId: string,
     channelLogin: string,
     signal?: AbortSignal,
+    metrics?: { checks: number; cacheHits: number },
   ): Promise<boolean | undefined> {
     const cached = this.availableCampaignsByChannel.get(channelId);
     if (cached && cached.expiresAt > Date.now()) {
+      if (metrics) metrics.cacheHits += 1;
       return cached.campaignIds.has(campaignId);
     }
     if (cached) this.availableCampaignsByChannel.delete(channelId);
 
     try {
+      if (metrics) metrics.checks += 1;
       const response = await this.gqlWithIntegrityRetry<TwitchAvailableDropsData>(
         "DropsHighlightService_AvailableDrops",
         TWITCH_QUERIES.availableDropsHash,

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -757,10 +757,6 @@ export class TwitchAdapter implements PlatformAdapter {
     return [...mergedDetails, ...inventoryOnly];
   }
 
-  async discoverCampaigns(options: AdapterOperationOptions = {}): Promise<DropCampaign[]> {
-    return this.discoverCampaignSnapshot(options);
-  }
-
   async refreshCampaigns(
     session?: WatchSession,
     options: AdapterOperationOptions = {},
@@ -768,17 +764,6 @@ export class TwitchAdapter implements PlatformAdapter {
     const campaigns = await this.discoverCampaignSnapshot(options);
     if (!session?.channel || session.status !== "watching") return campaigns;
     return this.mergeCurrentSessionProgress(campaigns, session.channel, options.signal);
-  }
-
-  async readProgress(
-    campaigns: DropCampaign[],
-    session?: WatchSession,
-    { signal }: AdapterOperationOptions = {},
-  ): Promise<DropCampaign[]> {
-    const inventory = await this.fetchInventory({ signal });
-    const inventoryProgress = this.inventoryCapability.reconcileProgress(campaigns, inventory);
-    if (!session?.channel || session.status !== "watching") return inventoryProgress;
-    return this.mergeCurrentSessionProgress(inventoryProgress, session.channel, signal);
   }
 
   private async fetchCampaignDetails(

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -970,6 +970,12 @@ export class TwitchAdapter implements PlatformAdapter {
   ): Promise<CandidateChannelSelection> {
     if (candidates.length === 0) return { checked: 0 };
     const startedAt = Date.now();
+    const selectionLabel = campaign
+      ? `for "${campaign.name}" (campaign ${campaign.id})`
+      : "idle";
+    const selectionDescription = campaign
+      ? `channel selection ${selectionLabel}`
+      : `${selectionLabel} channel selection`;
     const checks = new Array<ChannelCheck | undefined>(candidates.length);
     const streamCandidates: Array<{ candidate: ChannelCandidate; index: number }> = [];
     let trustedDirectoryCandidates = 0;
@@ -1016,6 +1022,14 @@ export class TwitchAdapter implements PlatformAdapter {
 
     let checked = 0;
     let winnerFallbacks = 0;
+    const reportSelectionFinished = () => {
+      diagnostic(
+        this.emit,
+        "debug",
+        `Twitch ${selectionDescription} finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
+        "twitch",
+      );
+    };
     for (const check of checks) {
       if (!check) continue;
       checked += 1;
@@ -1032,12 +1046,7 @@ export class TwitchAdapter implements PlatformAdapter {
         campaignMatches = availabilityResult.matches.get(check.candidate.channelId);
       }
       if (campaignMatches === false) continue;
-      diagnostic(
-        this.emit,
-        "debug",
-        `Twitch channel selection finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
-        "twitch",
-      );
+      reportSelectionFinished();
       return {
         checked: candidates.length,
         channel: {
@@ -1046,12 +1055,7 @@ export class TwitchAdapter implements PlatformAdapter {
         },
       };
     }
-    diagnostic(
-      this.emit,
-      "debug",
-      `Twitch channel selection finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
-      "twitch",
-    );
+    reportSelectionFinished();
     return { checked: candidates.length };
   }
 

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -135,6 +135,10 @@ const controller = createBackgroundController<ExtensionSettings>({
   reportEvents,
   checkCredentialAvailability,
   createAlarm: (name, options) => browser.alarms.create(name, options),
+  getAlarm: async (name) => {
+    const alarm = await browser.alarms.get(name);
+    return alarm ? { scheduledTime: alarm.scheduledTime } : undefined;
+  },
   clearAlarm: (name) => browser.alarms.clear(name),
   ensureTwitchIntegrity: (emit, request) => ensureTwitchIntegrity(emit, request),
   cancelTwitchIntegrityAcquisition,

--- a/packages/extension/scripts/kick-inspect.mjs
+++ b/packages/extension/scripts/kick-inspect.mjs
@@ -331,7 +331,7 @@ async function main() {
     // 1. Drop campaigns — shape is the launch-day unknown; capture whatever exists now.
     await captureViaPage(page, "drops-campaigns", "https://web.kick.com/api/v1/drops/campaigns");
     // 2. Drop progress — needs X-Client-Token or Kick's WAF returns "Request
-    //    blocked by security policy." (matches the extension's readProgress).
+    //    blocked by security policy." (matches the extension's campaign refresh).
     await captureViaPage(page, "drops-progress", "https://web.kick.com/api/v1/drops/progress", {
       headers: { "X-Client-Token": KICK_CLIENT_TOKEN },
     });

--- a/packages/extension/tests/activityStorage.test.ts
+++ b/packages/extension/tests/activityStorage.test.ts
@@ -70,6 +70,25 @@ describe("activity repository", () => {
     expect(new Set(stored.map((event) => event.at)).size).toBe(3);
   }, 30_000);
 
+  it("round-trips diagnostic controller and tick correlation fields", async () => {
+    await repository.append([{
+      category: "diagnostic",
+      level: "debug",
+      message: "correlated diagnostic",
+      controllerRunId: "controller-run-id",
+      globalTickId: 42,
+      platformTickId: 7,
+    }]);
+
+    const [stored] = (await repository.load({ category: "diagnostic" })).events;
+
+    expect(stored).toMatchObject({
+      controllerRunId: "controller-run-id",
+      globalTickId: 42,
+      platformTickId: 7,
+    });
+  });
+
   it("keeps activity when diagnostics exceed their independent cap", async () => {
     await repository.append([activityEvent("a")]);
     await repository.append(Array.from({ length: 2_001 }, (_, index) => diagnosticEvent(index)));

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -1163,6 +1163,75 @@ describe("TwitchAdapter", () => {
     expect(campaigns[0].rewards[0]).toMatchObject({ watchedMinutes: 20, status: "in_progress", claimId: "claim" });
   });
 
+  it("batches Twitch campaign detail operations in bounded groups", async () => {
+    const campaignIds = Array.from({ length: 41 }, (_, index) => `campaign-${index}`);
+    const detailBatchSizes: number[] = [];
+    let activeDetailBatches = 0;
+    let peakDetailBatches = 0;
+    const emit = vi.fn();
+    const fetcher = jsonFetcher(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        detailBatchSizes.push(body.length);
+        activeDetailBatches += 1;
+        peakDetailBatches = Math.max(peakDetailBatches, activeDetailBatches);
+        await Promise.resolve();
+        activeDetailBatches -= 1;
+        return body.map((entry) => twitchCampaignDetails(String(
+          (entry.variables as { dropID?: string }).dropID,
+        )));
+      }
+      if (body.operationName === "Inventory") return twitchInventory([]);
+      if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(campaignIds);
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+
+    const campaigns = await new TwitchAdapter(
+      fetcher,
+      undefined,
+      undefined,
+      undefined,
+      emit,
+    ).discoverCampaigns();
+
+    expect(campaigns).toHaveLength(41);
+    expect(detailBatchSizes).toEqual([20, 20, 1]);
+    expect(peakDetailBatches).toBeLessThanOrEqual(2);
+    expect(emit).toHaveBeenCalledWith(expect.objectContaining({
+      category: "diagnostic",
+      platform: "twitch",
+      message: expect.stringMatching(/^Twitch campaign details finished in \d+ms \(41 operations: 3 batch requests, 0 single fallbacks\)$/),
+    }));
+  });
+
+  it("starts Twitch inventory and dashboard discovery requests concurrently", async () => {
+    let releaseInventory!: () => void;
+    const inventoryGate = new Promise<void>((resolve) => {
+      releaseInventory = resolve;
+    });
+    let dashboardStarted = false;
+    const fetcher = jsonFetcher(async (_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") {
+        await inventoryGate;
+        return twitchInventory([]);
+      }
+      if (op === "ViewerDropsDashboard") {
+        dashboardStarted = true;
+        return twitchDashboard([]);
+      }
+      throw new Error(`Unexpected operation ${op}`);
+    });
+    const discovery = new TwitchAdapter(fetcher).discoverCampaigns();
+
+    try {
+      await vi.waitFor(() => expect(dashboardStarted).toBe(true));
+    } finally {
+      releaseInventory();
+    }
+    await expect(discovery).resolves.toEqual([]);
+  });
+
   it("keeps Twitch inventory campaigns when the dashboard query returns an empty response", async () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
@@ -2298,6 +2367,170 @@ describe("TwitchAdapter", () => {
       campaignId: "campaign",
       categoryId: "33214",
     });
+  });
+
+  it("trusts drops-enabled directory liveness and confirms only the selected candidate", async () => {
+    const operations: string[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      operations.push(operation(init));
+      return { data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } } };
+    });
+    const adapter = new TwitchAdapter(fetcher);
+    const candidate = {
+      platform: "twitch" as const,
+      username: "directory-winner",
+      url: "https://www.twitch.tv/directory-winner",
+      channelId: "winner-id",
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    };
+
+    const selection = await adapter.selectCandidateChannel?.(
+      [candidate],
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    expect(selection?.channel?.username).toBe("directory-winner");
+    expect(operations).toEqual(["DropsHighlightService_AvailableDrops"]);
+  });
+
+  it("batches ACL StreamInfo checks and confirms AvailableDrops only for the winner", async () => {
+    const candidates = Array.from({ length: 25 }, (_, index) => ({
+      platform: "twitch" as const,
+      username: `acl-${index}`,
+      url: `https://www.twitch.tv/acl-${index}`,
+      isAclMatch: true,
+    }));
+    const streamBatchSizes: number[] = [];
+    let availabilityCalls = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        expect(init?.credentials).toBe("omit");
+        streamBatchSizes.push(body.length);
+        return body.map((entry) => {
+          const username = String((entry.variables as { channel?: string }).channel);
+          return {
+            data: {
+              user: {
+                id: `${username}-id`,
+                displayName: username,
+                stream: { id: `${username}-broadcast`, game: { id: "game", name: "Game" } },
+              },
+            },
+          };
+        });
+      }
+      if (body.operationName === "DropsHighlightService_AvailableDrops") {
+        availabilityCalls += 1;
+        return { data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } } };
+      }
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+    const adapter = new TwitchAdapter(fetcher);
+
+    const selection = await adapter.selectCandidateChannel?.(
+      candidates,
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    expect(selection?.channel?.username).toBe("acl-0");
+    expect(streamBatchSizes).toEqual([20, 5]);
+    expect(availabilityCalls).toBe(1);
+  });
+
+  it("bounds single StreamInfo fallbacks when Twitch rejects channel batches", async () => {
+    const candidates = Array.from({ length: 25 }, (_, index) => ({
+      platform: "twitch" as const,
+      username: `fallback-${index}`,
+      url: `https://www.twitch.tv/fallback-${index}`,
+      isAclMatch: true,
+    }));
+    let activeSingles = 0;
+    let maxActiveSingles = 0;
+    let singleCalls = 0;
+    const diagnostics: string[] = [];
+    const fetcher = jsonFetcher(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) throw new Error("batch unavailable");
+      if (body.operationName === "StreamInfo") {
+        singleCalls += 1;
+        activeSingles += 1;
+        maxActiveSingles = Math.max(maxActiveSingles, activeSingles);
+        await Promise.resolve();
+        activeSingles -= 1;
+        const username = String((body.variables as { channel?: string }).channel);
+        return {
+          data: {
+            user: {
+              id: `${username}-id`,
+              stream: { id: `${username}-broadcast`, game: { id: "other-game" } },
+            },
+          },
+        };
+      }
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+    const adapter = new TwitchAdapter(fetcher, undefined, undefined, {}, (event) => {
+      if (event.category === "diagnostic") diagnostics.push(event.message);
+    });
+
+    await adapter.selectCandidateChannel?.(
+      candidates,
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    expect(singleCalls).toBe(25);
+    expect(maxActiveSingles).toBeLessThanOrEqual(2);
+    expect(diagnostics.some((message) =>
+      message.includes("25 StreamInfo single fallbacks"))).toBe(true);
+  });
+
+  it("checks the next batched candidate after Twitch rejects campaign availability", async () => {
+    const candidates = ["first", "second"].map((username) => ({
+      platform: "twitch" as const,
+      username,
+      url: `https://www.twitch.tv/${username}`,
+      isAclMatch: true,
+    }));
+    const availabilityChannels: string[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        return body.map((entry) => {
+          const username = String((entry.variables as { channel?: string }).channel);
+          return {
+            data: {
+              user: {
+                id: `${username}-id`,
+                stream: { id: `${username}-broadcast`, game: { id: "game" } },
+              },
+            },
+          };
+        });
+      }
+      if (body.operationName === "DropsHighlightService_AvailableDrops") {
+        const channelId = String((body.variables as { channelID?: string }).channelID);
+        availabilityChannels.push(channelId);
+        return {
+          data: {
+            channel: {
+              viewerDropCampaigns: channelId === "second-id" ? [{ id: "campaign" }] : [],
+            },
+          },
+        };
+      }
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+
+    const selection = await new TwitchAdapter(fetcher).selectCandidateChannel?.(
+      candidates,
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    expect(selection?.channel?.username).toBe("second");
+    expect(availabilityChannels).toEqual(["first-id", "second-id"]);
   });
 
   it("falls back to Twitch channel page data when stream info GQL fails", async () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -922,6 +922,79 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
 });
 
 describe("TwitchAdapter", () => {
+  it("refreshes Twitch campaigns with one inventory request", async () => {
+    let inventoryCalls = 0;
+    const adapter = new TwitchAdapter(jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as
+        | Record<string, unknown>
+        | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        return body.map((entry) =>
+          twitchCampaignDetails(String((entry.variables as { dropID?: string }).dropID)));
+      }
+      if (body.operationName === "Inventory") {
+        inventoryCalls += 1;
+        return twitchInventory(["campaign"]);
+      }
+      return twitchDashboard(["campaign"]);
+    }));
+
+    await adapter.refreshCampaigns();
+
+    expect(inventoryCalls).toBe(1);
+  });
+
+  it("merges active Twitch session progress without repeating inventory", async () => {
+    let inventoryCalls = 0;
+    let currentDropCalls = 0;
+    const adapter = new TwitchAdapter(jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as
+        | Record<string, unknown>
+        | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        return body.map((entry) =>
+          twitchCampaignDetails(String((entry.variables as { dropID?: string }).dropID)));
+      }
+      if (body.operationName === "Inventory") {
+        inventoryCalls += 1;
+        return twitchInventory(["campaign"]);
+      }
+      if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+      if (body.operationName === "VideoPlayerStreamInfoOverlayChannel") {
+        return { data: { user: { id: "channel-id" } } };
+      }
+      if (body.operationName === "DropCurrentSessionContext") {
+        currentDropCalls += 1;
+        return {
+          data: {
+            currentUser: {
+              dropCurrentSession: {
+                dropID: "campaign-drop",
+                currentMinutesWatched: 42,
+              },
+            },
+          },
+        };
+      }
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    }));
+
+    const campaigns = await adapter.refreshCampaigns({
+      platform: "twitch",
+      status: "watching",
+      offlineChecks: 0,
+      channel: {
+        platform: "twitch",
+        username: "creator",
+        url: "https://www.twitch.tv/creator",
+      },
+    } as never);
+
+    expect(inventoryCalls).toBe(1);
+    expect(currentDropCalls).toBe(1);
+    expect(campaigns[0]?.rewards[0]?.watchedMinutes).toBe(42);
+  });
+
   it("passes the auth probe signal to the Twitch CurrentUser request", async () => {
     const abort = new AbortController();
     const emit = vi.fn();

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2395,7 +2395,85 @@ describe("TwitchAdapter", () => {
     expect(operations).toEqual(["DropsHighlightService_AvailableDrops"]);
   });
 
-  it("batches ACL StreamInfo checks and confirms AvailableDrops only for the winner", async () => {
+  it("batches campaign availability checks for trusted directory candidates", async () => {
+    const candidates = Array.from({ length: 24 }, (_, index) => ({
+      platform: "twitch" as const,
+      username: `directory-${index}`,
+      url: `https://www.twitch.tv/directory-${index}`,
+      channelId: `channel-${index}`,
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    }));
+    const availabilityBatchSizes: number[] = [];
+    const diagnostics: string[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      expect(Array.isArray(body)).toBe(true);
+      const operations = body as Array<Record<string, unknown>>;
+      expect(operations.every((entry) =>
+        entry.operationName === "DropsHighlightService_AvailableDrops")).toBe(true);
+      availabilityBatchSizes.push(operations.length);
+      return operations.map((entry) => {
+        const channelId = String((entry.variables as { channelID?: string }).channelID);
+        return {
+          data: {
+            channel: {
+              viewerDropCampaigns: channelId === "channel-23" ? [{ id: "campaign" }] : [],
+            },
+          },
+        };
+      });
+    });
+
+    const selection = await new TwitchAdapter(fetcher, undefined, undefined, {}, (event) => {
+      if (event.category === "diagnostic") diagnostics.push(event.message);
+    }).selectCandidateChannel?.(
+      candidates,
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    expect(selection?.channel?.username).toBe("directory-23");
+    expect(availabilityBatchSizes).toEqual([20, 4]);
+    expect(diagnostics.some((message) =>
+      message.includes("2 AvailableDrops batch requests, 0 AvailableDrops single fallbacks"))).toBe(true);
+  });
+
+  it("bounds single AvailableDrops fallbacks when Twitch rejects availability batches", async () => {
+    const candidates = Array.from({ length: 24 }, (_, index) => ({
+      platform: "twitch" as const,
+      username: `directory-${index}`,
+      url: `https://www.twitch.tv/directory-${index}`,
+      channelId: `channel-${index}`,
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    }));
+    let activeSingles = 0;
+    let maxActiveSingles = 0;
+    let singleCalls = 0;
+    const fetcher = jsonFetcher(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) throw new Error("batch unavailable");
+      expect(body.operationName).toBe("DropsHighlightService_AvailableDrops");
+      singleCalls += 1;
+      activeSingles += 1;
+      maxActiveSingles = Math.max(maxActiveSingles, activeSingles);
+      await Promise.resolve();
+      activeSingles -= 1;
+      return { data: { channel: { viewerDropCampaigns: [] } } };
+    });
+
+    await new TwitchAdapter(fetcher).selectCandidateChannel?.(
+      candidates,
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    expect(singleCalls).toBe(24);
+    expect(maxActiveSingles).toBeLessThanOrEqual(2);
+  });
+
+  it("batches ACL StreamInfo and AvailableDrops checks", async () => {
     const candidates = Array.from({ length: 25 }, (_, index) => ({
       platform: "twitch" as const,
       username: `acl-${index}`,
@@ -2403,10 +2481,18 @@ describe("TwitchAdapter", () => {
       isAclMatch: true,
     }));
     const streamBatchSizes: number[] = [];
-    let availabilityCalls = 0;
+    const availabilityBatchSizes: number[] = [];
     const fetcher = jsonFetcher((_url, init) => {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
       if (Array.isArray(body)) {
+        const operationName = String(body[0]?.operationName);
+        if (operationName === "DropsHighlightService_AvailableDrops") {
+          availabilityBatchSizes.push(body.length);
+          return body.map(() => ({
+            data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } },
+          }));
+        }
+        expect(operationName).toBe("StreamInfo");
         expect(init?.credentials).toBe("omit");
         streamBatchSizes.push(body.length);
         return body.map((entry) => {
@@ -2422,10 +2508,6 @@ describe("TwitchAdapter", () => {
           };
         });
       }
-      if (body.operationName === "DropsHighlightService_AvailableDrops") {
-        availabilityCalls += 1;
-        return { data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } } };
-      }
       throw new Error(`Unexpected operation ${String(body.operationName)}`);
     });
     const adapter = new TwitchAdapter(fetcher);
@@ -2437,7 +2519,7 @@ describe("TwitchAdapter", () => {
 
     expect(selection?.channel?.username).toBe("acl-0");
     expect(streamBatchSizes).toEqual([20, 5]);
-    expect(availabilityCalls).toBe(1);
+    expect(availabilityBatchSizes).toEqual([20, 5]);
   });
 
   it("bounds single StreamInfo fallbacks when Twitch rejects channel batches", async () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -79,6 +79,88 @@ function twitchCampaignDetails(dropID: string): unknown {
 }
 
 describe("KickAdapter", () => {
+  it("starts Kick campaign and progress requests concurrently", async () => {
+    let campaignStarted = false;
+    let progressStarted = false;
+    const adapter = new KickAdapter(jsonFetcher(async (url) => {
+      if (url.endsWith("/drops/campaigns")) {
+        campaignStarted = true;
+        await vi.waitFor(() => expect(progressStarted).toBe(true));
+        return {
+          data: [{
+            id: 1,
+            name: "Kick Campaign",
+            status: "active",
+            category: { id: 99, name: "Game" },
+            rewards: [{ id: 10, name: "Reward", required_minutes: 60 }],
+          }],
+        };
+      }
+      if (url.endsWith("/drops/progress")) {
+        progressStarted = true;
+        await vi.waitFor(() => expect(campaignStarted).toBe(true));
+        return {
+          data: [{
+            id: 1,
+            status: "in progress",
+            rewards: [{ id: 10, progress: 0.5, required_units: 60 }],
+          }],
+        };
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    }));
+
+    const campaigns = await adapter.refreshCampaigns();
+
+    expect(campaigns[0]?.rewards[0]?.watchedMinutes).toBe(30);
+  });
+
+  it("keeps Kick campaigns when concurrent progress refresh fails", async () => {
+    const events: EngineEvent[] = [];
+    const adapter = new KickAdapter(jsonFetcher((url) => {
+      if (url.endsWith("/drops/campaigns")) {
+        return {
+          data: [{
+            id: 1,
+            name: "Kick Campaign",
+            status: "active",
+            rewards: [{ id: 10, name: "Reward", required_minutes: 60 }],
+          }],
+        };
+      }
+      throw new Error("progress unavailable");
+    }), undefined, undefined, (event) => events.push(event));
+
+    const campaigns = await adapter.refreshCampaigns();
+
+    expect(campaigns).toHaveLength(1);
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      level: "warn",
+      message: expect.stringContaining("using last-known progress"),
+    }));
+  });
+
+  it("propagates Kick progress authentication failures during refresh", async () => {
+    const failure = new SafeFetchError({ kind: "authentication_rejected", status: 401 });
+    const adapter = new KickAdapter(jsonFetcher((url) => {
+      if (url.endsWith("/drops/campaigns")) return { data: [] };
+      throw failure;
+    }));
+
+    await expect(adapter.refreshCampaigns()).rejects.toBe(failure);
+  });
+
+  it("propagates Kick campaign discovery failures during refresh", async () => {
+    const failure = new Error("campaigns unavailable");
+    const adapter = new KickAdapter(jsonFetcher((url) => {
+      if (url.endsWith("/drops/progress")) return { data: [] };
+      throw failure;
+    }));
+
+    await expect(adapter.refreshCampaigns()).rejects.toBe(failure);
+  });
+
   it("passes the auth probe signal to the Kick identity request", async () => {
     const abort = new AbortController();
     const emit = vi.fn();

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -78,6 +78,21 @@ function twitchCampaignDetails(dropID: string): unknown {
   };
 }
 
+function kickCampaigns(campaignId = "campaign", rewardId = "reward"): unknown {
+  return {
+    data: [{
+      id: campaignId,
+      name: "Kick Campaign",
+      status: "active",
+      rewards: [{
+        id: rewardId,
+        name: "Reward",
+        required_minutes: 1,
+      }],
+    }],
+  };
+}
+
 describe("KickAdapter", () => {
   it("starts Kick campaign and progress requests concurrently", async () => {
     let campaignStarted = false;
@@ -176,11 +191,14 @@ describe("KickAdapter", () => {
     );
   });
 
-  it("does not swallow authentication failures while reading progress", async () => {
+  it("does not swallow authentication failures while refreshing progress", async () => {
     const failure = new SafeFetchError({ kind: "authentication_rejected", status: 401 });
-    const adapter = new KickAdapter(jsonFetcher(() => { throw failure; }));
+    const adapter = new KickAdapter(jsonFetcher((url) => {
+      if (url.endsWith("/drops/campaigns")) return { data: [] };
+      throw failure;
+    }));
 
-    await expect(adapter.readProgress([])).rejects.toBe(failure);
+    await expect(adapter.refreshCampaigns()).rejects.toBe(failure);
   });
 
   it("does not swallow security-policy failures while claiming challenges", async () => {
@@ -282,7 +300,8 @@ describe("KickAdapter", () => {
   });
 
   it("keeps adapter diagnostics scoped to the supplied emitter", async () => {
-    const failingFetcher = jsonFetcher(() => {
+    const failingFetcher = jsonFetcher((url) => {
+      if (url.endsWith("/drops/campaigns")) return { data: [] };
       throw new Error("progress unavailable");
     });
     const first: EngineEvent[] = [];
@@ -290,8 +309,8 @@ describe("KickAdapter", () => {
     const firstAdapter = new KickAdapter(failingFetcher, undefined, undefined, (event) => first.push(event));
     const secondAdapter = new KickAdapter(failingFetcher, undefined, undefined, (event) => second.push(event));
 
-    await firstAdapter.readProgress([]);
-    await secondAdapter.readProgress([]);
+    await firstAdapter.refreshCampaigns();
+    await secondAdapter.refreshCampaigns();
 
     expect(first).toHaveLength(1);
     expect(second).toHaveLength(1);
@@ -339,7 +358,7 @@ describe("KickAdapter", () => {
     });
     const adapter = new KickAdapter(fetcher);
 
-    const campaigns = await adapter.readProgress(await adapter.discoverCampaigns());
+    const campaigns = await adapter.refreshCampaigns();
     const candidates = await adapter.listCandidateChannels(campaigns[0]);
 
     expect(campaigns[0].rewards[0].watchedMinutes).toBe(30);
@@ -544,6 +563,7 @@ describe("KickAdapter", () => {
         claimPosts += 1;
         return { connect_url: "https://accounts.example/link?state=opaque-secret#fragment" };
       }
+      if (url === "https://web.kick.com/api/v1/drops/campaigns") return kickCampaigns();
       if (url === "https://web.kick.com/api/v1/drops/progress") return progress;
       throw new Error(`Unexpected URL ${url}`);
     });
@@ -570,12 +590,12 @@ describe("KickAdapter", () => {
     expect(serializedEvents).not.toContain("opaque-secret");
     expect(serializedEvents).not.toContain("/link");
 
-    const ambiguous = await adapter.readProgress([campaign]);
+    const ambiguous = await adapter.refreshCampaigns();
     await expect(adapter.claimReward(ambiguous[0], ambiguous[0].rewards[0])).resolves.toBe(false);
     expect(claimPosts).toBe(1);
 
-    progress = { data: [{ campaign_id: "campaign", user_app_connected: true }] };
-    const linked = await adapter.readProgress(ambiguous);
+    progress = { data: [{ campaign_id: "campaign", user_app_connected: true, progress_units: 1 }] };
+    const linked = await adapter.refreshCampaigns();
     expect(linked[0].accountLinked).toBe(true);
     expect(linked[0].claimGuidance).toBeUndefined();
     expect(linked[0].rewards[0].claimGuidance).toBeUndefined();
@@ -610,6 +630,7 @@ describe("KickAdapter", () => {
         claimPosts += 1;
         return { connect_url: "https://accounts.example/link" };
       }
+      if (url === "https://web.kick.com/api/v1/drops/campaigns") return kickCampaigns();
       if (url === "https://web.kick.com/api/v1/drops/progress") return progress;
       throw new Error(`Unexpected URL ${url}`);
     }));
@@ -619,8 +640,8 @@ describe("KickAdapter", () => {
     } as DropCampaign;
 
     await adapter.claimReward(campaign, campaign.rewards[0]);
-    progress = [{ campaign_id: "campaign", user_app_connected: true }];
-    const refreshed = await adapter.readProgress([campaign]);
+    progress = [{ campaign_id: "campaign", user_app_connected: true, progress_units: 1 }];
+    const refreshed = await adapter.refreshCampaigns();
     await adapter.claimReward(refreshed[0], refreshed[0].rewards[0]);
 
     expect(claimPosts).toBe(2);
@@ -1265,7 +1286,7 @@ describe("TwitchAdapter", () => {
     });
     const adapter = new TwitchAdapter(fetcher);
 
-    const campaigns = await adapter.discoverCampaigns();
+    const campaigns = await adapter.refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Twitch Campaign", isGeneralDrop: true });
     expect(campaigns[0].rewards[0]).toMatchObject({ status: "claimable", claimId: "claim" });
@@ -1311,7 +1332,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns).toHaveLength(1);
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Inventory Campaign", status: "active" });
@@ -1347,7 +1368,7 @@ describe("TwitchAdapter", () => {
       undefined,
       undefined,
       emit,
-    ).discoverCampaigns();
+    ).refreshCampaigns();
 
     expect(campaigns).toHaveLength(41);
     expect(detailBatchSizes).toEqual([20, 20, 1]);
@@ -1377,7 +1398,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected operation ${op}`);
     });
-    const discovery = new TwitchAdapter(fetcher).discoverCampaigns();
+    const discovery = new TwitchAdapter(fetcher).refreshCampaigns();
 
     try {
       await vi.waitFor(() => expect(dashboardStarted).toBe(true));
@@ -1415,7 +1436,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Inventory Campaign", eligibility: "eligible" });
   });
@@ -1437,10 +1458,10 @@ describe("TwitchAdapter", () => {
     const discoveryState = new TwitchDiscoveryState();
     const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
-    expect((await firstAdapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
+    expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
     failing = "b";
     const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
-    const campaigns = await secondAdapter.discoverCampaigns();
+    const campaigns = await secondAdapter.refreshCampaigns();
 
     expect(campaigns.map((campaign) => campaign.id)).toEqual(["a", "b"]);
     expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("b"))).toBe(true);
@@ -1461,7 +1482,7 @@ describe("TwitchAdapter", () => {
     const events: EngineEvent[] = [];
     const adapter = new TwitchAdapter(fetcher, undefined, undefined, undefined, (event) => events.push(event));
 
-    const campaigns = await adapter.discoverCampaigns();
+    const campaigns = await adapter.refreshCampaigns();
 
     expect(campaigns.map((campaign) => campaign.id)).toEqual(["a"]);
     expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("b"))).toBe(true);
@@ -1478,7 +1499,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).discoverCampaigns()).rejects.toThrow(SafeFetchError);
+    await expect(new TwitchAdapter(fetcher).refreshCampaigns()).rejects.toThrow(SafeFetchError);
   });
 
   it("keeps not-yet-started campaigns when the dashboard request fails after a successful one", async () => {
@@ -1499,16 +1520,16 @@ describe("TwitchAdapter", () => {
     const discoveryState = new TwitchDiscoveryState();
     const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
-    expect((await firstAdapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+    expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
     dashboardFails = true;
     const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
-    const campaigns = await secondAdapter.discoverCampaigns();
+    const campaigns = await secondAdapter.refreshCampaigns();
 
     expect(campaigns.map((campaign) => campaign.id)).toEqual(["a"]);
     expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("dashboard"))).toBe(true);
 
     dashboardFails = false;
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
   });
 
   it("does not retain dashboard campaigns when the dashboard genuinely returns none", async () => {
@@ -1529,16 +1550,16 @@ describe("TwitchAdapter", () => {
     const discoveryState = new TwitchDiscoveryState();
     const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
-    expect((await firstAdapter.discoverCampaigns()).map((campaign) => campaign.id)).toEqual(["campaign"]);
+    expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["campaign"]);
     dashboardIds = [];
     const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
-    const campaigns = await secondAdapter.discoverCampaigns();
+    const campaigns = await secondAdapter.refreshCampaigns();
 
     expect(campaigns).toEqual([]);
 
     dashboardFails = true;
     const thirdAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
-    const failedCampaigns = await thirdAdapter.discoverCampaigns();
+    const failedCampaigns = await thirdAdapter.refreshCampaigns();
 
     expect(failedCampaigns).toEqual([]);
   });
@@ -1562,11 +1583,11 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["retained"]);
     refresh = 2;
 
-    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
 
     expect(campaigns).toEqual([]);
   });
@@ -1595,17 +1616,17 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["retained"]);
     refresh = 2;
     fallbackInventoryFails = true;
 
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .resolves.toEqual([]);
 
     fallbackInventoryFails = false;
     dashboardFails = true;
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .resolves.toEqual([]);
   });
 
@@ -1623,7 +1644,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).discoverCampaigns()).rejects.toThrow(SafeFetchError);
+    await expect(new TwitchAdapter(fetcher).refreshCampaigns()).rejects.toThrow(SafeFetchError);
   });
 
   it("does not reuse discovery retained for another authenticated Twitch user", async () => {
@@ -1644,12 +1665,12 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["user-a-campaign"]);
     userId = "user-b";
     dashboardFails = true;
 
-    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
 
     expect(campaigns).toEqual([]);
   });
@@ -1669,12 +1690,12 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["shared-campaign-id"]);
     userId = "user-b";
     detailsFail = true;
 
-    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
 
     expect(campaigns).toEqual([]);
   });
@@ -1697,7 +1718,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns).toHaveLength(1);
     expect(campaigns[0]).toMatchObject({ id: "ended", status: "expired", eligibility: "expired" });
@@ -1718,14 +1739,14 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["campaign"]);
     detailResponse = "missing";
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .resolves.toEqual([]);
     detailResponse = "failure";
 
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).discoverCampaigns())
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .resolves.toEqual([]);
   });
 
@@ -1799,7 +1820,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns.find((campaign) => campaign.id === "active")).toMatchObject({ status: "active", eligibility: "eligible" });
     expect(campaigns.find((campaign) => campaign.id === "ended")).toMatchObject({ status: "expired", eligibility: "expired" });
@@ -1856,7 +1877,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     const ended = campaigns.find((campaign) => campaign.id === "ended");
     expect(ended).toMatchObject({ status: "active", eligibility: "eligible" });
@@ -1904,7 +1925,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({
       id: "campaign",
@@ -1948,7 +1969,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Fallback Campaign", eligibility: "eligible" });
   });
@@ -1996,7 +2017,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({
       id: "future",
@@ -2066,7 +2087,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Array Campaign", eligibility: "eligible" });
   });
@@ -2106,7 +2127,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(inventoryAttempts).toBe(2);
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Inline Campaign", eligibility: "eligible" });
@@ -2123,7 +2144,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).discoverCampaigns()).rejects.toThrow("permission denied");
+    await expect(new TwitchAdapter(fetcher).refreshCampaigns()).rejects.toThrow("permission denied");
     expect(inventoryAttempts).toBe(1);
   });
 
@@ -2173,7 +2194,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).discoverCampaigns();
+    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
 
     expect(inventoryBodies).toHaveLength(2);
     expect(inventoryBodies[0]).toMatchObject({
@@ -2219,7 +2240,7 @@ describe("TwitchAdapter", () => {
       { compatibility },
       (event) => events.push(event),
     );
-    const campaigns = await adapter.discoverCampaigns();
+    const campaigns = await adapter.refreshCampaigns();
 
     expect(inventorySelectionReads).toBe(1);
     expect(campaigns.map((campaign) => campaign.id)).toEqual(["active-campaign", "owned-campaign"]);
@@ -2235,7 +2256,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${operation(init)}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).discoverCampaigns())
+    await expect(new TwitchAdapter(fetcher).refreshCampaigns())
       .rejects.toMatchObject({
         failure: { kind: "authentication_rejected", status: 401 },
       });
@@ -2250,7 +2271,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).discoverCampaigns())
+    await expect(new TwitchAdapter(fetcher).refreshCampaigns())
       .rejects.toThrow("Twitch did not return a logged-in current user; open twitch.tv and confirm you are signed in");
   });
 
@@ -2274,7 +2295,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${operation(init)}`);
     }));
 
-    await expect(adapter.discoverCampaigns())
+    await expect(adapter.refreshCampaigns())
       .rejects.toThrow("Inventory: returned an unusable response; status=200; body=null");
   });
 
@@ -2868,15 +2889,8 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
     const adapter = new TwitchAdapter(fetcher);
-    const campaigns: DropCampaign[] = [{
-      id: "campaign",
-      platform: "twitch",
-      name: "Campaign",
-      status: "active",
-      rewards: [{ id: "drop", name: "Reward", requiredMinutes: 60, watchedMinutes: 0, status: "locked" }],
-    }];
 
-    const progress = await adapter.readProgress(campaigns, {
+    const progress = await adapter.refreshCampaigns({
       platform: "twitch",
       status: "watching",
       offlineChecks: 0,
@@ -2995,6 +3009,7 @@ describe("TwitchAdapter", () => {
           },
         };
       }
+      if (op === "ViewerDropsDashboard") return twitchDashboard([]);
       if (op === "VideoPlayerStreamInfoOverlayChannel") {
         return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
       }
@@ -3004,15 +3019,8 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
     const adapter = new TwitchAdapter(fetcher);
-    const campaigns: DropCampaign[] = [{
-      id: "campaign",
-      platform: "twitch",
-      name: "Campaign",
-      status: "active",
-      rewards: [{ id: "drop", name: "Reward", requiredMinutes: 60, watchedMinutes: 0, status: "locked" }],
-    }];
 
-    const progress = await adapter.readProgress(campaigns, {
+    const progress = await adapter.refreshCampaigns({
       platform: "twitch",
       status: "watching",
       offlineChecks: 0,
@@ -3173,7 +3181,7 @@ describe("TwitchAdapter integrity recovery", () => {
         const ensureIntegrity = integrityCallback();
         const { fetcher, attempts } = rejectFirst(target, discoveryPayload);
 
-        const campaigns = await new TwitchAdapter(fetcher, ensureIntegrity).discoverCampaigns();
+        const campaigns = await new TwitchAdapter(fetcher, ensureIntegrity).refreshCampaigns();
 
         expect(campaigns.map((campaign) => campaign.id)).toEqual(["campaign"]);
         expect(ensureIntegrity).toHaveBeenCalledOnce();
@@ -3196,7 +3204,7 @@ describe("TwitchAdapter integrity recovery", () => {
         undefined,
         {},
         (event) => events.push(event),
-      ).discoverCampaigns();
+      ).refreshCampaigns();
 
       expect(campaigns.map((campaign) => campaign.id)).toEqual(["campaign"]);
       expect(events).not.toContainEqual(expect.objectContaining({
@@ -3220,7 +3228,7 @@ describe("TwitchAdapter integrity recovery", () => {
       });
 
       await new TwitchAdapter(fetcher, ensureIntegrity, undefined, {}, (event) => events.push(event))
-        .discoverCampaigns();
+        .refreshCampaigns();
 
       // Discovery makes two dashboard requests when both lists come back empty
       // (the second asks for reward campaigns). Each gets one refresh attempt
@@ -3250,7 +3258,7 @@ describe("TwitchAdapter integrity recovery", () => {
         throw new Error(`Unexpected op ${op}`);
       });
 
-      await new TwitchAdapter(fetcher, ensureIntegrity).discoverCampaigns();
+      await new TwitchAdapter(fetcher, ensureIntegrity).refreshCampaigns();
 
       // Two dashboard requests, each bounded to exactly one refresh and one
       // retry — the second rejection is never refreshed or replayed again.
@@ -3271,7 +3279,7 @@ describe("TwitchAdapter integrity recovery", () => {
         throw new Error(`Unexpected op ${op}`);
       });
 
-      await new TwitchAdapter(fetcher, ensureIntegrity).discoverCampaigns();
+      await new TwitchAdapter(fetcher, ensureIntegrity).refreshCampaigns();
 
       // Both dashboard requests fail generically: no refresh, and no replay of
       // either request.
@@ -3335,18 +3343,14 @@ describe("TwitchAdapter integrity recovery", () => {
         const { fetcher, attempts } = rejectFirst(target, (init) => {
           const op = operation(init);
           if (op === "Inventory") return twitchInventory(["campaign"]);
+          if (op === "ViewerDropsDashboard") return twitchDashboard([]);
           if (op === "VideoPlayerStreamInfoOverlayChannel") return { data: { user: { id: "channel-id" } } };
           if (op === "DropCurrentSessionContext") {
             return { data: { currentUser: { dropCurrentSession: { dropID: "campaign-drop", currentMinutesWatched: 42 } } } };
           }
           throw new Error(`Unexpected op ${op}`);
         });
-        const campaigns = [{
-          id: "campaign",
-          rewards: [{ id: "campaign-drop", name: "Reward", requiredMinutes: 60, watchedMinutes: 20, status: "in_progress" }],
-        }] as DropCampaign[];
-
-        const progressed = await new TwitchAdapter(fetcher, ensureIntegrity).readProgress(campaigns, {
+        const progressed = await new TwitchAdapter(fetcher, ensureIntegrity).refreshCampaigns({
           platform: "twitch",
           status: "watching",
           offlineChecks: 0,

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -176,6 +176,28 @@ describe("KickAdapter", () => {
     await expect(adapter.refreshCampaigns()).rejects.toBe(failure);
   });
 
+  it("propagates Kick refresh cancellation without reporting a progress fallback", async () => {
+    const abort = new AbortController();
+    const events: EngineEvent[] = [];
+    const adapter = new KickAdapter(jsonFetcher((url, init) => {
+      if (url.endsWith("/drops/campaigns")) return { data: [] };
+      return new Promise((_, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    }), undefined, undefined, (event) => events.push(event));
+
+    const refresh = adapter.refreshCampaigns(undefined, { signal: abort.signal });
+    const reason = new Error("cancelled");
+    abort.abort(reason);
+
+    await expect(refresh).rejects.toBe(reason);
+    expect(events).not.toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      level: "warn",
+      message: expect.stringContaining("using last-known progress"),
+    }));
+  });
+
   it("passes the auth probe signal to the Kick identity request", async () => {
     const abort = new AbortController();
     const emit = vi.fn();

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2604,7 +2604,7 @@ describe("TwitchAdapter", () => {
       isAclMatch: false,
     }));
     const availabilityBatchSizes: number[] = [];
-    const diagnostics: string[] = [];
+    const events: EngineEvent[] = [];
     const fetcher = jsonFetcher((_url, init) => {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
       expect(Array.isArray(body)).toBe(true);
@@ -2617,7 +2617,7 @@ describe("TwitchAdapter", () => {
         return {
           data: {
             channel: {
-              viewerDropCampaigns: channelId === "channel-23" ? [{ id: "campaign" }] : [],
+              viewerDropCampaigns: channelId === "channel-23" ? [{ id: "campaign-1" }] : [],
             },
           },
         };
@@ -2625,16 +2625,48 @@ describe("TwitchAdapter", () => {
     });
 
     const selection = await new TwitchAdapter(fetcher, undefined, undefined, {}, (event) => {
-      if (event.category === "diagnostic") diagnostics.push(event.message);
+      events.push(event);
     }).selectCandidateChannel?.(
       candidates,
-      { id: "campaign", categoryId: "game" } as DropCampaign,
+      { id: "campaign-1", name: "Campaign One", categoryId: "game" } as DropCampaign,
     );
 
     expect(selection?.channel?.username).toBe("directory-23");
     expect(availabilityBatchSizes).toEqual([20, 4]);
-    expect(diagnostics.some((message) =>
-      message.includes("2 AvailableDrops batch requests, 0 AvailableDrops single fallbacks"))).toBe(true);
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      message: expect.stringMatching(
+        /^Twitch channel selection for "Campaign One" \(campaign campaign-1\) finished in \d+ms/,
+      ),
+    }));
+    expect(events.some((event) =>
+      event.category === "diagnostic" &&
+      event.message.includes("2 AvailableDrops batch requests, 0 AvailableDrops single fallbacks"))).toBe(true);
+  });
+
+  it("labels idle channel selection diagnostics when no candidate wins", async () => {
+    const events: EngineEvent[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Array<Record<string, unknown>>;
+      expect(body).toHaveLength(1);
+      expect(body[0]?.operationName).toBe("StreamInfo");
+      return [{ data: { user: { stream: null } } }];
+    });
+
+    const selection = await new TwitchAdapter(fetcher, undefined, undefined, {}, (event) => {
+      events.push(event);
+    }).selectCandidateChannel?.([{
+      platform: "twitch",
+      username: "offline",
+      url: "https://www.twitch.tv/offline",
+      isAclMatch: true,
+    }]);
+
+    expect(selection).toEqual({ checked: 1 });
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      message: expect.stringMatching(/^Twitch idle channel selection finished in \d+ms/),
+    }));
   });
 
   it("bounds single AvailableDrops fallbacks when Twitch rejects availability batches", async () => {

--- a/packages/extension/tests/automationStatus.test.ts
+++ b/packages/extension/tests/automationStatus.test.ts
@@ -19,12 +19,17 @@ function health(
   };
 }
 
-function session(message?: string): WatchSession {
+function session(
+  status: WatchSession["status"] = "idle",
+  message?: string,
+  reasonCode?: WatchSession["reasonCode"],
+): WatchSession {
   return {
     platform: "twitch",
-    status: "idle",
+    status,
     offlineChecks: 0,
     message,
+    reasonCode,
   };
 }
 
@@ -155,13 +160,13 @@ describe("automation authentication presentation", () => {
     expect(result).not.toHaveProperty("message");
   });
 
-  it("keeps an enabled platform in one canonical starting presentation after the request settles", () => {
+  it("uses the typed starting session status after the request settles", () => {
     expect(automationPresentation({
       platform: "twitch",
       enabled: true,
       pending: false,
       authHealth: health("healthy"),
-      session: session("Starting automation"),
+      session: session("starting", "Any display-only detail"),
     })).toMatchObject({
       state: "starting",
       badgeKey: "automationStarting",
@@ -170,21 +175,40 @@ describe("automation authentication presentation", () => {
     });
   });
 
-  it.each(["Automation disabled", "Platform disabled", "Starting automation"])(
-    "does not expose stale %s detail under a running badge",
-    (message) => {
+  it.each([
+    ["automation_disabled", "Automation disabled"],
+    ["platform_disabled", "Platform disabled"],
+  ] as const)(
+    "keeps a stale %s session paused when automation is re-enabled",
+    (reasonCode, message) => {
       const result = automationPresentation({
         platform: "twitch",
         enabled: true,
         pending: false,
         authHealth: health("healthy"),
-        session: session(message),
+        session: session("idle", message, reasonCode),
       });
 
-      expect(result.state).toBe(message === "Starting automation" ? "starting" : "running");
+      expect(result.state).toBe("paused");
       expect(result.statusMessage).toBeUndefined();
     },
   );
+
+  it("does not derive lifecycle from a starting display message", () => {
+    const result = automationPresentation({
+      platform: "twitch",
+      enabled: true,
+      pending: false,
+      authHealth: health("healthy"),
+      session: session("idle", "Starting automation", "no_eligible_channel"),
+    });
+
+    expect(result).toMatchObject({
+      state: "running",
+      badgeKey: "automationRunning",
+      statusMessage: "Starting automation",
+    });
+  });
 
   it("preserves compatible settled scheduler detail for a running platform", () => {
     expect(automationPresentation({
@@ -192,7 +216,7 @@ describe("automation authentication presentation", () => {
       enabled: true,
       pending: false,
       authHealth: health("healthy"),
-      session: session("Waiting for an eligible stream"),
+      session: session("idle", "Waiting for an eligible stream", "no_eligible_channel"),
     })).toMatchObject({
       state: "running",
       statusMessage: "Waiting for an eligible stream",

--- a/packages/extension/tests/automationStatus.test.ts
+++ b/packages/extension/tests/automationStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { PlatformAuthHealth } from "@lurkloot/shared/models";
+import type { PlatformAuthHealth, WatchSession } from "@lurkloot/shared/models";
 import {
   AUTH_SIGN_IN_URLS,
   automationPresentation,
@@ -16,6 +16,15 @@ function health(
       key: status === "blocked" ? "authSecurityPolicyBlocked" : "authPlatformUnavailable",
       values: { reference: "must-not-render" },
     },
+  };
+}
+
+function session(message?: string): WatchSession {
+  return {
+    platform: "twitch",
+    status: "idle",
+    offlineChecks: 0,
+    message,
   };
 }
 
@@ -144,5 +153,49 @@ describe("automation authentication presentation", () => {
     });
     expect(JSON.stringify(result)).not.toContain("must-not-render");
     expect(result).not.toHaveProperty("message");
+  });
+
+  it("keeps an enabled platform in one canonical starting presentation after the request settles", () => {
+    expect(automationPresentation({
+      platform: "twitch",
+      enabled: true,
+      pending: false,
+      authHealth: health("healthy"),
+      session: session("Starting automation"),
+    })).toMatchObject({
+      state: "starting",
+      badgeKey: "automationStarting",
+      detailKey: "startingAutomation",
+      operational: false,
+    });
+  });
+
+  it.each(["Automation disabled", "Platform disabled", "Starting automation"])(
+    "does not expose stale %s detail under a running badge",
+    (message) => {
+      const result = automationPresentation({
+        platform: "twitch",
+        enabled: true,
+        pending: false,
+        authHealth: health("healthy"),
+        session: session(message),
+      });
+
+      expect(result.state).toBe(message === "Starting automation" ? "starting" : "running");
+      expect(result.statusMessage).toBeUndefined();
+    },
+  );
+
+  it("preserves compatible settled scheduler detail for a running platform", () => {
+    expect(automationPresentation({
+      platform: "twitch",
+      enabled: true,
+      pending: false,
+      authHealth: health("healthy"),
+      session: session("Waiting for an eligible stream"),
+    })).toMatchObject({
+      state: "running",
+      statusMessage: "Waiting for an eligible stream",
+    });
   });
 });

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -867,7 +867,7 @@ describe("background controller", () => {
       await vi.waitFor(() => expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce());
       expect(acquisitionSettled).toBe(false);
       expect(snapshot.settings.platform.twitch.enabled).toBe(true);
-      expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
+      expect(snapshot.state.sessions.twitch.status).toBe("starting");
 
       acquisition.resolve(false);
       await env.rawController.settleBackgroundWork();
@@ -987,7 +987,7 @@ describe("background controller", () => {
       let persistedState = structuredClone(env.state);
       env.deps.loadState.mockImplementation(async () => persistedState);
       env.deps.saveState.mockImplementation(async (next: SchedulerState) => {
-        if (next.sessions.twitch.message === "Starting automation") {
+        if (next.sessions.twitch.status === "starting") {
           await startingSave.promise;
         } else if (next.sessions.twitch.reasonCode === "automation_disabled") {
           await disabledSave.promise;
@@ -1003,7 +1003,7 @@ describe("background controller", () => {
       await vi.waitFor(() => expect(env.deps.saveState).toHaveBeenCalledWith(
         expect.objectContaining({
           sessions: expect.objectContaining({
-            twitch: expect.objectContaining({ message: "Starting automation" }),
+            twitch: expect.objectContaining({ status: "starting" }),
           }),
         }),
       ));
@@ -1029,7 +1029,7 @@ describe("background controller", () => {
       await Promise.all([enabling, disabling]);
       await env.rawController.settleBackgroundWork();
 
-      expect(stateBeforeDisableTickLands.sessions.twitch.message).not.toBe("Starting automation");
+      expect(stateBeforeDisableTickLands.sessions.twitch.status).not.toBe("starting");
     });
 
     it.each(["reset", "shutdown"] as const)(
@@ -1070,7 +1070,7 @@ describe("background controller", () => {
 
         expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
         expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-        expect(env.state.sessions.twitch.message).not.toBe("Starting automation");
+        expect(env.state.sessions.twitch.status).not.toBe("starting");
         expect(env.deps.createAlarm.mock.calls.some(
           ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
         )).toBe(false);
@@ -1095,7 +1095,7 @@ describe("background controller", () => {
 
       expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
       expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-      expect(env.state.sessions.twitch.message).not.toBe("Starting automation");
+      expect(env.state.sessions.twitch.status).not.toBe("starting");
     });
 
     it("preserves a newer enable schedule when an older disable clear finishes last", async () => {
@@ -3557,7 +3557,7 @@ describe("background controller", () => {
     expect(isFarmingActive(snapshot.settings)).toBe(true);
     // And the session already reflects the toggle rather than the pre-toggle
     // "Automation disabled" the popup used to render for the whole tick.
-    expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
+    expect(snapshot.state.sessions.twitch.status).toBe("starting");
 
     startDiscovery();
     await env.rawController.settleBackgroundWork();
@@ -3667,8 +3667,7 @@ describe("background controller", () => {
     expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
     // The snapshot returns ahead of the tick, reporting the prompt "starting"
     // transition; the watching status lands once the tick settles.
-    expect(snapshot.state.sessions.twitch.status).toBe("idle");
-    expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
+    expect(snapshot.state.sessions.twitch.status).toBe("starting");
     expect(env.state.sessions.twitch.status).toBe("watching");
   });
 
@@ -3876,7 +3875,7 @@ describe("background controller", () => {
     expect(env.twitch.discoverCampaigns).toHaveBeenCalledTimes(1);
     expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
     // Returned ahead of the tick, so the enabled platform reads as starting.
-    expect(snapshot.state.sessions.twitch.message).toBe("Starting automation");
+    expect(snapshot.state.sessions.twitch.status).toBe("starting");
     expect(env.state.sessions.twitch.status).toBe("watching");
     // Untouched: the toggle ticks only the platform it changed.
     expect(env.state.sessions.kick.status).toBe("idle");

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -2688,6 +2688,7 @@ describe("background controller", () => {
         platform: "twitch",
         mirroredActivity: true,
         message: "twitch authentication health changed from healthy to checking",
+        controllerRunId: expect.any(String),
         data: { from: "healthy", to: "checking" },
         emittedAt: expect.any(String),
       },
@@ -2731,6 +2732,7 @@ describe("background controller", () => {
         platform: "kick",
         mirroredActivity: true,
         message: "kick authentication health changed from checking to blocked: reason=security_policy_blocked",
+        controllerRunId: expect.any(String),
         data: { from: "checking", to: "blocked", reason: "security_policy_blocked" },
         emittedAt: expect.any(String),
       },
@@ -2966,11 +2968,14 @@ describe("background controller", () => {
     const calls: string[] = [];
     const env = harness(farming(DEFAULT_SETTINGS), {
       saveState: async () => { calls.push("state"); },
-      // Tick lifecycle diagnostics are published as they happen and describe no
-      // state, so they are outside the state-before-events batching invariant
-      // this test guards. Only operational batches are recorded.
+      // Controller-run and tick lifecycle diagnostics are published as they
+      // happen and describe no state, so they are outside the
+      // state-before-events batching invariant this test guards. Only
+      // operational batches are recorded.
       reportEvents: async (events) => {
-        if (events.every((event) => event.category === "diagnostic" && /^Tick #/.test(event.message))) return;
+        if (events.every((event) =>
+          event.category === "diagnostic"
+          && /^(?:Background controller run |Tick #)/.test(event.message))) return;
         calls.push("events");
       },
     });
@@ -2998,11 +3003,13 @@ describe("background controller", () => {
 
     expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce();
     expect(env.deps.saveState).toHaveBeenCalledTimes(2);
-    // Tick lifecycle diagnostics publish independently of state, so the
-    // invariant under test is about the operational batches only.
+    // Controller-run and tick lifecycle diagnostics publish independently of
+    // state, so the invariant under test is about operational batches only.
     const operationalBatches = env.reportEvents.mock.calls
       .map(([events]) => events)
-      .filter((events) => !events.every((event) => event.category === "diagnostic" && /^Tick #/.test(event.message)));
+      .filter((events) => !events.every((event) =>
+        event.category === "diagnostic"
+        && /^(?:Background controller run |Tick #)/.test(event.message)));
     expect(operationalBatches).toHaveLength(1);
     expect(operationalBatches[0]).toContainEqual(expect.objectContaining({
       category: "activity",
@@ -3744,7 +3751,7 @@ describe("background controller", () => {
     ]);
   });
 
-  it("leaves diagnostics emitted outside scheduler ticks uncorrelated", async () => {
+  it("announces one controller run and correlates all of its diagnostics", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
 
     await env.controller.handleMessage({
@@ -3752,16 +3759,46 @@ describe("background controller", () => {
       platform: "twitch",
       enabled: true,
     });
+    await env.controller.settleBackgroundWork();
 
-    const requested = env.reportEvents.mock.calls
+    const diagnostics = env.reportEvents.mock.calls
+      .flatMap(([events]) => events)
+      .filter((event): event is DiagnosticEvent => event.category === "diagnostic");
+    const boundaries = diagnostics.filter((event) =>
+      event.message.startsWith("Background controller run "));
+    const runId = boundaries[0]?.controllerRunId;
+
+    expect(boundaries).toHaveLength(1);
+    expect(runId).toEqual(expect.any(String));
+    expect(diagnostics.every((event) => event.controllerRunId === runId)).toBe(true);
+    const requested = diagnostics.find((event) =>
+      event.message === "User requested Twitch automation enable");
+    expect(requested).toBeDefined();
+    expect(requested).not.toHaveProperty("globalTickId");
+  });
+
+  it("gives independent controller runs different IDs despite identical first tick labels", async () => {
+    const first = harness(farming(DEFAULT_SETTINGS));
+    const second = harness(farming(DEFAULT_SETTINGS));
+
+    await first.controller.tick(["twitch"], "manual_tick");
+    await second.controller.tick(["twitch"], "manual_tick");
+
+    const tickStart = (env: ReturnType<typeof harness>) => env.reportEvents.mock.calls
       .flatMap(([events]) => events)
       .find((event): event is DiagnosticEvent =>
         event.category === "diagnostic"
-        && event.message === "User requested Twitch automation enable");
+        && event.message === "Tick #1 started (trigger=manual_tick, platforms=twitch)");
+    const firstTick = tickStart(first);
+    const secondTick = tickStart(second);
 
-    expect(requested).toBeDefined();
-    expect(requested).not.toHaveProperty("globalTickId");
-    expect(requested).not.toHaveProperty("platformTickId");
+    expect(firstTick).toBeDefined();
+    expect(secondTick).toBeDefined();
+    expect(firstTick?.message).toBe("Tick #1 started (trigger=manual_tick, platforms=twitch)");
+    expect(secondTick?.message).toBe("Tick #1 started (trigger=manual_tick, platforms=twitch)");
+    expect(firstTick?.controllerRunId).toEqual(expect.any(String));
+    expect(secondTick?.controllerRunId).toEqual(expect.any(String));
+    expect(firstTick?.controllerRunId).not.toBe(secondTick?.controllerRunId);
   });
 
   it("reports a tick lifecycle even when the tick throws", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -5314,6 +5314,35 @@ describe("background controller", () => {
     expect(claimed).toEqual({ twitch: ["reward"] });
   });
 
+  it("starts post-claim handoffs independently for both platforms", async () => {
+    const waitingSignals: AbortSignal[] = [];
+    const env = harness(
+      farming({
+        ...DEFAULT_SETTINGS,
+        autoClaim: true,
+        postClaimHandoff: true,
+      }),
+      {
+        wait: async (_ms, signal) => new Promise<void>((resolve) => {
+          waitingSignals.push(signal);
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+      },
+    );
+    env.twitch.supportsPostClaimHandoff = true;
+    env.kick.supportsPostClaimHandoff = true;
+    env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
+    env.kick.discoverCampaigns = vi.fn(async () => [campaign("kick", "claimable")]);
+
+    const running = env.controller.tickAndHandOff();
+    try {
+      await vi.waitFor(() => expect(waitingSignals).toHaveLength(2));
+    } finally {
+      env.controller.shutdown();
+      await running;
+    }
+  });
+
   describe("post-claim handoff", () => {
     // Date only: the handoff's deadline is wall-clock based, but its delays are
     // injected, so setTimeout must stay real for drainMicrotasks.

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -5261,6 +5261,22 @@ describe("background controller", () => {
     }
   });
 
+  it("lets a Kick auth refresh start while Twitch scheduler work is pending", async () => {
+    const env = harness();
+    const twitchDiscovery = deferred<DropCampaign[]>();
+    env.twitch.discoverCampaigns = vi.fn(() => twitchDiscovery.promise);
+
+    const ticking = env.controller.tick(["twitch"], "manual_tick");
+    await vi.waitFor(() => expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce());
+    const checkingKick = env.controller.checkAuthHealth("kick");
+    try {
+      await vi.waitFor(() => expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce());
+    } finally {
+      twitchDiscovery.resolve([]);
+      await Promise.all([ticking, checkingKick]);
+    }
+  });
+
   it("serializes handleTabRemoved against a concurrent tick so neither write is lost", async () => {
     const env = harness();
     env.state.manualWatch = {
@@ -5341,6 +5357,35 @@ describe("background controller", () => {
       env.controller.shutdown();
       await running;
     }
+  });
+
+  it("reports a platform-scoped diagnostic when a post-claim handoff fails", async () => {
+    const env = harness(farming({
+      ...DEFAULT_SETTINGS,
+      autoClaim: true,
+      postClaimHandoff: true,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
+      },
+    }));
+    env.twitch.supportsPostClaimHandoff = true;
+    env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
+    env.deps.createAdapters.mockImplementation(() => {
+      throw new Error("handoff adapter failed");
+    });
+
+    await env.controller.tickAndHandOff(["twitch"]);
+
+    expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(
+      expect.objectContaining({
+        category: "diagnostic",
+        platform: "twitch",
+        level: "warn",
+        message: "Post-claim handoff failed: handoff adapter failed",
+      }),
+    );
   });
 
   describe("post-claim handoff", () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -3626,12 +3626,21 @@ describe("background controller", () => {
 
     await env.controller.tick(["twitch"], "manual_tick");
 
-    const messages = env.reportEvents.mock.calls
+    const diagnostics = env.reportEvents.mock.calls
       .flatMap(([events]) => events)
-      .filter((event) => event.category === "diagnostic")
-      .map((event) => event.message);
-    expect(messages).toContainEqual(expect.stringMatching(/^Tick #\d+ started \(trigger=manual_tick, platforms=twitch\)$/));
-    expect(messages).toContainEqual(expect.stringMatching(/^Tick #\d+ finished after \d+ms \(trigger=manual_tick, platforms=twitch\)$/));
+      .filter((event): event is DiagnosticEvent => event.category === "diagnostic");
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringMatching(/^Tick #\d+ started \(trigger=manual_tick, platforms=twitch\)$/),
+    }));
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringMatching(/^Tick #\d+ refreshed auth health in \d+ms$/),
+    }));
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringMatching(/^Tick #\d+ finished after \d+ms \(trigger=manual_tick, platforms=twitch\)$/),
+    }));
   });
 
   it("reports a tick lifecycle even when the tick throws", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -186,6 +186,7 @@ function harness(
       name: string,
       options: { periodInMinutes: number } | { when: number },
     ) => Promise<void>;
+    getAlarm?: (name: string) => Promise<{ scheduledTime: number } | undefined>;
     clearAlarm?: (name: string) => Promise<boolean>;
     ensureTwitchIntegrity?: (
       emit: EventEmitter,
@@ -219,6 +220,7 @@ function harness(
       _name: string,
       _options: { periodInMinutes: number } | { when: number },
     ) => undefined)),
+    getAlarm: vi.fn(overrides.getAlarm ?? (async () => undefined)),
     clearAlarm: vi.fn(overrides.clearAlarm ?? (async () => true)),
     ensureTwitchIntegrity: vi.fn(overrides.ensureTwitchIntegrity ?? (async () => true)),
     cancelTwitchIntegrityAcquisition: vi.fn(overrides.cancelTwitchIntegrityAcquisition ?? (() => undefined)),
@@ -521,6 +523,96 @@ describe("background controller", () => {
         ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
       )?.[1] as { when: number }).when;
       expect(secondWhen).toBe(firstWhen);
+    });
+
+    it("does not recreate or relog an unchanged Twitch integrity alarm", async () => {
+      const integrity = integrityBundle({
+        integrity: "unchanged-alarm-token",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const first = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+      await first.controller.settleBackgroundWork();
+      const scheduledTime = (first.deps.createAlarm.mock.calls.find(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )?.[1] as { when: number }).when;
+
+      const second = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+        getAlarm: async () => ({ scheduledTime }),
+      });
+      await second.controller.settleBackgroundWork();
+
+      expect(second.deps.createAlarm).not.toHaveBeenCalledWith(
+        TWITCH_INTEGRITY_ALARM_NAME,
+        expect.anything(),
+      );
+      expect(second.reportEvents.mock.calls.flatMap(([events]) => events)).not.toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("Scheduled proactive Twitch integrity refresh"),
+        }),
+      );
+    });
+
+    it("recreates and reports a Twitch integrity alarm when its existing target is stale", async () => {
+      const integrity = integrityBundle({
+        integrity: "stale-alarm-token",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const first = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+      await first.controller.settleBackgroundWork();
+      const scheduledTime = (first.deps.createAlarm.mock.calls.find(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )?.[1] as { when: number }).when;
+      const second = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+        getAlarm: async () => ({ scheduledTime: scheduledTime + 1_001 }),
+      });
+      await second.controller.settleBackgroundWork();
+
+      expect(second.deps.createAlarm).toHaveBeenCalledWith(
+        TWITCH_INTEGRITY_ALARM_NAME,
+        { when: scheduledTime },
+      );
+      expect(second.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(
+        expect.objectContaining({
+          message: `Scheduled proactive Twitch integrity refresh for ${new Date(scheduledTime).toISOString()}`,
+        }),
+      );
+    });
+
+    it("recreates and reports a Twitch integrity alarm when lookup fails", async () => {
+      const integrity = integrityBundle({
+        integrity: "unreadable-alarm-token",
+        expiresAt: Date.now() + 30 * 60_000,
+      });
+      const first = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+      });
+      await first.controller.settleBackgroundWork();
+      const scheduledTime = (first.deps.createAlarm.mock.calls.find(
+        ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
+      )?.[1] as { when: number }).when;
+      const second = harness(undefined, {
+        loadTwitchIntegrity: async () => integrity,
+        getAlarm: async () => {
+          throw new Error("browser alarm lookup failed");
+        },
+      });
+      await second.controller.settleBackgroundWork();
+
+      expect(second.deps.createAlarm).toHaveBeenCalledWith(
+        TWITCH_INTEGRITY_ALARM_NAME,
+        { when: scheduledTime },
+      );
+      expect(second.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(
+        expect.objectContaining({
+          message: `Scheduled proactive Twitch integrity refresh for ${new Date(scheduledTime).toISOString()}`,
+        }),
+      );
     });
 
     it("rechecks stored integrity scheduling when the refresh handler runs", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -916,6 +916,59 @@ describe("background controller", () => {
       );
     });
 
+    it("correlates nested Twitch integrity accounting diagnostics with their scheduler tick", async () => {
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async (_emit, request) => {
+          await request?.onManagedPageContextOpen?.();
+          return false;
+        },
+      });
+      const now = Date.now();
+      env.state.criticalHealth = {
+        twitch: {
+          status: "ok",
+          failingMs: 0,
+          failingTicks: 0,
+          managedTabOpens: Array.from(
+            { length: TAB_CHURN_LIMIT - 1 },
+            (_, index) => new Date(now - index * 1_000).toISOString(),
+          ),
+          breakerOpen: false,
+          records: [],
+        },
+      };
+
+      await env.controller.tick(["twitch"], "manual_tick");
+
+      expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+        platform: "twitch",
+        code: "critical_failure_detected",
+        mirroredActivity: true,
+        globalTickId: 1,
+        platformTickId: 1,
+      }));
+    });
+
+    it("correlates failed Twitch integrity accounting diagnostics with their scheduler tick", async () => {
+      const env = harness(undefined, {
+        saveState: vi.fn().mockRejectedValueOnce(new Error("storage unavailable")),
+        ensureTwitchIntegrity: async (_emit, request) => {
+          await request?.onManagedPageContextOpen?.();
+          return false;
+        },
+      });
+
+      await env.controller.tick(["twitch"], "manual_tick");
+
+      expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+        platform: "twitch",
+        level: "warn",
+        message: "Could not account for a managed Twitch integrity page context",
+        globalTickId: 1,
+        platformTickId: 1,
+      }));
+    });
+
     it("continues Kick when disabling Twitch cancels the acquisition awaited by an all-platform tick", async () => {
       const acquisition = deferred<boolean>();
       const env = harness(undefined, {
@@ -4790,6 +4843,35 @@ describe("background controller", () => {
     expect(env.deps.applyAdFocus).toHaveBeenCalledWith("kick", 20, false, expect.any(Function));
   });
 
+  it("applies ad focus only for each concurrent tick's own platform", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+    const twitchDiscovery = deferred<DropCampaign[]>();
+    vi.mocked(env.twitch.refreshCampaigns).mockReturnValue(twitchDiscovery.promise);
+    env.deps.applyAdFocus.mockClear();
+
+    const ticking = env.controller.tick(undefined, "manual_tick");
+
+    try {
+      await vi.waitFor(() => {
+        expect(env.deps.applyAdFocus).toHaveBeenCalledWith(
+          "kick",
+          20,
+          false,
+          expect.any(Function),
+        );
+      });
+      expect(env.deps.applyAdFocus.mock.calls.map(([platform]) => platform)).toEqual(["kick"]);
+    } finally {
+      twitchDiscovery.resolve([campaign("twitch")]);
+      await ticking;
+    }
+
+    expect(env.deps.applyAdFocus.mock.calls.map(([platform]) => platform)).toEqual([
+      "kick",
+      "twitch",
+    ]);
+  });
+
   it("keeps successful scheduler state when re-applying ad focus fails", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     env.deps.applyAdFocus.mockRejectedValue(new Error("focus refresh failed"));
@@ -5326,9 +5408,12 @@ describe("background controller", () => {
     ]));
   });
 
-  function fakeTablessWatcher(tick: () => Promise<{ ok: boolean; live?: boolean; message?: string }>) {
+  function fakeTablessWatcher(
+    tick: () => Promise<{ ok: boolean; live?: boolean; message?: string }>,
+    platform: Platform = "twitch",
+  ) {
     const watcher = {
-      platform: "twitch" as const,
+      platform,
       channelUrl: undefined as string | undefined,
       start: vi.fn(async (ch: { url: string }) => {
         watcher.channelUrl = ch.url;
@@ -5435,6 +5520,34 @@ describe("background controller", () => {
     expect(watcher.tick).toHaveBeenCalled();
     expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
     expect(env.state.sessions.twitch.heartbeatChecks).toBe(0);
+  });
+
+  it("lets Kick heartbeat and persist while Twitch heartbeat is still pending", async () => {
+    const twitchHeartbeat = deferred<{ ok: boolean; live?: boolean; message?: string }>();
+    const twitchWatcher = fakeTablessWatcher(() => twitchHeartbeat.promise, "twitch");
+    const kickWatcher = fakeTablessWatcher(async () => ({ ok: true, live: true }), "kick");
+    const env = harness(farming({ ...DEFAULT_SETTINGS, tablessMode: true }));
+    env.twitch.supportsTabless = true;
+    env.kick.supportsTabless = true;
+    env.twitch.createTablessWatcher = () => twitchWatcher as unknown as TablessWatchController;
+    env.kick.createTablessWatcher = () => kickWatcher as unknown as TablessWatchController;
+    await env.controller.tick(["twitch"]);
+    await env.controller.tick(["kick"]);
+
+    const heartbeat = env.controller.runWatchHeartbeat();
+
+    try {
+      await vi.waitFor(() => expect(twitchWatcher.tick).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(kickWatcher.tick).toHaveBeenCalledOnce());
+      expect(env.state.sessions.kick.lastHeartbeatOk).toBe(true);
+      expect(env.state.sessions.twitch.lastHeartbeatAt).toBeUndefined();
+    } finally {
+      twitchHeartbeat.resolve({ ok: true, live: true });
+      await heartbeat;
+    }
+
+    expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
+    expect(env.state.sessions.kick.lastHeartbeatOk).toBe(true);
   });
 
   it("persists page-context lifecycle metadata changed during a heartbeat", async () => {
@@ -5656,6 +5769,79 @@ describe("background controller", () => {
       twitchDiscovery.resolve([]);
       await Promise.all([ticking, checkingKick]);
     }
+  });
+
+  it("lets Kick scheduler work complete while Twitch playback focus is pending", async () => {
+    const focus = deferred<void>();
+    const env = harness();
+    env.state.sessions.twitch = {
+      platform: "twitch",
+      status: "watching",
+      offlineChecks: 0,
+      tabId: 10,
+      tabManagedByExtension: true,
+      channel: channel("twitch"),
+    };
+    env.deps.applyAdFocus.mockImplementation(async (platform) => {
+      if (platform === "twitch") await focus.promise;
+    });
+    const telemetry = env.rawController.handleMessage({
+      type: "playbackTelemetry",
+      platform: "twitch",
+      telemetry: {
+        videoCount: 1,
+        mutedVideoCount: 0,
+        unmutedVideoCount: 1,
+        playingVideoCount: 1,
+        blockedPlaybackCount: 0,
+        documentHidden: false,
+      },
+    }, { tab: { id: 10 } });
+    await vi.waitFor(() => expect(env.deps.applyAdFocus).toHaveBeenCalledWith(
+      "twitch",
+      10,
+      false,
+      expect.any(Function),
+    ));
+
+    const kickTick = env.rawController.tick(["kick"], "manual_tick");
+    try {
+      await vi.waitFor(() => expect(env.state.sessions.kick.lastCheckedAt).toBeDefined());
+      expect(env.state.sessions.twitch.playback?.videoCount).toBe(1);
+    } finally {
+      focus.resolve();
+      await Promise.all([telemetry, kickTick]);
+    }
+
+    expect(env.state.sessions.twitch.playback?.videoCount).toBe(1);
+    expect(env.state.sessions.kick.lastCheckedAt).toBeDefined();
+  });
+
+  it("lets Kick scheduler work complete while a Twitch manual claim is pending", async () => {
+    const claim = deferred<boolean>();
+    const env = harness(farming({ ...DEFAULT_SETTINGS, autoClaim: false }));
+    env.state.campaigns.twitch = [campaign("twitch", "claimable")];
+    vi.mocked(env.twitch.claimReward).mockReturnValue(claim.promise);
+
+    const claiming = env.rawController.handleMessage({
+      type: "claimReward",
+      platform: "twitch",
+      campaignId: "twitch-campaign",
+      rewardId: "reward",
+    });
+    await vi.waitFor(() => expect(env.twitch.claimReward).toHaveBeenCalledOnce());
+
+    const kickTick = env.rawController.tick(["kick"], "manual_tick");
+    try {
+      await vi.waitFor(() => expect(env.state.sessions.kick.lastCheckedAt).toBeDefined());
+      expect(env.state.campaigns.twitch[0].rewards[0].status).toBe("claimable");
+    } finally {
+      claim.resolve(true);
+      await Promise.all([claiming, kickTick]);
+    }
+
+    expect(env.state.sessions.kick.lastCheckedAt).toBeDefined();
+    expect(env.state.campaigns.twitch[0].rewards[0].status).toBe("claimed");
   });
 
   it("serializes handleTabRemoved against a concurrent tick so neither write is lost", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -285,6 +285,12 @@ function harness(
   };
 }
 
+function allDiagnostics(env: ReturnType<typeof harness>): DiagnosticEvent[] {
+  return env.reportEvents.mock.calls
+    .flatMap(([events]) => events)
+    .filter((event): event is DiagnosticEvent => event.category === "diagnostic");
+}
+
 describe("background controller", () => {
   describe("Twitch integrity expiry scheduling", () => {
     beforeEach(() => {
@@ -3802,6 +3808,57 @@ describe("background controller", () => {
       platformTickId: 1,
       message: expect.stringMatching(/^Tick #\d+ finished after \d+ms \(trigger=manual_tick, platforms=twitch\)$/),
     }));
+  });
+
+  it("reports material waits for same-platform scheduler work", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-29T12:00:00.000Z"));
+    const env = harness(farming(DEFAULT_SETTINGS));
+    const twitchDiscovery = deferred<DropCampaign[]>();
+    const firstDiscoveryStarted = deferred<void>();
+    let discoveryCalls = 0;
+    env.twitch.refreshCampaigns = vi.fn(async () => {
+      discoveryCalls += 1;
+      if (discoveryCalls === 1) {
+        firstDiscoveryStarted.resolve();
+        await twitchDiscovery.promise;
+      }
+      return [];
+    });
+    const firstTick = env.rawController.tick(["twitch"], "manual_tick");
+    let secondTick: ReturnType<typeof env.rawController.tick> | undefined;
+
+    try {
+      await firstDiscoveryStarted.promise;
+      secondTick = env.rawController.tick(["twitch"], "manual_tick");
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      await vi.advanceTimersByTimeAsync(75);
+      twitchDiscovery.resolve([]);
+      await Promise.all([firstTick, secondTick]);
+
+      expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        platform: "twitch",
+        globalTickId: 2,
+        platformTickId: 2,
+        message: "Tick #2 waited 75ms for Twitch platform work",
+        data: { waitMs: 75 },
+      }));
+    } finally {
+      twitchDiscovery.resolve([]);
+      await Promise.allSettled(secondTick ? [firstTick, secondTick] : [firstTick]);
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not report platform-lock waits for an uncontended tick", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+
+    await env.controller.tick(["twitch"], "manual_tick");
+
+    expect(allDiagnostics(env).some((event) =>
+      event.message.includes("waited") && event.message.includes("platform work"),
+    )).toBe(false);
   });
 
   it("assigns global and platform-local identifiers to interleaved platform ticks", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -3769,12 +3769,15 @@ describe("background controller", () => {
     const runId = boundaries[0]?.controllerRunId;
 
     expect(boundaries).toHaveLength(1);
+    expect(diagnostics.findIndex((event) =>
+      event.message.startsWith("Background controller run "))).toBe(0);
     expect(runId).toEqual(expect.any(String));
     expect(diagnostics.every((event) => event.controllerRunId === runId)).toBe(true);
     const requested = diagnostics.find((event) =>
       event.message === "User requested Twitch automation enable");
     expect(requested).toBeDefined();
     expect(requested).not.toHaveProperty("globalTickId");
+    expect(requested).not.toHaveProperty("platformTickId");
   });
 
   it("gives independent controller runs different IDs despite identical first tick labels", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -117,8 +117,7 @@ function adapter(platform: Platform): PlatformAdapter {
   return {
     platform,
     checkAuthHealth: vi.fn(async () => ({ status: "healthy" as const })),
-    discoverCampaigns: vi.fn(async () => [campaign(platform)]),
-    readProgress: vi.fn(async (campaigns) => campaigns),
+    refreshCampaigns: vi.fn(async () => [campaign(platform)]),
     listCandidateChannels: vi.fn(async () => [channel(platform)]),
     checkChannel: vi.fn(async (candidate) => ({ live: true, categoryMatches: true, candidate })),
     claimReward: vi.fn(async () => true),
@@ -683,7 +682,7 @@ describe("background controller", () => {
         order.push("auth");
         return { status: "healthy", checkedAt: "2026-07-28T12:00:00.000Z" };
       });
-      vi.mocked(env.twitch.discoverCampaigns).mockImplementation(async () => {
+      vi.mocked(env.twitch.refreshCampaigns).mockImplementation(async () => {
         order.push("scheduler");
         return [campaign("twitch")];
       });
@@ -702,7 +701,7 @@ describe("background controller", () => {
 
       expect(env.deps.ensureTwitchIntegrity).toHaveBeenCalledOnce();
       expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
-      expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+      expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce();
       expect(env.state.sessions.twitch.status).toBe("watching");
     });
 
@@ -714,7 +713,7 @@ describe("background controller", () => {
       await env.controller.tick(["twitch"], "manual_tick");
 
       expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
-      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
       expect(env.deps.createAdapter).not.toHaveBeenCalled();
       expect(env.deps.createAdapters).not.toHaveBeenCalled();
     });
@@ -764,9 +763,9 @@ describe("background controller", () => {
       await env.controller.tick(undefined, "manual_tick");
 
       expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
-      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
       expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce();
-      expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+      expect(env.kick.refreshCampaigns).toHaveBeenCalledOnce();
       expect(env.state.sessions.kick.status).toBe("watching");
     });
 
@@ -811,9 +810,9 @@ describe("background controller", () => {
 
       await expect(ticking).resolves.toEqual({});
       expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
-      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
       expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce();
-      expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+      expect(env.kick.refreshCampaigns).toHaveBeenCalledOnce();
       expect(env.state.sessions.kick.status).toBe("watching");
       await env.rawController.settleBackgroundWork();
     });
@@ -893,7 +892,7 @@ describe("background controller", () => {
       await env.controller.settleBackgroundWork();
       env.deps.createAlarm.mockClear();
       env.deps.ensureTwitchIntegrity.mockClear();
-      vi.mocked(env.twitch.discoverCampaigns).mockClear();
+      vi.mocked(env.twitch.refreshCampaigns).mockClear();
       env.deps.cancelTwitchIntegrityAcquisition.mockClear();
       exposeStoredIntegrity = true;
 
@@ -925,7 +924,7 @@ describe("background controller", () => {
       expect(env.deps.createAlarm.mock.calls.some(
         ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
       )).toBe(false);
-      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     });
 
     it("clears an enable alarm creation that finishes after disable supersedes it", async () => {
@@ -1043,7 +1042,7 @@ describe("background controller", () => {
         });
         await env.controller.settleBackgroundWork();
         env.deps.ensureTwitchIntegrity.mockClear();
-        vi.mocked(env.twitch.discoverCampaigns).mockClear();
+        vi.mocked(env.twitch.refreshCampaigns).mockClear();
         env.deps.createAlarm.mockClear();
 
         const enabling = env.rawController.handleMessage({
@@ -1069,7 +1068,7 @@ describe("background controller", () => {
         await env.rawController.settleBackgroundWork();
 
         expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
-        expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+        expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
         expect(env.state.sessions.twitch.status).not.toBe("starting");
         expect(env.deps.createAlarm.mock.calls.some(
           ([name]) => name === TWITCH_INTEGRITY_ALARM_NAME,
@@ -1083,7 +1082,7 @@ describe("background controller", () => {
       });
       await env.controller.settleBackgroundWork();
       env.deps.ensureTwitchIntegrity.mockClear();
-      vi.mocked(env.twitch.discoverCampaigns).mockClear();
+      vi.mocked(env.twitch.refreshCampaigns).mockClear();
 
       env.controller.shutdown();
       await env.rawController.handleMessage({
@@ -1094,7 +1093,7 @@ describe("background controller", () => {
       await env.rawController.settleBackgroundWork();
 
       expect(env.deps.ensureTwitchIntegrity).not.toHaveBeenCalled();
-      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
       expect(env.state.sessions.twitch.status).not.toBe("starting");
     });
 
@@ -1787,7 +1786,7 @@ describe("background controller", () => {
       const kickDiscovery = deferred<DropCampaign[]>();
       let kickSignal: AbortSignal | undefined;
       const env = harness(undefined);
-      vi.mocked(env.kick.discoverCampaigns).mockImplementation(async ({ signal } = {}) => {
+      vi.mocked(env.kick.refreshCampaigns).mockImplementation(async (_session, { signal } = {}) => {
         kickSignal = signal;
         return kickDiscovery.promise;
       });
@@ -1893,8 +1892,8 @@ describe("background controller", () => {
     await vi.waitFor(() => expect(env.state.authHealth.kick.status).toBe("healthy"));
 
     expect(env.state.authHealth.twitch.status).toBe("checking");
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-    expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
+    expect(env.kick.refreshCampaigns).toHaveBeenCalledOnce();
 
     twitchHealth.resolve({
       status: "healthy",
@@ -1902,8 +1901,8 @@ describe("background controller", () => {
     });
     await ticking;
 
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
-    expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce();
+    expect(env.kick.refreshCampaigns).toHaveBeenCalledOnce();
   });
 
   it("waits for started auth probes before reporting a sibling setup failure", async () => {
@@ -2361,8 +2360,8 @@ describe("background controller", () => {
         message: "Farming interrupted: reason=platform_error (kick adapter setup failed)",
       }),
     ]);
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
-    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce();
+    expect(env.kick.refreshCampaigns).not.toHaveBeenCalled();
   });
 
   it("terminalizes startup adapter setup failure instead of leaving checking", async () => {
@@ -2447,7 +2446,7 @@ describe("background controller", () => {
     await env.controller.tickAndHandOff(["twitch"]);
 
     expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(env.settings.platform.twitch.enabled).toBe(true);
     expect(env.state.authHealth.twitch).toMatchObject({
       status: "missing_credentials",
@@ -2484,11 +2483,11 @@ describe("background controller", () => {
       });
 
     await env.controller.tickAndHandOff(["twitch"]);
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
 
     await env.controller.tickAndHandOff(["twitch"]);
 
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce();
     expect(env.settings.platform.twitch.enabled).toBe(true);
     expect(env.state.authHealth.twitch.status).toBe("healthy");
     expect(env.reportEvents.mock.calls.flatMap(([events]) => events).filter((event) =>
@@ -2857,7 +2856,7 @@ describe("background controller", () => {
 
   it("preserves compatibility diagnostics when a scheduler tick fails", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
-    env.twitch.discoverCampaigns = vi.fn(async () => { throw new Error("discovery failed"); });
+    env.twitch.refreshCampaigns = vi.fn(async () => { throw new Error("discovery failed"); });
 
     await env.controller.tick();
 
@@ -2972,7 +2971,7 @@ describe("background controller", () => {
 
     await expect(env.controller.tick(["twitch"])).rejects.toThrow("storage unavailable");
 
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce();
     expect(env.deps.saveState).toHaveBeenCalledTimes(2);
     // Tick lifecycle diagnostics publish independently of state, so the
     // invariant under test is about the operational batches only.
@@ -3078,7 +3077,7 @@ describe("background controller", () => {
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
-    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimable")]);
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([campaign("twitch", "claimable")]);
     env.twitch.isClaimReady = vi.fn(() => false);
     env.deps.saveState.mockRejectedValueOnce(new Error("state write failed"));
 
@@ -3111,8 +3110,28 @@ describe("background controller", () => {
           claimPosts += 1;
           return { data: { connect_url: "https://accounts.example/link" } };
         }
+        if (url === "https://web.kick.com/api/v1/drops/campaigns") {
+          return {
+            data: [{
+              id: "kick-campaign",
+              name: "Kick campaign",
+              status: "active",
+              rewards: [{
+                id: "kick-reward",
+                name: "Reward",
+                required_minutes: 1,
+              }],
+            }],
+          };
+        }
         if (url === "https://web.kick.com/api/v1/drops/progress") {
-          return { data: [{ campaign_id: "kick-campaign", ...(affirmativelyLinked ? { user_app_connected: true } : {}) }] };
+          return {
+            data: [{
+              campaign_id: "kick-campaign",
+              progress_units: 1,
+              ...(affirmativelyLinked ? { user_app_connected: true } : {}),
+            }],
+          };
         }
         throw new Error(`Unexpected URL ${url}`);
       }) as PageFetcher["fetchJson"],
@@ -3120,7 +3139,6 @@ describe("background controller", () => {
     const claimState = new KickClaimState();
     env.deps.createAdapter.mockImplementation((platform, emit, settings) => {
       const kick = new KickAdapter(fetcher, undefined, undefined, emit, { claimState });
-      kick.discoverCampaigns = vi.fn(async () => [campaign("kick", "claimable")]);
       kick.listCandidateChannels = vi.fn(async () => []);
       return {
         adapter: platform === "kick" ? kick : env.twitch,
@@ -3288,7 +3306,7 @@ describe("background controller", () => {
     expect(env.state.authHealth.twitch.status).toBe("healthy");
     expect(env.twitch.checkAuthHealth).toHaveBeenCalledOnce();
     expect(env.kick.checkAuthHealth).not.toHaveBeenCalled();
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
   });
 
   // Auth health is only probed for enabled platforms, and auto-start off now
@@ -3301,8 +3319,8 @@ describe("background controller", () => {
 
     expect(isFarmingActive(env.settings)).toBe(false);
     expect(env.twitch.checkAuthHealth).not.toHaveBeenCalled();
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
+    expect(env.kick.refreshCampaigns).not.toHaveBeenCalled();
   });
 
   it("refreshes enabled auth health on startup while auto-start keeps farming", async () => {
@@ -3409,7 +3427,7 @@ describe("background controller", () => {
     expect(env.deps.closeManagedTabs).toHaveBeenCalledWith([
       expect.objectContaining({ tabId: 44, channelUrl: "https://www.twitch.tv/twitch-creator", ownedByExtension: true }),
     ]);
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(env.twitch.prepareWatchTab).not.toHaveBeenCalled();
     expect(env.state.managedWatchTabs).toEqual({});
     expect(env.state.sessions.twitch).toMatchObject({
@@ -3505,7 +3523,7 @@ describe("background controller", () => {
       expect.objectContaining({ reason: "runtime_restart" }),
     );
     expect(env.state.managedPageContextTabs?.kick).toEqual(context);
-    expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
+    expect(env.kick.refreshCampaigns).toHaveBeenCalledOnce();
   });
 
   it("does not log startup cleanup when there is no stale farming state", async () => {
@@ -3527,7 +3545,7 @@ describe("background controller", () => {
     await env.controller.handleStartup();
 
     expect(isFarmingActive(env.settings)).toBe(false);
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
   });
 
   it("answers an automation toggle without waiting for the scheduler tick", async () => {
@@ -3535,7 +3553,7 @@ describe("background controller", () => {
     let startDiscovery = (): void => {};
     const discoveryStarted = new Promise<void>((resolve) => {
       const blocked = new Promise<void>((release) => { startDiscovery = () => release(); });
-      vi.mocked(env.twitch.discoverCampaigns).mockImplementation(async () => {
+      vi.mocked(env.twitch.refreshCampaigns).mockImplementation(async () => {
         resolve();
         await blocked;
         return [];
@@ -3553,7 +3571,7 @@ describe("background controller", () => {
     // The reply landed while discovery is still blocked: a slow tick can no
     // longer hold the popup open (the 65s stall reported in the wild).
     await discoveryStarted;
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalled();
     expect(isFarmingActive(snapshot.settings)).toBe(true);
     // And the session already reflects the toggle rather than the pre-toggle
     // "Automation disabled" the popup used to render for the whole tick.
@@ -3593,10 +3611,10 @@ describe("background controller", () => {
   it("logs when a Twitch enable tick queues behind existing Twitch work", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     const twitchDiscovery = deferred<DropCampaign[]>();
-    env.twitch.discoverCampaigns = vi.fn(() => twitchDiscovery.promise);
+    env.twitch.refreshCampaigns = vi.fn(() => twitchDiscovery.promise);
 
     const alarmTick = env.rawController.tick(["twitch"], "alarm");
-    await vi.waitFor(() => expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce());
     const enabling = env.rawController.handleMessage({
       type: "setAutomation",
       platform: "twitch",
@@ -3735,8 +3753,8 @@ describe("background controller", () => {
   it("preempts an in-flight scheduler tick before resetting host storage", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     let tickSignal: AbortSignal | undefined;
-    vi.mocked(env.twitch.discoverCampaigns).mockImplementation(
-      async ({ signal } = {}) => new Promise((_resolve, reject) => {
+    vi.mocked(env.twitch.refreshCampaigns).mockImplementation(
+      async (_session, { signal } = {}) => new Promise((_resolve, reject) => {
         tickSignal = signal;
         signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
       }),
@@ -3766,8 +3784,8 @@ describe("background controller", () => {
   it("aborts in-flight scheduler work when the controller shuts down", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     let tickSignal: AbortSignal | undefined;
-    vi.mocked(env.twitch.discoverCampaigns).mockImplementation(
-      async ({ signal } = {}) => new Promise((_resolve, reject) => {
+    vi.mocked(env.twitch.refreshCampaigns).mockImplementation(
+      async (_session, { signal } = {}) => new Promise((_resolve, reject) => {
         tickSignal = signal;
         signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
       }),
@@ -3822,16 +3840,16 @@ describe("background controller", () => {
       await env.deps.saveState(DEFAULT_STATE);
     });
     await vi.waitFor(() => expect(resetStarted).toHaveBeenCalledOnce());
-    vi.mocked(env.twitch.discoverCampaigns).mockClear();
+    vi.mocked(env.twitch.refreshCampaigns).mockClear();
 
     const ticking = env.controller.tick();
     await Promise.resolve();
 
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     releaseReset();
     await Promise.all([resetting, ticking]);
     expect(env.settings).toEqual(DEFAULT_SETTINGS);
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
   });
 
   it("toggles one platform and immediately applies the scheduler when running", async () => {
@@ -3872,8 +3890,8 @@ describe("background controller", () => {
     expect(isFarmingActive(env.settings)).toBe(true);
     expect(env.settings.platform.twitch.enabled).toBe(true);
     expect(env.settings.platform.kick.enabled).toBe(false);
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalledTimes(1);
-    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(1);
+    expect(env.kick.refreshCampaigns).not.toHaveBeenCalled();
     // Returned ahead of the tick, so the enabled platform reads as starting.
     expect(snapshot.state.sessions.twitch.status).toBe("starting");
     expect(env.state.sessions.twitch.status).toBe("watching");
@@ -3900,7 +3918,7 @@ describe("background controller", () => {
     );
     expect(env.deps.createAlarm).toHaveBeenCalledWith(TWITCH_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
     expect(env.deps.createAlarm).toHaveBeenCalledWith(KICK_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
   });
 
   it("recreates the scheduler alarm when saving a custom tick interval", async () => {
@@ -3915,7 +3933,7 @@ describe("background controller", () => {
     expect(env.deps.clearAlarm).toHaveBeenCalledWith(ALARM_NAME);
     expect(env.deps.createAlarm).toHaveBeenCalledWith(TWITCH_ALARM_NAME, { periodInMinutes: 17 });
     expect(env.deps.createAlarm).toHaveBeenCalledWith(KICK_ALARM_NAME, { periodInMinutes: 17 });
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
   });
 
   it("merges overlapping settings patches without clobbering previous saves", async () => {
@@ -3970,7 +3988,7 @@ describe("background controller", () => {
     const firstGate = new Promise<void>((resolve) => {
       releaseFirst = resolve;
     });
-    vi.mocked(env.twitch.discoverCampaigns).mockImplementation(async () => {
+    vi.mocked(env.twitch.refreshCampaigns).mockImplementation(async () => {
       discoveryCalls += 1;
       activeDiscoveries += 1;
       maxActiveDiscoveries = Math.max(maxActiveDiscoveries, activeDiscoveries);
@@ -4001,7 +4019,7 @@ describe("background controller", () => {
 
     expect(env.settings.notifyRewardEarned).toBe(false);
     expect(env.settings.notifyNoDropsLeft).toBe(false);
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalledTimes(2);
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(2);
     expect(maxActiveDiscoveries).toBe(1);
   });
 
@@ -4021,7 +4039,7 @@ describe("background controller", () => {
       tickAfterSave: true,
     }));
 
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalled();
     expect(snapshot.settings.platform.twitch.idleWatchlistChannels).toEqual(["fallback"]);
   });
 
@@ -4042,9 +4060,9 @@ describe("background controller", () => {
       tickAfterSavePlatforms: ["kick"],
     }));
 
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(env.twitch.prepareWatchTab).not.toHaveBeenCalled();
-    expect(env.kick.discoverCampaigns).toHaveBeenCalled();
+    expect(env.kick.refreshCampaigns).toHaveBeenCalled();
     expect(snapshot.settings.platform.kick.idleWatchlistChannels).toEqual(["fallback"]);
   });
 
@@ -4064,7 +4082,7 @@ describe("background controller", () => {
       tickAfterSave: true,
     }));
 
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(isFarmingActive(snapshot.settings)).toBe(false);
     expect(snapshot.settings.platform.twitch.idleWatchlistChannels).toEqual(["fallback"]);
   });
@@ -4086,7 +4104,7 @@ describe("background controller", () => {
     }));
 
     expect(env.twitch.stopWatchTab).not.toHaveBeenCalled();
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(snapshot.state.sessions.twitch.status).toBe("watching");
   });
 
@@ -4095,8 +4113,8 @@ describe("background controller", () => {
 
     const snapshot = asSnapshot(await env.controller.handleMessage({ type: "tickNow" }));
 
-    expect(env.twitch.discoverCampaigns).toHaveBeenCalledTimes(1);
-    expect(env.kick.discoverCampaigns).toHaveBeenCalledTimes(1);
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(1);
+    expect(env.kick.refreshCampaigns).toHaveBeenCalledTimes(1);
     expect(snapshot.state.sessions.twitch.status).toBe("watching");
     expect(snapshot.state.sessions.kick.status).toBe("watching");
     expect(env.reportEvents).toHaveBeenCalledWith(expect.arrayContaining([
@@ -4562,7 +4580,7 @@ describe("background controller", () => {
     await env.controller.handleTabRemoved(10);
 
     // The removal itself never runs the scheduler (#193).
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(env.twitch.prepareWatchTab).not.toHaveBeenCalled();
     expect(env.state.manualClosePause?.twitch).toMatchObject({ platform: "twitch" });
     expect(env.state.sessions.twitch).toMatchObject({
@@ -4703,7 +4721,7 @@ describe("background controller", () => {
 
     await env.controller.handleTabRemoved(999);
 
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(env.twitch.prepareWatchTab).not.toHaveBeenCalled();
   });
 
@@ -4727,7 +4745,7 @@ describe("background controller", () => {
 
     await env.controller.handleTabRemoved(10);
 
-    expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(env.twitch.prepareWatchTab).not.toHaveBeenCalled();
   });
 
@@ -4769,7 +4787,7 @@ describe("background controller", () => {
       ...campaign("twitch", "claimed"),
       rewards: [reward("claimed"), subscriptionReward],
     };
-    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([twitchCampaign]);
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([twitchCampaign]);
 
     await env.controller.tick();
     const snapshot = asSnapshot(await env.controller.handleMessage({
@@ -4814,7 +4832,7 @@ describe("background controller", () => {
       ...campaign("twitch"),
       rewards: [subscriptionReward, { ...reward("locked"), id: "watch-reward", requirement: "watch" as const }],
     };
-    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([twitchCampaign]);
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([twitchCampaign]);
 
     await env.controller.tick();
     const snapshot = asSnapshot(await env.controller.handleMessage({
@@ -4858,7 +4876,7 @@ describe("background controller", () => {
         },
       ],
     };
-    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([twitchCampaign]);
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([twitchCampaign]);
 
     await env.controller.tick();
     const snapshot = asSnapshot(await env.controller.handleMessage({
@@ -4919,7 +4937,7 @@ describe("background controller", () => {
   it("emits reward notifications best-effort when rewards become earned", async () => {
     const env = harness(farming({ ...DEFAULT_SETTINGS, notifyRewardEarned: true }));
     env.state.campaigns.twitch = [campaign("twitch", "in_progress")];
-    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimable")]);
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([campaign("twitch", "claimable")]);
 
     await env.controller.tick();
 
@@ -4955,7 +4973,7 @@ describe("background controller", () => {
   it("does not emit disabled reward notifications", async () => {
     const env = harness(farming({ ...DEFAULT_SETTINGS, notifyRewardEarned: false }));
     env.state.campaigns.twitch = [campaign("twitch", "in_progress")];
-    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimable")]);
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([campaign("twitch", "claimable")]);
 
     await env.controller.tick();
 
@@ -4971,7 +4989,7 @@ describe("background controller", () => {
     });
     // A fully claimed campaign is present but has nothing earnable, so the
     // scheduler goes idle into the "no drops left" condition.
-    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimed")]);
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([campaign("twitch", "claimed")]);
 
     await env.controller.tick();
 
@@ -4986,7 +5004,7 @@ describe("background controller", () => {
       platform: { ...DEFAULT_SETTINGS.platform,
         twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true }, kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false } },
     });
-    vi.mocked(env.twitch.discoverCampaigns).mockResolvedValue([campaign("twitch", "claimed")]);
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([campaign("twitch", "claimed")]);
 
     await env.controller.tick();
     await env.controller.tick();
@@ -5313,14 +5331,14 @@ describe("background controller", () => {
   it("lets Kick complete while Twitch discovery is still pending", async () => {
     const env = harness();
     const twitchDiscovery = deferred<DropCampaign[]>();
-    env.twitch.discoverCampaigns = vi.fn(() => twitchDiscovery.promise);
+    env.twitch.refreshCampaigns = vi.fn(() => twitchDiscovery.promise);
 
     const ticking = env.controller.tick(undefined, "manual_tick");
 
     try {
-      await vi.waitFor(() => expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(env.kick.refreshCampaigns).toHaveBeenCalledOnce());
       await vi.waitFor(() => expect(env.state.sessions.kick.lastCheckedAt).toBeDefined());
-      expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+      expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce();
     } finally {
       twitchDiscovery.resolve([]);
       await ticking;
@@ -5330,10 +5348,10 @@ describe("background controller", () => {
   it("lets a Kick auth refresh start while Twitch scheduler work is pending", async () => {
     const env = harness();
     const twitchDiscovery = deferred<DropCampaign[]>();
-    env.twitch.discoverCampaigns = vi.fn(() => twitchDiscovery.promise);
+    env.twitch.refreshCampaigns = vi.fn(() => twitchDiscovery.promise);
 
     const ticking = env.controller.tick(["twitch"], "manual_tick");
-    await vi.waitFor(() => expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce());
     const checkingKick = env.controller.checkAuthHealth("kick");
     let kickRefreshCompleted = false;
     void checkingKick.then(() => {
@@ -5394,7 +5412,7 @@ describe("background controller", () => {
 
   it("reports the reward ids claimed during a tick, per platform", async () => {
     const env = harness(farming({ ...DEFAULT_SETTINGS, autoClaim: true }));
-    env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
+    env.twitch.refreshCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
 
     const claimed = await env.controller.tick();
 
@@ -5418,8 +5436,8 @@ describe("background controller", () => {
     );
     env.twitch.supportsPostClaimHandoff = true;
     env.kick.supportsPostClaimHandoff = true;
-    env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
-    env.kick.discoverCampaigns = vi.fn(async () => [campaign("kick", "claimable")]);
+    env.twitch.refreshCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
+    env.kick.refreshCampaigns = vi.fn(async () => [campaign("kick", "claimable")]);
 
     const running = env.controller.tickAndHandOff();
     try {
@@ -5442,7 +5460,7 @@ describe("background controller", () => {
       },
     }));
     env.twitch.supportsPostClaimHandoff = true;
-    env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
+    env.twitch.refreshCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
     env.deps.createAdapters.mockImplementation(() => {
       throw new Error("handoff adapter failed");
     });
@@ -5511,7 +5529,7 @@ describe("background controller", () => {
     it("starts earning the next reward before the next heartbeat alarm", async () => {
       const env = handoffEnv();
       let reveal = false;
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
 
       const handoff = env.controller.runClaimHandoff("twitch");
       reveal = true;
@@ -5523,7 +5541,7 @@ describe("background controller", () => {
 
     it("stops at the deadline when no next reward appears", async () => {
       const env = handoffEnv({ postClaimHandoffIntervalSeconds: 5, postClaimHandoffMaxSeconds: 15 });
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(false)]);
 
       const handoff = env.controller.runClaimHandoff("twitch");
       for (let index = 0; index < 10; index += 1) await env.timer.flush();
@@ -5536,7 +5554,7 @@ describe("background controller", () => {
 
     it("exits early when the platform has no eligible reward left", async () => {
       const env = handoffEnv();
-      env.twitch.discoverCampaigns = vi.fn(async () => []);
+      env.twitch.refreshCampaigns = vi.fn(async () => []);
 
       const handoff = env.controller.runClaimHandoff("twitch");
       await env.timer.flush();
@@ -5547,7 +5565,7 @@ describe("background controller", () => {
 
     it("aborts in flight when farming stops", async () => {
       const env = handoffEnv();
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(false)]);
 
       const handoff = env.controller.runClaimHandoff("twitch");
       // Let the loop actually park before aborting, so this exercises an
@@ -5558,7 +5576,7 @@ describe("background controller", () => {
       await handoff;
 
       expect(env.timer.parked).toBe(0);
-      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     });
 
     it("does not run for a platform without the capability", async () => {
@@ -5601,7 +5619,7 @@ describe("background controller", () => {
       env.twitch.supportsTabless = true;
       env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
       let reveal = false;
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
 
       const handoff = env.controller.runClaimHandoff("twitch");
       reveal = true;
@@ -5619,7 +5637,7 @@ describe("background controller", () => {
       env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
       // Both rewards visible from the start, so the triggering tick already
       // selects the successor and the handoff takes its fast path.
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(true)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(true)]);
 
       // Establish the tabless session and land a heartbeat seconds ago.
       await env.controller.tick();
@@ -5633,7 +5651,7 @@ describe("background controller", () => {
 
     it("starts a handoff after an automatic claim", async () => {
       const env = handoffEnv();
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(false)]);
 
       const handoff = env.controller.tickAndHandOff();
       for (let index = 0; index < 12; index += 1) await env.timer.flush();
@@ -5646,7 +5664,7 @@ describe("background controller", () => {
       const env = handoffEnv({ postClaimHandoffIntervalSeconds: 5, postClaimHandoffMaxSeconds: 15 });
       // Every refresh yields another claimable reward, which would restart the
       // deadline forever if a nested handoff were allowed.
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(false)]);
 
       const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
       for (let index = 0; index < 10; index += 1) await env.timer.flush();
@@ -5657,7 +5675,7 @@ describe("background controller", () => {
 
     it("keeps an active handoff running during an ordinary settings save", async () => {
       const env = handoffEnv({ postClaimHandoffIntervalSeconds: 5, postClaimHandoffMaxSeconds: 15 });
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(false)]);
 
       const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
       await drainMicrotasks();
@@ -5671,12 +5689,12 @@ describe("background controller", () => {
       expect(env.timer.parked).toBe(1);
       for (let index = 0; index < 4; index += 1) await env.timer.flush();
       await handoff;
-      expect(env.twitch.discoverCampaigns).toHaveBeenCalled();
+      expect(env.twitch.refreshCampaigns).toHaveBeenCalled();
     });
 
     it("aborts running handoffs when farming is switched off", async () => {
       const env = handoffEnv();
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(false)]);
 
       const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
       await drainMicrotasks();
@@ -5689,7 +5707,7 @@ describe("background controller", () => {
 
     it("does not start a second handoff while the first is still starting", async () => {
       const env = handoffEnv();
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(false)]);
 
       // Both calls are made before either has finished its async setup.
       const first = env.controller.runClaimHandoff("twitch", ["reward-1"]);
@@ -5704,7 +5722,7 @@ describe("background controller", () => {
 
     it("honors an abort issued while the handoff is still starting", async () => {
       const env = handoffEnv();
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(false)]);
 
       const handoff = env.controller.runClaimHandoff("twitch", ["reward-1"]);
       // Synchronously, before any setup await has resolved.
@@ -5712,7 +5730,7 @@ describe("background controller", () => {
       await env.timer.flush();
       await handoff;
 
-      expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
+      expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
     });
 
     it("never refreshes after the maximum duration has elapsed", async () => {
@@ -5722,13 +5740,13 @@ describe("background controller", () => {
       // The session keeps watching the reward that was just claimed, so the loop
       // never succeeds and never sees "nothing left" — only the deadline can end
       // it. Without that, the early exit would mask any overshoot.
-      env.twitch.discoverCampaigns = vi.fn(async () => [campaign("twitch")]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [campaign("twitch")]);
 
       const handoff = env.controller.runClaimHandoff("twitch", ["reward"]);
       for (let index = 0; index < 5; index += 1) await env.timer.flush();
       await handoff;
 
-      expect(env.twitch.discoverCampaigns).toHaveBeenCalledTimes(1);
+      expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(1);
     });
 
     it("sends no heartbeat when the abort lands while state is being read", async () => {
@@ -5736,7 +5754,7 @@ describe("background controller", () => {
       const env = handoffEnv({ tablessMode: true });
       env.twitch.supportsTabless = true;
       env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(true)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(true)]);
 
       await env.controller.tick();
       watcher.tick.mockClear();
@@ -5759,7 +5777,7 @@ describe("background controller", () => {
       const env = handoffEnv({ tablessMode: false });
       env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
       let reveal = false;
-      env.twitch.discoverCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(reveal)]);
 
       const handoff = env.controller.runClaimHandoff("twitch");
       reveal = true;
@@ -5784,7 +5802,7 @@ describe("background controller critical health", () => {
     // Adapters are constructed with the tick's emitter before discovery runs, so
     // the last recorded call carries the live emitter for this tick.
     const emitFromTick = (): EventEmitter => env.deps.createAdapter.mock.calls.at(-1)![1];
-    env.kick.discoverCampaigns = vi.fn(async () => {
+    env.kick.refreshCampaigns = vi.fn(async () => {
       emitFromTick()({
         category: "activity",
         code: "page_context_opened",
@@ -5809,7 +5827,7 @@ describe("background controller critical health", () => {
   it("opens the breaker and syncs the registry after repeated page context opens", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     const emitFromTick = (): EventEmitter => env.deps.createAdapter.mock.calls.at(-1)![1];
-    env.kick.discoverCampaigns = vi.fn(async () => {
+    env.kick.refreshCampaigns = vi.fn(async () => {
       emitFromTick()({
         category: "activity",
         code: "page_context_opened",

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ALARM_NAME,
   createBackgroundController,
+  KICK_ALARM_NAME,
+  TWITCH_ALARM_NAME,
   TWITCH_INTEGRITY_ALARM_NAME,
   type CredentialAvailability,
 } from "@lurkloot/core/controller";
@@ -3209,7 +3211,9 @@ describe("background controller", () => {
 
     await env.controller.ensureAlarm();
 
-    expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: 11 });
+    expect(env.deps.clearAlarm).toHaveBeenCalledWith(ALARM_NAME);
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(TWITCH_ALARM_NAME, { periodInMinutes: 11 });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(KICK_ALARM_NAME, { periodInMinutes: 11 });
   });
 
   it("stamps the install time once through the serialized controller lifecycle", async () => {
@@ -3361,7 +3365,8 @@ describe("background controller", () => {
 
     await env.controller.handleStartup();
 
-    expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(TWITCH_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(KICK_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
     expect(env.deps.closeManagedTabs).toHaveBeenCalledWith([
       expect.objectContaining({ tabId: 44, channelUrl: "https://www.twitch.tv/twitch-creator", ownedByExtension: true }),
     ]);
@@ -3508,7 +3513,8 @@ describe("background controller", () => {
 
     await env.controller.handleStartup();
 
-    expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(TWITCH_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(KICK_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
     expect(env.deps.closeManagedTabs).not.toHaveBeenCalled();
     expect(env.reportEvents.mock.calls.flatMap(([events]) => events).some((event) =>
       event.category === "diagnostic" && event.message.includes("Browser restarted")
@@ -3589,7 +3595,8 @@ describe("background controller", () => {
     const snapshot = asSnapshot(await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true }));
 
     expect(env.settings.platform.twitch.enabled).toBe(true);
-    expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(TWITCH_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(KICK_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
     expect(env.twitch.prepareWatchTab).toHaveBeenCalled();
     // The snapshot returns ahead of the tick, reporting the prompt "starting"
     // transition; the watching status lands once the tick settles.
@@ -3825,7 +3832,8 @@ describe("background controller", () => {
     expect(env.deps.saveSettings).toHaveBeenCalledWith(
       expect.objectContaining({ tablessFallbackFailureLimit: 10 }),
     );
-    expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(TWITCH_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(KICK_ALARM_NAME, { periodInMinutes: DEFAULT_SETTINGS.pollIntervalMinutes });
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
   });
 
@@ -3838,7 +3846,9 @@ describe("background controller", () => {
     });
 
     expect(env.settings.pollIntervalMinutes).toBe(17);
-    expect(env.deps.createAlarm).toHaveBeenCalledWith(ALARM_NAME, { periodInMinutes: 17 });
+    expect(env.deps.clearAlarm).toHaveBeenCalledWith(ALARM_NAME);
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(TWITCH_ALARM_NAME, { periodInMinutes: 17 });
+    expect(env.deps.createAlarm).toHaveBeenCalledWith(KICK_ALARM_NAME, { periodInMinutes: 17 });
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
   });
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1855,10 +1855,8 @@ describe("background controller", () => {
         throw new Error(`Unexpected Twitch operation ${operation}`);
       }) as PageFetcher["fetchJson"],
     };
-    vi.mocked(env.deps.createAdapters).mockImplementation((emit, settings) => ({
-      adapters: {
-        twitch: new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, emit),
-      },
+    vi.mocked(env.deps.createAdapter).mockImplementation((_platform, emit, settings) => ({
+      adapter: new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, emit),
       ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
     }));
 
@@ -1869,7 +1867,7 @@ describe("background controller", () => {
     detailsFail = true;
     await env.controller.tick();
 
-    expect(env.deps.createAdapters).toHaveBeenCalledTimes(2);
+    expect(env.deps.createAdapter).toHaveBeenCalledTimes(6);
     expect(env.state.campaigns.twitch.map((item) => item.id)).toEqual(["retained"]);
   });
 
@@ -1894,7 +1892,7 @@ describe("background controller", () => {
 
     expect(env.state.authHealth.twitch.status).toBe("checking");
     expect(env.twitch.discoverCampaigns).not.toHaveBeenCalled();
-    expect(env.kick.discoverCampaigns).not.toHaveBeenCalled();
+    expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce();
 
     twitchHealth.resolve({
       status: "healthy",
@@ -2308,11 +2306,9 @@ describe("background controller", () => {
     });
     const error = await ticking.catch((caught: unknown) => caught);
 
-    expect(error).toBeInstanceOf(AggregateError);
-    expect((error as AggregateError).errors).toEqual(expect.arrayContaining([
-      expect.objectContaining({ platform: "twitch", message: "twitch adapter setup failed" }),
-      expect.objectContaining({ message: "kick auth persistence failed" }),
-    ]));
+    expect(error).toEqual(expect.objectContaining({
+      message: "kick auth persistence failed",
+    }));
     expect(env.state.authHealth.twitch).toMatchObject({
       status: "unavailable",
       reasonCode: "platform_unavailable",
@@ -2959,6 +2955,7 @@ describe("background controller", () => {
       "state", "events",
       "state", "events",
       "state", "events",
+      "state", "events",
     ]);
   });
 
@@ -3001,10 +2998,10 @@ describe("background controller", () => {
 
   it("preserves adapter and scheduler event order within one tick batch", async () => {
     const env = harness();
-    vi.mocked(env.deps.createAdapters).mockImplementation((emit, settings) => {
+    vi.mocked(env.deps.createAdapter).mockImplementation((platform, emit, settings) => {
       emit({ category: "diagnostic", level: "debug", message: "adapter-created" });
       return {
-        adapters: { twitch: env.twitch, kick: env.kick },
+        adapter: platform === "twitch" ? env.twitch : env.kick,
         ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
       };
     });
@@ -3119,12 +3116,12 @@ describe("background controller", () => {
       }) as PageFetcher["fetchJson"],
     };
     const claimState = new KickClaimState();
-    env.deps.createAdapters.mockImplementation((emit, settings) => {
+    env.deps.createAdapter.mockImplementation((platform, emit, settings) => {
       const kick = new KickAdapter(fetcher, undefined, undefined, emit, { claimState });
       kick.discoverCampaigns = vi.fn(async () => [campaign("kick", "claimable")]);
       kick.listCandidateChannels = vi.fn(async () => []);
       return {
-        adapters: { twitch: env.twitch, kick },
+        adapter: platform === "kick" ? kick : env.twitch,
         ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
       };
     });
@@ -4927,7 +4924,7 @@ describe("background controller", () => {
 
   it("reports a controller-fatal interruption even when diagnostics are filtered by the host", async () => {
     const env = harness();
-    vi.mocked(env.deps.createAdapters).mockImplementation(() => {
+    vi.mocked(env.deps.createAdapter).mockImplementation(() => {
       throw new Error("adapter factory failed");
     });
 
@@ -4935,7 +4932,11 @@ describe("background controller", () => {
 
     expect(env.reportEvents).toHaveBeenCalledWith(expect.arrayContaining([
       expect.objectContaining({ category: "activity", code: "interruption", level: "error" }),
-      expect.objectContaining({ category: "diagnostic", level: "error", message: "adapter factory failed" }),
+      expect.objectContaining({
+        category: "diagnostic",
+        level: "error",
+        message: expect.stringContaining("adapter factory failed"),
+      }),
     ]));
   });
 
@@ -5226,16 +5227,28 @@ describe("background controller", () => {
       env.controller.tick(),
     ]);
 
-    // Serialized: every load is immediately followed by that operation's save
-    // before the next operation's load (never load, load, save, save).
-    expect(trace.length).toBeGreaterThanOrEqual(4);
-    for (let i = 0; i + 1 < trace.length; i += 2) {
-      expect(trace[i]).toBe("load");
-      expect(trace[i + 1]).toBe("save");
-    }
+    expect(trace.filter((entry) => entry === "load").length)
+      .toBeGreaterThanOrEqual(trace.filter((entry) => entry === "save").length);
     // Both writers' changes survive in the final persisted state.
     expect(env.state.sessions.twitch.playback).toBeDefined();
     expect(env.state.lastTickAt).toBeDefined();
+  });
+
+  it("lets Kick complete while Twitch discovery is still pending", async () => {
+    const env = harness();
+    const twitchDiscovery = deferred<DropCampaign[]>();
+    env.twitch.discoverCampaigns = vi.fn(() => twitchDiscovery.promise);
+
+    const ticking = env.controller.tick(undefined, "manual_tick");
+
+    try {
+      await vi.waitFor(() => expect(env.kick.discoverCampaigns).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(env.state.sessions.kick.lastCheckedAt).toBeDefined());
+      expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce();
+    } finally {
+      twitchDiscovery.resolve([]);
+      await ticking;
+    }
   });
 
   it("serializes handleTabRemoved against a concurrent tick so neither write is lost", async () => {
@@ -5274,12 +5287,8 @@ describe("background controller", () => {
       env.controller.tick(),
     ]);
 
-    // Serialized: every load is immediately followed by that operation's save.
-    expect(trace.length).toBeGreaterThanOrEqual(4);
-    for (let i = 0; i + 1 < trace.length; i += 2) {
-      expect(trace[i]).toBe("load");
-      expect(trace[i + 1]).toBe("save");
-    }
+    expect(trace.filter((entry) => entry === "load").length)
+      .toBeGreaterThanOrEqual(trace.filter((entry) => entry === "save").length);
     // Both writers' changes survive: the manual-watch entry is removed AND the
     // concurrent tick committed its progress.
     expect(env.state.manualWatch?.kick).toBeUndefined();
@@ -5619,7 +5628,7 @@ describe("background controller critical health", () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     // Adapters are constructed with the tick's emitter before discovery runs, so
     // the last recorded call carries the live emitter for this tick.
-    const emitFromTick = (): EventEmitter => env.deps.createAdapters.mock.calls.at(-1)![0];
+    const emitFromTick = (): EventEmitter => env.deps.createAdapter.mock.calls.at(-1)![1];
     env.kick.discoverCampaigns = vi.fn(async () => {
       emitFromTick()({
         category: "activity",
@@ -5644,7 +5653,7 @@ describe("background controller critical health", () => {
 
   it("opens the breaker and syncs the registry after repeated page context opens", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
-    const emitFromTick = (): EventEmitter => env.deps.createAdapters.mock.calls.at(-1)![0];
+    const emitFromTick = (): EventEmitter => env.deps.createAdapter.mock.calls.at(-1)![1];
     env.kick.discoverCampaigns = vi.fn(async () => {
       emitFromTick()({
         category: "activity",

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -3563,6 +3563,64 @@ describe("background controller", () => {
     await env.rawController.settleBackgroundWork();
   });
 
+  it.each([
+    ["twitch", true, "Twitch automation enable"],
+    ["kick", false, "Kick automation disable"],
+  ] as const)("logs the requested and completed %s automation transition", async (platform, enabled, transition) => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+
+    await env.controller.handleMessage({
+      type: "setAutomation",
+      platform,
+      enabled,
+    });
+
+    const diagnostics = env.reportEvents.mock.calls
+      .flatMap(([events]) => events)
+      .filter((event): event is DiagnosticEvent => event.category === "diagnostic");
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform,
+      level: "info",
+      message: `User requested ${transition}`,
+    }));
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform,
+      level: "info",
+      message: `${transition} completed`,
+    }));
+  });
+
+  it("logs when a Twitch enable tick queues behind existing Twitch work", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+    const twitchDiscovery = deferred<DropCampaign[]>();
+    env.twitch.discoverCampaigns = vi.fn(() => twitchDiscovery.promise);
+
+    const alarmTick = env.rawController.tick(["twitch"], "alarm");
+    await vi.waitFor(() => expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce());
+    const enabling = env.rawController.handleMessage({
+      type: "setAutomation",
+      platform: "twitch",
+      enabled: true,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(
+          expect.objectContaining({
+            category: "diagnostic",
+            platform: "twitch",
+            level: "info",
+            message: "Twitch automation enable queued behind an active tick",
+          }),
+        );
+      });
+    } finally {
+      twitchDiscovery.resolve([]);
+      await Promise.all([alarmTick, enabling]);
+      await env.rawController.settleBackgroundWork();
+    }
+  });
+
   it("brackets every tick with a lifecycle diagnostic naming its trigger and duration", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -692,6 +692,31 @@ describe("background controller", () => {
       expect(order).toEqual(["integrity", "auth", "scheduler"]);
     });
 
+    it("correlates integrity readiness diagnostics with their scheduler tick", async () => {
+      const env = harness(undefined, {
+        ensureTwitchIntegrity: async (emit) => {
+          emit({
+            category: "diagnostic",
+            platform: "twitch",
+            level: "info",
+            message: "Integrity readiness probe",
+          });
+          return true;
+        },
+      });
+
+      await env.controller.tick(["twitch"], "manual_tick");
+
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(
+        expect.objectContaining({
+          category: "diagnostic",
+          message: "Integrity readiness probe",
+          globalTickId: 1,
+          platformTickId: 1,
+        }),
+      );
+    });
+
     it("continues the same Twitch tick after successful acquisition", async () => {
       const env = harness(undefined, {
         ensureTwitchIntegrity: async () => true,
@@ -3649,16 +3674,94 @@ describe("background controller", () => {
       .filter((event): event is DiagnosticEvent => event.category === "diagnostic");
     expect(diagnostics).toContainEqual(expect.objectContaining({
       platform: "twitch",
+      globalTickId: 1,
+      platformTickId: 1,
       message: expect.stringMatching(/^Tick #\d+ started \(trigger=manual_tick, platforms=twitch\)$/),
     }));
     expect(diagnostics).toContainEqual(expect.objectContaining({
       platform: "twitch",
+      globalTickId: 1,
+      platformTickId: 1,
+      code: "auth_health_changed",
+      mirroredActivity: true,
+    }));
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      globalTickId: 1,
+      platformTickId: 1,
       message: expect.stringMatching(/^Tick #\d+ refreshed auth health in \d+ms$/),
     }));
     expect(diagnostics).toContainEqual(expect.objectContaining({
       platform: "twitch",
+      globalTickId: 1,
+      platformTickId: 1,
+      message: expect.stringMatching(/^Campaign refresh finished in \d+ms/),
+    }));
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      globalTickId: 1,
+      platformTickId: 1,
       message: expect.stringMatching(/^Tick #\d+ finished after \d+ms \(trigger=manual_tick, platforms=twitch\)$/),
     }));
+  });
+
+  it("assigns global and platform-local identifiers to interleaved platform ticks", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+
+    await env.controller.tick(["twitch"], "manual_tick");
+    await env.controller.tick(["kick"], "manual_tick");
+    await env.controller.tick(["twitch"], "manual_tick");
+
+    const starts = env.reportEvents.mock.calls
+      .flatMap(([events]) => events)
+      .filter((event): event is DiagnosticEvent =>
+        event.category === "diagnostic" && event.message.includes("started (trigger=manual_tick"));
+
+    expect(starts.map((event) => ({
+      platform: event.platform,
+      globalTickId: event.globalTickId,
+      platformTickId: event.platformTickId,
+      message: event.message,
+    }))).toEqual([
+      {
+        platform: "twitch",
+        globalTickId: 1,
+        platformTickId: 1,
+        message: "Tick #1 started (trigger=manual_tick, platforms=twitch)",
+      },
+      {
+        platform: "kick",
+        globalTickId: 2,
+        platformTickId: 1,
+        message: "Tick #1 started (trigger=manual_tick, platforms=kick)",
+      },
+      {
+        platform: "twitch",
+        globalTickId: 3,
+        platformTickId: 2,
+        message: "Tick #2 started (trigger=manual_tick, platforms=twitch)",
+      },
+    ]);
+  });
+
+  it("leaves diagnostics emitted outside scheduler ticks uncorrelated", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+
+    await env.controller.handleMessage({
+      type: "setAutomation",
+      platform: "twitch",
+      enabled: true,
+    });
+
+    const requested = env.reportEvents.mock.calls
+      .flatMap(([events]) => events)
+      .find((event): event is DiagnosticEvent =>
+        event.category === "diagnostic"
+        && event.message === "User requested Twitch automation enable");
+
+    expect(requested).toBeDefined();
+    expect(requested).not.toHaveProperty("globalTickId");
+    expect(requested).not.toHaveProperty("platformTickId");
   });
 
   it("reports a tick lifecycle even when the tick throws", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -5269,8 +5269,13 @@ describe("background controller", () => {
     const ticking = env.controller.tick(["twitch"], "manual_tick");
     await vi.waitFor(() => expect(env.twitch.discoverCampaigns).toHaveBeenCalledOnce());
     const checkingKick = env.controller.checkAuthHealth("kick");
+    let kickRefreshCompleted = false;
+    void checkingKick.then(() => {
+      kickRefreshCompleted = true;
+    });
     try {
       await vi.waitFor(() => expect(env.kick.checkAuthHealth).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(kickRefreshCompleted).toBe(true));
     } finally {
       twitchDiscovery.resolve([]);
       await Promise.all([ticking, checkingKick]);

--- a/packages/extension/tests/backgroundEntrypoint.test.ts
+++ b/packages/extension/tests/backgroundEntrypoint.test.ts
@@ -44,11 +44,16 @@ describe("background integrity alarm wiring", () => {
     };
     const listener = createBackgroundAlarmListener(controller);
 
+    listener({ name: "lurkloot.tick.twitch" });
+    listener({ name: "lurkloot.tick.kick" });
+    listener({ name: "lurkloot.tick" });
     listener({ name: "lurkloot.twitch-integrity" });
     listener({ name: "unrelated.alarm" });
 
     expect(controller.runTwitchIntegrityRefresh).toHaveBeenCalledOnce();
-    expect(controller.tickAndHandOff).not.toHaveBeenCalled();
+    expect(controller.tickAndHandOff).toHaveBeenNthCalledWith(1, ["twitch"], "alarm");
+    expect(controller.tickAndHandOff).toHaveBeenNthCalledWith(2, ["kick"], "alarm");
+    expect(controller.tickAndHandOff).toHaveBeenCalledTimes(2);
     expect(controller.runWatchHeartbeat).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/tests/backgroundEntrypoint.test.ts
+++ b/packages/extension/tests/backgroundEntrypoint.test.ts
@@ -14,6 +14,12 @@ describe("background integrity alarm wiring", () => {
 
   it("injects the one-shot alarm and integrity lifecycle dependencies", () => {
     expect(source).toContain("createAlarm: (name, options) => browser.alarms.create(name, options),");
+    expect(source).toContain([
+      "  getAlarm: async (name) => {",
+      "    const alarm = await browser.alarms.get(name);",
+      "    return alarm ? { scheduledTime: alarm.scheduledTime } : undefined;",
+      "  },",
+    ].join("\n"));
     expect(source).toContain("clearAlarm: (name) => browser.alarms.clear(name),");
     expect(source).toContain("ensureTwitchIntegrity: (emit, request) => ensureTwitchIntegrity(emit, request),");
     expect(source).toContain("cancelTwitchIntegrityAcquisition,");

--- a/packages/extension/tests/criticalHealth.test.ts
+++ b/packages/extension/tests/criticalHealth.test.ts
@@ -540,6 +540,20 @@ describe("managed tab circuit breaker registry", () => {
     expect(managedTabBreakerOpen("twitch")).toBe(false);
   });
 
+  it("updates breaker mirrors only for the requested platform", () => {
+    syncManagedTabBreakers({
+      criticalHealth: {
+        twitch: { ...DEFAULT_CRITICAL_HEALTH, breakerOpen: true },
+        kick: { ...DEFAULT_CRITICAL_HEALTH, breakerOpen: true },
+      },
+    });
+
+    syncManagedTabBreakers({}, ["twitch"]);
+
+    expect(managedTabBreakerOpen("twitch")).toBe(false);
+    expect(managedTabBreakerOpen("kick")).toBe(true);
+  });
+
   it("closes again once the failure is dismissed", () => {
     let state = baseState();
     for (let index = 0; index < TAB_CHURN_LIMIT; index += 1) {

--- a/packages/extension/tests/platformState.test.ts
+++ b/packages/extension/tests/platformState.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { Platform, SchedulerState } from "@lurkloot/shared/models";
+import { mergePlatformState } from "@lurkloot/core/background/platformState";
+
+function state(label: string, lastTickAt: string): SchedulerState {
+  const session = (platform: Platform) => ({
+    platform,
+    status: "idle" as const,
+    offlineChecks: 0,
+    message: `${label}-${platform}`,
+  });
+  return {
+    sessions: {
+      twitch: session("twitch"),
+      kick: session("kick"),
+    },
+    authHealth: {
+      twitch: { status: "healthy" },
+      kick: { status: "healthy" },
+    },
+    campaigns: {
+      twitch: [],
+      kick: [],
+    },
+    managedWatchTabs: {
+      twitch: {
+        platform: "twitch",
+        tabId: label === "source" ? 11 : 10,
+        channelUrl: `https://www.twitch.tv/${label}`,
+        ownedByExtension: true,
+      },
+      kick: {
+        platform: "kick",
+        tabId: label === "source" ? 21 : 20,
+        channelUrl: `https://kick.com/${label}`,
+        ownedByExtension: true,
+      },
+    },
+    deadlineInfeasibleRewardIds: {
+      twitch: [`${label}-twitch`],
+      kick: [`${label}-kick`],
+    },
+    installedAt: `${label}-installed`,
+    lastTickAt,
+  };
+}
+
+describe("mergePlatformState", () => {
+  it("replaces only the owned platform slice and preserves the newest tick time", () => {
+    const destination = state("destination", "2026-07-29T12:00:00.000Z");
+    const source = state("source", "2026-07-29T11:00:00.000Z");
+
+    const merged = mergePlatformState(destination, source, "twitch");
+
+    expect(merged.sessions.twitch).toEqual(source.sessions.twitch);
+    expect(merged.sessions.kick).toEqual(destination.sessions.kick);
+    expect(merged.managedWatchTabs?.twitch).toEqual(source.managedWatchTabs?.twitch);
+    expect(merged.managedWatchTabs?.kick).toEqual(destination.managedWatchTabs?.kick);
+    expect(merged.deadlineInfeasibleRewardIds?.twitch).toEqual(
+      source.deadlineInfeasibleRewardIds?.twitch,
+    );
+    expect(merged.deadlineInfeasibleRewardIds?.kick).toEqual(
+      destination.deadlineInfeasibleRewardIds?.kick,
+    );
+    expect(merged.installedAt).toBe(destination.installedAt);
+    expect(merged.lastTickAt).toBe("2026-07-29T12:00:00.000Z");
+  });
+
+  it("deletes absent optional entries only for the owned platform", () => {
+    const destination = state("destination", "2026-07-29T11:00:00.000Z");
+    const source = state("source", "2026-07-29T12:00:00.000Z");
+    delete source.managedWatchTabs?.twitch;
+    delete source.deadlineInfeasibleRewardIds?.twitch;
+
+    const merged = mergePlatformState(destination, source, "twitch");
+
+    expect(merged.managedWatchTabs?.twitch).toBeUndefined();
+    expect(merged.managedWatchTabs?.kick).toEqual(destination.managedWatchTabs?.kick);
+    expect(merged.deadlineInfeasibleRewardIds?.twitch).toBeUndefined();
+    expect(merged.deadlineInfeasibleRewardIds?.kick).toEqual(
+      destination.deadlineInfeasibleRewardIds?.kick,
+    );
+    expect(merged.lastTickAt).toBe("2026-07-29T12:00:00.000Z");
+  });
+});

--- a/packages/extension/tests/popupAuthHealth.test.tsx
+++ b/packages/extension/tests/popupAuthHealth.test.tsx
@@ -19,7 +19,10 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-async function mountWithSnapshots(authStatuses: Array<RuntimeSnapshot["state"]["authHealth"]["twitch"]>) {
+async function mountWithSnapshots(
+  authStatuses: Array<RuntimeSnapshot["state"]["authHealth"]["twitch"]>,
+  twitchSession?: Partial<RuntimeSnapshot["state"]["sessions"]["twitch"]>,
+) {
   vi.useFakeTimers();
   const { document, window } = parseHTML("<div id=app></div>");
   vi.stubGlobal("window", window);
@@ -54,6 +57,7 @@ async function mountWithSnapshots(authStatuses: Array<RuntimeSnapshot["state"]["
           ...base.state.sessions.twitch,
           message: "secret-cookie=must-not-render",
           status: "watching" as const,
+          ...twitchSession,
         },
       },
     },
@@ -124,5 +128,29 @@ describe("popup authentication health", () => {
     expect(container.querySelector('[data-automation-state="running"]')).not.toBeNull();
     expect(container.textContent).toContain("Running · Twitch");
     expect(sent).not.toContainEqual(expect.objectContaining({ type: "setAutomation" }));
+  });
+
+  it("renders one canonical starting state after the enable request settles", async () => {
+    const { container } = await mountWithSnapshots(
+      [{ status: "healthy", checkedAt: "2026-07-29T19:00:00.000Z" }],
+      { status: "idle", message: "Starting automation" },
+    );
+
+    const hero = container.querySelector('[data-automation-state="starting"]');
+    expect(hero).not.toBeNull();
+    expect(hero?.textContent).toContain("Starting");
+    expect(hero?.textContent).toContain("Starting automation...");
+  });
+
+  it("does not render stale disabled detail for an enabled running platform", async () => {
+    const { container } = await mountWithSnapshots(
+      [{ status: "healthy", checkedAt: "2026-07-29T19:00:00.000Z" }],
+      { status: "idle", message: "Automation disabled" },
+    );
+
+    const hero = container.querySelector('[data-automation-state="running"]');
+    expect(hero).not.toBeNull();
+    expect(hero?.textContent).toContain("Running");
+    expect(hero?.textContent).not.toContain("Automation disabled");
   });
 });

--- a/packages/extension/tests/popupAuthHealth.test.tsx
+++ b/packages/extension/tests/popupAuthHealth.test.tsx
@@ -133,7 +133,7 @@ describe("popup authentication health", () => {
   it("renders one canonical starting state after the enable request settles", async () => {
     const { container } = await mountWithSnapshots(
       [{ status: "healthy", checkedAt: "2026-07-29T19:00:00.000Z" }],
-      { status: "idle", message: "Starting automation" },
+      { status: "starting", message: "Starting automation" },
     );
 
     const hero = container.querySelector('[data-automation-state="starting"]');
@@ -142,15 +142,15 @@ describe("popup authentication health", () => {
     expect(hero?.textContent).toContain("Starting automation...");
   });
 
-  it("does not render stale disabled detail for an enabled running platform", async () => {
+  it("keeps a stale disabled session paused after automation is re-enabled", async () => {
     const { container } = await mountWithSnapshots(
       [{ status: "healthy", checkedAt: "2026-07-29T19:00:00.000Z" }],
-      { status: "idle", message: "Automation disabled" },
+      { status: "idle", message: "Automation disabled", reasonCode: "automation_disabled" },
     );
 
-    const hero = container.querySelector('[data-automation-state="running"]');
+    const hero = container.querySelector('[data-automation-state="paused"]');
     expect(hero).not.toBeNull();
-    expect(hero?.textContent).toContain("Running");
+    expect(hero?.textContent).toContain("Paused");
     expect(hero?.textContent).not.toContain("Automation disabled");
   });
 });

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -54,8 +54,7 @@ function adapter(platform: Platform, campaigns: DropCampaign[], candidates: Chan
   return {
     platform,
     checkAuthHealth: vi.fn(async () => ({ status: "checking" as const })),
-    discoverCampaigns: vi.fn(async () => campaigns),
-    readProgress: vi.fn(async (value) => value),
+    refreshCampaigns: vi.fn(async () => campaigns),
     listCandidateChannels: vi.fn(async () => candidates),
     checkChannel: vi.fn(async (candidate) => ({ live: true, categoryMatches: true, candidate })),
     claimReward: vi.fn(async () => true),
@@ -877,8 +876,7 @@ describe("scheduler tick", () => {
     );
 
     expect(kick.stopWatchTab).toHaveBeenCalledWith(previous, { signal: undefined });
-    expect(kick.discoverCampaigns).not.toHaveBeenCalled();
-    expect(kick.readProgress).not.toHaveBeenCalled();
+    expect(kick.refreshCampaigns).not.toHaveBeenCalled();
     expect(kick.claimReward).not.toHaveBeenCalled();
     expect(kick.claimChallenges).not.toHaveBeenCalled();
     expect(kick.listCandidateChannels).not.toHaveBeenCalled();
@@ -1113,8 +1111,7 @@ describe("scheduler tick", () => {
       expect.objectContaining({ tabId: 7 }),
       { signal: undefined },
     );
-    expect(twitch.readProgress).toHaveBeenCalledWith(
-      expect.any(Array),
+    expect(twitch.refreshCampaigns).toHaveBeenCalledWith(
       expect.objectContaining({ channel: first }),
       { signal: undefined },
     );
@@ -1149,7 +1146,7 @@ describe("scheduler tick", () => {
       tabId: undefined,
     });
     expect(twitch.stopWatchTab).toHaveBeenCalled();
-    expect(twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(result.state.sessions.kick.status).toBe("watching");
     expect(kick.prepareWatchTab).toHaveBeenCalled();
   });
@@ -1212,16 +1209,17 @@ describe("scheduler tick", () => {
 
     expect(diagnostics).toContainEqual(expect.objectContaining({
       platform: "twitch",
-      message: expect.stringMatching(/^Campaign discovery finished in \d+ms \(1 campaign\)$/),
-    }));
-    expect(diagnostics).toContainEqual(expect.objectContaining({
-      platform: "twitch",
-      message: expect.stringMatching(/^Campaign progress refresh finished in \d+ms \(1 campaign\)$/),
+      message: expect.stringMatching(/^Campaign refresh finished in \d+ms \(1 campaign\)$/),
     }));
     expect(diagnostics).toContainEqual(expect.objectContaining({
       platform: "twitch",
       message: expect.stringMatching(/^Campaign selection finished in \d+ms \(1 campaign checked, 2 candidates checked\)$/),
     }));
+    expect(twitch.refreshCampaigns).toHaveBeenCalledOnce();
+    expect(twitch.refreshCampaigns).toHaveBeenCalledWith(
+      baseState.sessions.twitch,
+      expect.objectContaining({ signal: undefined }),
+    );
   });
 
   it("retains the highest-priority current watch before listing replacement candidates", async () => {
@@ -2543,7 +2541,7 @@ describe("scheduler tick", () => {
       { platforms: ["kick"] },
     );
 
-    expect(twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(twitch.prepareWatchTab).not.toHaveBeenCalled();
     expect(result.state.sessions.twitch.status).toBe("watching");
     expect(result.state.campaigns.twitch).toEqual([campaign("existing")]);
@@ -2668,7 +2666,7 @@ describe("scheduler tick", () => {
 
   it("isolates adapter failures per platform", async () => {
     const twitch = adapter("twitch", [], []);
-    vi.mocked(twitch.discoverCampaigns).mockRejectedValue(new Error("Twitch unavailable"));
+    vi.mocked(twitch.refreshCampaigns).mockRejectedValue(new Error("Twitch unavailable"));
     const kickCandidate = { ...channel("kicklive"), platform: "kick" as const, url: "https://kick.com/kicklive" };
     const kick = adapter("kick", [campaign("kick-drops", { platform: "kick" })], [kickCandidate]);
 
@@ -2694,7 +2692,7 @@ describe("scheduler tick", () => {
 
   it("uses Idle Watchlist fallback when drop discovery fails and idle watchlist channels exist", async () => {
     const twitch = adapter("twitch", [], []);
-    vi.mocked(twitch.discoverCampaigns).mockRejectedValue(new Error("Twitch drops unavailable"));
+    vi.mocked(twitch.refreshCampaigns).mockRejectedValue(new Error("Twitch drops unavailable"));
     vi.mocked(twitch.checkChannel).mockResolvedValue({
       live: true,
       categoryMatches: true,
@@ -2714,7 +2712,6 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.readProgress).not.toHaveBeenCalled();
     expect(twitch.prepareWatchTab).toHaveBeenCalledWith(
       expect.objectContaining({ username: "fallback", live: true }),
       expect.any(Object),
@@ -2732,7 +2729,7 @@ describe("scheduler tick", () => {
   it("keeps previously discovered campaigns when discovery fails and the Idle Watchlist takes over", async () => {
     const known = campaign("known-drops");
     const twitch = adapter("twitch", [], []);
-    vi.mocked(twitch.discoverCampaigns).mockRejectedValue(new Error("Twitch drops unavailable"));
+    vi.mocked(twitch.refreshCampaigns).mockRejectedValue(new Error("Twitch drops unavailable"));
     vi.mocked(twitch.checkChannel).mockResolvedValue({
       live: true,
       categoryMatches: true,
@@ -2764,7 +2761,7 @@ describe("scheduler tick", () => {
   it("keeps previously discovered campaigns when discovery fails without idle watchlist channels", async () => {
     const known = campaign("known-drops");
     const twitch = adapter("twitch", [], []);
-    vi.mocked(twitch.discoverCampaigns).mockRejectedValue(new Error("Twitch drops unavailable"));
+    vi.mocked(twitch.refreshCampaigns).mockRejectedValue(new Error("Twitch drops unavailable"));
 
     const result = await runSchedulerTick(
       {
@@ -2807,7 +2804,7 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(result.state.sessions.twitch.retryAfter).toBe(retryAfter);
     expect(result.events.some((event) => event.category === "diagnostic" && event.message.includes("Waiting until"))).toBe(true);
   });
@@ -2834,7 +2831,7 @@ describe("scheduler tick", () => {
       { twitch, kick: adapter("kick", [], []) },
     );
 
-    expect(twitch.discoverCampaigns).toHaveBeenCalled();
+    expect(twitch.refreshCampaigns).toHaveBeenCalled();
     expect(result.state.sessions.twitch.status).toBe("watching");
     expect(result.state.sessions.twitch.errorChecks).toBe(0);
     expect(result.state.sessions.twitch.retryAfter).toBeUndefined();
@@ -3022,7 +3019,7 @@ describe("scheduler tick", () => {
 
   it("keeps transient platform failures on ordinary backoff", async () => {
     const kick = adapter("kick", [], []);
-    vi.mocked(kick.discoverCampaigns).mockRejectedValueOnce(
+    vi.mocked(kick.refreshCampaigns).mockRejectedValueOnce(
       new SafeFetchError({ kind: "http_error", status: 503 }),
     );
 
@@ -3044,7 +3041,7 @@ describe("scheduler tick", () => {
 
   it("does not turn an authentication failure into an Idle Watchlist session", async () => {
     const kick = adapter("kick", [], []);
-    vi.mocked(kick.discoverCampaigns).mockRejectedValueOnce(
+    vi.mocked(kick.refreshCampaigns).mockRejectedValueOnce(
       new SafeFetchError({ kind: "authentication_rejected", status: 401 }),
     );
 
@@ -3277,7 +3274,7 @@ describe("scheduler critical health observations", () => {
 
   function failingAdapter(): PlatformAdapter {
     const twitch = adapter("twitch", [], [channel("fallback")]);
-    vi.mocked(twitch.discoverCampaigns).mockRejectedValue(new SafeFetchError({ kind: "http_error", status: 503 }));
+    vi.mocked(twitch.refreshCampaigns).mockRejectedValue(new SafeFetchError({ kind: "http_error", status: 503 }));
     return twitch;
   }
 
@@ -3380,7 +3377,7 @@ describe("scheduler critical health observations", () => {
 
     // The backoff branch exits the platform iteration early; the detector must
     // still see this tick, otherwise the churn window never drains.
-    expect(twitch.discoverCampaigns).not.toHaveBeenCalled();
+    expect(twitch.refreshCampaigns).not.toHaveBeenCalled();
     expect(result.state.criticalHealth?.twitch?.lastObservedAt).toBeDefined();
     expect(result.state.criticalHealth?.twitch?.failingTicks).toBe(1);
     expect(result.state.criticalHealth?.twitch?.records.at(-1)).toMatchObject({
@@ -3421,7 +3418,7 @@ describe("scheduler critical health observations", () => {
       { platforms: ["twitch"] },
     );
 
-    expect(twitch.discoverCampaigns).toHaveBeenCalled();
+    expect(twitch.refreshCampaigns).toHaveBeenCalled();
     expect(result.state.sessions.twitch.reasonCode).toBe("platform_error");
     // The accrual observation set before the throw must not survive as a healthy tick.
     expect(result.state.criticalHealth?.twitch?.failingTicks).toBe(6);

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1172,6 +1172,197 @@ describe("scheduler tick", () => {
     }));
   });
 
+  it("retains the highest-priority current watch before listing replacement candidates", async () => {
+    const current = channel("current");
+    const twitch = adapter(
+      "twitch",
+      [campaign("drops")],
+      Array.from({ length: 25 }, (_, index) => channel(`candidate-${index}`)),
+    );
+    vi.mocked(twitch.checkChannel).mockImplementation(async (candidate) => ({
+      live: true,
+      categoryMatches: true,
+      campaignMatches: true,
+      candidate,
+    }));
+
+    const result = await runSchedulerTick(
+      {
+        ...baseState,
+        sessions: {
+          ...baseState.sessions,
+          twitch: {
+            platform: "twitch",
+            status: "watching",
+            channel: current,
+            campaignId: "drops",
+            rewardId: "reward-in_progress",
+            offlineChecks: 0,
+            playbackChecks: 0,
+            watchMode: "tabless",
+          },
+        },
+      },
+      settings({
+        platform: {
+          twitch: { enabled: true, idleWatchlistChannels: [] },
+          kick: { enabled: false, idleWatchlistChannels: [] },
+        },
+      }),
+      { twitch, kick: adapter("kick", [], []) },
+      { platforms: ["twitch"] },
+    );
+
+    expect(twitch.listCandidateChannels).not.toHaveBeenCalled();
+    expect(twitch.checkChannel).toHaveBeenCalledOnce();
+    expect(twitch.checkChannel).toHaveBeenCalledWith(current, {
+      campaign: expect.objectContaining({ id: "drops" }),
+      signal: undefined,
+    });
+    expect(result.state.sessions.twitch.reasonCode).toBe("keeping_current_watch");
+    expect(result.events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      platform: "twitch",
+      message: expect.stringMatching(/^Campaign selection fast path retained current watch in \d+ms \(1 candidate checked\)$/),
+    }));
+  });
+
+  it("bypasses current-watch retention when a higher-priority campaign is available", async () => {
+    const current = channel("current");
+    const replacement = channel("replacement");
+    const twitch = adapter(
+      "twitch",
+      [campaign("current"), campaign("urgent")],
+      [replacement],
+    );
+
+    const result = await runSchedulerTick(
+      {
+        ...baseState,
+        sessions: {
+          ...baseState.sessions,
+          twitch: {
+            platform: "twitch",
+            status: "watching",
+            channel: current,
+            campaignId: "current",
+            rewardId: "reward-in_progress",
+            offlineChecks: 0,
+            playbackChecks: 0,
+            watchMode: "tabless",
+          },
+        },
+      },
+      settings({
+        campaignPriorities: { urgent: 10 },
+        platform: {
+          twitch: { enabled: true, idleWatchlistChannels: [] },
+          kick: { enabled: false, idleWatchlistChannels: [] },
+        },
+      }),
+      { twitch, kick: adapter("kick", [], []) },
+      { platforms: ["twitch"] },
+    );
+
+    expect(twitch.listCandidateChannels).toHaveBeenCalledOnce();
+    expect(result.state.sessions.twitch.campaignId).toBe("urgent");
+    expect(result.state.sessions.twitch.channel?.username).toBe("replacement");
+    expect(result.state.sessions.twitch.reasonCode).toBe("higher_priority_reward");
+  });
+
+  it("falls back to full selection when the current channel no longer offers the campaign", async () => {
+    const current = channel("current");
+    const replacement = channel("replacement");
+    const twitch = adapter("twitch", [campaign("drops")], [replacement]);
+    vi.mocked(twitch.checkChannel)
+      .mockResolvedValueOnce({
+        live: true,
+        categoryMatches: true,
+        campaignMatches: false,
+        candidate: current,
+      })
+      .mockResolvedValue({
+        live: true,
+        categoryMatches: true,
+        campaignMatches: true,
+        candidate: replacement,
+      });
+
+    const result = await runSchedulerTick(
+      {
+        ...baseState,
+        sessions: {
+          ...baseState.sessions,
+          twitch: {
+            platform: "twitch",
+            status: "watching",
+            channel: current,
+            campaignId: "drops",
+            rewardId: "reward-in_progress",
+            offlineChecks: 0,
+            playbackChecks: 0,
+            watchMode: "tabless",
+          },
+        },
+      },
+      settings({
+        platform: {
+          twitch: { enabled: true, idleWatchlistChannels: [] },
+          kick: { enabled: false, idleWatchlistChannels: [] },
+        },
+      }),
+      { twitch, kick: adapter("kick", [], []) },
+      { platforms: ["twitch"] },
+    );
+
+    expect(twitch.listCandidateChannels).toHaveBeenCalledOnce();
+    expect(result.state.sessions.twitch.channel?.username).toBe("replacement");
+  });
+
+  it("bypasses current-watch retention when the current reward completes", async () => {
+    const current = channel("current");
+    const replacement = channel("replacement");
+    const completed = { ...reward("claimed"), id: "finished" };
+    const next = { ...reward("locked"), id: "next" };
+    const twitch = adapter(
+      "twitch",
+      [campaign("drops", { rewards: [completed, next] })],
+      [replacement],
+    );
+
+    const result = await runSchedulerTick(
+      {
+        ...baseState,
+        sessions: {
+          ...baseState.sessions,
+          twitch: {
+            platform: "twitch",
+            status: "watching",
+            channel: current,
+            campaignId: "drops",
+            rewardId: "finished",
+            offlineChecks: 0,
+            playbackChecks: 0,
+            watchMode: "tabless",
+          },
+        },
+      },
+      settings({
+        platform: {
+          twitch: { enabled: true, idleWatchlistChannels: [] },
+          kick: { enabled: false, idleWatchlistChannels: [] },
+        },
+      }),
+      { twitch, kick: adapter("kick", [], []) },
+      { platforms: ["twitch"] },
+    );
+
+    expect(twitch.listCandidateChannels).toHaveBeenCalledOnce();
+    expect(result.state.sessions.twitch.rewardId).toBe("next");
+    expect(result.state.sessions.twitch.channel?.username).toBe("replacement");
+    expect(result.state.sessions.twitch.reasonCode).toBe("watch_requirement_completed");
+  });
+
   it("switches on category mismatch", async () => {
     const old = channel("old");
     const next = channel("new");

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1135,6 +1135,43 @@ describe("scheduler tick", () => {
     expect(quiet.events.some((event) => event.category === "diagnostic" && event.message.startsWith("Tick start"))).toBe(false);
   });
 
+  it("reports platform-scoped timings and candidate counts for scheduler phases", async () => {
+    const first = channel("offline");
+    const second = channel("creator");
+    const twitch = adapter("twitch", [campaign("drops")], [first, second]);
+    vi.mocked(twitch.checkChannel)
+      .mockResolvedValueOnce({ live: false, categoryMatches: true, candidate: first })
+      .mockResolvedValueOnce({ live: true, categoryMatches: true, candidate: second });
+
+    const result = await runSchedulerTick(
+      baseState,
+      settings({
+        platform: {
+          twitch: { enabled: true, idleWatchlistChannels: [] },
+          kick: { enabled: false, idleWatchlistChannels: [] },
+        },
+      }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+    const diagnostics = result.events.filter(
+      (event): event is Extract<typeof event, { category: "diagnostic" }> =>
+        event.category === "diagnostic",
+    );
+
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringMatching(/^Campaign discovery finished in \d+ms \(1 campaign\)$/),
+    }));
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringMatching(/^Campaign progress refresh finished in \d+ms \(1 campaign\)$/),
+    }));
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringMatching(/^Campaign selection finished in \d+ms \(1 campaign checked, 2 candidates checked\)$/),
+    }));
+  });
+
   it("switches on category mismatch", async () => {
     const old = channel("old");
     const next = channel("new");

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -574,6 +574,58 @@ describe("scheduler campaign selection", () => {
     expect(kickDecision.channel?.username).toBe("blocked");
   });
 
+  it("deduplicates candidate usernames before platform checks", async () => {
+    const duplicate = channel("creator");
+    const checkChannel = vi.fn(async (candidate: ChannelCandidate) => ({
+      live: true,
+      categoryMatches: true,
+      candidate,
+    }));
+
+    const decision = await chooseCampaignDecision(
+      "twitch",
+      [campaign("drops")],
+      settings(),
+      {
+        listCandidateChannels: vi.fn(async () => [
+          duplicate,
+          { ...duplicate, displayName: "CREATOR" },
+        ]),
+        checkChannel,
+      },
+    );
+
+    expect(decision.action).toBe("watch");
+    expect(checkChannel).toHaveBeenCalledOnce();
+  });
+
+  it("reuses general directory candidates only within one selection pass", async () => {
+    const listCandidateChannels = vi.fn(async () => [channel("creator")]);
+    const checkChannel = vi.fn(async (
+      candidate: ChannelCandidate,
+      options?: { campaign?: DropCampaign },
+    ) => ({
+      live: true,
+      categoryMatches: true,
+      campaignMatches: options?.campaign?.id === "second",
+      candidate,
+    }));
+
+    const decision = await chooseCampaignDecision(
+      "twitch",
+      [
+        campaign("first", { categoryId: "game", slug: "game" }),
+        campaign("second", { categoryId: "game", slug: "game" }),
+      ],
+      settings(),
+      { listCandidateChannels, checkChannel },
+    );
+
+    expect(decision.campaign?.id).toBe("second");
+    expect(listCandidateChannels).toHaveBeenCalledOnce();
+    expect(checkChannel).toHaveBeenCalledTimes(2);
+  });
+
   it("tries another campaign when all candidates for one campaign are excluded", async () => {
     const decision = await chooseCampaignDecision(
       "twitch",

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -2060,6 +2060,39 @@ describe("scheduler tick", () => {
     expect(result.state.campaigns.twitch[0].rewards[0].status).toBe("claimed");
   });
 
+  it("does not reclaim the same reward while fresh inventory remains stale", async () => {
+    const ready = campaign("drops", {
+      rewards: [{ ...reward("claimable"), claimId: "user#drops#reward-claimable" }],
+    });
+    const twitch = {
+      ...adapter("twitch", [ready], [channel("allowed")]),
+      isClaimReady: vi.fn(() => true),
+    };
+    const enabledSettings = settings({
+      platform: {
+        twitch: { enabled: true, idleWatchlistChannels: [] },
+        kick: { enabled: false, idleWatchlistChannels: [] },
+      },
+    });
+    const adapters = { twitch, kick: adapter("kick", [], []) };
+    const initialState: SchedulerState = {
+      authHealth: HEALTHY_AUTH,
+      sessions: {
+        twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
+        kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+      },
+      campaigns: { twitch: [], kick: [] },
+    };
+
+    const first = await runSchedulerTick(initialState, enabledSettings, adapters);
+    const second = await runSchedulerTick(first.state, enabledSettings, adapters);
+
+    expect(twitch.claimReward).toHaveBeenCalledTimes(1);
+    expect(second.state.campaigns.twitch[0].rewards[0].status).toBe("claimed");
+    expect(second.events.some((event) =>
+      event.category === "activity" && event.code === "reward_claimed")).toBe(false);
+  });
+
   it("does not claim rewards after their claim window has expired", async () => {
     const ready = campaign("drops", { rewards: [{ ...reward("claimable"), claimUntil: "2020-01-01T00:00:00.000Z" }] });
     const twitch = adapter("twitch", [ready], [channel("allowed")]);

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1211,6 +1211,12 @@ describe("scheduler tick", () => {
       platform: "twitch",
       message: expect.stringMatching(/^Campaign refresh finished in \d+ms \(1 campaign\)$/),
     }));
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({
+      message: expect.stringContaining("Campaign discovery finished"),
+    }));
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({
+      message: expect.stringContaining("Campaign progress refresh finished"),
+    }));
     expect(diagnostics).toContainEqual(expect.objectContaining({
       platform: "twitch",
       message: expect.stringMatching(/^Campaign selection finished in \d+ms \(1 campaign checked, 2 candidates checked\)$/),

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -1223,7 +1223,7 @@ describe("twitch integrity refresh", () => {
       expect(browser.tabs.remove).not.toHaveBeenCalled();
     });
 
-    it("creates a tab when none exists and retains it for reuse", async () => {
+    it("closes a tab created only to capture Twitch integrity", async () => {
       const browser = browserMock();
       browser.tabs.create.mockResolvedValue({ id: 14 });
 
@@ -1236,9 +1236,8 @@ describe("twitch integrity refresh", () => {
         pinned: false,
         active: false,
       });
-      // Retained for the next claim instead of being torn down each time.
-      expect(browser.tabs.remove).not.toHaveBeenCalled();
-      expect(currentManagedPageContextTabs()).toMatchObject({ twitch: { tabId: 14 } });
+      expect(browser.tabs.remove).toHaveBeenCalledWith(14);
+      expect(currentManagedPageContextTabs()).not.toHaveProperty("twitch");
     });
 
     it("opens page context immediately on the first missing-token check", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -95,6 +95,28 @@ describe("tab manager", () => {
     resetPlaybackPriming();
   });
 
+  it("updates retained page contexts only for the requested platform", () => {
+    const twitch = {
+      platform: "twitch" as const,
+      tabId: 10,
+      originUrl: "https://www.twitch.tv",
+      origin: "https://www.twitch.tv",
+      ownedByExtension: true as const,
+    };
+    const kick = {
+      platform: "kick" as const,
+      tabId: 20,
+      originUrl: "https://kick.com",
+      origin: "https://kick.com",
+      ownedByExtension: true as const,
+    };
+    registerManagedPageContextTabs({ twitch, kick });
+
+    registerManagedPageContextTabs({}, ["twitch"]);
+
+    expect(currentManagedPageContextTabs()).toEqual({ kick });
+  });
+
   it("reports tab lifecycle events to the supplied emitter", async () => {
     const events: EngineEvent[] = [];
     const emit = (event: EngineEvent) => events.push(event);

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -2003,6 +2003,25 @@ describe("fetchTwitchInBackgroundWith", () => {
     vi.unstubAllGlobals();
   });
 
+  it("preserves multi-operation Twitch GQL batch responses", async () => {
+    const response = [
+      { data: { dropCampaign: { id: "first" } } },
+      { data: { dropCampaign: { id: "second" } } },
+    ];
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })));
+
+    await expect(fetchTwitchInBackgroundWith(
+      cookieApi,
+      "https://gql.twitch.tv/gql",
+      { method: "POST", body: "[]" },
+    )).resolves.toEqual(response);
+
+    vi.unstubAllGlobals();
+  });
+
   it("replays a captured integrity token with its matching device and session id", async () => {
     let captured: RequestInit | undefined;
     vi.stubGlobal("fetch", vi.fn(async (_url: string, init: RequestInit) => {

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -530,6 +530,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
       enabled: automation[id],
       pending: pendingAutomation[id] != null,
       authHealth: snapshot.state.authHealth[id],
+      session: snapshot.state.sessions[id],
       manualClosePaused: Boolean(snapshot.state.manualClosePause?.[id]),
     })]),
   ) as Record<Platform, AutomationPresentation>;
@@ -660,7 +661,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                     />
                   ) : null}
                 </AnimatePresence>
-                <AutomationHero platform={platform} platformLabel={PLATFORMS[platform].label} enabled={enabled} pending={automationPending} presentation={presentation} farmingTitle={activeCampaign?.title} farmingChannel={farmingChannel} onFarmingTitleClick={onFarmingTitleClick} statusMessage={session.message} onChange={setAutomation} onResume={resumeAfterManualClose} />
+                <AutomationHero platform={platform} platformLabel={PLATFORMS[platform].label} enabled={enabled} pending={automationPending} presentation={presentation} farmingTitle={activeCampaign?.title} farmingChannel={farmingChannel} onFarmingTitleClick={onFarmingTitleClick} onChange={setAutomation} onResume={resumeAfterManualClose} />
                 {settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} /> : null}
                 <SubTabs
                   tabs={[

--- a/packages/popup-ui/src/automation.tsx
+++ b/packages/popup-ui/src/automation.tsx
@@ -39,7 +39,7 @@ export function PlatformSwitcher({ active, presentation, onChange }: { active: P
   );
 }
 
-export function AutomationHero({ platform, platformLabel, enabled, pending, presentation, onChange, farmingTitle, farmingChannel, onFarmingTitleClick, statusMessage, onResume }: { platform: Platform; platformLabel: string; enabled: boolean; pending: boolean; presentation: AutomationPresentation; onChange(value: boolean): Promise<void>; farmingTitle?: string; farmingChannel?: FarmingChannelView; onFarmingTitleClick?(): void; statusMessage?: string; onResume?(): void }) {
+export function AutomationHero({ platform, platformLabel, enabled, pending, presentation, onChange, farmingTitle, farmingChannel, onFarmingTitleClick, onResume }: { platform: Platform; platformLabel: string; enabled: boolean; pending: boolean; presentation: AutomationPresentation; onChange(value: boolean): Promise<void>; farmingTitle?: string; farmingChannel?: FarmingChannelView; onFarmingTitleClick?(): void; onResume?(): void }) {
   const t = useT();
   const runtime = usePopupRuntime();
 
@@ -70,7 +70,7 @@ export function AutomationHero({ platform, platformLabel, enabled, pending, pres
                     {farmingChannel.viewers != null && <span className="shrink-0 text-zinc-400 dark:text-zinc-500">· {formatViewers(farmingChannel.viewers)}</span>}
                   </p>
                 ) : (
-                  <p className="line-clamp-2 leading-snug" title={statusMessage}>{statusMessage ?? t("waitingEligibleStream")}</p>
+                  <p className="line-clamp-2 leading-snug" title={presentation.statusMessage}>{presentation.statusMessage ?? t("waitingEligibleStream")}</p>
                 )}
                 {farmingTitle && (
                   <p className="flex items-center gap-1 truncate">

--- a/packages/popup-ui/src/automationStatus.ts
+++ b/packages/popup-ui/src/automationStatus.ts
@@ -53,13 +53,10 @@ export function automationPresentation({
       ? presentation("starting", "automationStarting", "startingAutomation")
       : presentation("stopping", "automationStopping", "pausingAutomation");
   }
-  if (enabled && session?.message === "Starting automation") {
-    return presentation("starting", "automationStarting", "startingAutomation");
-  }
   if (!enabled) return presentation("paused", "pausedStatus", "watchingPausedHint");
   // Ranked above auth health: the user caused this stop, so telling them why
   // and how to undo it matters more than any background probe result.
-  if (manualClosePaused) {
+  if (manualClosePaused || session?.reasonCode === "manual_tab_close") {
     return {
       ...presentation("paused_tab_closed", "automationPausedTabClosed", "watchTabClosedPauseDetail", "warning"),
       action: { kind: "resume", labelKey: "resumeFarming" },
@@ -67,15 +64,26 @@ export function automationPresentation({
   }
 
   switch (authHealth.status) {
-    case "healthy":
+    case "healthy": {
+      if (session?.status === "starting") {
+        return presentation("starting", "automationStarting", "startingAutomation");
+      }
+      if (
+        session?.status === "paused"
+        || session?.reasonCode === "automation_disabled"
+        || session?.reasonCode === "platform_disabled"
+      ) {
+        return presentation("paused", "pausedStatus", "watchingPausedHint");
+      }
       return {
         state: "running",
         badgeKey: "automationRunning",
         detailKey: undefined,
         tone: "accent",
         operational: true,
-        statusMessage: safeRunningStatusMessage(session?.message),
+        statusMessage: session?.message,
       };
+    }
     case "checking":
       return presentation("checking", "automationChecking", "authCheckingDetail");
     case "missing_credentials":
@@ -93,16 +101,6 @@ export function automationPresentation({
       return presentation("unavailable", "automationUnavailable", detailKey, "warning");
     }
   }
-}
-
-const INCOMPATIBLE_RUNNING_MESSAGES = new Set([
-  "Starting automation",
-  "Automation disabled",
-  "Platform disabled",
-]);
-
-function safeRunningStatusMessage(message?: string): string | undefined {
-  return message && !INCOMPATIBLE_RUNNING_MESSAGES.has(message) ? message : undefined;
 }
 
 function presentation(

--- a/packages/popup-ui/src/automationStatus.ts
+++ b/packages/popup-ui/src/automationStatus.ts
@@ -1,4 +1,4 @@
-import type { Platform, PlatformAuthHealth } from "@lurkloot/shared/models";
+import type { Platform, PlatformAuthHealth, WatchSession } from "@lurkloot/shared/models";
 
 export type AutomationPresentationState =
   | "starting"
@@ -19,6 +19,7 @@ export interface AutomationPresentation {
   detailKey?: string;
   tone: AutomationTone;
   operational: boolean;
+  statusMessage?: string;
   action?: AutomationAction;
 }
 
@@ -37,18 +38,23 @@ export function automationPresentation({
   enabled,
   pending,
   authHealth,
+  session,
   manualClosePaused = false,
 }: {
   platform: Platform;
   enabled: boolean;
   pending: boolean;
   authHealth: PlatformAuthHealth;
+  session?: WatchSession;
   manualClosePaused?: boolean;
 }): AutomationPresentation {
   if (pending) {
     return enabled
       ? presentation("starting", "automationStarting", "startingAutomation")
       : presentation("stopping", "automationStopping", "pausingAutomation");
+  }
+  if (enabled && session?.message === "Starting automation") {
+    return presentation("starting", "automationStarting", "startingAutomation");
   }
   if (!enabled) return presentation("paused", "pausedStatus", "watchingPausedHint");
   // Ranked above auth health: the user caused this stop, so telling them why
@@ -68,6 +74,7 @@ export function automationPresentation({
         detailKey: undefined,
         tone: "accent",
         operational: true,
+        statusMessage: safeRunningStatusMessage(session?.message),
       };
     case "checking":
       return presentation("checking", "automationChecking", "authCheckingDetail");
@@ -86,6 +93,16 @@ export function automationPresentation({
       return presentation("unavailable", "automationUnavailable", detailKey, "warning");
     }
   }
+}
+
+const INCOMPATIBLE_RUNNING_MESSAGES = new Set([
+  "Starting automation",
+  "Automation disabled",
+  "Platform disabled",
+]);
+
+function safeRunningStatusMessage(message?: string): string | undefined {
+  return message && !INCOMPATIBLE_RUNNING_MESSAGES.has(message) ? message : undefined;
 }
 
 function presentation(

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -61,6 +61,8 @@ export type DiagnosticEvent = {
   level: LogLevel;
   platform?: Platform;
   message: string;
+  globalTickId?: number;
+  platformTickId?: number;
   code?: string;
   // Set on the English restatement of an activity event. Hosts that already
   // render activity in English (the CLI) use it to avoid logging the same thing

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -61,6 +61,7 @@ export type DiagnosticEvent = {
   level: LogLevel;
   platform?: Platform;
   message: string;
+  controllerRunId?: string;
   globalTickId?: number;
   platformTickId?: number;
   code?: string;

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -130,7 +130,7 @@ export interface WatchSession {
   playbackChecks?: number;
   errorChecks?: number;
   retryAfter?: string;
-  status: "idle" | "watching" | "paused" | "error";
+  status: "idle" | "starting" | "watching" | "paused" | "error";
   message?: string;
   reasonCode?: WatchReasonCode;
   playback?: PlaybackTelemetry;


### PR DESCRIPTION
## Summary

- fan out every multi-platform scheduler trigger into independent Twitch and Kick operations
- protect same-platform work with platform queues while merging completed platform slices through a short storage commit queue
- scope managed page-context and breaker mirrors by platform
- replace the legacy combined scheduler alarm with separate Twitch and Kick alarms, including upgrade cleanup
- run post-claim handoffs independently and preserve CLI bootstrap isolation

## Why

A slow Twitch discovery or integrity operation previously held the global scheduler/state lock and prevented Kick from doing any work. Both platforms also shared whole-state module registries, so simply adding another alarm would still have serialized or clobbered their state.

This keeps the existing `SchedulerState` storage format while making platform work independent and preserving same-platform ordering.

Closes #294.

## Testing

- `pnpm verify`
- `pnpm --filter @lurkloot/extension exec vitest run tests/coreBoundary.test.ts`
- focused red/green coverage for platform-state merging, scoped registries, overlapping scheduler execution, alarm routing, independent handoffs, and CLI bootstrap behavior

`pnpm verify` passed with 132 CLI tests, 1,176 extension tests, workspace typechecks, site checks/build, and Chrome and Firefox production builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Platform-scoped scheduler ticking with dedicated Twitch/Kick repeating alarms and safer concurrent handoff.
  - Unified campaign refresh using `refreshCampaigns`.
  - Popup automation now supports a consistent **starting** lifecycle state.
- **Bug Fixes**
  - Prevented cross-platform persistence, diagnostics, and tab/breaker updates from impacting the wrong platform.
  - Improved claim idempotency and platform-safe state merging.
- **Documentation**
  - Added/updated plans for platform concurrency, unified refresh, automation presentation, and diagnostics.
- **Tests**
  - Expanded test coverage for alarm routing, `getAlarm` lookup behavior, diagnostics correlation, and platform-specific tab retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->