### PR TITLE
feat(settings): add settings import/export

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { parse as parseJsonc, printParseErrorCode, type ParseError } from "jsonc-parser";
 import { resolveCompatibility } from "@lurkloot/core";
 import type { CompatibilityWarning } from "@lurkloot/shared/compatibility";
@@ -245,4 +245,18 @@ export function loadConfig(configPath: string): CliConfig {
 
 function isErrno(error: unknown, code: string): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === code;
+}
+
+// Overwrites the config's `settings` block in place, keeping `transport` and
+// `authDir` untouched. Used only by `config import`: the config file is
+// otherwise never rewritten (see the warning-formatting comments above), so
+// this is a deliberate, explicit exception the user asked for by running that
+// command. The commented JSONC template is not preserved — the file becomes
+// plain JSON after the first import — which is why the CLI logs where it wrote.
+export function saveConfigSettings(config: CliConfig, settings: CliSettings): void {
+  writeFileSync(config.configPath, `${JSON.stringify({
+    transport: config.transport,
+    authDir: relative(dirname(config.configPath), config.authDir) || ".",
+    settings,
+  }, null, 2)}\n`, "utf8");
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -260,3 +260,12 @@ export function saveConfigSettings(config: CliConfig, settings: CliSettings): vo
     settings,
   }, null, 2)}\n`, "utf8");
 }
+
+// `config export --out` must never resolve to the active config file: the
+// export envelope carries only `settings`, not `transport`/`authDir`, so
+// writing it over config.json would silently drop both on the next load.
+export function assertExportOutputPath(outputPath: string, config: CliConfig): void {
+  if (outputPath === config.configPath) {
+    throw new Error(`--out must not be the active config file (${config.configPath}); the export envelope does not carry "transport"/"authDir" and would corrupt it`);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import yargs, { type Argv, type ArgumentsCamelCase, type CommandModule } from "yargs";
 import { hideBin } from "yargs/helpers";
 import type { DropCampaign, Platform } from "@lurkloot/shared/models";
 import { KickWafBlockedError } from "@lurkloot/core/tabs";
-import { loadConfig, TRANSPORTS, type CliConfig, type Transport } from "./config";
+import { loadConfig, saveConfigSettings, TRANSPORTS, type CliConfig, type Transport } from "./config";
+import { buildCliSettingsExportPayload, parseCliSettingsImportPayload } from "./settings";
 import { credentialAvailabilityOf, describeCredentialHealth, forgetCredentials, hasKickAuth, hasTwitchAuth, loadCredentials } from "./authStore";
 import { createTransport, type EnabledPlatforms } from "./transport";
 import { runLoop } from "./runtime/run";
@@ -59,6 +61,50 @@ const validateConfigCommand: CommandModule = {
     const config = configOf(argv, logger);
     process.stdout.write(`${JSON.stringify({ transport: config.transport, authDir: config.authDir, settings: config.settings }, null, 2)}\n`);
   },
+};
+
+const configCommand: CommandModule = {
+  command: "config",
+  describe: "Export or import the settings block of the config file",
+  builder: (y) => y
+    .command({
+      command: "export",
+      describe: 'Print the current settings as a portable file ("-" or --out - = stdout)',
+      builder: (yy) => yy.option("out", { type: "string", default: "-", describe: 'Output file, or "-" for stdout' }),
+      handler: (argv) => {
+        const logger = loggerOf(argv);
+        const config = configOf(argv, logger);
+        const payload = buildCliSettingsExportPayload(config.settings);
+        const text = `${JSON.stringify(payload, null, 2)}\n`;
+        const out = String(argv.out ?? "-");
+        if (out === "-") {
+          process.stdout.write(text);
+        } else {
+          writeFileSync(resolve(process.cwd(), out), text, "utf8");
+          logger.info(`Exported settings to ${resolve(process.cwd(), out)}`, "config");
+        }
+      },
+    })
+    .command({
+      command: "import <file>",
+      describe: 'Import a settings export into the config file ("-" = stdin)',
+      builder: (yy) => yy.positional("file", { type: "string", describe: "Export file, or - to read stdin", demandOption: true }),
+      handler: (argv) => {
+        const logger = loggerOf(argv);
+        const config = configOf(argv, logger);
+        // yargs-parser renders a bare "-" positional as "" — restore the stdin sentinel.
+        const file = argv.file === "" ? "-" : String(argv.file);
+        const text = file === "-" ? readFileSync(0, "utf8") : readFileSync(resolve(process.cwd(), file), "utf8");
+        const raw = JSON.parse(text);
+        const { settings, diagnostics } = parseCliSettingsImportPayload(raw);
+        for (const diagnostic of diagnostics) logger.warn(diagnostic.message, "config");
+        saveConfigSettings(config, settings);
+        logger.info(`Imported settings into ${config.configPath} (comments in the config file were not preserved)`, "config");
+      },
+    })
+    .demandCommand(1, "Specify a config subcommand (export | import)")
+    .strict(),
+  handler: () => { /* a subcommand always runs; see demandCommand above */ },
 };
 
 const discoverCommand: CommandModule = {
@@ -226,6 +272,7 @@ function buildCli(argv: string[]): Argv {
     .option("config", { type: "string", default: "config.json", describe: "Config file (created with defaults if missing)", global: true })
     .option("log", { type: "string", choices: ["debug", "info", "warn", "error"], default: "info", describe: "Log level", global: true })
     .command(validateConfigCommand)
+    .command(configCommand)
     .command(discoverCommand)
     .command(runCommand)
     .command(authCommand)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,7 @@ import yargs, { type Argv, type ArgumentsCamelCase, type CommandModule } from "y
 import { hideBin } from "yargs/helpers";
 import type { DropCampaign, Platform } from "@lurkloot/shared/models";
 import { KickWafBlockedError } from "@lurkloot/core/tabs";
-import { loadConfig, saveConfigSettings, TRANSPORTS, type CliConfig, type Transport } from "./config";
+import { assertExportOutputPath, loadConfig, saveConfigSettings, TRANSPORTS, type CliConfig, type Transport } from "./config";
 import { buildCliSettingsExportPayload, parseCliSettingsImportPayload } from "./settings";
 import { credentialAvailabilityOf, describeCredentialHealth, forgetCredentials, hasKickAuth, hasTwitchAuth, loadCredentials } from "./authStore";
 import { createTransport, type EnabledPlatforms } from "./transport";
@@ -80,8 +80,10 @@ const configCommand: CommandModule = {
         if (out === "-") {
           process.stdout.write(text);
         } else {
-          writeFileSync(resolve(process.cwd(), out), text, "utf8");
-          logger.info(`Exported settings to ${resolve(process.cwd(), out)}`, "config");
+          const outputPath = resolve(process.cwd(), out);
+          assertExportOutputPath(outputPath, config);
+          writeFileSync(outputPath, text, "utf8");
+          logger.info(`Exported settings to ${outputPath}`, "config");
         }
       },
     })

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -10,7 +10,8 @@ import {
   normalizeIdList,
   normalizePriorities,
 } from "@lurkloot/shared/settings";
-import { migrateSettings, type SettingsMigrationDiagnostic } from "@lurkloot/shared/settingsSchema";
+import { CURRENT_SETTINGS_SCHEMA_VERSION, migrateSettings, type SettingsMigrationDiagnostic } from "@lurkloot/shared/settingsSchema";
+import { SETTINGS_EXPORT_KIND } from "@lurkloot/shared/settingsExport";
 import type { CompatibilitySettings, EngineSettings, KickPlatformSettings, Platform, PlatformSettingsByPlatform, PriorityMode, TwitchPlatformSettings } from "@lurkloot/shared/models";
 
 // The CLI's own settings surface — intentionally decoupled from the extension's
@@ -185,6 +186,43 @@ export function parseCliSettingsWithDiagnostics(raw: unknown): CliSettingsParseR
 
 export function parseCliSettings(raw: unknown): CliSettings {
   return parseCliSettingsWithDiagnostics(raw).settings;
+}
+
+export interface CliSettingsExportPayload {
+  kind: typeof SETTINGS_EXPORT_KIND;
+  schemaVersion: number;
+  exportedAt: string;
+  settings: CliSettings;
+}
+
+// Uses the same envelope (`kind`/`schemaVersion`) the extension's export does,
+// so a file can be recognized by either host — but the settings block itself
+// is the CLI's own strict schema, not the extension's. Feeding an
+// extension-exported file into `config import` therefore fails with the same
+// per-key "extension-only setting" errors parseCliSettingsWithDiagnostics
+// already gives a copy-pasted config, rather than silently accepting inert
+// extension knobs.
+export function buildCliSettingsExportPayload(settings: CliSettings): CliSettingsExportPayload {
+  return {
+    kind: SETTINGS_EXPORT_KIND,
+    schemaVersion: CURRENT_SETTINGS_SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    settings: parseCliSettingsWithDiagnostics(settings).settings,
+  };
+}
+
+export function parseCliSettingsImportPayload(raw: unknown): CliSettingsParseResult {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Not a lurkloot settings file: expected a JSON object");
+  }
+  const envelope = raw as Record<string, unknown>;
+  if (envelope.kind !== SETTINGS_EXPORT_KIND) {
+    throw new Error('Not a lurkloot settings file: unrecognized "kind"');
+  }
+  if (envelope.settings === null || typeof envelope.settings !== "object" || Array.isArray(envelope.settings)) {
+    throw new Error('Not a lurkloot settings file: missing "settings"');
+  }
+  return parseCliSettingsWithDiagnostics({ ...(envelope.settings as Record<string, unknown>), schemaVersion: envelope.schemaVersion });
 }
 
 // Validates and normalizes an already-migrated settings payload. See

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -11,7 +11,7 @@ import {
   normalizePriorities,
 } from "@lurkloot/shared/settings";
 import { CURRENT_SETTINGS_SCHEMA_VERSION, migrateSettings, type SettingsMigrationDiagnostic } from "@lurkloot/shared/settingsSchema";
-import { SETTINGS_EXPORT_KIND } from "@lurkloot/shared/settingsExport";
+import { SETTINGS_EXPORT_KIND, type SettingsExportEnvelope } from "@lurkloot/shared/settingsExport";
 import type { CompatibilitySettings, EngineSettings, KickPlatformSettings, Platform, PlatformSettingsByPlatform, PriorityMode, TwitchPlatformSettings } from "@lurkloot/shared/models";
 
 // The CLI's own settings surface — intentionally decoupled from the extension's
@@ -188,12 +188,7 @@ export function parseCliSettings(raw: unknown): CliSettings {
   return parseCliSettingsWithDiagnostics(raw).settings;
 }
 
-export interface CliSettingsExportPayload {
-  kind: typeof SETTINGS_EXPORT_KIND;
-  schemaVersion: number;
-  exportedAt: string;
-  settings: CliSettings;
-}
+export type CliSettingsExportPayload = SettingsExportEnvelope<CliSettings>;
 
 // Uses the same envelope (`kind`/`schemaVersion`) the extension's export does,
 // so a file can be recognized by either host — but the settings block itself

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -298,3 +298,40 @@ describe("CLI config warning integration", () => {
     }
   });
 });
+
+describe("config export/import", () => {
+  it("refuses to export over the active config file and leaves it untouched", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lurkloot-command-"));
+    try {
+      const configPath = writeLegacyConfig(dir);
+      const before = readFileSync(configPath, "utf8");
+      const result = runCli(configPath, ["config", "export", "--out", configPath]);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toMatch(/--out must not be the active config file/);
+      expect(readFileSync(configPath, "utf8")).toBe(before);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips settings through export and import", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lurkloot-command-"));
+    try {
+      const configPath = writeLegacyConfig(dir);
+      const exportPath = join(dir, "exported.json");
+      const exportResult = runCli(configPath, ["config", "export", "--out", exportPath]);
+      expect(exportResult.status, exportResult.stderr).toBe(0);
+
+      const importResult = runCli(configPath, ["config", "import", exportPath]);
+      expect(importResult.status, importResult.stderr).toBe(0);
+
+      const validateResult = runCli(configPath, ["validate-config"]);
+      expect(validateResult.status, validateResult.stderr).toBe(0);
+      const settings = JSON.parse(validateResult.stdout).settings;
+      expect(settings.platform.twitch.enabled).toBe(false);
+      expect(settings.platform.kick.enabled).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/tests/settings.test.ts
+++ b/packages/cli/tests/settings.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { mergeSettings } from "@lurkloot/shared/settings";
 import { migrateSettings } from "@lurkloot/shared/settingsSchema";
-import { DEFAULT_CLI_SETTINGS, parseCliSettings, parseCliSettingsWithDiagnostics, toEngineSettings } from "../src/settings";
+import { SETTINGS_EXPORT_KIND } from "@lurkloot/shared/settingsExport";
+import {
+  DEFAULT_CLI_SETTINGS,
+  buildCliSettingsExportPayload,
+  parseCliSettings,
+  parseCliSettingsImportPayload,
+  parseCliSettingsWithDiagnostics,
+  toEngineSettings,
+} from "../src/settings";
 
 describe("parseCliSettings", () => {
   it("migrates legacy Watch Queue settings and reports them", () => {
@@ -294,5 +302,40 @@ describe("toEngineSettings", () => {
     expect(cliEngine.platform.kick.idleWatchlistChannels).toEqual(extension.platform.kick.idleWatchlistChannels);
     expect(cliEngine.platform.twitch.autoClaimChannelPoints).toBe(extension.platform.twitch.autoClaimChannelPoints);
     expect(cliEngine.platform.twitch.autoClaimChannelPoints).toBe(false);
+  });
+});
+
+describe("CLI settings export/import", () => {
+  it("round-trips a customized settings object", () => {
+    const settings = parseCliSettings({
+      autoClaim: false,
+      excludedCampaignIds: ["abc123"],
+      platform: { twitch: { enabled: true, idleWatchlistChannels: ["someone"] } },
+    });
+    const payload = buildCliSettingsExportPayload(settings);
+    expect(payload.kind).toBe(SETTINGS_EXPORT_KIND);
+
+    const { settings: imported } = parseCliSettingsImportPayload(JSON.parse(JSON.stringify(payload)));
+    expect(imported).toEqual(settings);
+  });
+
+  it("never carries credential-shaped fields", () => {
+    const payload = buildCliSettingsExportPayload(DEFAULT_CLI_SETTINGS);
+    expect(JSON.stringify(payload)).not.toMatch(/authToken|sessionToken|deviceId|twitchIntegrity/i);
+  });
+
+  it("rejects a file that is not a lurkloot settings export", () => {
+    expect(() => parseCliSettingsImportPayload({ foo: "bar" })).toThrow(/unrecognized "kind"/);
+    expect(() => parseCliSettingsImportPayload(null)).toThrow(/expected a JSON object/);
+    expect(() => parseCliSettingsImportPayload({ kind: SETTINGS_EXPORT_KIND })).toThrow(/missing "settings"/);
+  });
+
+  it("rejects an extension-exported file the same way it rejects a copy-pasted extension config", () => {
+    const payload = {
+      kind: SETTINGS_EXPORT_KIND,
+      schemaVersion: 4,
+      settings: { autoClaim: true, muteFarmingTabs: true },
+    };
+    expect(() => parseCliSettingsImportPayload(payload)).toThrow(/"muteFarmingTabs" is an extension-only setting/);
   });
 });

--- a/packages/extension/entrypoints/popup/app.tsx
+++ b/packages/extension/entrypoints/popup/app.tsx
@@ -56,6 +56,38 @@ export function createExtensionPopupAdapter(): PopupAdapter {
       anchor.click();
       setTimeout(() => URL.revokeObjectURL(url), 0);
     },
+    exportSettings: (payload) => {
+      const url = URL.createObjectURL(new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" }));
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = "lurkloot-settings.json";
+      anchor.click();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    },
+    importSettings: () => new Promise<unknown | null>((resolve, reject) => {
+      const input = document.createElement("input");
+      input.type = "file";
+      input.accept = "application/json";
+      let settled = false;
+      const settle = (result: Promise<unknown | null> | unknown | null) => {
+        if (settled) return;
+        settled = true;
+        Promise.resolve(result).then(resolve, reject);
+      };
+      input.onchange = () => {
+        const file = input.files?.[0];
+        settle(file ? file.text().then((text) => JSON.parse(text)) : null);
+      };
+      // Some browsers never fire onchange when the picker is dismissed without
+      // a selection. `focus` fires right after the dialog closes either way; by
+      // then `input.files` already reflects the user's choice, so this only
+      // resolves the no-selection case. If a file WAS chosen, do nothing here —
+      // onchange (already in flight or about to fire) owns settling the promise.
+      window.addEventListener("focus", () => setTimeout(() => {
+        if (!input.files?.length) settle(null);
+      }, 300), { once: true });
+      input.click();
+    }),
     writeClipboard: async (text) => {
       try {
         await navigator.clipboard.writeText(text);

--- a/packages/extension/tests/settingsExportImport.test.ts
+++ b/packages/extension/tests/settingsExportImport.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS, mergeSettings } from "@lurkloot/shared/settings";
+import {
+  InvalidSettingsImportError,
+  SETTINGS_EXPORT_KIND,
+  buildSettingsExportPayload,
+  parseSettingsImportPayload,
+} from "@lurkloot/shared/settingsExport";
+import { CURRENT_SETTINGS_SCHEMA_VERSION, UnsupportedSettingsVersionError } from "@lurkloot/shared/settingsSchema";
+
+describe("settings export/import", () => {
+  it("round-trips a customized settings object", () => {
+    const settings = mergeSettings({
+      ...DEFAULT_SETTINGS,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true, idleWatchlistChannels: ["someone"] },
+      },
+      excludedCampaignIds: ["abc123"],
+      languageOverride: "es",
+    });
+
+    const payload = buildSettingsExportPayload(settings);
+    expect(payload.kind).toBe(SETTINGS_EXPORT_KIND);
+    expect(payload.schemaVersion).toBe(CURRENT_SETTINGS_SCHEMA_VERSION);
+
+    const { settings: imported, diagnostics } = parseSettingsImportPayload(JSON.parse(JSON.stringify(payload)));
+    expect(imported).toEqual(settings);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("never carries credential-shaped fields, even when injected into the source object", () => {
+    const settings = mergeSettings({
+      ...DEFAULT_SETTINGS,
+      // These are not real ExtensionSettings fields; simulate an attacker (or a
+      // stale build) putting them on the object handed to buildSettingsExportPayload.
+      authToken: "secret-token",
+      sessionToken: "secret-session",
+      deviceId: "secret-device",
+      twitchIntegrity: { clientIntegrity: "secret" },
+    } as never);
+
+    const payload = buildSettingsExportPayload(settings);
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toMatch(/authToken|sessionToken|deviceId|twitchIntegrity|secret-/i);
+  });
+
+  it("strips credential-shaped fields injected directly into an import file", () => {
+    const payload = buildSettingsExportPayload(DEFAULT_SETTINGS);
+    const tampered = {
+      ...payload,
+      settings: {
+        ...payload.settings,
+        authToken: "secret-token",
+        sessionToken: "secret-session",
+      },
+    };
+
+    const { settings } = parseSettingsImportPayload(tampered);
+    expect(settings).not.toHaveProperty("authToken");
+    expect(settings).not.toHaveProperty("sessionToken");
+    expect(JSON.stringify(settings)).not.toMatch(/secret-/);
+  });
+
+  it("rejects a payload from a future schema version instead of corrupting state", () => {
+    const payload = buildSettingsExportPayload(DEFAULT_SETTINGS);
+    const future = { ...payload, schemaVersion: CURRENT_SETTINGS_SCHEMA_VERSION + 1 };
+    expect(() => parseSettingsImportPayload(future)).toThrow(UnsupportedSettingsVersionError);
+  });
+
+  it("migrates an older-version payload forward", () => {
+    const payload = {
+      kind: SETTINGS_EXPORT_KIND,
+      schemaVersion: 0,
+      exportedAt: new Date().toISOString(),
+      settings: { autoClaim: false, watchQueueFallbackOnly: true },
+    };
+    const { settings, diagnostics } = parseSettingsImportPayload(payload);
+    expect(settings.autoClaim).toBe(false);
+    expect(settings.idleWatchlistFallbackOnly).toBe(true);
+    expect(diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("drops a non-https category imageUrl from a crafted import instead of rendering it as <img src>", () => {
+    const payload = buildSettingsExportPayload(DEFAULT_SETTINGS);
+    const tampered = {
+      ...payload,
+      settings: {
+        ...payload.settings,
+        platform: {
+          ...payload.settings.platform,
+          twitch: {
+            ...payload.settings.platform.twitch,
+            categories: [
+              { id: "javascript:alert(1)", name: "javascript", imageUrl: "javascript:alert(1)" },
+              { id: "http-beacon", name: "http beacon", imageUrl: "http://attacker.example/beacon.png" },
+              { id: "safe", name: "Safe Game", imageUrl: "https://cdn.example/safe.png" },
+            ],
+          },
+        },
+      },
+    };
+
+    const { settings } = parseSettingsImportPayload(tampered);
+    const categories = settings.platform.twitch.categories;
+    expect(categories.find((c) => c.id === "javascript:alert(1)")?.imageUrl).toBeUndefined();
+    expect(categories.find((c) => c.id === "http-beacon")?.imageUrl).toBeUndefined();
+    expect(categories.find((c) => c.id === "safe")?.imageUrl).toBe("https://cdn.example/safe.png");
+  });
+
+  it("rejects a file that is not a lurkloot settings export", () => {
+    expect(() => parseSettingsImportPayload({ foo: "bar" })).toThrow(InvalidSettingsImportError);
+    expect(() => parseSettingsImportPayload(null)).toThrow(InvalidSettingsImportError);
+    expect(() => parseSettingsImportPayload("not json")).toThrow(InvalidSettingsImportError);
+    expect(() => parseSettingsImportPayload({ kind: SETTINGS_EXPORT_KIND })).toThrow(InvalidSettingsImportError);
+  });
+});

--- a/packages/extension/tests/settingsExportImportUi.test.tsx
+++ b/packages/extension/tests/settingsExportImportUi.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Popup, createDemoPopupAdapter, screenshotVariant, type PopupAdapter } from "@lurkloot/popup-ui";
+import { buildSettingsExportPayload } from "@lurkloot/shared/settingsExport";
+import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
+import { resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
+
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
+
+const labels: Record<string, string> = {
+  openSettings: "Open settings",
+  back: "Back",
+  settingsSearchPlaceholder: "Search settings…",
+  settingsShowAdvancedTitle: "Show advanced settings",
+  settingsExportHint: "Save your settings to a file.",
+  settingsExportButton: "Export settings",
+  settingsImportButton: "Import settings",
+  settingsImportConfirm: "This replaces your current settings.",
+  settingsImportCancel: "Cancel",
+  settingsImportConfirmButton: "Choose file and import",
+  settingsImportFailed: "That file isn't a valid Lurkloot settings export.",
+};
+
+let root: Root | undefined;
+
+afterEach(() => {
+  resetCatalogTracking();
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+async function mount(overrides: Partial<PopupAdapter> = {}) {
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => window.setTimeout(() => callback(Date.now()), 0));
+  vi.stubGlobal("cancelAnimationFrame", (handle: number) => window.clearTimeout(handle));
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr" }));
+  const container = document.getElementById("app")!;
+  const demoAdapter = createDemoPopupAdapter();
+  const adapter: PopupAdapter = {
+    ...demoAdapter,
+    getMessage: (key) => labels[key] ?? demoAdapter.getMessage(key),
+    exportSettings: vi.fn(),
+    importSettings: vi.fn(),
+    ...overrides,
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} initialState={{ preview: true, variant: screenshotVariant("settings") }} />);
+  });
+  await waitForCatalog();
+  return { container, exportSettings: adapter.exportSettings as ReturnType<typeof vi.fn>, importSettings: adapter.importSettings as ReturnType<typeof vi.fn> };
+}
+
+function byText(container: Element, text: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find((item) => item.textContent?.includes(text));
+  if (!button) throw new Error(`Missing button: ${text}`);
+  return button as HTMLButtonElement;
+}
+
+describe("settings export/import", () => {
+  it("exports the current settings without a confirmation step", async () => {
+    const { container, exportSettings } = await mount();
+
+    expect(container.textContent).toContain("Export settings");
+    act(() => byText(container, "Export settings").click());
+
+    expect(exportSettings).toHaveBeenCalledTimes(1);
+    const payload = exportSettings.mock.calls[0][0];
+    expect(payload.kind).toBe(buildSettingsExportPayload(DEFAULT_SETTINGS).kind);
+    expect(payload.settings).toBeDefined();
+  });
+
+  it("requires arm-then-confirm before importing, and cancel does not call the adapter", async () => {
+    const { container, importSettings } = await mount();
+
+    expect(container.textContent).not.toContain("Choose file and import");
+    act(() => byText(container, "Import settings").click());
+    expect(container.textContent).toContain("This replaces your current settings.");
+    expect(importSettings).not.toHaveBeenCalled();
+
+    act(() => byText(container, "Cancel").click());
+    expect(container.textContent).not.toContain("Choose file and import");
+    expect(importSettings).not.toHaveBeenCalled();
+  });
+
+  it("applies an imported settings payload on confirm", async () => {
+    const imported = buildSettingsExportPayload({
+      ...DEFAULT_SETTINGS,
+      platform: { ...DEFAULT_SETTINGS.platform, twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true } },
+    });
+    const { container, importSettings } = await mount({
+      importSettings: vi.fn().mockResolvedValue(imported),
+    });
+
+    act(() => byText(container, "Import settings").click());
+    await act(async () => byText(container, "Choose file and import").click());
+
+    expect(importSettings).toHaveBeenCalledTimes(1);
+    expect(container.textContent).not.toContain("This replaces your current settings.");
+    expect(container.textContent).not.toContain("That file isn't a valid Lurkloot settings export.");
+  });
+
+  it("shows a failure message when the selected file is not a valid export", async () => {
+    const { container } = await mount({
+      importSettings: vi.fn().mockResolvedValue({ not: "a settings export" }),
+    });
+
+    act(() => byText(container, "Import settings").click());
+    await act(async () => byText(container, "Choose file and import").click());
+
+    expect(container.textContent).toContain("That file isn't a valid Lurkloot settings export.");
+  });
+
+  it("does not call the adapter when the user cancels the file picker", async () => {
+    const { container } = await mount({
+      importSettings: vi.fn().mockResolvedValue(null),
+    });
+
+    act(() => byText(container, "Import settings").click());
+    await act(async () => byText(container, "Choose file and import").click());
+
+    expect(container.textContent).toContain("This replaces your current settings.");
+    expect(container.textContent).not.toContain("That file isn't a valid Lurkloot settings export.");
+  });
+});

--- a/packages/extension/tests/settingsExportImportUi.test.tsx
+++ b/packages/extension/tests/settingsExportImportUi.test.tsx
@@ -44,8 +44,14 @@ async function mount(overrides: Partial<PopupAdapter> = {}) {
   vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr" }));
   const container = document.getElementById("app")!;
   const demoAdapter = createDemoPopupAdapter();
+  const sentMessages: unknown[] = [];
+  const send: PopupAdapter["send"] = (message) => {
+    sentMessages.push(message);
+    return demoAdapter.send(message);
+  };
   const adapter: PopupAdapter = {
     ...demoAdapter,
+    send,
     getMessage: (key) => labels[key] ?? demoAdapter.getMessage(key),
     exportSettings: vi.fn(),
     importSettings: vi.fn(),
@@ -56,13 +62,22 @@ async function mount(overrides: Partial<PopupAdapter> = {}) {
     root.render(<Popup adapter={adapter} initialState={{ preview: true, variant: screenshotVariant("settings") }} />);
   });
   await waitForCatalog();
-  return { container, exportSettings: adapter.exportSettings as ReturnType<typeof vi.fn>, importSettings: adapter.importSettings as ReturnType<typeof vi.fn> };
+  return {
+    container,
+    exportSettings: adapter.exportSettings as ReturnType<typeof vi.fn>,
+    importSettings: adapter.importSettings as ReturnType<typeof vi.fn>,
+    sentMessages,
+  };
 }
 
 function byText(container: Element, text: string): HTMLButtonElement {
   const button = [...container.querySelectorAll("button")].find((item) => item.textContent?.includes(text));
   if (!button) throw new Error(`Missing button: ${text}`);
   return button as HTMLButtonElement;
+}
+
+function saveSettingsCalls(sentMessages: unknown[]): unknown[] {
+  return sentMessages.filter((message) => (message as { type: string }).type === "saveSettings");
 }
 
 describe("settings export/import", () => {
@@ -96,7 +111,7 @@ describe("settings export/import", () => {
       ...DEFAULT_SETTINGS,
       platform: { ...DEFAULT_SETTINGS.platform, twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true } },
     });
-    const { container, importSettings } = await mount({
+    const { container, importSettings, sentMessages } = await mount({
       importSettings: vi.fn().mockResolvedValue(imported),
     });
 
@@ -106,6 +121,14 @@ describe("settings export/import", () => {
     expect(importSettings).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("This replaces your current settings.");
     expect(container.textContent).not.toContain("That file isn't a valid Lurkloot settings export.");
+
+    // Confirms the imported settings were actually applied through the normal
+    // save path, not just parsed and discarded.
+    const saved = saveSettingsCalls(sentMessages);
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({
+      settingsPatch: expect.objectContaining({ platform: expect.objectContaining({ twitch: expect.objectContaining({ enabled: true }) }) }),
+    });
   });
 
   it("shows a failure message when the selected file is not a valid export", async () => {
@@ -119,14 +142,19 @@ describe("settings export/import", () => {
     expect(container.textContent).toContain("That file isn't a valid Lurkloot settings export.");
   });
 
-  it("does not call the adapter when the user cancels the file picker", async () => {
-    const { container } = await mount({
+  it("opens the file picker but does not save settings when the user cancels it", async () => {
+    const { container, importSettings, sentMessages } = await mount({
       importSettings: vi.fn().mockResolvedValue(null),
     });
 
     act(() => byText(container, "Import settings").click());
     await act(async () => byText(container, "Choose file and import").click());
 
+    // importSettings must run to open the OS file picker; cancelling it (a
+    // resolved null) is what leaves the confirm panel open with no error and
+    // nothing saved — distinct from the invalid-file case above.
+    expect(importSettings).toHaveBeenCalledTimes(1);
+    expect(saveSettingsCalls(sentMessages)).toHaveLength(0);
     expect(container.textContent).toContain("This replaces your current settings.");
     expect(container.textContent).not.toContain("That file isn't a valid Lurkloot settings export.");
   });

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "تصدير بيانات الاعتماد"
   },
+  "settingsExportTitle": {
+    "message": "استيراد/تصدير الإعدادات"
+  },
+  "settingsExportHint": {
+    "message": "احفظ إعداداتك في ملف، أو حمّلها على متصفح آخر. لا يتضمن أبدًا بيانات تسجيل الدخول إلى Twitch أو Kick."
+  },
+  "settingsExportButton": {
+    "message": "تصدير الإعدادات"
+  },
+  "settingsImportButton": {
+    "message": "استيراد الإعدادات"
+  },
+  "settingsImportConfirm": {
+    "message": "سيؤدي هذا إلى استبدال إعداداتك الحالية بالإعدادات من الملف المحدد. هل تريد المتابعة؟"
+  },
+  "settingsImportCancel": {
+    "message": "إلغاء"
+  },
+  "settingsImportConfirmButton": {
+    "message": "اختر ملفًا واستورد"
+  },
+  "settingsImportFailed": {
+    "message": "هذا الملف ليس تصديرًا صالحًا لإعدادات Lurkloot."
+  },
   "factoryResetTitle": {
     "message": "إعادة ضبط Lurkloot"
   },

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "عرض الإعدادات المتقدمة"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "الانتقال إلى قسم"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "إجراءات متقدمة"
+  },
   "settingsSectionGeneral": {
     "message": "عام"
   },

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "هذا الملف ليس تصديرًا صالحًا لإعدادات Lurkloot."
   },
+  "settingsExportFailed": {
+    "message": "تعذّر على Lurkloot تصدير إعداداتك. حاول مرة أخرى."
+  },
   "factoryResetTitle": {
     "message": "إعادة ضبط Lurkloot"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "Diese Datei ist kein gültiger Lurkloot-Einstellungsexport."
   },
+  "settingsExportFailed": {
+    "message": "Lurkloot konnte deine Einstellungen nicht exportieren. Versuche es erneut."
+  },
   "factoryResetTitle": {
     "message": "Lurkloot zurücksetzen"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "Anmeldedaten exportieren"
   },
+  "settingsExportTitle": {
+    "message": "Einstellungen importieren/exportieren"
+  },
+  "settingsExportHint": {
+    "message": "Speichere deine Einstellungen in einer Datei oder lade sie in einem anderen Browser. Enthält niemals deine Twitch- oder Kick-Anmeldedaten."
+  },
+  "settingsExportButton": {
+    "message": "Einstellungen exportieren"
+  },
+  "settingsImportButton": {
+    "message": "Einstellungen importieren"
+  },
+  "settingsImportConfirm": {
+    "message": "Dies ersetzt deine aktuellen Einstellungen durch die aus der ausgewählten Datei. Fortfahren?"
+  },
+  "settingsImportCancel": {
+    "message": "Abbrechen"
+  },
+  "settingsImportConfirmButton": {
+    "message": "Datei wählen und importieren"
+  },
+  "settingsImportFailed": {
+    "message": "Diese Datei ist kein gültiger Lurkloot-Einstellungsexport."
+  },
   "factoryResetTitle": {
     "message": "Lurkloot zurücksetzen"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "Erweiterte Einstellungen anzeigen"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "Zu Abschnitt springen"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "Erweiterte Aktionen"
+  },
   "settingsSectionGeneral": {
     "message": "Allgemein"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "That file isn't a valid Lurkloot settings export."
   },
+  "settingsExportFailed": {
+    "message": "Lurkloot couldn't export your settings. Try again."
+  },
   "factoryResetTitle": {
     "message": "Reset Lurkloot"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "Show advanced settings"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "Jump to section"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "Advanced actions"
+  },
   "settingsSectionGeneral": {
     "message": "General"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "Export credentials"
   },
+  "settingsExportTitle": {
+    "message": "Import / export settings"
+  },
+  "settingsExportHint": {
+    "message": "Save your settings to a file, or load them on another browser. Never includes your Twitch or Kick login."
+  },
+  "settingsExportButton": {
+    "message": "Export settings"
+  },
+  "settingsImportButton": {
+    "message": "Import settings"
+  },
+  "settingsImportConfirm": {
+    "message": "This replaces your current settings with the ones from the selected file. Continue?"
+  },
+  "settingsImportCancel": {
+    "message": "Cancel"
+  },
+  "settingsImportConfirmButton": {
+    "message": "Choose file and import"
+  },
+  "settingsImportFailed": {
+    "message": "That file isn't a valid Lurkloot settings export."
+  },
   "factoryResetTitle": {
     "message": "Reset Lurkloot"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "Mostrar configuración avanzada"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "Ir a la sección"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "Acciones avanzadas"
+  },
   "settingsSectionGeneral": {
     "message": "General"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "Exportar credenciales"
   },
+  "settingsExportTitle": {
+    "message": "Importar/exportar configuración"
+  },
+  "settingsExportHint": {
+    "message": "Guarda tu configuración en un archivo o cárgala en otro navegador. Nunca incluye tu inicio de sesión de Twitch o Kick."
+  },
+  "settingsExportButton": {
+    "message": "Exportar configuración"
+  },
+  "settingsImportButton": {
+    "message": "Importar configuración"
+  },
+  "settingsImportConfirm": {
+    "message": "Esto reemplazará tu configuración actual con la del archivo seleccionado. ¿Continuar?"
+  },
+  "settingsImportCancel": {
+    "message": "Cancelar"
+  },
+  "settingsImportConfirmButton": {
+    "message": "Elegir archivo e importar"
+  },
+  "settingsImportFailed": {
+    "message": "Ese archivo no es una exportación de configuración válida de Lurkloot."
+  },
   "factoryResetTitle": {
     "message": "Restablecer Lurkloot"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "Ese archivo no es una exportación de configuración válida de Lurkloot."
   },
+  "settingsExportFailed": {
+    "message": "Lurkloot no pudo exportar tu configuración. Inténtalo de nuevo."
+  },
   "factoryResetTitle": {
     "message": "Restablecer Lurkloot"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "Afficher les paramètres avancés"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "Aller à la section"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "Actions avancées"
+  },
   "settingsSectionGeneral": {
     "message": "Général"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "Ce fichier n'est pas une exportation de paramètres Lurkloot valide."
   },
+  "settingsExportFailed": {
+    "message": "Lurkloot n'a pas pu exporter vos paramètres. Réessayez."
+  },
   "factoryResetTitle": {
     "message": "Réinitialiser Lurkloot"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "Exporter les identifiants"
   },
+  "settingsExportTitle": {
+    "message": "Importer/exporter les paramètres"
+  },
+  "settingsExportHint": {
+    "message": "Enregistrez vos paramètres dans un fichier ou chargez-les sur un autre navigateur. N'inclut jamais vos identifiants Twitch ou Kick."
+  },
+  "settingsExportButton": {
+    "message": "Exporter les paramètres"
+  },
+  "settingsImportButton": {
+    "message": "Importer les paramètres"
+  },
+  "settingsImportConfirm": {
+    "message": "Cela remplacera vos paramètres actuels par ceux du fichier sélectionné. Continuer ?"
+  },
+  "settingsImportCancel": {
+    "message": "Annuler"
+  },
+  "settingsImportConfirmButton": {
+    "message": "Choisir un fichier et importer"
+  },
+  "settingsImportFailed": {
+    "message": "Ce fichier n'est pas une exportation de paramètres Lurkloot valide."
+  },
   "factoryResetTitle": {
     "message": "Réinitialiser Lurkloot"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "उन्नत सेटिंग्स दिखाएँ"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "अनुभाग पर जाएँ"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "उन्नत कार्रवाइयाँ"
+  },
   "settingsSectionGeneral": {
     "message": "सामान्य"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "क्रेडेंशियल निर्यात करें"
   },
+  "settingsExportTitle": {
+    "message": "सेटिंग्स आयात/निर्यात करें"
+  },
+  "settingsExportHint": {
+    "message": "अपनी सेटिंग्स को एक फ़ाइल में सहेजें, या उन्हें किसी अन्य ब्राउज़र पर लोड करें। इसमें कभी भी आपका Twitch या Kick लॉगिन शामिल नहीं होता।"
+  },
+  "settingsExportButton": {
+    "message": "सेटिंग्स निर्यात करें"
+  },
+  "settingsImportButton": {
+    "message": "सेटिंग्स आयात करें"
+  },
+  "settingsImportConfirm": {
+    "message": "यह आपकी वर्तमान सेटिंग्स को चयनित फ़ाइल की सेटिंग्स से बदल देगा। जारी रखें?"
+  },
+  "settingsImportCancel": {
+    "message": "रद्द करें"
+  },
+  "settingsImportConfirmButton": {
+    "message": "फ़ाइल चुनें और आयात करें"
+  },
+  "settingsImportFailed": {
+    "message": "वह फ़ाइल एक मान्य Lurkloot सेटिंग्स निर्यात नहीं है।"
+  },
   "factoryResetTitle": {
     "message": "Lurkloot रीसेट करें"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "वह फ़ाइल एक मान्य Lurkloot सेटिंग्स निर्यात नहीं है।"
   },
+  "settingsExportFailed": {
+    "message": "Lurkloot आपकी सेटिंग्स निर्यात नहीं कर सका। फिर से कोशिश करें।"
+  },
   "factoryResetTitle": {
     "message": "Lurkloot रीसेट करें"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "Quel file non è un'esportazione di impostazioni Lurkloot valida."
   },
+  "settingsExportFailed": {
+    "message": "Lurkloot non è riuscito a esportare le tue impostazioni. Riprova."
+  },
   "factoryResetTitle": {
     "message": "Reimposta Lurkloot"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "Esporta credenziali"
   },
+  "settingsExportTitle": {
+    "message": "Importa/esporta impostazioni"
+  },
+  "settingsExportHint": {
+    "message": "Salva le tue impostazioni in un file oppure caricale su un altro browser. Non include mai il tuo login Twitch o Kick."
+  },
+  "settingsExportButton": {
+    "message": "Esporta impostazioni"
+  },
+  "settingsImportButton": {
+    "message": "Importa impostazioni"
+  },
+  "settingsImportConfirm": {
+    "message": "Questo sostituirà le tue impostazioni attuali con quelle del file selezionato. Continuare?"
+  },
+  "settingsImportCancel": {
+    "message": "Annulla"
+  },
+  "settingsImportConfirmButton": {
+    "message": "Scegli file e importa"
+  },
+  "settingsImportFailed": {
+    "message": "Quel file non è un'esportazione di impostazioni Lurkloot valida."
+  },
   "factoryResetTitle": {
     "message": "Reimposta Lurkloot"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "Mostra impostazioni avanzate"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "Vai alla sezione"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "Azioni avanzate"
+  },
   "settingsSectionGeneral": {
     "message": "Generale"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "Exportar credenciais"
   },
+  "settingsExportTitle": {
+    "message": "Importar/exportar configurações"
+  },
+  "settingsExportHint": {
+    "message": "Salve suas configurações em um arquivo ou carregue-as em outro navegador. Nunca inclui seu login do Twitch ou Kick."
+  },
+  "settingsExportButton": {
+    "message": "Exportar configurações"
+  },
+  "settingsImportButton": {
+    "message": "Importar configurações"
+  },
+  "settingsImportConfirm": {
+    "message": "Isso substituirá suas configurações atuais pelas do arquivo selecionado. Continuar?"
+  },
+  "settingsImportCancel": {
+    "message": "Cancelar"
+  },
+  "settingsImportConfirmButton": {
+    "message": "Escolher arquivo e importar"
+  },
+  "settingsImportFailed": {
+    "message": "Esse arquivo não é uma exportação de configurações válida do Lurkloot."
+  },
   "factoryResetTitle": {
     "message": "Redefinir o Lurkloot"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "Mostrar configurações avançadas"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "Ir para a seção"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "Ações avançadas"
+  },
   "settingsSectionGeneral": {
     "message": "Geral"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "Esse arquivo não é uma exportação de configurações válida do Lurkloot."
   },
+  "settingsExportFailed": {
+    "message": "O Lurkloot não conseguiu exportar suas configurações. Tente novamente."
+  },
   "factoryResetTitle": {
     "message": "Redefinir o Lurkloot"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "Экспортировать учётные данные"
   },
+  "settingsExportTitle": {
+    "message": "Импорт/экспорт настроек"
+  },
+  "settingsExportHint": {
+    "message": "Сохраните настройки в файл или загрузите их в другом браузере. Никогда не включает вход в Twitch или Kick."
+  },
+  "settingsExportButton": {
+    "message": "Экспортировать настройки"
+  },
+  "settingsImportButton": {
+    "message": "Импортировать настройки"
+  },
+  "settingsImportConfirm": {
+    "message": "Это заменит текущие настройки настройками из выбранного файла. Продолжить?"
+  },
+  "settingsImportCancel": {
+    "message": "Отмена"
+  },
+  "settingsImportConfirmButton": {
+    "message": "Выбрать файл и импортировать"
+  },
+  "settingsImportFailed": {
+    "message": "Этот файл не является допустимым экспортом настроек Lurkloot."
+  },
   "factoryResetTitle": {
     "message": "Сбросить Lurkloot"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "Показать дополнительные настройки"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "Перейти к разделу"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "Дополнительные действия"
+  },
   "settingsSectionGeneral": {
     "message": "Общие"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "Этот файл не является допустимым экспортом настроек Lurkloot."
   },
+  "settingsExportFailed": {
+    "message": "Lurkloot не удалось экспортировать настройки. Повторите попытку."
+  },
   "factoryResetTitle": {
     "message": "Сбросить Lurkloot"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "Gelişmiş ayarlar"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "Bölüme git"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "Gelişmiş işlemler"
+  },
   "settingsSectionGeneral": {
     "message": "Genel"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "Giriş bilgilerini indir"
   },
+  "settingsExportTitle": {
+    "message": "Ayarları içe/dışa aktar"
+  },
+  "settingsExportHint": {
+    "message": "Ayarlarınızı bir dosyaya kaydedin veya başka bir tarayıcıya yükleyin. Twitch veya Kick giriş bilgilerinizi asla içermez."
+  },
+  "settingsExportButton": {
+    "message": "Ayarları dışa aktar"
+  },
+  "settingsImportButton": {
+    "message": "Ayarları içe aktar"
+  },
+  "settingsImportConfirm": {
+    "message": "Bu, mevcut ayarlarınızı seçilen dosyadaki ayarlarla değiştirecek. Devam edilsin mi?"
+  },
+  "settingsImportCancel": {
+    "message": "İptal"
+  },
+  "settingsImportConfirmButton": {
+    "message": "Dosya seç ve içe aktar"
+  },
+  "settingsImportFailed": {
+    "message": "Bu dosya geçerli bir Lurkloot ayar dışa aktarımı değil."
+  },
   "factoryResetTitle": {
     "message": "Lurkloot'u Sıfırla"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "Bu dosya geçerli bir Lurkloot ayar dışa aktarımı değil."
   },
+  "settingsExportFailed": {
+    "message": "Lurkloot ayarlarınızı dışa aktaramadı. Tekrar deneyin."
+  },
   "factoryResetTitle": {
     "message": "Lurkloot'u Sıfırla"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -818,6 +818,9 @@
   "settingsImportFailed": {
     "message": "该文件不是有效的 Lurkloot 设置导出文件。"
   },
+  "settingsExportFailed": {
+    "message": "Lurkloot 无法导出您的设置。请重试。"
+  },
   "factoryResetTitle": {
     "message": "重置 Lurkloot"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -65,6 +65,12 @@
   "settingsShowAdvancedTitle": {
     "message": "显示高级设置"
   },
+  "settingsSectionJumpNavLabel": {
+    "message": "跳转到分区"
+  },
+  "settingsSectionAdvancedActions": {
+    "message": "高级操作"
+  },
   "settingsSectionGeneral": {
     "message": "常规"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -788,6 +788,30 @@
   "cliExportButton": {
     "message": "导出凭据"
   },
+  "settingsExportTitle": {
+    "message": "导入/导出设置"
+  },
+  "settingsExportHint": {
+    "message": "将设置保存到文件，或在其他浏览器中加载它们。绝不包含您的 Twitch 或 Kick 登录信息。"
+  },
+  "settingsExportButton": {
+    "message": "导出设置"
+  },
+  "settingsImportButton": {
+    "message": "导入设置"
+  },
+  "settingsImportConfirm": {
+    "message": "这将用所选文件中的设置替换您当前的设置。是否继续？"
+  },
+  "settingsImportCancel": {
+    "message": "取消"
+  },
+  "settingsImportConfirmButton": {
+    "message": "选择文件并导入"
+  },
+  "settingsImportFailed": {
+    "message": "该文件不是有效的 Lurkloot 设置导出文件。"
+  },
   "factoryResetTitle": {
     "message": "重置 Lurkloot"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -13,6 +13,7 @@ import type { ActivityPage, CategorySearchResult, CliCredentialBlob, RuntimeSnap
 import type { ActivityHistoryRecord } from "@lurkloot/shared/events";
 import type { CategorySelection, ExtensionSettings, Platform } from "@lurkloot/shared/models";
 import { applySettingsPatch, DEFAULT_SETTINGS, mergeSettings, type SettingsPatch } from "@lurkloot/shared/settings";
+import { buildSettingsExportPayload, parseSettingsImportPayload } from "@lurkloot/shared/settingsExport";
 import { effectiveLocale, isRtlLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
 import { loadCatalog } from "@lurkloot/locales";
 import { buildFailureReport } from "@lurkloot/shared/failureReport";
@@ -488,6 +489,27 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   }
 
   const settings = mergeSettings(snapshot.settings);
+
+  // Downloads the current settings as a portable JSON file. Available only
+  // when the host adapter supports it (the live extension, not the demo).
+  const exportSettings = adapter.exportSettings
+    ? () => adapter.exportSettings?.(buildSettingsExportPayload(settingsRef.current ?? settings))
+    : undefined;
+
+  // Prompts for a settings file, validates/migrates it (never trusting file
+  // contents), and applies the result as a full patch — the same save path
+  // every other settings mutation uses, so it goes through the same queue and
+  // storage lock. Returns false when the user cancels the file picker.
+  const importSettings = adapter.importSettings
+    ? async () => {
+        const raw = await adapter.importSettings!();
+        if (raw == null) return false;
+        const { settings: imported } = parseSettingsImportPayload(raw);
+        await updateSettings(imported as SettingsPatch, { tickAfterSave: true });
+        return true;
+      }
+    : undefined;
+
   const compatibilityResolution = adapter.resolveCompatibility?.(settings.compatibility);
   const excludedIds = new Set(settings.excludedCampaignIds);
   const rawCampaigns = sortCampaignsForPopup(snapshot.state.campaigns[platform].filter((campaign) => isCampaignVisible(campaign, settings.dropsListFilter, settings.farmingEligibility, excludedIds)), settings);
@@ -618,7 +640,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
           <AnimatePresence mode="wait" initial={false}>
             {settingsOpen ? (
               <motion.div key="settings" initial={{ opacity: 0, x: 14 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 14 }} transition={{ duration: 0.18 }} className="space-y-2.5">
-                <SettingsView suggestions={dropCategorySuggestions} onSearchCategories={searchCategories} settings={settings} onSettingsChange={updateSettings} onExportCredentials={exportCredentials} onReset={resetExtension} exportConfirmationResetKey={settingsOpenGeneration} compatibilityRegistry={adapter.compatibilityRegistry} compatibilityResolution={compatibilityResolution} />
+                <SettingsView suggestions={dropCategorySuggestions} onSearchCategories={searchCategories} settings={settings} onSettingsChange={updateSettings} onExportCredentials={exportCredentials} onExportSettings={exportSettings} onImportSettings={importSettings} onReset={resetExtension} exportConfirmationResetKey={settingsOpenGeneration} compatibilityRegistry={adapter.compatibilityRegistry} compatibilityResolution={compatibilityResolution} />
               </motion.div>
             ) : activityOpen ? (
               <motion.div key="activity" initial={{ opacity: 0, x: 14 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 14 }} transition={{ duration: 0.18 }}>

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -32,6 +32,8 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
   const [query, setQuery] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [exportArmed, setExportArmed] = useState(false);
+  const [exportingSettings, setExportingSettings] = useState(false);
+  const [exportSettingsFailed, setExportSettingsFailed] = useState(false);
   const [importArmed, setImportArmed] = useState(false);
   const [importing, setImporting] = useState(false);
   const [importFailed, setImportFailed] = useState(false);
@@ -40,11 +42,31 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
   const [resetFailed, setResetFailed] = useState(false);
   useEffect(() => {
     setExportArmed(false);
+    setExportingSettings(false);
+    setExportSettingsFailed(false);
     setImportArmed(false);
     setImportFailed(false);
     setResetArmed(false);
     setResetFailed(false);
   }, [exportConfirmationResetKey]);
+
+  // Export needs no arm/confirm step (it only reads, never mutates), but it
+  // still needs a busy/failure state like import and reset: a slow or failed
+  // download (disk full, permission denied) should not look identical to a
+  // successful one, and a second click while one is in flight should be a
+  // no-op rather than racing two downloads.
+  async function confirmExportSettings(): Promise<void> {
+    if (!onExportSettings || exportingSettings) return;
+    setExportingSettings(true);
+    setExportSettingsFailed(false);
+    try {
+      await onExportSettings();
+    } catch {
+      setExportSettingsFailed(true);
+    } finally {
+      setExportingSettings(false);
+    }
+  }
 
   async function confirmImport(): Promise<void> {
     if (!onImportSettings || importing) return;
@@ -210,12 +232,14 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
                 ) : (
                   <div className="mt-1.5 space-y-2">
                     <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("settingsExportHint")}</p>
+                    {exportSettingsFailed ? <p role="alert" className="text-xs font-medium text-red-600 dark:text-red-400">{t("settingsExportFailed")}</p> : null}
                     <div className="flex flex-wrap justify-end gap-2">
                       {onExportSettings ? (
                         <button
                           type="button"
-                          className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                          onClick={() => void onExportSettings()}
+                          disabled={exportingSettings}
+                          className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                          onClick={() => void confirmExportSettings()}
                         >
                           <Download size={13} />
                           {t("settingsExportButton")}

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Download, RotateCcw, Terminal, Upload } from "lucide-react";
 import type { CategorySelection, ExtensionSettings, Platform } from "@lurkloot/shared/models";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
@@ -101,12 +101,45 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
     [sections, t, query, showAdvanced],
   );
   const searching = query.trim().length > 0;
+  const topBarRef = useRef<HTMLDivElement>(null);
+
+  // Not scrollIntoView: that only guarantees the target clears the *viewport*
+  // edge, not our own sticky search/jump-nav bar layered on top of it, so the
+  // section header would land hidden underneath. Scroll by the bar's live
+  // height instead — measured, not hardcoded, so it holds regardless of
+  // locale or how many lines the chip row wraps to.
+  function jumpTo(id: string): void {
+    const target = document.getElementById(`settings-section-${id}`);
+    const scrollParent = target?.closest(".nice-scroll") as HTMLElement | null;
+    if (!target || !scrollParent) {
+      target?.scrollIntoView({ behavior: "smooth", block: "start" });
+      return;
+    }
+    const barHeight = topBarRef.current?.offsetHeight ?? 0;
+    const targetTop = target.getBoundingClientRect().top - scrollParent.getBoundingClientRect().top + scrollParent.scrollTop;
+    scrollParent.scrollTo({ top: targetTop - barHeight - 8, behavior: "smooth" });
+  }
 
   return (
     <div className="space-y-4">
-      <div className="space-y-2">
+      <div ref={topBarRef} className="sticky top-0 z-20 -mx-3 space-y-2 bg-zinc-50 px-3 pb-2 pt-3 dark:bg-zinc-950">
         <SettingsSearchBox value={query} onChange={setQuery} />
         <AdvancedSettingsSwitch checked={showAdvanced} onChange={toggleAdvanced} />
+        {!searching && visible.length > 1 ? (
+          <nav aria-label={t("settingsSectionJumpNavLabel")} className="flex items-center gap-1.5 overflow-x-auto pb-0.5">
+            {visible.map((section) => (
+              <button
+                key={section.id}
+                type="button"
+                onClick={() => jumpTo(section.id)}
+                className="flex shrink-0 items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-zinc-600 outline-none transition-colors hover:border-[var(--accent-ring)] hover:text-zinc-900 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
+              >
+                {section.iconNode ?? (section.icon ? <section.icon size={12} /> : null)}
+                {t(section.titleKey)}
+              </button>
+            ))}
+          </nav>
+        ) : null}
       </div>
 
       {visible.length === 0 ? (
@@ -139,174 +172,168 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
         </div>
       )}
 
-      {(onExportSettings || onImportSettings) && !searching ? (
-        <div className="pt-2">
-          <div className="mb-1 flex items-center gap-1.5 px-1">
-            <span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">{t("settingsExportTitle")}</span>
-            <span className="h-px flex-1 bg-zinc-100 dark:bg-zinc-800/70" />
+      {(onExportSettings || onImportSettings || onExportCredentials || onReset) && !searching ? (
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5 px-1">
+            <span className="text-[12px] font-bold uppercase tracking-wide text-zinc-700 dark:text-zinc-200">{t("settingsSectionAdvancedActions")}</span>
           </div>
-          {importArmed ? (
-            <div className="space-y-2 px-1 py-1">
-              <p className="text-xs leading-relaxed text-amber-700 dark:text-amber-300">{t("settingsImportConfirm")}</p>
-              {importFailed ? <p role="alert" className="text-xs font-medium text-red-600 dark:text-red-400">{t("settingsImportFailed")}</p> : null}
-              <div className="flex flex-wrap justify-end gap-2">
-                <button
-                  type="button"
-                  disabled={importing}
-                  className="rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                  onClick={() => {
-                    setImportArmed(false);
-                    setImportFailed(false);
-                  }}
-                >
-                  {t("settingsImportCancel")}
-                </button>
-                <button
-                  type="button"
-                  disabled={importing}
-                  className="rounded-xl bg-[var(--accent)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-contrast)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50"
-                  onClick={() => void confirmImport()}
-                >
-                  {t("settingsImportConfirmButton")}
-                </button>
+          <div className="divide-y divide-zinc-100 rounded-xl border border-zinc-200/70 bg-white dark:divide-zinc-800/70 dark:border-zinc-800 dark:bg-zinc-900/40">
+            {onExportSettings || onImportSettings ? (
+              <div className="p-2.5">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">{t("settingsExportTitle")}</div>
+                {importArmed ? (
+                  <div className="mt-1.5 space-y-2">
+                    <p className="text-xs leading-relaxed text-amber-700 dark:text-amber-300">{t("settingsImportConfirm")}</p>
+                    {importFailed ? <p role="alert" className="text-xs font-medium text-red-600 dark:text-red-400">{t("settingsImportFailed")}</p> : null}
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <button
+                        type="button"
+                        disabled={importing}
+                        className="rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        onClick={() => {
+                          setImportArmed(false);
+                          setImportFailed(false);
+                        }}
+                      >
+                        {t("settingsImportCancel")}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={importing}
+                        className="rounded-xl bg-[var(--accent)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-contrast)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50"
+                        onClick={() => void confirmImport()}
+                      >
+                        {t("settingsImportConfirmButton")}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mt-1.5 space-y-2">
+                    <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("settingsExportHint")}</p>
+                    <div className="flex flex-wrap justify-end gap-2">
+                      {onExportSettings ? (
+                        <button
+                          type="button"
+                          className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                          onClick={() => void onExportSettings()}
+                        >
+                          <Download size={13} />
+                          {t("settingsExportButton")}
+                        </button>
+                      ) : null}
+                      {onImportSettings ? (
+                        <button
+                          type="button"
+                          className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                          onClick={() => setImportArmed(true)}
+                        >
+                          <Upload size={13} />
+                          {t("settingsImportButton")}
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                )}
               </div>
-            </div>
-          ) : (
-            <div className="space-y-2 px-1 pb-1">
-              <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("settingsExportHint")}</p>
-              <div className="flex flex-wrap justify-end gap-2">
-                {onExportSettings ? (
-                  <button
-                    type="button"
-                    className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                    onClick={() => void onExportSettings()}
-                  >
-                    <Download size={13} />
-                    {t("settingsExportButton")}
-                  </button>
-                ) : null}
-                {onImportSettings ? (
-                  <button
-                    type="button"
-                    className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                    onClick={() => setImportArmed(true)}
-                  >
-                    <Upload size={13} />
-                    {t("settingsImportButton")}
-                  </button>
-                ) : null}
-              </div>
-            </div>
-          )}
-        </div>
-      ) : null}
+            ) : null}
 
-      {onExportCredentials && !searching ? (
-        <div className="pt-2">
-          {/* Labelled like a group header so the action reads as deliberate
-              rather than orphaned, without becoming a settings section: this is
-              an action, not a setting. The header's own trailing rule is the
-              separator — a border on this wrapper would stack a second line
-              directly above it. */}
-          <div className="mb-1 flex items-center gap-1.5 px-1">
-            <span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">{t("cliExportTitle")}</span>
-            <span className="h-px flex-1 bg-zinc-100 dark:bg-zinc-800/70" />
-          </div>
-          {exportArmed ? (
-            <div className="space-y-2 px-1 py-1">
-              <p className="text-xs leading-relaxed text-amber-700 dark:text-amber-300">{t("cliExportConfirm")}</p>
-              <div className="flex flex-wrap justify-end gap-2">
-                <button
-                  type="button"
-                  className="rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                  onClick={() => setExportArmed(false)}
-                >
-                  {t("cliExportCancel")}
-                </button>
-                <button
-                  type="button"
-                  className="rounded-xl bg-[var(--accent)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-contrast)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
-                  onClick={() => {
-                    setExportArmed(false);
-                    void onExportCredentials();
-                  }}
-                >
-                  {t("cliExportConfirmButton")}
-                </button>
+            {onExportCredentials ? (
+              <div className="p-2.5">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">{t("cliExportTitle")}</div>
+                {exportArmed ? (
+                  <div className="mt-1.5 space-y-2">
+                    <p className="text-xs leading-relaxed text-amber-700 dark:text-amber-300">{t("cliExportConfirm")}</p>
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <button
+                        type="button"
+                        className="rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        onClick={() => setExportArmed(false)}
+                      >
+                        {t("cliExportCancel")}
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-xl bg-[var(--accent)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-contrast)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+                        onClick={() => {
+                          setExportArmed(false);
+                          void onExportCredentials();
+                        }}
+                      >
+                        {t("cliExportConfirmButton")}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  // The button stays secondary here and the accent is spent on the
+                  // confirm step, which is the one that actually writes session
+                  // tokens to disk.
+                  <div className="mt-1.5 space-y-2">
+                    <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("cliExportHint")}</p>
+                    <div className="flex justify-end">
+                      <button
+                        type="button"
+                        className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        onClick={() => setExportArmed(true)}
+                      >
+                        <Terminal size={13} />
+                        {t("cliExportButton")}
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
-            </div>
-          ) : (
-            // The hint gets the full width so it wraps as prose instead of a
-            // ragged column beside the button. The button stays secondary here
-            // and the accent is spent on the confirm step, which is the one
-            // that actually writes session tokens to disk.
-            <div className="space-y-2 px-1 pb-1">
-              <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("cliExportHint")}</p>
-              <div className="flex justify-end">
-                <button
-                  type="button"
-                  className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                  onClick={() => setExportArmed(true)}
-                >
-                  <Terminal size={13} />
-                  {t("cliExportButton")}
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-      ) : null}
+            ) : null}
 
-      {onReset && !searching ? (
-        <div className="pt-2">
-          <div className="mb-1 flex items-center gap-1.5 px-1">
-            <span className="text-[10px] font-semibold uppercase tracking-wide text-red-500 dark:text-red-400">{t("factoryResetTitle")}</span>
-            <span className="h-px flex-1 bg-red-100 dark:bg-red-950" />
+            {onReset ? (
+              <div className="p-2.5">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-red-500 dark:text-red-400">{t("factoryResetTitle")}</div>
+                {resetArmed ? (
+                  <div className="mt-1.5 space-y-2">
+                    <p className="text-xs leading-relaxed text-zinc-600 dark:text-zinc-300">{t("factoryResetConfirm")}</p>
+                    {resetFailed ? <p role="alert" className="text-xs font-medium text-red-600 dark:text-red-400">{t("factoryResetFailed")}</p> : null}
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <button
+                        type="button"
+                        disabled={resetting}
+                        className="rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        onClick={() => {
+                          setResetArmed(false);
+                          setResetFailed(false);
+                        }}
+                      >
+                        {t("factoryResetCancel")}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={resetting}
+                        className="rounded-xl bg-red-600 px-3 py-1.5 text-xs font-semibold text-white outline-none transition-colors hover:bg-red-700 focus-visible:ring-2 focus-visible:ring-red-400 disabled:opacity-50 dark:bg-red-700 dark:hover:bg-red-600"
+                        onClick={() => void confirmReset()}
+                      >
+                        {t(resetting ? "factoryResetProgress" : resetFailed ? "factoryResetRetry" : "factoryResetConfirmButton")}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mt-1.5 space-y-2">
+                    <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("factoryResetHint")}</p>
+                    <div className="flex justify-end">
+                      <button
+                        type="button"
+                        className="flex items-center gap-1.5 rounded-xl border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 outline-none transition-colors hover:bg-red-50 focus-visible:ring-2 focus-visible:ring-red-400 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950/40"
+                        onClick={() => {
+                          setResetArmed(true);
+                          setResetFailed(false);
+                        }}
+                      >
+                        <RotateCcw size={13} />
+                        {t("factoryResetButton")}
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : null}
           </div>
-          {resetArmed ? (
-            <div className="space-y-2 px-1 py-1">
-              <p className="text-xs leading-relaxed text-zinc-600 dark:text-zinc-300">{t("factoryResetConfirm")}</p>
-              {resetFailed ? <p role="alert" className="text-xs font-medium text-red-600 dark:text-red-400">{t("factoryResetFailed")}</p> : null}
-              <div className="flex flex-wrap justify-end gap-2">
-                <button
-                  type="button"
-                  disabled={resetting}
-                  className="rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                  onClick={() => {
-                    setResetArmed(false);
-                    setResetFailed(false);
-                  }}
-                >
-                  {t("factoryResetCancel")}
-                </button>
-                <button
-                  type="button"
-                  disabled={resetting}
-                  className="rounded-xl bg-red-600 px-3 py-1.5 text-xs font-semibold text-white outline-none transition-colors hover:bg-red-700 focus-visible:ring-2 focus-visible:ring-red-400 disabled:opacity-50 dark:bg-red-700 dark:hover:bg-red-600"
-                  onClick={() => void confirmReset()}
-                >
-                  {t(resetting ? "factoryResetProgress" : resetFailed ? "factoryResetRetry" : "factoryResetConfirmButton")}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-2 px-1 pb-1">
-              <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("factoryResetHint")}</p>
-              <div className="flex justify-end">
-                <button
-                  type="button"
-                  className="flex items-center gap-1.5 rounded-xl border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 outline-none transition-colors hover:bg-red-50 focus-visible:ring-2 focus-visible:ring-red-400 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950/40"
-                  onClick={() => {
-                    setResetArmed(true);
-                    setResetFailed(false);
-                  }}
-                >
-                  <RotateCcw size={13} />
-                  {t("factoryResetButton")}
-                </button>
-              </div>
-            </div>
-          )}
         </div>
       ) : null}
     </div>

--- a/packages/popup-ui/src/settings.tsx
+++ b/packages/popup-ui/src/settings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { RotateCcw, Terminal } from "lucide-react";
+import { Download, RotateCcw, Terminal, Upload } from "lucide-react";
 import type { CategorySelection, ExtensionSettings, Platform } from "@lurkloot/shared/models";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
 import { SHOW_ADVANCED_SETTINGS_KEY } from "./constants";
@@ -9,7 +9,7 @@ import { filterSettingsTree } from "./settingsSearch";
 import { usePopupRuntime, useT } from "./context";
 import type { GameItem, PopupCompatibilityRegistry, PopupCompatibilityResolution } from "./types";
 
-export function SettingsView({ suggestions, onSearchCategories, settings, onSettingsChange, onExportCredentials, onReset, exportConfirmationResetKey, compatibilityRegistry, compatibilityResolution }: {
+export function SettingsView({ suggestions, onSearchCategories, settings, onSettingsChange, onExportCredentials, onExportSettings, onImportSettings, onReset, exportConfirmationResetKey, compatibilityRegistry, compatibilityResolution }: {
   suggestions: Record<Platform, GameItem[]>;
   onSearchCategories(platform: Platform, query: string): Promise<CategorySelection[]>;
   settings: ExtensionSettings;
@@ -17,6 +17,11 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
   // Optional: when provided, the settings view shows an "Export credentials"
   // action for the headless CLI. The extension wires it; the demo omits it.
   onExportCredentials?: () => void | Promise<void>;
+  // Optional: download the current settings as a portable JSON file.
+  onExportSettings?: () => void | Promise<void>;
+  // Optional: prompt for a settings file and apply it. Resolves false when the
+  // user cancels the file picker, throws when the file is invalid/corrupt.
+  onImportSettings?: () => Promise<boolean>;
   onReset?: () => Promise<void>;
   exportConfirmationResetKey: number;
   compatibilityRegistry?: PopupCompatibilityRegistry;
@@ -27,14 +32,34 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
   const [query, setQuery] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [exportArmed, setExportArmed] = useState(false);
+  const [importArmed, setImportArmed] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [importFailed, setImportFailed] = useState(false);
   const [resetArmed, setResetArmed] = useState(false);
   const [resetting, setResetting] = useState(false);
   const [resetFailed, setResetFailed] = useState(false);
   useEffect(() => {
     setExportArmed(false);
+    setImportArmed(false);
+    setImportFailed(false);
     setResetArmed(false);
     setResetFailed(false);
   }, [exportConfirmationResetKey]);
+
+  async function confirmImport(): Promise<void> {
+    if (!onImportSettings || importing) return;
+    setImporting(true);
+    setImportFailed(false);
+    try {
+      const applied = await onImportSettings();
+      if (applied) setImportArmed(false);
+    } catch {
+      setImportArmed(true);
+      setImportFailed(true);
+    } finally {
+      setImporting(false);
+    }
+  }
 
   async function confirmReset(): Promise<void> {
     if (!onReset || resetting) return;
@@ -113,6 +138,68 @@ export function SettingsView({ suggestions, onSearchCategories, settings, onSett
           ))}
         </div>
       )}
+
+      {(onExportSettings || onImportSettings) && !searching ? (
+        <div className="pt-2">
+          <div className="mb-1 flex items-center gap-1.5 px-1">
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">{t("settingsExportTitle")}</span>
+            <span className="h-px flex-1 bg-zinc-100 dark:bg-zinc-800/70" />
+          </div>
+          {importArmed ? (
+            <div className="space-y-2 px-1 py-1">
+              <p className="text-xs leading-relaxed text-amber-700 dark:text-amber-300">{t("settingsImportConfirm")}</p>
+              {importFailed ? <p role="alert" className="text-xs font-medium text-red-600 dark:text-red-400">{t("settingsImportFailed")}</p> : null}
+              <div className="flex flex-wrap justify-end gap-2">
+                <button
+                  type="button"
+                  disabled={importing}
+                  className="rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  onClick={() => {
+                    setImportArmed(false);
+                    setImportFailed(false);
+                  }}
+                >
+                  {t("settingsImportCancel")}
+                </button>
+                <button
+                  type="button"
+                  disabled={importing}
+                  className="rounded-xl bg-[var(--accent)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-contrast)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] disabled:opacity-50"
+                  onClick={() => void confirmImport()}
+                >
+                  {t("settingsImportConfirmButton")}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2 px-1 pb-1">
+              <p className="text-[11px] leading-snug text-zinc-500 dark:text-zinc-400">{t("settingsExportHint")}</p>
+              <div className="flex flex-wrap justify-end gap-2">
+                {onExportSettings ? (
+                  <button
+                    type="button"
+                    className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                    onClick={() => void onExportSettings()}
+                  >
+                    <Download size={13} />
+                    {t("settingsExportButton")}
+                  </button>
+                ) : null}
+                {onImportSettings ? (
+                  <button
+                    type="button"
+                    className="flex items-center gap-1.5 rounded-xl border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-600 outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                    onClick={() => setImportArmed(true)}
+                  >
+                    <Upload size={13} />
+                    {t("settingsImportButton")}
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : null}
 
       {onExportCredentials && !searching ? (
         <div className="pt-2">

--- a/packages/popup-ui/src/settingsControls.tsx
+++ b/packages/popup-ui/src/settingsControls.tsx
@@ -52,18 +52,18 @@ export function SettingsSection({ id, title, description, icon: Icon, iconNode, 
   const expanded = forceExpanded || !collapsed;
 
   return (
-    <section>
+    <section id={`settings-section-${id}`} className="scroll-mt-2">
       <header className="mb-1.5 px-0.5">
         <button
           type="button"
           aria-expanded={expanded}
           onClick={toggleCollapsed}
-          className="flex w-full items-start justify-between gap-3 rounded-lg px-1 py-1 text-left outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:hover:bg-zinc-900/70"
+          className="flex w-full items-start justify-between gap-3 rounded-lg border border-zinc-200/70 bg-white px-2 py-1.5 text-left outline-none transition-colors hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:border-zinc-800 dark:bg-zinc-900/70 dark:hover:bg-zinc-900"
         >
           <span className="min-w-0">
             <span className="flex items-center gap-1.5">
-              {iconNode ?? (Icon ? <Icon size={13} className="text-zinc-400 dark:text-zinc-500" /> : null)}
-              <span className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">{title}</span>
+              {iconNode ?? (Icon ? <Icon size={14} className="text-zinc-500 dark:text-zinc-400" /> : null)}
+              <span className="text-[12px] font-bold uppercase tracking-wide text-zinc-700 dark:text-zinc-200">{title}</span>
               {badge}
             </span>
             {description ? <span className="mt-1 block text-[11px] leading-snug text-zinc-400 dark:text-zinc-500">{description}</span> : null}

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -1,5 +1,6 @@
 import type { CliCredentialBlob, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import type { ClaimGuidance, CompatibilitySettings, DropCampaign, Platform, RewardRequirementType, SupportedLocale } from "@lurkloot/shared/models";
+import type { SettingsExportPayload } from "@lurkloot/shared/settingsExport";
 
 export type CompatibilityLifecycle = "recommended" | "legacy" | "experimental";
 export interface CompatibilityOptionMetadata {
@@ -126,6 +127,14 @@ export interface PopupAdapter {
   // Optional: download/persist an exported credential blob for the headless CLI.
   // Only the live extension implements it (the demo omits it, hiding the action).
   exportCredentials?(blob: CliCredentialBlob): void;
+  // Optional: download the current settings as a portable JSON file. Only the
+  // live extension implements it (the demo omits it, hiding the action).
+  exportSettings?(payload: SettingsExportPayload): void;
+  // Optional: prompt the user for a settings file and resolve its raw parsed
+  // JSON contents (or null if they cancel the picker). Validation/migration of
+  // the result happens in Popup.tsx via @lurkloot/shared/settingsExport, not
+  // here, so this stays a thin file-read.
+  importSettings?(): Promise<unknown | null>;
   // Optional: write text to the system clipboard, resolving to whether it
   // worked. Hosts that omit it (the site demo) make the critical-failure panel
   // fall back to a selectable textarea instead of pretending the copy succeeded.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
     "./messages": "./src/messages.ts",
     "./settings": "./src/settings.ts",
     "./settingsSchema": "./src/settingsSchema.ts",
+    "./settingsExport": "./src/settingsExport.ts",
     "./i18n": "./src/i18n.ts",
     "./logging": "./src/logging.ts",
     "./rewards": "./src/rewards.ts",

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -270,6 +270,23 @@ export function clampNumber(value: number | undefined, min: number, max: number,
 // non-empty name. The legacy `gamePriority: string[]` is intentionally NOT
 // migrated: it stored ids without display names (and was an ordering hint, not an
 // allowlist), so carrying it over would surface bare numeric ids like "13".
+// Category images render unconditionally as <img src> as soon as the settings
+// view is open — no click required — so an https-only allowlist matters here
+// the same way it does for openHttpsLink's click-through guidance: settings
+// can come from an imported file (see @lurkloot/shared/settingsExport), and a
+// crafted category with a non-https imageUrl would otherwise beacon or probe
+// the local network the instant the popup renders it.
+function httpsUrlOrUndefined(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try {
+    return new URL(trimmed).protocol === "https:" ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function normalizeCategorySelections(value: CategorySelection[] | undefined): CategorySelection[] {
   if (!Array.isArray(value)) return [];
   const seen = new Set<string>();
@@ -281,7 +298,7 @@ export function normalizeCategorySelections(value: CategorySelection[] | undefin
     const key = id.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
-    const imageUrl = typeof entry?.imageUrl === "string" && entry.imageUrl.trim() ? entry.imageUrl.trim() : undefined;
+    const imageUrl = httpsUrlOrUndefined(entry?.imageUrl);
     result.push(imageUrl ? { id, name, imageUrl } : { id, name });
   }
   return result;

--- a/packages/shared/src/settingsExport.ts
+++ b/packages/shared/src/settingsExport.ts
@@ -1,0 +1,68 @@
+// Builds and parses the portable settings file the popup and the CLI both
+// produce for "move my configuration" (issue #252). The payload only ever
+// carries ExtensionSettings fields: mergeSettings() reads settings by name, so
+// any extra property on an imported file — however it got there — is silently
+// dropped rather than merged in. That is what keeps this format safe to hand
+// to another person: it can never carry a credential, token, cookie, or
+// session value, because none of those live on ExtensionSettings in the first
+// place.
+
+import type { ExtensionSettings } from "./models";
+import { mergeSettings } from "./settings";
+import { CURRENT_SETTINGS_SCHEMA_VERSION, migrateSettings, type SettingsMigrationDiagnostic } from "./settingsSchema";
+
+export const SETTINGS_EXPORT_KIND = "lurkloot-settings";
+
+export interface SettingsExportPayload {
+  kind: typeof SETTINGS_EXPORT_KIND;
+  schemaVersion: number;
+  exportedAt: string;
+  settings: ExtensionSettings;
+}
+
+export class InvalidSettingsImportError extends Error {
+  constructor(reason: string) {
+    super(`Not a lurkloot settings file: ${reason}`);
+    this.name = "InvalidSettingsImportError";
+  }
+}
+
+export function buildSettingsExportPayload(settings: ExtensionSettings): SettingsExportPayload {
+  return {
+    kind: SETTINGS_EXPORT_KIND,
+    schemaVersion: CURRENT_SETTINGS_SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    // Normalized first, so the file on disk always reflects what the running
+    // extension actually holds rather than whatever partial shape called in.
+    settings: mergeSettings(settings),
+  };
+}
+
+export interface SettingsImportResult {
+  settings: ExtensionSettings;
+  diagnostics: SettingsMigrationDiagnostic[];
+}
+
+// Re-runs the same migrate-then-normalize pipeline every host already applies
+// to its own persisted document (see storage.ts#loadSettings), so an import
+// degrades exactly like opening an old or new build would: unknown/removed
+// properties are dropped, renamed ones are carried forward, and a schema
+// version newer than this build understands throws UnsupportedSettingsVersionError
+// rather than corrupting state.
+export function parseSettingsImportPayload(raw: unknown): SettingsImportResult {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new InvalidSettingsImportError("expected a JSON object");
+  }
+  const envelope = raw as Record<string, unknown>;
+  if (envelope.kind !== SETTINGS_EXPORT_KIND) {
+    throw new InvalidSettingsImportError(`unrecognized "kind"`);
+  }
+  if (typeof envelope.settings !== "object" || envelope.settings === null || Array.isArray(envelope.settings)) {
+    throw new InvalidSettingsImportError(`missing "settings"`);
+  }
+
+  const rawSettings = { ...(envelope.settings as Record<string, unknown>), schemaVersion: envelope.schemaVersion };
+  const migration = migrateSettings(rawSettings);
+  const settings = mergeSettings(migration.settings as Partial<ExtensionSettings>);
+  return { settings, diagnostics: migration.diagnostics };
+}

--- a/packages/shared/src/settingsExport.ts
+++ b/packages/shared/src/settingsExport.ts
@@ -13,12 +13,17 @@ import { CURRENT_SETTINGS_SCHEMA_VERSION, migrateSettings, type SettingsMigratio
 
 export const SETTINGS_EXPORT_KIND = "lurkloot-settings";
 
-export interface SettingsExportPayload {
+// Generic over the settings shape so each host can alias it to its own
+// settings type (ExtensionSettings here, CliSettings in @lurkloot/cli)
+// without redeclaring the shared kind/schemaVersion/exportedAt envelope.
+export interface SettingsExportEnvelope<TSettings> {
   kind: typeof SETTINGS_EXPORT_KIND;
   schemaVersion: number;
   exportedAt: string;
-  settings: ExtensionSettings;
+  settings: TSettings;
 }
+
+export type SettingsExportPayload = SettingsExportEnvelope<ExtensionSettings>;
 
 export class InvalidSettingsImportError extends Error {
   constructor(reason: string) {


### PR DESCRIPTION
## Summary
- Adds a portable, versioned settings file for both the extension popup and the CLI (closes #252). The export payload is built entirely from `mergeSettings()`/the CLI's own strict `parseCliSettingsWithDiagnostics()`, so it can only ever carry known settings fields — credentials, tokens, and session data have no way to leak in.
- Imports are re-migrated and re-normalized through the same pipeline each host already runs on its own persisted document, so an old or new file degrades predictably instead of corrupting state.
- CLI gets `lurkloot config export` / `lurkloot config import <file>`, sharing the same envelope/`kind` as the extension export but validated against `CliSettings`'s stricter schema (an extension-exported file is rejected the same way a copy-pasted extension config already is).
- Hardens `normalizeCategorySelections` to only accept `https:` image URLs — a crafted import could otherwise point a rendered `<img src>` at an attacker-controlled URL as soon as Settings opens.
- Localized new UI strings across all 11 catalogs.
- Along the way, reworked the Settings view for navigability: a sticky search/jump-nav bar (General/Twitch/Kick chips), heavier section headers, and the three separate footer action blocks (Import/Export, CLI export, Reset) consolidated into one "Advanced actions" card instead of three repeated near-identical sections.

## Testing performed
- `pnpm typecheck` (all 7 workspace packages)
- `pnpm test` — extension suite: 1247 passed; CLI suite: 136 passed
- `pnpm check` (typecheck + tests + Astro site build)
- New tests: shared export/import round-trip + credential-stripping + version-mismatch (`packages/extension/tests/settingsExportImport.test.ts`), popup UI arm/confirm/cancel flow (`settingsExportImportUi.test.tsx`), CLI export/import + rejecting extension-only keys (`packages/cli/tests/settings.test.ts`)
- Manual: built the unpacked extension, loaded it in a real Chrome instance via chrome-devtools-mcp, opened Settings, exercised the jump-nav, verified the consolidated Advanced Actions card and the export/import flow end-to-end
- Manual: `lurkloot config export` → `config import` round-trip against a real config file, and confirmed a garbage/non-lurkloot file is rejected with a clear error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settings export and import through the browser extension and CLI.
  * Settings can be backed up to, and restored from, portable JSON files.
  * Import includes confirmation prompts, validation, migration, and clear error handling.
  * Added quick navigation between settings sections and consolidated settings actions.
  * Exported files exclude credentials and session data.

* **Bug Fixes**
  * Improved security by restricting imported category images to HTTPS URLs.

* **Localization**
  * Added translated settings navigation and import/export messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->