### PR TITLE
fix(twitch): trust current campaign reward progress

### DIFF
--- a/docs/superpowers/plans/2026-07-30-twitch-cross-campaign-benefits.md
+++ b/docs/superpowers/plans/2026-07-30-twitch-cross-campaign-benefits.md
@@ -1,0 +1,130 @@
+# Twitch Cross-Campaign Benefit Claim-State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent rewards claimed in an earlier Twitch campaign from marking partially watched rewards with reused benefit IDs claimed in the current campaign.
+
+**Architecture:** When inventory v2 provides `earnedDropRewards`, treat a matching `dropCampaignsInProgress` entry as authoritative and suppress the campaign-agnostic `gameEventDrops` fallback. Preserve legacy v1 behavior and the ownership fallback for campaigns absent from the progress payload.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace
+
+## Global Constraints
+
+- Keep the change confined to the Twitch parser and its deterministic parser tests.
+- Do not change shared models, storage, scheduler behavior, UI, permissions, or localization.
+- Preserve the ownership fallback for inventory v1 and when a campaign is absent from `dropCampaignsInProgress`.
+- Use strict TypeScript, explicit imports, two-space indentation, double quotes, and semicolons.
+
+---
+
+### Task 1: Make Current Twitch Progress Authoritative
+
+**Files:**
+- Modify: `packages/extension/tests/parsers.test.ts`
+- Modify: `packages/core/src/platforms/twitch/parser.ts`
+
+**Interfaces:**
+- Consumes: `parseTwitchInventory(input): DropCampaign[]` and `mergeTwitchCampaignProgress(campaigns, inventory): DropCampaign[]`
+- Produces: unchanged public interfaces; only claim-state precedence changes
+
+- [ ] **Step 1: Add failing direct-parse and merge regression tests**
+
+Add two tests under `describe("Twitch parsers")`. Both use a v2 response with
+an empty `earnedDropRewards.edges` array and one reward with
+`requiredMinutesWatched: 420`, `currentMinutesWatched: 210`,
+`isClaimed: false`, and benefit ID `"reused-lootbox"`, while
+`gameEventDrops` contains `"reused-lootbox"`.
+
+The direct test calls `parseTwitchInventory` with the campaign under
+`dropCampaignsInProgress` and asserts:
+
+```ts
+expect(campaigns[0].rewards[0]).toMatchObject({
+  watchedMinutes: 210,
+  status: "in_progress",
+});
+```
+
+The merge test creates campaign details through `parseTwitchCampaigns`, merges
+the same in-progress inventory, and asserts the identical literal result.
+
+- [ ] **Step 2: Run the focused tests and verify the regression fails**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- parsers.test.ts
+```
+
+Expected: both new tests fail because the reward is reported with
+`watchedMinutes: 420` and `status: "claimed"`.
+
+- [ ] **Step 3: Suppress ownership inference while per-tier progress exists**
+
+In `parseTwitchCampaignSource`, suppress ownership-eligible benefit IDs when
+`source.hasPerTierProgress` is true and `source.earnedCounts` is defined. Pass
+that empty set through the existing `parseTwitchReward` path for v2
+`dropCampaignsInProgress`; retain the existing shared-benefit filtering for v1.
+
+In `mergeTwitchCampaignProgress`, require either no matching progress campaign
+or no v2 earned counts before applying the `gameEventDrops` fallback:
+
+```ts
+if (
+  (!progress || !earnedCounts)
+  && merged.status !== "claimed"
+  && isWatchReward(merged)
+  && ownsRewardBenefit(...)
+) {
+```
+
+Do not alter the campaign-scoped `claimedByEarned` branch. Use an explicit
+`earnedCounts !== undefined` check in production if it reads more clearly than
+the abbreviated plan expression.
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- parsers.test.ts
+```
+
+Expected: all parser tests pass.
+
+- [ ] **Step 5: Verify historical fallback coverage**
+
+Run the existing parser tests that cover both legacy v1 in-progress ownership
+and an owned reward whose campaign is absent from `dropCampaignsInProgress`.
+Confirm their claimed/completed assertions remain green. If the direct parsing
+test no longer clearly exercises a bare campaign source, add a literal
+regression using `dropCampaigns` rather than `dropCampaignsInProgress` and
+assert:
+
+```ts
+expect(campaigns[0].rewards[0]).toMatchObject({
+  watchedMinutes: 420,
+  status: "claimed",
+});
+```
+
+- [ ] **Step 6: Run repository verification**
+
+Run:
+
+```bash
+pnpm test
+pnpm typecheck
+pnpm check
+git diff --check
+```
+
+Expected: every command exits zero with no test, type, build, or whitespace
+failures.
+
+- [ ] **Step 7: Commit the fix**
+
+```bash
+git add packages/core/src/platforms/twitch/parser.ts packages/extension/tests/parsers.test.ts
+git commit -m "fix(twitch): trust current campaign reward progress"
+```

--- a/docs/superpowers/specs/2026-07-30-twitch-cross-campaign-benefits-design.md
+++ b/docs/superpowers/specs/2026-07-30-twitch-cross-campaign-benefits-design.md
@@ -1,0 +1,71 @@
+# Twitch Cross-Campaign Benefit Claim-State Design
+
+## Problem
+
+Twitch's `gameEventDrops` inventory is campaign-agnostic and deduplicated by
+benefit ID. Overwatch reused the `RoT S3 Lootbox` and `RoT S3 Epic Lootbox`
+benefits in consecutive campaigns. A user who claimed those benefits in the
+earlier campaign therefore still has their IDs in `gameEventDrops`.
+
+Lurkloot currently uses that ownership as a fallback signal that a watch reward
+is claimed. During the later campaign this overrides authoritative in-progress
+state (`self.isClaimed === false` with partial watched minutes), causing the
+reused rewards to appear complete.
+
+## Required Behavior
+
+When Twitch inventory v2 includes a campaign in `dropCampaignsInProgress`, its
+per-reward `self` state and campaign-scoped `earnedDropRewards` are
+authoritative. Campaign-agnostic benefit ownership must not mark any reward in
+that campaign claimed.
+
+When a campaign is absent from the progress payload, Lurkloot may retain its
+existing completion fallbacks:
+
+1. Prefer campaign-scoped `earnedDropRewards` counts when available.
+2. Use campaign-agnostic `gameEventDrops` ownership only for benefits not
+   covered by those counts.
+
+This preserves completion recognition after Twitch removes a finished campaign
+from `dropCampaignsInProgress`.
+
+Legacy inventory v1 does not provide campaign-scoped earned-reward evidence.
+It must retain its existing ownership fallback even while a campaign is in
+progress because Twitch can leave `self.isClaimed` false for an already-owned
+reward. Inventory v1 remains an explicit compatibility rollback; automatic
+selection uses v2.
+
+## Implementation
+
+The Twitch parser already distinguishes inventory sources that contain
+per-tier progress from bare campaign lists. Extend that distinction to the
+owned-benefit fallback:
+
+- While parsing an inventory campaign with per-tier progress and a v2
+  `earnedDropRewards` field, pass no benefit IDs to the ownership fallback.
+- While merging detailed campaign metadata with v2 inventory progress,
+  suppress the ownership fallback whenever the matching progress campaign is
+  present.
+- Preserve the existing ownership behavior for v1 inventory responses that
+  have no `earnedDropRewards` field.
+- Leave campaign-scoped earned-reward handling unchanged.
+- Leave behavior for campaigns absent from the progress payload unchanged.
+
+No shared model, storage, scheduler, UI, permission, or localization change is
+required.
+
+## Tests
+
+Add parser regression tests proving:
+
+1. Under v2, a reward with partial progress and `isClaimed: false` stays in
+   progress even when `gameEventDrops` contains the same benefit from an
+   earlier campaign.
+2. The same rule applies when detailed campaign metadata is merged with an
+   in-progress v2 inventory response.
+3. A campaign absent from `dropCampaignsInProgress` can still use the ownership
+   fallback, protecting the historical completed-campaign behavior.
+4. Existing v1 ownership-fallback coverage stays green.
+
+Run the focused parser tests first, then the repository test, typecheck, and
+verification commands appropriate to the change.

--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -207,11 +207,16 @@ function parseTwitchCampaignSource(source: TwitchCampaignSource): DropCampaign[]
     // Twitch includes subscription, purchase, and other action-gated rewards in
     // timeBasedDrops. Retain them internally so an obtained reward can still be
     // claimed, but mark them as non-watch rewards so they never drive farming.
-    const sharedBenefitIds = hasPerTierProgress
-      ? benefitIdsSharedAcrossRewards(
-        (campaign.timeBasedDrops ?? []).map((drop) =>
-          (drop.benefitEdges ?? []).map((edge) => edge.benefit?.id)),
-      )
+    const rewardBenefitIds = (campaign.timeBasedDrops ?? []).map((drop) =>
+      (drop.benefitEdges ?? []).map((edge) => edge.benefit?.id));
+    // v2 has campaign-scoped earned rewards, so its current per-tier state can
+    // reject a gameEventDrops match left behind by an earlier campaign that
+    // awarded the same benefit. Legacy v1 lacks that evidence and retains the
+    // ownership fallback, except where one benefit is ambiguous across tiers.
+    const benefitIdsExcludedFromOwnership = hasPerTierProgress
+      ? earnedCounts !== undefined
+        ? new Set(rewardBenefitIds.flat().filter((id): id is string => Boolean(id)))
+        : benefitIdsSharedAcrossRewards(rewardBenefitIds)
       : new Set<string>();
     const claimedByEarned = rewardIdsClaimedByEarnedCounts(
       (campaign.timeBasedDrops ?? []).map((drop) => ({
@@ -223,7 +228,7 @@ function parseTwitchCampaignSource(source: TwitchCampaignSource): DropCampaign[]
     );
     const earnedBenefitIds = new Set(earnedCounts?.get(campaign.id)?.keys() ?? []);
     const parsedRewards = (campaign.timeBasedDrops ?? [])
-      .map((drop) => parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops, sharedBenefitIds, claimedByEarned, earnedBenefitIds));
+      .map((drop) => parseTwitchReward(drop, campaign.id, userId, endsAt, gameEventDrops, benefitIdsExcludedFromOwnership, claimedByEarned, earnedBenefitIds));
     const rewards = parsedRewards.map((reward) => ({
       ...reward,
       preconditionsMet: (reward.preconditionRewardIds ?? []).every((id) =>
@@ -279,7 +284,7 @@ function parseTwitchReward(
   userId?: string,
   campaignEndsAt?: string,
   gameEventDrops: readonly TwitchGameEventDrop[] = [],
-  sharedBenefitIds: ReadonlySet<string> = new Set(),
+  benefitIdsExcludedFromOwnership: ReadonlySet<string> = new Set(),
   claimedByEarnedRewardIds: ReadonlySet<string> = new Set(),
   earnedBenefitIds: ReadonlySet<string> = new Set(),
 ): DropReward {
@@ -309,11 +314,14 @@ function parseTwitchReward(
   // A benefit the earned-reward counts mention is fully accounted for by them, so
   // the owned-benefit fallback must not add claims on top — otherwise a count of 3
   // over 4 tiers would still mark the fourth claimed. Benefits absent from the
-  // counts keep the fallback: Twitch only surfaces recently earned rewards, so an
-  // old campaign may have no edges at all.
+  // counts keep the fallback only when campaign-scoped progress cannot answer:
+  // an old campaign may have no recent edges at all, while legacy v1 has no
+  // earned-reward field. The caller excludes every benefit for an in-progress
+  // v2 campaign so an identically reused benefit from an older campaign cannot
+  // override the current self edge.
   const benefitIdsForOwnership = benefits
     .map((benefit) => benefit.id)
-    .filter((id) => id != null && !sharedBenefitIds.has(id) && !earnedBenefitIds.has(id));
+    .filter((id) => id != null && !benefitIdsExcludedFromOwnership.has(id) && !earnedBenefitIds.has(id));
   const ownsBenefit = isWatchBased && ownsRewardBenefit(benefitIdsForOwnership, gameEventDrops);
   // An earned-reward count is per claim and campaign-scoped, so it outranks both
   // the self edge (absent once a campaign leaves the progress payload) and the
@@ -413,11 +421,13 @@ export function mergeTwitchCampaignProgress(
       }
       // A claimed watch campaign falls out of dropCampaignsInProgress, so the
       // merge above can't update it. gameEventDrops is always returned, so
-      // cross-check watch ownership without applying its campaign-agnostic
-      // benefit ids to subscription rewards, or to a benefit shared by several
+      // cross-check watch ownership only when the campaign-scoped v2 evidence
+      // cannot answer: after a campaign leaves progress, or under legacy v1.
+      // Never apply it to subscription rewards or a benefit shared by several
       // tiers of this campaign (see parseTwitchReward).
       if (
-        merged.status !== "claimed"
+        (!progress || earnedCounts === undefined)
+        && merged.status !== "claimed"
         && isWatchReward(merged)
         && ownsRewardBenefit(
           (merged.benefitIds ?? []).filter((id) => !sharedBenefitIds.has(id) && !earnedBenefitIds.has(id)),

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -829,6 +829,36 @@ describe("Twitch parsers", () => {
     expect(campaigns[0].eligibility).toBe("completed");
   });
 
+  it("keeps v2 progress authoritative when an earlier campaign awarded the same benefit", () => {
+    const campaigns = parseTwitchInventory({
+      data: {
+        currentUser: {
+          inventory: {
+            earnedDropRewards: { edges: [] },
+            gameEventDrops: [{
+              id: "reused-lootbox",
+              lastAwardedAt: "2026-07-01T12:00:00.000Z",
+            }],
+            dropCampaignsInProgress: [{
+              id: "midseason",
+              timeBasedDrops: [{
+                id: "current-lootbox",
+                requiredMinutesWatched: 420,
+                benefitEdges: [{ benefit: { id: "reused-lootbox", name: "RoT S3 Lootbox" } }],
+                self: { currentMinutesWatched: 210, isClaimed: false },
+              }],
+            }],
+          },
+        },
+      },
+    });
+
+    expect(campaigns[0].rewards[0]).toMatchObject({
+      watchedMinutes: 210,
+      status: "in_progress",
+    });
+  });
+
   // Hunt: Showdown grants one "Supply Crate" benefit across several watch tiers, so
   // owning the benefit says nothing about which tiers are still unclaimed. Only the
   // per-tier self edge can answer that.
@@ -1159,6 +1189,44 @@ describe("Twitch parsers", () => {
     expect(merged[0].connectionUrls?.[0]).toContain("/directory/category/game-slug");
     expect(merged[0].rewards[0].watchedMinutes).toBe(45);
     expect(merged[0].rewards[0].status).toBe("in_progress");
+  });
+
+  it("keeps merged v2 progress authoritative when an earlier campaign awarded the same benefit", () => {
+    const details = parseTwitchCampaigns([{
+      id: "midseason",
+      timeBasedDrops: [{
+        id: "current-lootbox",
+        requiredMinutesWatched: 420,
+        benefitEdges: [{ benefit: { id: "reused-lootbox", name: "RoT S3 Lootbox" } }],
+      }],
+    }]);
+
+    const merged = mergeTwitchCampaignProgress(details, {
+      data: {
+        currentUser: {
+          inventory: {
+            earnedDropRewards: { edges: [] },
+            gameEventDrops: [{
+              id: "reused-lootbox",
+              lastAwardedAt: "2026-07-01T12:00:00.000Z",
+            }],
+            dropCampaignsInProgress: [{
+              id: "midseason",
+              timeBasedDrops: [{
+                id: "current-lootbox",
+                requiredMinutesWatched: 420,
+                self: { currentMinutesWatched: 210, isClaimed: false },
+              }],
+            }],
+          },
+        },
+      },
+    });
+
+    expect(merged[0].rewards[0]).toMatchObject({
+      watchedMinutes: 210,
+      status: "in_progress",
+    });
   });
 
   it("marks a tracked campaign completed when its benefit is owned but it dropped out of in-progress", () => {


### PR DESCRIPTION
## Summary

- make Twitch inventory v2 treat campaign-scoped earned rewards and current per-tier progress as authoritative
- prevent campaign-agnostic `gameEventDrops` from marking reused benefits claimed in an active campaign
- preserve the legacy inventory v1 ownership fallback and completed-campaign fallback
- add direct parsing and progress-merge regression coverage

## Root cause

Twitch reused the `RoT S3 Lootbox` and `RoT S3 Epic Lootbox` benefits across consecutive Overwatch campaigns. `gameEventDrops` is campaign-agnostic, so Lurkloot could interpret ownership from the earlier campaign as completion in the current campaign even while Twitch reported partial progress.

## Impact

Users on the recommended Twitch inventory v2 profile now retain their real current progress for reused rewards. The explicit v1 compatibility rollback retains its prior behavior because it lacks campaign-scoped earned-reward evidence.

## Testing

- `pnpm --filter @lurkloot/extension test -- parsers.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm check`
- `pnpm build`
- `git diff --check`

Fixes #304