### PR TITLE
fix(twitch): keep genuinely in-progress reused-benefit rewards unclaimed

### DIFF
--- a/packages/core/src/platforms/twitch/parser.ts
+++ b/packages/core/src/platforms/twitch/parser.ts
@@ -424,10 +424,19 @@ export function mergeTwitchCampaignProgress(
       // cross-check watch ownership only when the campaign-scoped v2 evidence
       // cannot answer: after a campaign leaves progress, or under legacy v1.
       // Never apply it to subscription rewards or a benefit shared by several
-      // tiers of this campaign (see parseTwitchReward).
+      // tiers of this campaign (see parseTwitchReward). A reward with nonzero
+      // watched minutes below its requirement already carries a real, partial
+      // self edge (from campaign details or a prior progress merge) — that's
+      // unambiguous on its own, so a benefit owned from an older campaign must
+      // not fast-forward it to claimed. Zero minutes is left to the fallback
+      // below: it's indistinguishable from a reward Twitch no longer tracks at
+      // all, which is exactly the blind case the fallback exists for.
+      const hasIncompleteWatchProgress = merged.watchedMinutes > 0
+        && merged.watchedMinutes < merged.requiredMinutes;
       if (
         (!progress || earnedCounts === undefined)
         && merged.status !== "claimed"
+        && !hasIncompleteWatchProgress
         && isWatchReward(merged)
         && ownsRewardBenefit(
           (merged.benefitIds ?? []).filter((id) => !sharedBenefitIds.has(id) && !earnedBenefitIds.has(id)),

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -1258,6 +1258,37 @@ describe("Twitch parsers", () => {
     expect(merged[0].eligibility).toBe("completed");
   });
 
+  it("keeps a genuinely in-progress reused-benefit reward in progress when it drops out of the progress payload", () => {
+    const details = parseTwitchCampaigns([{
+      id: "midseason",
+      timeBasedDrops: [{
+        id: "current-lootbox",
+        requiredMinutesWatched: 420,
+        benefitEdges: [{ benefit: { id: "reused-lootbox", name: "RoT S3 Lootbox" } }],
+        self: { currentMinutesWatched: 210, isClaimed: false },
+      }],
+    }]);
+
+    const merged = mergeTwitchCampaignProgress(details, {
+      data: {
+        currentUser: {
+          inventory: {
+            gameEventDrops: [{
+              id: "reused-lootbox",
+              lastAwardedAt: "2026-07-01T12:00:00.000Z",
+            }],
+            dropCampaignsInProgress: [],
+          },
+        },
+      },
+    });
+
+    expect(merged[0].rewards[0]).toMatchObject({
+      status: "in_progress",
+      watchedMinutes: 210,
+    });
+  });
+
   it("does not treat an old owned benefit as the current campaign's subscription reward", () => {
     const [campaign] = parseTwitchInventory({
       data: {


### PR DESCRIPTION
## Summary

- Fixes #304 (reopened): after #308 shipped, ulllupollllo reported it still reproduced on v1.10.0 — screenshots showed Twitch's own dashboard reporting the "RoT S3 Lootbox"/"RoT S3 Epic Lootbox" rewards at 85%/60% real progress, while Lurkloot showed the campaign as 100% / Finished / 9/9.
- Root cause: `mergeTwitchCampaignProgress`'s `gameEventDrops` ownership fallback (needed for legacy/no-data cases) fires whenever the campaign is momentarily absent from `dropCampaignsInProgress` on a given poll. #308 only excluded benefits already accounted for by campaign-scoped `earnedDropRewards`/self edges *while the campaign is still listed in progress*; it didn't guard the moment the campaign briefly drops out of that list mid-farm while genuinely incomplete. When an older campaign already owns the same reused benefit id, the fallback then fast-forwards the still-watching reward straight to `claimed`.
- Fix: a reward whose own progress data already shows real, nonzero, incomplete watch minutes (`0 < watchedMinutes < requiredMinutes`) is unambiguous — the ownership fallback must not override it. Zero minutes is left untouched, since that's indistinguishable from a reward Twitch no longer reports any data for at all, which is the case the fallback exists to handle.

## Testing

- `pnpm --filter @lurkloot/extension test -- parsers` — 57 files / 1232 tests pass, including a new regression reproducing the exact 210/420-minute scenario from the issue, and confirming the legacy zero-progress ownership fallback still applies.
- `pnpm test`
- `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Twitch watch-based rewards with partial viewing progress being incorrectly marked as claimed.
  * Preserved in-progress reward status when campaign progress data is temporarily missing but watch time is recorded.

* **Tests**
  * Added regression coverage for reused rewards and incomplete watch progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->