### PR TITLE
docs(site): update 1.10.0 changelog with reliability work

### DIFF
--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -1,7 +1,11 @@
 [
   {
-    "version": "1.11.0",
+    "version": "1.10.0",
     "changes": [
+      {
+        "kind": "new",
+        "text": "Campaign filters now decide what Lurkloot farms, not just what the Drops list shows. Two new settings control farming — “Farm campaigns without a linked account” and “Farm campaigns that require a subscription”, both on by default — while the Drops list keeps its own show/hide chips. Anything being farmed always stays visible in the list."
+      },
       {
         "kind": "new",
         "text": "Added a dedicated Diagnostics view with full English detail on what Lurkloot is doing, and the popup now warns you when the extension has critically failed instead of silently going idle."
@@ -28,6 +32,18 @@
       },
       {
         "kind": "fixed",
+        "text": "Fixed Twitch and Kick getting stuck on “Checking your signed-in session…” in the popup when an unrelated part of a refresh failed."
+      },
+      {
+        "kind": "fixed",
+        "text": "Campaigns no longer disappear from the popup when Twitch or Kick briefly fails to respond — your known campaigns and progress are kept until a successful refresh replaces them."
+      },
+      {
+        "kind": "fixed",
+        "text": "Finished and expired Kick campaigns now show up again, so the “Visible campaigns” settings work the same way on Kick as they do on Twitch."
+      },
+      {
+        "kind": "fixed",
         "text": "Fixed Kick's ad detection and Twitch's playback priming occasionally stealing focus from the tab you were watching."
       },
       {
@@ -43,28 +59,6 @@
         "text": "Fixed automation toggles in the popup not responding promptly, and platform sign-in status not resolving as quickly as it should."
       }
     ]
-  },
-  {
-    "version": "1.10.0",
-    "changes": [
-      {
-        "kind": "new",
-        "text": "Campaign filters now decide what Lurkloot farms, not just what the Drops list shows. Two new settings control farming — “Farm campaigns without a linked account” and “Farm campaigns that require a subscription”, both on by default — while the Drops list keeps its own show/hide chips. Anything being farmed always stays visible in the list."
-      },
-      {
-        "kind": "fixed",
-        "text": "Fixed Twitch and Kick getting stuck on “Checking your signed-in session…” in the popup when an unrelated part of a refresh failed."
-      },
-      {
-        "kind": "fixed",
-        "text": "Campaigns no longer disappear from the popup when Twitch or Kick briefly fails to respond — your known campaigns and progress are kept until a successful refresh replaces them."
-      },
-      {
-        "kind": "fixed",
-        "text": "Finished and expired Kick campaigns now show up again, so the “Visible campaigns” settings work the same way on Kick as they do on Twitch."
-      }
-    ],
-    "date": "2026-07-24"
   },
   {
     "version": "1.9.0",

--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -1,5 +1,50 @@
 [
   {
+    "version": "1.11.0",
+    "changes": [
+      {
+        "kind": "new",
+        "text": "Added a dedicated Diagnostics view with full English detail on what Lurkloot is doing, and the popup now warns you when the extension has critically failed instead of silently going idle."
+      },
+      {
+        "kind": "new",
+        "text": "Added a header button in the popup that jumps straight to your Twitch or Kick inventory page."
+      },
+      {
+        "kind": "improved",
+        "text": "Twitch and Kick now run independently, so a slowdown on one platform no longer delays farming on the other."
+      },
+      {
+        "kind": "improved",
+        "text": "Farming now pauses automatically when you close a platform's watch tab, and a new watch tab gets a short grace period before it's judged unhealthy."
+      },
+      {
+        "kind": "improved",
+        "text": "The activity log can be copied directly from the popup, and diagnostics are recorded by default."
+      },
+      {
+        "kind": "improved",
+        "text": "Drops cards in the popup stay collapsed unless their campaign is actively farming, keeping the list easier to scan."
+      },
+      {
+        "kind": "fixed",
+        "text": "Fixed Kick's ad detection and Twitch's playback priming occasionally stealing focus from the tab you were watching."
+      },
+      {
+        "kind": "fixed",
+        "text": "Fixed several Twitch drop-claiming edge cases: tiers that share a campaign benefit, benefits reused across drops with a different award window, campaigns dropping out of view during a scheduler tick, and reward progress not being trusted when it should be."
+      },
+      {
+        "kind": "fixed",
+        "text": "Fixed Twitch's anti-bot integrity checks sometimes leaving farming stuck after a rejected request, including recovering rejected tokens across retries and avoiding repeated unnecessary verification work."
+      },
+      {
+        "kind": "fixed",
+        "text": "Fixed automation toggles in the popup not responding promptly, and platform sign-in status not resolving as quickly as it should."
+      }
+    ]
+  },
+  {
     "version": "1.10.0",
     "changes": [
       {


### PR DESCRIPTION
## Summary
- 1.10.0 is still an unshipped pre-release (`gh release view v1.10.0` shows `prerelease: true`, not yet promoted), so fold the reliability/fix work merged into `develop` since that entry was written into the existing `1.10.0` entry instead of adding a new `1.11.0` one
- New: dedicated Diagnostics view, critical-failure popup warning, popup inventory shortcut
- Improved: independent Twitch/Kick scheduling, watch-tab pause/grace-period, copyable activity log, collapsed drops cards
- Fixed: focus-stealing during Kick ad detection and Twitch playback priming, several Twitch drop-claiming edge cases, integrity/anti-bot recovery, unresponsive automation toggles

The entry stays undated — release preparation assigns the date and bumps package versions.

## Testing
- `node scripts/release/cli.mjs notes --version 1.10.0 --out /tmp/notes.md`
- `pnpm --filter @lurkloot/site build`