### PR TITLE
fix(twitch): preserve claimable reused rewards

### DIFF
--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -423,11 +423,15 @@ export function mergeTwitchCampaignProgress(
       // merge above can't update it. gameEventDrops is always returned, so
       // cross-check watch ownership only when the campaign-scoped v2 evidence
       // cannot answer: after a campaign leaves progress, or under legacy v1.
+      // Preserve an explicit claimable state from campaign details: it carries
+      // the current reward's real drop-instance id and outranks historical,
+      // campaign-agnostic ownership of a reused benefit.
       // Never apply it to subscription rewards or a benefit shared by several
       // tiers of this campaign (see parseTwitchReward).
       if (
         (!progress || earnedCounts === undefined)
         && merged.status !== "claimed"
+        && !(merged.status === "claimable" && merged.claimId)
         && isWatchReward(merged)
         && ownsRewardBenefit(
           (merged.benefitIds ?? []).filter((id) => !sharedBenefitIds.has(id) && !earnedBenefitIds.has(id)),

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -1229,6 +1229,75 @@ describe("Twitch parsers", () => {
     });
   });
 
+  it("keeps a completed reused reward claimable after it leaves v2 progress", () => {
+    const details = parseTwitchCampaigns([{
+      id: "midseason",
+      timeBasedDrops: [{
+        id: "current-lootbox",
+        requiredMinutesWatched: 420,
+        benefitEdges: [{ benefit: { id: "reused-lootbox", name: "RoT S3 Lootbox" } }],
+        self: {
+          currentMinutesWatched: 420,
+          isClaimed: false,
+          dropInstanceID: "user#midseason#current-lootbox",
+        },
+      }],
+    }]);
+
+    const merged = mergeTwitchCampaignProgress(details, {
+      data: {
+        currentUser: {
+          inventory: {
+            earnedDropRewards: { edges: [] },
+            gameEventDrops: [{
+              id: "reused-lootbox",
+              lastAwardedAt: "2026-07-01T12:00:00.000Z",
+            }],
+            dropCampaignsInProgress: [],
+          },
+        },
+      },
+    });
+
+    expect(merged[0].rewards[0]).toMatchObject({
+      watchedMinutes: 420,
+      status: "claimable",
+      claimId: "user#midseason#current-lootbox",
+    });
+  });
+
+  it("uses owned-benefit completion when a watched reward has no claim instance", () => {
+    const details = parseTwitchCampaigns([{
+      id: "completed-campaign",
+      timeBasedDrops: [{
+        id: "completed-reward",
+        requiredMinutesWatched: 120,
+        benefitEdges: [{ benefit: { id: "owned-benefit", name: "Owned Reward" } }],
+        self: {
+          currentMinutesWatched: 120,
+          isClaimed: false,
+        },
+      }],
+    }]);
+
+    const merged = mergeTwitchCampaignProgress(details, {
+      data: {
+        currentUser: {
+          inventory: {
+            earnedDropRewards: { edges: [] },
+            gameEventDrops: [{ id: "owned-benefit" }],
+            dropCampaignsInProgress: [],
+          },
+        },
+      },
+    });
+
+    expect(merged[0].rewards[0]).toMatchObject({
+      status: "claimed",
+      claimId: undefined,
+    });
+  });
+
   it("marks a tracked campaign completed when its benefit is owned but it dropped out of in-progress", () => {
     const details = parseTwitchCampaigns([{
       id: "campaign",


### PR DESCRIPTION
## Summary

- Fixes #307: rewards that reuse a benefit id from an older campaign (e.g. the recurring Overwatch "RoT S3 Lootbox") could render as already claimed even though Twitch still showed them as claimable.
- Root cause: once a completed campaign leaves `dropCampaignsInProgress`, `mergeTwitchCampaignProgress` falls back to campaign-agnostic `gameEventDrops` ownership to detect completion (needed for legacy/no-progress cases). That fallback could override a reward that was already resolved as `claimable` with a real `dropInstanceID` from the campaign-details `self` edge, because an older campaign had already earned the same reused benefit.
- Fix: when the campaign-details parse already produced a `claimable` reward with a concrete `claimId`, that explicit per-drop state now outranks the historical ownership fallback, so the reward stays claimable (and the scheduler's claim loop can still act on it) instead of being silently marked `claimed`.

## Testing

- `pnpm --filter @lurkloot/extension test -- parsers` — 57 files / 1233 tests pass, including two new regression cases: a reused-benefit reward that stays claimable after leaving v2 progress, and confirming the legitimate owned-benefit-completion fallback (no claim instance) is unaffected.
- `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the claimable status of Twitch rewards when valid claim information is available.
  * Correctly marks eligible rewards as claimed when no claim instance exists, without creating an invalid claim ID.

* **Tests**
  * Added regression coverage for Twitch reward status reconciliation in campaigns no longer in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->