### PR TITLE
feat(popup): add campaign search and fix category/reward visibility gaps

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,8 @@ Each scheduler tick runs enabled platforms independently:
 
 Campaign ordering is shared across platforms: explicit campaign priority, platform game priority, campaign priority field, optional lowest-availability mode, ending soonest, then campaign name. Per-platform excluded drop channels filter campaign candidates only; they do not suppress Idle Watchlist fallback channels. `farmingEligibility` also narrows eligibility, through its two farming flags (`farmUnlinkedCampaigns`, `farmSubscriptionCampaigns`); the separate `dropsListFilter` is a popup view preference that affects nothing the engine does.
 
+For exactly how a campaign's farmability (`campaignFarmable`, feeding `isEligible`) and its popup visibility (`isCampaignVisible`) are decided — and why they deliberately diverge on reward timing — see [`campaign-farmability-visibility.md`](campaign-farmability-visibility.md).
+
 ## Same-Origin Fetching
 
 In the extension, most platform calls go through the page-context fetch helpers wired by `packages/extension/src/core/tabs.ts` onto abstractions from `@lurkloot/core/tabs`. They find or open a temporary tab on the platform origin, then execute `fetch` in the page `MAIN` world. This keeps requests inside the browser's normal logged-in session and any page clearance context.

--- a/docs/campaign-farmability-visibility.md
+++ b/docs/campaign-farmability-visibility.md
@@ -1,0 +1,106 @@
+# Farmability & Visibility — `packages/shared/src/campaignFilters.ts`
+
+Two questions, one shared foundation.
+
+- `campaignFarmable` answers **"will the engine actually watch this?"**
+- `isCampaignVisible` answers **"does it show in the popup's Drops list?"**
+
+Both are built from the same `campaignEligibleClass` check, so a campaign the
+engine is farming can never be hidden from the person watching it happen.
+
+## 1. Can the engine farm it right now? — `campaignFarmable`
+
+Used by the scheduler's `isEligible`. Six structural gates, then one timing
+gate on the rewards themselves.
+
+```
+status === "active"?              no  -> FALSE
+  |yes
+already ended?                    yes -> FALSE
+  |no
+eligibility set and != eligible?  yes -> FALSE
+  |no
+excluded by id?                   yes -> FALSE
+  |no
+class allowed?                    no  -> FALSE
+(farmUnlinkedCampaigns / farmSubscriptionCampaigns)
+  |yes
+outside selected categories?      yes -> FALSE
+(farmAllCategories off + not in list)
+  |no
+Twitch AND not linked?            yes -> FALSE
+  |no
+any reward farmable right now?    no  -> FALSE
+(not claimed, preconditions met, in its window, deadline feasible)
+  |yes
+TRUE — engine farms it
+```
+
+`campaignFarmable` = `campaignEligibleClass` (section 2) + that last
+reward-timing gate.
+
+## 2. Is it in a farmable class at all? — `campaignEligibleClass`
+
+The first six gates above, on their own, ignoring reward timing entirely —
+just "does this campaign have anything left to earn or claim." This is the
+shape both farmability and visibility are built from.
+
+> **Why split it out:** a campaign can fail the reward-timing gate (deadline
+> too tight, a locked follow-up reward) without being structurally dead.
+> Hiding it would also hide it from `campaignPriorities` drag-reordering — in
+> "priority list only" mode that's the *only* way to make a campaign
+> farmable, so visibility deliberately stops one gate short of full
+> farmability.
+
+## 3. What shows in the popup? — `isCampaignVisible`
+
+Two fast paths first, then the category filter (no override, always wins),
+then one bucket per remaining reason with its own display flag. The first
+`true` reason wins — buckets are checked in this fixed order.
+
+```
+any reward status === "claimable"?  yes -> TRUE (claim it, regardless of anything else)
+  |no
+campaignEligibleClass?              yes -> TRUE   <-- THE INVARIANT:
+  |no                                              farmable ⟹ visible
+outside selected categories?        yes -> FALSE (no override, ever)
+  |no
+excluded by id?                     yes -> showExcluded flag decides
+  |no
+finished?                           yes -> showFinished flag decides
+  |no
+expired?                            yes -> showExpired flag decides
+  |no
+upcoming?                           yes -> showUpcoming flag decides
+  |no
+not linked?                         yes -> showNotLinked flag decides
+  |no
+subscription-gated?                 yes -> showSubscription flag decides
+  |no
+FALSE — no bucket, no flag
+```
+
+## Reference
+
+| function | answers | used by |
+|---|---|---|
+| `campaignEligibleClass` | could this campaign's class ever be farmed, ignoring reward timing? | `campaignFarmable`, `isCampaignVisible` |
+| `campaignFarmable` | eligible class, and a reward is farmable right this moment | `isEligible` (scheduler) |
+| `isCampaignVisible` | should the Drops list render this campaign? | the popup (`Popup.tsx`) |
+| `isRewardFarmableNow` | not claimed, preconditions met, in its window, deadline feasible | `campaignFarmable` |
+| `campaignPassesFarmingEligibility` | is this campaign's class (not-linked / subscription) allowed at all? | `campaignEligibleClass` |
+
+## The relationship that matters most
+
+`campaignEligibleClass` is the shared base.
+
+- `campaignFarmable` = that base **+** one extra reward-timing check (used
+  for actual farming decisions).
+- `isCampaignVisible` uses **only** the base, never the extra check — so a
+  campaign that's momentarily un-farmable for timing reasons (tight deadline,
+  unmet precondition) stays visible instead of vanishing, and the category
+  filter is checked before all the display-flag buckets since nothing
+  overrides it.
+
+---
+*Source: `packages/shared/src/campaignFilters.ts`, `packages/shared/src/rewards.ts`*

--- a/docs/campaign-farmability-visibility.md
+++ b/docs/campaign-farmability-visibility.md
@@ -13,27 +13,25 @@ engine is farming can never be hidden from the person watching it happen.
 Used by the scheduler's `isEligible`. Six structural gates, then one timing
 gate on the rewards themselves.
 
-```
-status === "active"?              no  -> FALSE
-  |yes
-already ended?                    yes -> FALSE
-  |no
-eligibility set and != eligible?  yes -> FALSE
-  |no
-excluded by id?                   yes -> FALSE
-  |no
-class allowed?                    no  -> FALSE
-(farmUnlinkedCampaigns / farmSubscriptionCampaigns)
-  |yes
-outside selected categories?      yes -> FALSE
-(farmAllCategories off + not in list)
-  |no
-Twitch AND not linked?            yes -> FALSE
-  |no
-any reward farmable right now?    no  -> FALSE
-(not claimed, preconditions met, in its window, deadline feasible)
-  |yes
-TRUE — engine farms it
+```mermaid
+flowchart TD
+    A["campaignFarmable(campaign, settings)"] --> B{"status === active?"}
+    B -- no --> N1["FALSE"]
+    B -- yes --> C{"already ended?<br/>hasCampaignEnded"}
+    C -- yes --> N1
+    C -- no --> D{"eligibility set<br/>and ≠ eligible?"}
+    D -- yes --> N1
+    D -- no --> E{"id in<br/>excludedCampaignIds?"}
+    E -- yes --> N1
+    E -- no --> F{"class allowed?<br/>farmUnlinkedCampaigns /<br/>farmSubscriptionCampaigns"}
+    F -- no --> N1
+    F -- yes --> G{"outside selected<br/>categories?<br/>farmAllCategories off"}
+    G -- yes --> N1
+    G -- no --> H{"Twitch AND<br/>not linked?"}
+    H -- yes --> N1
+    H -- no --> I{"any reward<br/>farmable right now?<br/>not claimed, preconditions met,<br/>relevant, deadline feasible"}
+    I -- no --> N1
+    I -- yes --> Y1["TRUE — engine farms it"]
 ```
 
 `campaignFarmable` = `campaignEligibleClass` (section 2) + that last
@@ -58,26 +56,27 @@ Two fast paths first, then the category filter (no override, always wins),
 then one bucket per remaining reason with its own display flag. The first
 `true` reason wins — buckets are checked in this fixed order.
 
-```
-any reward status === "claimable"?  yes -> TRUE (claim it, regardless of anything else)
-  |no
-campaignEligibleClass?              yes -> TRUE   <-- THE INVARIANT:
-  |no                                              farmable ⟹ visible
-outside selected categories?        yes -> FALSE (no override, ever)
-  |no
-excluded by id?                     yes -> showExcluded flag decides
-  |no
-finished?                           yes -> showFinished flag decides
-  |no
-expired?                            yes -> showExpired flag decides
-  |no
-upcoming?                           yes -> showUpcoming flag decides
-  |no
-not linked?                         yes -> showNotLinked flag decides
-  |no
-subscription-gated?                 yes -> showSubscription flag decides
-  |no
-FALSE — no bucket, no flag
+```mermaid
+flowchart TD
+    A["isCampaignVisible(campaign, settings)"] --> B{"any reward<br/>status === claimable?"}
+    B -- yes --> Y1["TRUE — claim it,<br/>regardless of anything else"]
+    B -- no --> C{"campaignEligibleClass?<br/>(section 2 above)"}
+    C -- yes --> Y2["TRUE — the invariant:<br/>farmable ⟹ visible"]
+    C -- no --> D{"outside selected<br/>categories?"}
+    D -- yes --> N1["FALSE — no override,<br/>ever"]
+    D -- no --> E{"excluded by id?"}
+    E -- yes --> F1["showExcluded decides"]
+    E -- no --> G{"finished?"}
+    G -- yes --> F2["showFinished decides"]
+    G -- no --> H{"expired?"}
+    H -- yes --> F3["showExpired decides"]
+    H -- no --> I{"upcoming?"}
+    I -- yes --> F4["showUpcoming decides"]
+    I -- no --> J{"not linked?"}
+    J -- yes --> F5["showNotLinked decides"]
+    J -- no --> K{"subscription-gated?"}
+    K -- yes --> F6["showSubscription decides"]
+    K -- no --> N2["FALSE — no bucket,<br/>no flag"]
 ```
 
 ## Reference

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -12,8 +12,15 @@ import type {
   WatchSession,
 } from "@lurkloot/shared/models";
 import { categoryListIndex } from "@lurkloot/shared/categories";
-import { campaignPassesFarmingEligibility, hasCampaignEnded } from "@lurkloot/shared/campaignFilters";
-import { isSubscriptionReward, isWatchReward, reconcileCampaignAfterClaims, rewardFeasibility } from "@lurkloot/shared/rewards";
+import { campaignFarmable, campaignPassesFarmingEligibility, hasCampaignEnded } from "@lurkloot/shared/campaignFilters";
+import {
+  canClaimReward,
+  isRewardAvailableToEarn,
+  isRewardDeadlineFeasible,
+  isSubscriptionReward,
+  reconcileCampaignAfterClaims,
+  rewardFeasibility,
+} from "@lurkloot/shared/rewards";
 import { autoClaimChallengesFor, autoClaimChannelPointsFor, isFarmingActive } from "@lurkloot/shared/settings";
 import type { EngineEvent, EventEmitter, FarmingStopReason, PageContextCloseReason } from "@lurkloot/shared/events";
 import { currentManagedPageContextTabs, forgetManagedPageContextTabs, registerManagedPageContextTabs, syncManagedTabBreakers, type SchedulerManagedPageContexts } from "./tabs";
@@ -46,7 +53,7 @@ function activeReward(campaign: DropCampaign, settings: EngineSettings): DropRew
   const earnable = campaign.rewards.filter((reward) =>
     reward.preconditionsMet !== false
     && isRewardAvailableToEarn(reward)
-    && isRewardDeadlineFeasible(campaign, reward, settings));
+    && isRewardDeadlineFeasible(campaign, reward, settings.skipUnfinishableRewards, settings.deadlineSafetyMarginMinutes));
   return earnable.find((reward) => reward.status === "in_progress")
     ?? earnable.find((reward) => reward.status === "locked");
 }
@@ -68,34 +75,16 @@ function chooseTablessWatch(
 }
 
 function isEligible(campaign: DropCampaign, settings: EngineSettings): boolean {
-  if (campaign.status !== "active") return false;
-  if (hasCampaignEnded(campaign)) return false;
-  if (campaign.eligibility && campaign.eligibility !== "eligible") return false;
-  if (settings.excludedCampaignIds.includes(campaign.id)) return false;
-  // Farming eligibility: the two flags farmUnlinkedCampaigns and
-  // farmSubscriptionCampaigns gate whether unlinked or subscription-gated
-  // campaigns are farmed. The display-only dropsListFilter is never consulted
-  // here, so hiding finished campaigns in the popup never stops farming.
-  if (!campaignPassesFarmingEligibility(campaign, settings.farmingEligibility)) return false;
-  // Category filter: when "Farm all categories" is off for this platform, only
-  // campaigns whose category is on the list are farmable (an empty list then
-  // farms nothing).
-  const platformSettings = settings.platform[campaign.platform];
-  if (!platformSettings.farmAllCategories && categoryListIndex(campaign, platformSettings.categories) === -1) return false;
-  // Twitch cannot earn drops until the account is linked, so an unlinked Twitch
-  // campaign is skipped. Kick DOES accrue watch progress before linking (the
-  // link is only required to claim), so we keep farming unlinked Kick campaigns
-  // and surface the claim-time "link your account" guidance instead.
-  if (campaign.platform !== "kick" && campaign.accountLinked === false) return false;
-  // "Priority list only" farms exclusively the campaigns the user explicitly
-  // reordered (campaignPriorities). Category curation is owned by the separate
-  // per-platform "Farm all categories" filter above.
+  // campaignFarmable is the single shared definition of "is this campaign
+  // farmable" (shared with the popup's isCampaignVisible, so display and
+  // farming never drift apart). "Priority list only" is the one farming-
+  // strategy layer on top of it: it farms exclusively the campaigns the user
+  // explicitly reordered (campaignPriorities), which is deliberately NOT part
+  // of campaignFarmable — a deprioritized campaign must stay farmable-shaped
+  // for display so the user can still add it to the list.
+  if (!campaignFarmable(campaign, settings)) return false;
   if (settings.priorityMode === "priority_list_only" && !isInPriorityList(campaign, settings)) return false;
-  return campaign.rewards.some((reward) =>
-    reward.status !== "claimed"
-    && reward.preconditionsMet !== false
-    && isRewardRelevantNow(reward)
-    && (canClaimReward(reward) || isRewardDeadlineFeasible(campaign, reward, settings)));
+  return true;
 }
 
 // Reason codes that mean the watch stopped accruing for an explainable reason
@@ -349,7 +338,7 @@ function noEligibleCampaignReason(campaigns: DropCampaign[], settings: EngineSet
     && !campaign.rewards.some((reward) =>
       reward.preconditionsMet !== false
       && isRewardAvailableToEarn(reward)
-      && isRewardDeadlineFeasible(campaign, reward, settings)))) {
+      && isRewardDeadlineFeasible(campaign, reward, settings.skipUnfinishableRewards, settings.deadlineSafetyMarginMinutes)))) {
     return "Available rewards cannot be completed before their deadline";
   }
   return "No eligible campaigns";
@@ -1275,38 +1264,8 @@ function preserveClaimedRewards(
   });
 }
 
-function isRewardRelevantNow(reward: DropReward): boolean {
-  return canClaimReward(reward) || isRewardAvailableToEarn(reward);
-}
-
-function isRewardDeadlineFeasible(campaign: DropCampaign, reward: DropReward, settings: EngineSettings): boolean {
-  return rewardFeasibility(
-    campaign,
-    reward,
-    settings.skipUnfinishableRewards,
-    settings.deadlineSafetyMarginMinutes,
-  ).kind !== "insufficient_time";
-}
-
 function campaignDiagnosticFingerprint(campaigns: readonly DropCampaign[]): string {
   return campaigns.map((campaign) => `${campaign.id}:${campaign.status}:${campaign.rewards.map((reward) => `${reward.id}:${reward.status}`).join(",")}`).join("|");
-}
-
-function isRewardAvailableToEarn(reward: DropReward): boolean {
-  if (!isWatchReward(reward)) return false;
-  const now = Date.now();
-  const startsAt = reward.availableFrom ? Date.parse(reward.availableFrom) : undefined;
-  const endsAt = reward.availableUntil ? Date.parse(reward.availableUntil) : undefined;
-  if (startsAt != null && !Number.isNaN(startsAt) && now < startsAt) return false;
-  if (endsAt != null && !Number.isNaN(endsAt) && now >= endsAt) return false;
-  return reward.status !== "claimed" && reward.status !== "claimable";
-}
-
-function canClaimReward(reward: DropReward): boolean {
-  if (reward.status !== "claimable") return false;
-  if (!reward.claimUntil) return true;
-  const claimUntil = Date.parse(reward.claimUntil);
-  return Number.isNaN(claimUntil) || Date.now() < claimUntil;
 }
 
 async function evaluatePreferredCurrentWatch(

--- a/packages/extension/tests/campaignFilters.test.ts
+++ b/packages/extension/tests/campaignFilters.test.ts
@@ -449,10 +449,27 @@ describe("isCampaignVisible category selection", () => {
     expect(visible(c, { dropsListFilter: ALL_OFF, categorySelection: selectedOnly })).toBe(false);
   });
 
-  // The category filter has no display-flag override anywhere else; a
-  // not-linked or subscription campaign outside the selected categories must
-  // not slip through via showNotLinked/showSubscription — those flags only
-  // rescue a campaign from ITS OWN class hide, not from the category filter.
+  // The category filter has no display-flag override anywhere, so it wins over
+  // every other bucket — even ones with their own flag turned fully on — for a
+  // campaign that is ALSO in that other bucket's class.
+  it("hides an excluded campaign outside the selected categories even with showExcluded on", () => {
+    const c = campaign({ gameName: "Other Game" });
+    expect(visible(c, { dropsListFilter: SHOW_ALL, excludedCampaignIds: ["campaign"], categorySelection: selectedOnly })).toBe(false);
+  });
+
+  it("hides a finished campaign outside the selected categories even with showFinished on", () => {
+    const c = campaign({
+      gameName: "Other Game",
+      rewards: [{ ...campaign().rewards[0]!, status: "claimed" }],
+    });
+    expect(visible(c, { dropsListFilter: SHOW_ALL, categorySelection: selectedOnly })).toBe(false);
+  });
+
+  it("hides an upcoming campaign outside the selected categories even with showUpcoming on", () => {
+    const c = campaign({ status: "upcoming", gameName: "Other Game" });
+    expect(visible(c, { dropsListFilter: SHOW_ALL, categorySelection: selectedOnly })).toBe(false);
+  });
+
   it("hides a not-linked campaign outside the selected categories even with showNotLinked on", () => {
     const c = campaign({ accountLinked: false, gameName: "Other Game" });
     expect(visible(c, { dropsListFilter: SHOW_ALL, categorySelection: selectedOnly })).toBe(false);

--- a/packages/extension/tests/campaignFilters.test.ts
+++ b/packages/extension/tests/campaignFilters.test.ts
@@ -450,28 +450,35 @@ describe("isCampaignVisible category selection", () => {
   });
 });
 
-describe("isCampaignVisible reward-level farmability (no display flag rescues this)", () => {
-  // Regression coverage for a real gap: an ordinary active, linked,
-  // non-subscription, in-category campaign used to stay visible unconditionally
-  // (the old code's final `return true`), even when none of its rewards were
-  // actually farmable right now. There is no display flag for this case — an
-  // un-farmable ordinary campaign must be hidden outright.
-  it("hides an ordinary campaign whose only reward has an infeasible deadline", () => {
+describe("isCampaignVisible stays visible despite reward-timing infeasibility", () => {
+  // A campaign whose only reward is momentarily un-farmable for TIMING reasons
+  // (deadline infeasible under skipUnfinishableRewards, an unmet precondition on
+  // a locked follow-up reward) must NOT vanish from the list, even though
+  // campaignFarmable (and therefore isEligible) correctly refuses to farm it:
+  // the user still needs to see it to adjust settings, or — in "priority list
+  // only" mode — drag it into their priority list, which is the only way to
+  // ever make it farmable there. prioritiesFromOrder (popup-ui) builds
+  // campaignPriorities purely from the rendered/visible list order, so a hidden
+  // campaign could never be prioritized: hiding it here would be a regression,
+  // not a stricter invariant.
+  it("stays visible when the only reward has an infeasible deadline, but is not farmable", () => {
     const c = campaign({
       endsAt: new Date(Date.now() + 60_000).toISOString(),
       rewards: [{ ...campaign().rewards[0]!, requiredMinutes: 120, watchedMinutes: 0 }],
     });
     expect(campaignFarmable(c, settings())).toBe(false);
-    expect(visible(c)).toBe(false);
+    expect(visible(c)).toBe(true);
   });
 
-  it("hides an ordinary campaign whose only reward's precondition is not met", () => {
+  it("stays visible when the only reward's precondition is not met, but is not farmable", () => {
     const c = campaign({ rewards: [{ ...campaign().rewards[0]!, preconditionsMet: false }] });
-    expect(visible(c)).toBe(false);
+    expect(campaignFarmable(c, settings())).toBe(false);
+    expect(visible(c)).toBe(true);
   });
 
-  it("shows the campaign again once the reward becomes farmable", () => {
+  it("is also farmable once the reward's timing becomes feasible again", () => {
     const c = campaign({ rewards: [{ ...campaign().rewards[0]!, preconditionsMet: true }] });
+    expect(campaignFarmable(c, settings())).toBe(true);
     expect(visible(c)).toBe(true);
   });
 });

--- a/packages/extension/tests/campaignFilters.test.ts
+++ b/packages/extension/tests/campaignFilters.test.ts
@@ -1,14 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
+  campaignFarmable,
   campaignFilterCategories,
   campaignPassesFarmingEligibility,
   isCampaignVisible,
 } from "@lurkloot/shared/campaignFilters";
-import type { DropCampaign, EngineSettings, ExtensionSettings } from "@lurkloot/shared/models";
+import { mergeSettings } from "@lurkloot/shared/settings";
+import type { DropCampaign, EngineSettings, ExtensionSettings, PlatformSettings } from "@lurkloot/shared/models";
 
 const ELIGIBLE_ALL: EngineSettings["farmingEligibility"] = {
   farmUnlinkedCampaigns: true,
   farmSubscriptionCampaigns: true,
+};
+
+const FARM_ALL_CATEGORIES: Pick<PlatformSettings, "farmAllCategories" | "categories"> = {
+  farmAllCategories: true,
+  categories: [],
 };
 
 const SHOW_ALL: ExtensionSettings["dropsListFilter"] = {
@@ -30,6 +37,34 @@ const ALL_OFF: ExtensionSettings["dropsListFilter"] = {
   showNotLinked: false,
   showSubscription: false,
 };
+
+// Builds a full ExtensionSettings so isCampaignVisible/campaignFarmable — which
+// both now read one settings object — can be exercised with the same terse
+// per-axis overrides the old piecemeal-argument tests used.
+function settings(overrides: {
+  dropsListFilter?: ExtensionSettings["dropsListFilter"];
+  farmingEligibility?: EngineSettings["farmingEligibility"];
+  excludedCampaignIds?: string[];
+  categorySelection?: Pick<PlatformSettings, "farmAllCategories" | "categories">;
+} = {}): ExtensionSettings {
+  const base = mergeSettings(undefined);
+  const categorySelection = overrides.categorySelection ?? FARM_ALL_CATEGORIES;
+  return {
+    ...base,
+    dropsListFilter: overrides.dropsListFilter ?? SHOW_ALL,
+    farmingEligibility: overrides.farmingEligibility ?? ELIGIBLE_ALL,
+    excludedCampaignIds: overrides.excludedCampaignIds ?? [],
+    platform: {
+      twitch: { ...base.platform.twitch, ...categorySelection },
+      kick: { ...base.platform.kick, ...categorySelection },
+    },
+  };
+}
+
+function visible(campaign: DropCampaign, overrides: Parameters<typeof settings>[0] = {}): boolean {
+  const s = settings(overrides);
+  return isCampaignVisible(campaign, s, new Set(s.excludedCampaignIds));
+}
 
 function campaign(overrides: Partial<DropCampaign> = {}): DropCampaign {
   return {
@@ -86,53 +121,141 @@ describe("campaignPassesFarmingEligibility", () => {
   });
 });
 
+describe("campaignFarmable", () => {
+  // The single shared definition consumed by both the scheduler (isEligible)
+  // and the popup (isCampaignVisible). These mirror what used to be the private
+  // engine-only isEligible tests, now directly testable since the predicate is
+  // exported from shared.
+  it("is true for an ordinary active campaign with an earnable reward", () => {
+    expect(campaignFarmable(campaign(), settings())).toBe(true);
+  });
+
+  it("is false once every reward is claimed", () => {
+    const c = campaign({ rewards: [{ ...campaign().rewards[0]!, status: "claimed" }] });
+    expect(campaignFarmable(c, settings())).toBe(false);
+  });
+
+  it("is false for a non-active status", () => {
+    expect(campaignFarmable(campaign({ status: "expired" }), settings())).toBe(false);
+    expect(campaignFarmable(campaign({ status: "upcoming" }), settings())).toBe(false);
+  });
+
+  it("is false for an ended campaign even while status is still active", () => {
+    const c = campaign({ endsAt: new Date(Date.now() - 1000).toISOString() });
+    expect(campaignFarmable(c, settings())).toBe(false);
+  });
+
+  it("is false when eligibility says otherwise", () => {
+    expect(campaignFarmable(campaign({ eligibility: "expired" }), settings())).toBe(false);
+  });
+
+  it("is false for an excluded campaign", () => {
+    const s = settings({ excludedCampaignIds: ["campaign"] });
+    expect(campaignFarmable(campaign(), s)).toBe(false);
+  });
+
+  it("is false when the class flag turns off unlinked or subscription farming", () => {
+    expect(campaignFarmable(campaign({ accountLinked: false }), settings({ farmingEligibility: { ...ELIGIBLE_ALL, farmUnlinkedCampaigns: false } }))).toBe(false);
+    expect(campaignFarmable(subscriptionCampaign(), settings({ farmingEligibility: { ...ELIGIBLE_ALL, farmSubscriptionCampaigns: false } }))).toBe(false);
+  });
+
+  it("is false outside the selected categories when farmAllCategories is off", () => {
+    const c = campaign({ gameName: "Other Game" });
+    const s = settings({ categorySelection: { farmAllCategories: false, categories: [{ id: "selected-game", name: "Selected Game" }] } });
+    expect(campaignFarmable(c, s)).toBe(false);
+  });
+
+  it("is false for an unlinked Twitch campaign even with farmUnlinkedCampaigns on (platform block)", () => {
+    const c = campaign({ platform: "twitch", accountLinked: false });
+    expect(campaignFarmable(c, settings())).toBe(false);
+  });
+
+  it("is true for an unlinked Kick campaign (no platform block)", () => {
+    const c = campaign({ platform: "kick", accountLinked: false });
+    expect(campaignFarmable(c, settings())).toBe(true);
+  });
+
+  it("is false when the only reward's precondition is not met", () => {
+    const c = campaign({ rewards: [{ ...campaign().rewards[0]!, preconditionsMet: false }] });
+    expect(campaignFarmable(c, settings())).toBe(false);
+  });
+
+  it("is false when the reward's deadline is infeasible under skipUnfinishableRewards", () => {
+    const c = campaign({
+      endsAt: new Date(Date.now() + 60_000).toISOString(), // ends in 1 minute
+      rewards: [{ ...campaign().rewards[0]!, requiredMinutes: 120, watchedMinutes: 0 }], // needs 2 hours
+    });
+    expect(campaignFarmable(c, settings())).toBe(false);
+  });
+
+  it("is true when skipUnfinishableRewards is off despite an infeasible deadline", () => {
+    const c = campaign({
+      endsAt: new Date(Date.now() + 60_000).toISOString(),
+      rewards: [{ ...campaign().rewards[0]!, requiredMinutes: 120, watchedMinutes: 0 }],
+    });
+    const s: ExtensionSettings = { ...settings(), skipUnfinishableRewards: false };
+    expect(campaignFarmable(c, s)).toBe(true);
+  });
+});
+
 describe("isCampaignVisible not-linked / subscription class flags", () => {
-  // These two classes obey farming-on OR show-flag-on: the display flag can hide
-  // a campaign ONLY when the user is also not farming that class. Farming-on
-  // always forces visibility (the invariant), so the flag is a free toggle only
-  // for a class you have already opted out of farming.
+  // These two classes are visible when campaignFarmable(...) says true (the
+  // invariant: a farmable campaign is always visible) OR the class's own
+  // display flag is on. The class flags below (farmUnlinkedCampaigns /
+  // farmSubscriptionCampaigns) only matter insofar as they feed into
+  // campaignFarmable; isCampaignVisible itself no longer reads them directly.
   const NOT_FARMED_UNLINKED = { ...ELIGIBLE_ALL, farmUnlinkedCampaigns: false };
   const NOT_FARMED_SUBSCRIPTION = { ...ELIGIBLE_ALL, farmSubscriptionCampaigns: false };
 
   it("hides a not-linked campaign only when it is not farmed and showNotLinked is off", () => {
     const c = campaign({ accountLinked: false });
     // Not farmed + hidden → gone.
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showNotLinked: false }, NOT_FARMED_UNLINKED, new Set())).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showNotLinked: false }, farmingEligibility: NOT_FARMED_UNLINKED })).toBe(false);
     // Not farmed + shown → visible.
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showNotLinked: true }, NOT_FARMED_UNLINKED, new Set())).toBe(true);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showNotLinked: true }, farmingEligibility: NOT_FARMED_UNLINKED })).toBe(true);
   });
 
   it("keeps a farmed not-linked campaign visible even with showNotLinked off (invariant)", () => {
     const c = campaign({ accountLinked: false });
     // Farming this class forces visibility regardless of the display flag.
     expect(campaignPassesFarmingEligibility(c, ELIGIBLE_ALL)).toBe(true);
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showNotLinked: false }, ELIGIBLE_ALL, new Set())).toBe(true);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showNotLinked: false }, farmingEligibility: ELIGIBLE_ALL })).toBe(true);
   });
 
   it("hides a subscription campaign only when it is not farmed and showSubscription is off", () => {
     const c = subscriptionCampaign();
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showSubscription: false }, NOT_FARMED_SUBSCRIPTION, new Set())).toBe(false);
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showSubscription: true }, NOT_FARMED_SUBSCRIPTION, new Set())).toBe(true);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showSubscription: false }, farmingEligibility: NOT_FARMED_SUBSCRIPTION })).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showSubscription: true }, farmingEligibility: NOT_FARMED_SUBSCRIPTION })).toBe(true);
   });
 
   it("keeps a farmed subscription campaign visible even with showSubscription off (invariant)", () => {
-    const c = subscriptionCampaign();
-    expect(campaignPassesFarmingEligibility(c, ELIGIBLE_ALL)).toBe(true);
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showSubscription: false }, ELIGIBLE_ALL, new Set())).toBe(true);
+    // A pure, still-locked subscription reward is never reward-level farmable —
+    // there is nothing to actively watch, only a subscription to wait for — so
+    // farmSubscriptionCampaigns alone cannot force it visible; only a mixed
+    // campaign with a genuinely earnable watch reward can exercise the
+    // farming-forces-visible invariant for this class.
+    const c = subscriptionCampaign({
+      rewards: [
+        { id: "sub", name: "Subscriber reward", requiredMinutes: 0, requirement: "subscription", requiredSubs: 1, watchedMinutes: 0, status: "locked" },
+        { id: "watch", name: "Watch reward", requiredMinutes: 30, requirement: "watch", isWatchBased: true, watchedMinutes: 0, status: "locked" },
+      ],
+    });
+    expect(campaignFarmable(c, settings({ farmingEligibility: ELIGIBLE_ALL }))).toBe(true);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showSubscription: false }, farmingEligibility: ELIGIBLE_ALL })).toBe(true);
   });
 });
 
 describe("isCampaignVisible display flags", () => {
   it("hides upcoming campaigns unless showUpcoming is on", () => {
     const c = campaign({ status: "upcoming" });
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showUpcoming: false }, ELIGIBLE_ALL, new Set())).toBe(false);
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showUpcoming: true }, ELIGIBLE_ALL, new Set())).toBe(true);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showUpcoming: false } })).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showUpcoming: true } })).toBe(true);
   });
 
   it("hides expired campaigns unless showExpired is on", () => {
     const c = campaign({ status: "expired" });
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showExpired: false }, ELIGIBLE_ALL, new Set())).toBe(false);
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showExpired: true }, ELIGIBLE_ALL, new Set())).toBe(true);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showExpired: false } })).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showExpired: true } })).toBe(true);
   });
 
   it("hides finished campaigns unless showFinished is on", () => {
@@ -147,14 +270,14 @@ describe("isCampaignVisible display flags", () => {
         status: "claimed",
       }],
     });
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showFinished: false }, ELIGIBLE_ALL, new Set())).toBe(false);
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showFinished: true }, ELIGIBLE_ALL, new Set())).toBe(true);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showFinished: false } })).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showFinished: true } })).toBe(true);
   });
 
   it("hides excluded campaigns unless showExcluded is on", () => {
     const c = campaign();
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showExcluded: false }, ELIGIBLE_ALL, new Set(["campaign"]))).toBe(false);
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showExcluded: true }, ELIGIBLE_ALL, new Set(["campaign"]))).toBe(true);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showExcluded: false }, excludedCampaignIds: ["campaign"] })).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showExcluded: true }, excludedCampaignIds: ["campaign"] })).toBe(true);
   });
 
   it("finished wins over expired precedence", () => {
@@ -172,7 +295,7 @@ describe("isCampaignVisible display flags", () => {
         status: "claimed",
       }],
     });
-    expect(isCampaignVisible(c, { ...SHOW_ALL, showFinished: false, showExpired: true }, ELIGIBLE_ALL, new Set())).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showFinished: false, showExpired: true } })).toBe(false);
   });
 
   it("keeps the claimable escape hatch even when every display flag is off", () => {
@@ -188,8 +311,7 @@ describe("isCampaignVisible display flags", () => {
         status: "claimable",
       }],
     });
-    const allOff = ALL_OFF;
-    expect(isCampaignVisible(c, allOff, ELIGIBLE_ALL, new Set(["campaign"]))).toBe(true);
+    expect(visible(c, { dropsListFilter: ALL_OFF, excludedCampaignIds: ["campaign"] })).toBe(true);
   });
 });
 
@@ -218,26 +340,24 @@ describe("campaignFilterCategories", () => {
 
 describe("eligibility-driven lifecycle hides in the Drops list", () => {
   // Aligning display with the engine's eligibility view: none of these states is
-  // farmable (isEligible rejects any eligibility !== "eligible"), so hiding them
-  // cannot hide a farmable campaign.
-  const allOff = ALL_OFF;
-
+  // farmable (campaignFarmable rejects any eligibility !== "eligible"), so hiding
+  // them cannot hide a farmable campaign.
   it("hides an active/upcoming-eligibility campaign when showUpcoming is off", () => {
     const c = campaign({ status: "active", eligibility: "upcoming" });
-    expect(isCampaignVisible(c, allOff, ELIGIBLE_ALL, new Set())).toBe(false);
-    expect(isCampaignVisible(c, { ...allOff, showUpcoming: true }, ELIGIBLE_ALL, new Set())).toBe(true);
+    expect(visible(c, { dropsListFilter: ALL_OFF })).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...ALL_OFF, showUpcoming: true } })).toBe(true);
   });
 
   it("hides an active/expired-eligibility campaign when showExpired is off", () => {
     const c = campaign({ status: "active", eligibility: "expired" });
-    expect(isCampaignVisible(c, allOff, ELIGIBLE_ALL, new Set())).toBe(false);
-    expect(isCampaignVisible(c, { ...allOff, showExpired: true }, ELIGIBLE_ALL, new Set())).toBe(true);
+    expect(visible(c, { dropsListFilter: ALL_OFF })).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...ALL_OFF, showExpired: true } })).toBe(true);
   });
 
   it("hides an active/completed-eligibility campaign when showFinished is off", () => {
     const c = campaign({ status: "active", eligibility: "completed" });
-    expect(isCampaignVisible(c, allOff, ELIGIBLE_ALL, new Set())).toBe(false);
-    expect(isCampaignVisible(c, { ...allOff, showFinished: true }, ELIGIBLE_ALL, new Set())).toBe(true);
+    expect(visible(c, { dropsListFilter: ALL_OFF })).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...ALL_OFF, showFinished: true } })).toBe(true);
   });
 });
 
@@ -250,11 +370,8 @@ describe("visibility invariant: every farmable campaign stays visible", () => {
   // farmSubscriptionCampaigns both default to on. ALL_OFF turns off every
   // display flag INCLUDING showNotLinked/showSubscription, so the not-linked and
   // subscription cases here specifically prove that farming-on overrides the
-  // class show-flags: the four lifecycle/excluded states are non-farmable, and
-  // the two class states are held visible by the farming-on branch. It must
-  // return true for all of these. If a future change makes a farmable campaign
-  // hideable, this fails.
-  const allOff = ALL_OFF;
+  // class show-flags. It must return true for all of these. If a future change
+  // makes a farmable campaign hideable, this fails.
 
   // The kind of campaign the engine actually farms: active, eligible, with an
   // unclaimed watch reward that still has minutes to earn.
@@ -263,7 +380,8 @@ describe("visibility invariant: every farmable campaign stays visible", () => {
     campaign({ eligibility: "eligible" }),
     // Active campaign, eligibility left absent (also farmed).
     campaign(),
-    // Unlinked campaign — still farmed because farmUnlinkedCampaigns defaults on.
+    // Unlinked campaign — still farmed because farmUnlinkedCampaigns defaults on
+    // and the default platform is Kick, which has no unlink block.
     campaign({ accountLinked: false }),
     // Subscription-gated campaign — still farmed because farmSubscriptionCampaigns
     // defaults on and it carries an earnable watch reward.
@@ -282,9 +400,78 @@ describe("visibility invariant: every farmable campaign stays visible", () => {
 
   it("keeps every farmable campaign visible with all display flags off", () => {
     for (const c of farmable) {
-      // The engine's farming-eligibility gate passes with defaults on.
-      expect(campaignPassesFarmingEligibility(c, ELIGIBLE_ALL)).toBe(true);
-      expect(isCampaignVisible(c, allOff, ELIGIBLE_ALL, new Set())).toBe(true);
+      const s = settings({ dropsListFilter: ALL_OFF });
+      expect(campaignFarmable(c, s)).toBe(true);
+      expect(isCampaignVisible(c, s, new Set())).toBe(true);
     }
+  });
+});
+
+describe("isCampaignVisible category selection", () => {
+  const selectedOnly = {
+    farmAllCategories: false,
+    categories: [{ id: "selected-game", name: "Selected Game" }],
+  };
+
+  it("hides a campaign outside the selected categories when farmAllCategories is off", () => {
+    const c = campaign({ gameName: "Other Game" });
+    expect(visible(c, { categorySelection: selectedOnly })).toBe(false);
+  });
+
+  it("keeps a campaign in the selected categories visible", () => {
+    const c = campaign({ gameName: "Selected Game" });
+    expect(visible(c, { categorySelection: selectedOnly })).toBe(true);
+  });
+
+  it("shows every campaign when farmAllCategories is on regardless of the list", () => {
+    const c = campaign({ gameName: "Other Game" });
+    expect(visible(c, { categorySelection: { farmAllCategories: true, categories: [] } })).toBe(true);
+  });
+
+  it("keeps a claimable reward visible even outside the selected categories", () => {
+    const c = campaign({
+      gameName: "Other Game",
+      rewards: [{
+        id: "reward",
+        name: "Reward",
+        requiredMinutes: 30,
+        requirement: "watch",
+        isWatchBased: true,
+        watchedMinutes: 30,
+        status: "claimable",
+      }],
+    });
+    expect(visible(c, { categorySelection: selectedOnly })).toBe(true);
+  });
+
+  it("matches the engine's farming rule: a category-filtered-out campaign is never farmable either", () => {
+    const c = campaign({ gameName: "Other Game" });
+    expect(visible(c, { dropsListFilter: ALL_OFF, categorySelection: selectedOnly })).toBe(false);
+  });
+});
+
+describe("isCampaignVisible reward-level farmability (no display flag rescues this)", () => {
+  // Regression coverage for a real gap: an ordinary active, linked,
+  // non-subscription, in-category campaign used to stay visible unconditionally
+  // (the old code's final `return true`), even when none of its rewards were
+  // actually farmable right now. There is no display flag for this case — an
+  // un-farmable ordinary campaign must be hidden outright.
+  it("hides an ordinary campaign whose only reward has an infeasible deadline", () => {
+    const c = campaign({
+      endsAt: new Date(Date.now() + 60_000).toISOString(),
+      rewards: [{ ...campaign().rewards[0]!, requiredMinutes: 120, watchedMinutes: 0 }],
+    });
+    expect(campaignFarmable(c, settings())).toBe(false);
+    expect(visible(c)).toBe(false);
+  });
+
+  it("hides an ordinary campaign whose only reward's precondition is not met", () => {
+    const c = campaign({ rewards: [{ ...campaign().rewards[0]!, preconditionsMet: false }] });
+    expect(visible(c)).toBe(false);
+  });
+
+  it("shows the campaign again once the reward becomes farmable", () => {
+    const c = campaign({ rewards: [{ ...campaign().rewards[0]!, preconditionsMet: true }] });
+    expect(visible(c)).toBe(true);
   });
 });

--- a/packages/extension/tests/campaignFilters.test.ts
+++ b/packages/extension/tests/campaignFilters.test.ts
@@ -448,6 +448,29 @@ describe("isCampaignVisible category selection", () => {
     const c = campaign({ gameName: "Other Game" });
     expect(visible(c, { dropsListFilter: ALL_OFF, categorySelection: selectedOnly })).toBe(false);
   });
+
+  // The category filter has no display-flag override anywhere else; a
+  // not-linked or subscription campaign outside the selected categories must
+  // not slip through via showNotLinked/showSubscription — those flags only
+  // rescue a campaign from ITS OWN class hide, not from the category filter.
+  it("hides a not-linked campaign outside the selected categories even with showNotLinked on", () => {
+    const c = campaign({ accountLinked: false, gameName: "Other Game" });
+    expect(visible(c, { dropsListFilter: SHOW_ALL, categorySelection: selectedOnly })).toBe(false);
+  });
+
+  it("hides a subscription campaign outside the selected categories even with showSubscription on", () => {
+    const c = subscriptionCampaign({ gameName: "Other Game" });
+    expect(visible(c, { dropsListFilter: SHOW_ALL, categorySelection: selectedOnly })).toBe(false);
+  });
+
+  it("shows a not-linked campaign in the selected categories, governed by showNotLinked as usual", () => {
+    // farmUnlinkedCampaigns off so campaignEligibleClass is false for a reason
+    // OTHER than category, landing this campaign in the showNotLinked bucket.
+    const c = campaign({ accountLinked: false, gameName: "Selected Game" });
+    const farmingEligibility = { ...ELIGIBLE_ALL, farmUnlinkedCampaigns: false };
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showNotLinked: false }, farmingEligibility, categorySelection: selectedOnly })).toBe(false);
+    expect(visible(c, { dropsListFilter: { ...SHOW_ALL, showNotLinked: true }, farmingEligibility, categorySelection: selectedOnly })).toBe(true);
+  });
 });
 
 describe("isCampaignVisible stays visible despite reward-timing infeasibility", () => {

--- a/packages/extension/tests/campaignSearch.test.ts
+++ b/packages/extension/tests/campaignSearch.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { filterCampaigns } from "../../popup-ui/src/campaignSearch";
+import type { CampaignView, GameItem } from "../../popup-ui/src/types";
+
+function campaign(overrides: Partial<CampaignView> & { id: string }): CampaignView {
+  return {
+    gameId: "game-a",
+    title: "Some campaign",
+    status: "active",
+    linked: true,
+    excluded: false,
+    starts: "2026-01-01T00:00:00.000Z",
+    ends: "2026-01-02T00:00:00.000Z",
+    channels: [],
+    thumbnail: "",
+    tint: "",
+    rewards: [],
+    hasWatchRewards: true,
+    hasSubscriptionRewards: false,
+    ...overrides,
+  };
+}
+
+function reward(name: string) {
+  return {
+    id: name,
+    name,
+    requiredMinutes: 60,
+    requirement: "watch" as const,
+    obtained: false,
+    art: "",
+    tint: "",
+  };
+}
+
+const gameMap: Record<string, GameItem> = {
+  "game-a": { id: "game-a", name: "Marge de sécurité", short: "MDS", accent: "" },
+  "game-b": { id: "game-b", name: "Palworld", short: "PW", accent: "" },
+};
+
+describe("filterCampaigns", () => {
+  const campaigns = [
+    campaign({ id: "a", title: "Deadline safety margin", gameId: "game-a", rewards: [reward("Emote pack")] }),
+    campaign({ id: "b", title: "Frostbite drops", gameId: "game-b", rewards: [reward("Rare skin")] }),
+  ];
+
+  it("returns every campaign for an empty or blank query", () => {
+    expect(filterCampaigns(campaigns, gameMap, "")).toEqual(campaigns);
+    expect(filterCampaigns(campaigns, gameMap, "   ")).toEqual(campaigns);
+  });
+
+  it("matches by campaign title", () => {
+    expect(filterCampaigns(campaigns, gameMap, "deadline").map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("matches by game/category name, case and diacritic insensitive", () => {
+    expect(filterCampaigns(campaigns, gameMap, "securite").map((c) => c.id)).toEqual(["a"]);
+    expect(filterCampaigns(campaigns, gameMap, "PALWORLD").map((c) => c.id)).toEqual(["b"]);
+  });
+
+  it("matches by reward name", () => {
+    expect(filterCampaigns(campaigns, gameMap, "rare skin").map((c) => c.id)).toEqual(["b"]);
+  });
+
+  it("requires every whitespace-separated token to match, in any order", () => {
+    expect(filterCampaigns(campaigns, gameMap, "safety margin").map((c) => c.id)).toEqual(["a"]);
+    expect(filterCampaigns(campaigns, gameMap, "margin safety").map((c) => c.id)).toEqual(["a"]);
+    expect(filterCampaigns(campaigns, gameMap, "safety unrelated")).toEqual([]);
+  });
+
+  it("returns no matches when nothing satisfies the query", () => {
+    expect(filterCampaigns(campaigns, gameMap, "nonexistent")).toEqual([]);
+  });
+
+  it("tolerates a campaign whose game id is missing from the game map", () => {
+    const orphan = [campaign({ id: "c", title: "Orphan campaign", gameId: "missing-game" })];
+    expect(filterCampaigns(orphan, gameMap, "orphan").map((c) => c.id)).toEqual(["c"]);
+    expect(filterCampaigns(orphan, gameMap, "missing-game")).toEqual([]);
+  });
+});

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -271,13 +271,13 @@ describe("subscription drop popup views", () => {
     // Decoupling: dropsListFilter is display-only, so a subscription campaign
     // stays in the Drops list even when farmingEligibility would skip it. The
     // view filter has no subscription axis to turn off.
-    expect(isCampaignVisible(source, settings.dropsListFilter, settings.farmingEligibility, excludedIds)).toBe(true);
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(true);
     settings.farmingEligibility.farmSubscriptionCampaigns = false;
-    expect(isCampaignVisible(source, settings.dropsListFilter, settings.farmingEligibility, excludedIds)).toBe(true);
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(true);
     expect(isCampaignVisible({
       ...source,
       rewards: [{ ...source.rewards[0], status: "claimable" }],
-    }, settings.dropsListFilter, settings.farmingEligibility, excludedIds)).toBe(true);
+    }, settings, excludedIds)).toBe(true);
   });
 
   // Kick used to drop ended campaigns at parse time, which made these two
@@ -293,10 +293,10 @@ describe("subscription drop popup views", () => {
 
     expect(campaignFilterCategories(source, excludedIds)).toEqual(["finished"]);
     expect(settings.dropsListFilter.showFinished).toBe(true);
-    expect(isCampaignVisible(source, settings.dropsListFilter, settings.farmingEligibility, excludedIds)).toBe(true);
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(true);
 
     settings.dropsListFilter.showFinished = false;
-    expect(isCampaignVisible(source, settings.dropsListFilter, settings.farmingEligibility, excludedIds)).toBe(false);
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(false);
   });
 
   it("applies the expired filter to an expired Kick campaign", () => {
@@ -310,9 +310,9 @@ describe("subscription drop popup views", () => {
 
     expect(campaignFilterCategories(source, excludedIds)).toEqual(["expired"]);
     expect(settings.dropsListFilter.showExpired).toBe(false);
-    expect(isCampaignVisible(source, settings.dropsListFilter, settings.farmingEligibility, excludedIds)).toBe(false);
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(false);
 
     settings.dropsListFilter.showExpired = true;
-    expect(isCampaignVisible(source, settings.dropsListFilter, settings.farmingEligibility, excludedIds)).toBe(true);
+    expect(isCampaignVisible(source, settings, excludedIds)).toBe(true);
   });
 });

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "لم يتم اكتشاف أي حملات بعد."
   },
+  "campaignSearchPlaceholder": {
+    "message": "البحث في الحملات…"
+  },
+  "campaignSearchNoResults": {
+    "message": "لا توجد حملات تطابق «$1»."
+  },
   "noActivity": {
     "message": "لم يتم تسجيل أي نشاط بعد. اضغط تحديث لتشغيل فحص."
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "Noch keine Kampagnen gefunden."
   },
+  "campaignSearchPlaceholder": {
+    "message": "Kampagnen durchsuchen…"
+  },
+  "campaignSearchNoResults": {
+    "message": "Keine Kampagnen entsprechen „$1“."
+  },
   "noActivity": {
     "message": "Noch keine Aktivität aufgezeichnet. Aktualisieren drücken, um eine Prüfung auszuführen."
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "No campaigns discovered yet."
   },
+  "campaignSearchPlaceholder": {
+    "message": "Search campaigns…"
+  },
+  "campaignSearchNoResults": {
+    "message": "No campaigns match “$1”."
+  },
   "noActivity": {
     "message": "No activity recorded yet. Press refresh to run a check."
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "Aún no se han descubierto campañas."
   },
+  "campaignSearchPlaceholder": {
+    "message": "Buscar campañas…"
+  },
+  "campaignSearchNoResults": {
+    "message": "Ninguna campaña coincide con «$1»."
+  },
   "noActivity": {
     "message": "Aún no hay actividad registrada. Pulsa actualizar para ejecutar una comprobación."
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "Aucune campagne découverte pour le moment."
   },
+  "campaignSearchPlaceholder": {
+    "message": "Rechercher des campagnes…"
+  },
+  "campaignSearchNoResults": {
+    "message": "Aucune campagne ne correspond à « $1 »."
+  },
   "noActivity": {
     "message": "Aucune activité enregistrée. Appuyez sur actualiser pour lancer une vérification."
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "अभी कोई अभियान नहीं मिला।"
   },
+  "campaignSearchPlaceholder": {
+    "message": "अभियान खोजें…"
+  },
+  "campaignSearchNoResults": {
+    "message": "कोई अभियान “$1” से मेल नहीं खाता।"
+  },
   "noActivity": {
     "message": "अभी कोई गतिविधि रिकॉर्ड नहीं हुई। जाँच चलाने के लिए रीफ़्रेश दबाएँ।"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "Nessuna campagna scoperta finora."
   },
+  "campaignSearchPlaceholder": {
+    "message": "Cerca campagne…"
+  },
+  "campaignSearchNoResults": {
+    "message": "Nessuna campagna corrisponde a «$1»."
+  },
   "noActivity": {
     "message": "Nessuna attività registrata. Premi aggiorna per eseguire un controllo."
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "Nenhuma campanha descoberta ainda."
   },
+  "campaignSearchPlaceholder": {
+    "message": "Pesquisar campanhas…"
+  },
+  "campaignSearchNoResults": {
+    "message": "Nenhuma campanha corresponde a “$1”."
+  },
   "noActivity": {
     "message": "Nenhuma atividade registrada ainda. Pressione atualizar para executar uma verificação."
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "Кампании пока не обнаружены."
   },
+  "campaignSearchPlaceholder": {
+    "message": "Искать кампании…"
+  },
+  "campaignSearchNoResults": {
+    "message": "Кампании, соответствующие «$1», не найдены."
+  },
   "noActivity": {
     "message": "Активность пока не записана. Нажмите обновить, чтобы выполнить проверку."
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "Aktif kampanya yok."
   },
+  "campaignSearchPlaceholder": {
+    "message": "Kampanyalarda ara…"
+  },
+  "campaignSearchNoResults": {
+    "message": "“$1” ile ilgili kampanya bulunamadı."
+  },
   "noActivity": {
     "message": "Henüz işlem kaydı yok."
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -182,6 +182,12 @@
   "noCampaigns": {
     "message": "尚未发现活动。"
   },
+  "campaignSearchPlaceholder": {
+    "message": "搜索活动…"
+  },
+  "campaignSearchNoResults": {
+    "message": "未找到与“$1”匹配的活动。"
+  },
   "noActivity": {
     "message": "尚未记录活动。按刷新运行检查。"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -490,7 +490,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const settings = mergeSettings(snapshot.settings);
   const compatibilityResolution = adapter.resolveCompatibility?.(settings.compatibility);
   const excludedIds = new Set(settings.excludedCampaignIds);
-  const rawCampaigns = sortCampaignsForPopup(snapshot.state.campaigns[platform].filter((campaign) => isCampaignVisible(campaign, settings.dropsListFilter, settings.farmingEligibility, excludedIds)), settings);
+  const rawCampaigns = sortCampaignsForPopup(snapshot.state.campaigns[platform].filter((campaign) => isCampaignVisible(campaign, settings, excludedIds)), settings);
   const session = snapshot.state.sessions[platform];
   const sessionChannel = channelViewFromSession(session);
   const criticalFailure = snapshot.state.criticalHealth?.[platform];

--- a/packages/popup-ui/src/campaignSearch.ts
+++ b/packages/popup-ui/src/campaignSearch.ts
@@ -1,0 +1,10 @@
+import { matchesSearch } from "./settingsSearch";
+import type { CampaignView, GameItem } from "./types";
+
+export function filterCampaigns(campaigns: CampaignView[], gameMap: Record<string, GameItem>, query: string): CampaignView[] {
+  if (!query.trim()) return campaigns;
+  return campaigns.filter((campaign) => matchesSearch(
+    [campaign.title, gameMap[campaign.gameId]?.name ?? "", ...campaign.rewards.map((reward) => reward.name)],
+    query,
+  ));
+}

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { DndContext, DragOverlay, closestCenter, type DragEndEvent, type DragStartEvent } from "@dnd-kit/core";
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -22,6 +22,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { PopupRuntimeContext, useT } from "./context";
+import { filterCampaigns } from "./campaignSearch";
 import { formatCountdown, formatHours, formatMinutes } from "./format";
 import { campaignStats, fallbackGame } from "./viewModels";
 import type { CampaignLifecycleState, CampaignView, GameItem, RewardView, TFunction } from "./types";
@@ -32,6 +33,7 @@ import {
   MetaStat,
   Pill,
   ProgressBar,
+  SearchBox,
   cn,
   moveById,
   useDndSensors,
@@ -53,10 +55,13 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, onRefreshCam
   const t = useT();
   const sensors = useDndSensors();
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
   const farmingId = farmingCampaignId(campaigns);
   const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>(() => initialExpandedIds(campaigns));
   const autoExpandedId = useRef<string | undefined>(farmingId);
   const listRef = useRef<HTMLDivElement>(null);
+  const searching = query.trim().length > 0;
+  const visibleCampaigns = useMemo(() => filterCampaigns(campaigns, gameMap, query), [campaigns, gameMap, query]);
 
   // Campaigns can arrive after mount, and the farmed campaign can change while the
   // popup is open. Expand the new one when that happens, but never collapse anything:
@@ -91,18 +96,33 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, onRefreshCam
   }
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={(event: DragStartEvent) => setActiveId(String(event.active.id))} onDragEnd={endDrag} onDragCancel={() => setActiveId(null)}>
-      <SortableContext items={campaigns.map((campaign) => campaign.id)} strategy={verticalListSortingStrategy}>
-        <div ref={listRef} className="space-y-2">
-          {campaigns.map((campaign, index) => (
-            <SortableCampaign key={campaign.id} campaign={campaign} index={index} anyFarming={anyFarming} game={gameMap[campaign.gameId] ?? fallbackGame(campaign, index, t)} expanded={Boolean(expandedIds[campaign.id])} refreshing={refreshing} onToggle={() => setExpandedIds((current) => ({ ...current, [campaign.id]: !current[campaign.id] }))} onRefreshCampaign={onRefreshCampaign} onToggleExclude={onToggleExclude} />
-          ))}
-        </div>
-      </SortableContext>
-      <DragOverlay dropAnimation={null}>
-        {activeCampaign ? <CampaignCard campaign={activeCampaign} index={activeIndex} anyFarming={anyFarming} game={gameMap[activeCampaign.gameId] ?? fallbackGame(activeCampaign, activeIndex, t)} expanded={false} refreshing={refreshing} onToggle={() => undefined} onRefreshCampaign={onRefreshCampaign} isOverlay dragHandle={<GripVertical size={16} className="text-zinc-400" />} /> : null}
-      </DragOverlay>
-    </DndContext>
+    <div className="space-y-2">
+      <SearchBox value={query} onChange={setQuery} placeholder={t("campaignSearchPlaceholder")} />
+      {searching ? (
+        visibleCampaigns.length === 0 ? (
+          <p className="px-1 py-6 text-center text-xs text-zinc-400 dark:text-zinc-500">{t("campaignSearchNoResults", query.trim())}</p>
+        ) : (
+          <div className="space-y-2">
+            {visibleCampaigns.map((campaign, index) => (
+              <CampaignCard key={campaign.id} campaign={campaign} index={index} anyFarming={anyFarming} game={gameMap[campaign.gameId] ?? fallbackGame(campaign, index, t)} expanded={Boolean(expandedIds[campaign.id])} refreshing={refreshing} onToggle={() => setExpandedIds((current) => ({ ...current, [campaign.id]: !current[campaign.id] }))} onRefreshCampaign={onRefreshCampaign} onToggleExclude={onToggleExclude} />
+            ))}
+          </div>
+        )
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={(event: DragStartEvent) => setActiveId(String(event.active.id))} onDragEnd={endDrag} onDragCancel={() => setActiveId(null)}>
+          <SortableContext items={campaigns.map((campaign) => campaign.id)} strategy={verticalListSortingStrategy}>
+            <div ref={listRef} className="space-y-2">
+              {campaigns.map((campaign, index) => (
+                <SortableCampaign key={campaign.id} campaign={campaign} index={index} anyFarming={anyFarming} game={gameMap[campaign.gameId] ?? fallbackGame(campaign, index, t)} expanded={Boolean(expandedIds[campaign.id])} refreshing={refreshing} onToggle={() => setExpandedIds((current) => ({ ...current, [campaign.id]: !current[campaign.id] }))} onRefreshCampaign={onRefreshCampaign} onToggleExclude={onToggleExclude} />
+              ))}
+            </div>
+          </SortableContext>
+          <DragOverlay dropAnimation={null}>
+            {activeCampaign ? <CampaignCard campaign={activeCampaign} index={activeIndex} anyFarming={anyFarming} game={gameMap[activeCampaign.gameId] ?? fallbackGame(activeCampaign, activeIndex, t)} expanded={false} refreshing={refreshing} onToggle={() => undefined} onRefreshCampaign={onRefreshCampaign} isOverlay dragHandle={<GripVertical size={16} className="text-zinc-400" />} /> : null}
+          </DragOverlay>
+        </DndContext>
+      )}
+    </div>
   );
 }
 

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { motion } from "motion/react";
-import { GripVertical, X, type LucideIcon } from "lucide-react";
+import { GripVertical, Search, X, type LucideIcon } from "lucide-react";
 import type { PopupTab } from "./types";
 
 export function cn(...classes: Array<string | false | null | undefined>): string {
@@ -15,6 +15,22 @@ export function moveById<T extends { id: string }>(list: T[], activeId: string, 
   const newIndex = list.findIndex((item) => item.id === overId);
   if (oldIndex === -1 || newIndex === -1) return list;
   return arrayMove(list, oldIndex, newIndex);
+}
+
+export function SearchBox({ value, onChange, placeholder }: { value: string; onChange(value: string): void; placeholder: string }) {
+  return (
+    <div className="relative">
+      <Search size={13} className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-zinc-400" />
+      <input
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        aria-label={placeholder}
+        placeholder={placeholder}
+        className="w-full rounded-xl border border-zinc-200 bg-white py-2 pl-8 pr-3 text-xs font-medium text-zinc-900 outline-none focus:border-[var(--accent-ring)] dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
+      />
+    </div>
+  );
 }
 
 export function useDndSensors() {

--- a/packages/popup-ui/src/settingsControls.tsx
+++ b/packages/popup-ui/src/settingsControls.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { Ban, ChevronDown, Lock, Search, TriangleAlert, type LucideIcon } from "lucide-react";
+import { Ban, ChevronDown, Lock, TriangleAlert, type LucideIcon } from "lucide-react";
 import type { ExtensionSettings } from "@lurkloot/shared/models";
 import {
   COLLAPSED_SETTINGS_SECTIONS_KEY,
   DROPS_LIST_FILTERS,
 } from "./constants";
 import { usePopupRuntime, useT } from "./context";
-import { Toggle, cn } from "./primitives";
+import { SearchBox, Toggle, cn } from "./primitives";
 
 export function SettingsSection({ id, title, description, icon: Icon, iconNode, badge, forceExpanded, children }: {
   // Stable, locale-independent identity. Collapse state is keyed by this, not by
@@ -105,19 +105,7 @@ export function SettingsGroup({ title, description, badge, advanced = false, chi
 
 export function SettingsSearchBox({ value, onChange }: { value: string; onChange(value: string): void }) {
   const t = useT();
-  return (
-    <div className="relative">
-      <Search size={13} className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-zinc-400" />
-      <input
-        type="search"
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        aria-label={t("settingsSearchPlaceholder")}
-        placeholder={t("settingsSearchPlaceholder")}
-        className="w-full rounded-xl border border-zinc-200 bg-white py-2 pl-8 pr-3 text-xs font-medium text-zinc-900 outline-none focus:border-[var(--accent-ring)] dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
-      />
-    </div>
-  );
+  return <SearchBox value={value} onChange={onChange} placeholder={t("settingsSearchPlaceholder")} />;
 }
 
 export function AdvancedSettingsSwitch({ checked, onChange }: { checked: boolean; onChange(value: boolean): void }) {

--- a/packages/shared/src/campaignFilters.ts
+++ b/packages/shared/src/campaignFilters.ts
@@ -79,13 +79,21 @@ export function isRewardFarmableNow(
     || isRewardDeadlineFeasible(campaign, reward, settings.skipUnfinishableRewards, settings.deadlineSafetyMarginMinutes);
 }
 
-// The single definition of "is this campaign farmable right now" — everything
-// the engine's isEligible checks EXCEPT settings.priorityMode. Priority-list-only
-// mode is a farming-strategy choice, not a fact about the campaign itself: a
-// campaign the user hasn't prioritized yet must stay farmable-shaped here (and
-// visible in isCampaignVisible below) so they can add it to the list, which is
-// why the scheduler layers that check on top of this rather than folding it in.
-export function campaignFarmable(campaign: DropCampaign, settings: EngineSettings): boolean {
+// Whether a campaign's CLASS could ever be farmed, ignoring the moment-to-moment
+// timing of any individual reward (deadline feasibility, preconditions). This is
+// everything campaignFarmable checks except the final per-reward relevance
+// check, replaced with the much looser "has something left to earn or claim at
+// all". Deliberately separate from campaignFarmable: the popup's visibility
+// (isCampaignVisible) keys off THIS, not full farmability, because a campaign
+// that is momentarily un-farmable for reward-timing reasons (an infeasible
+// deadline under skipUnfinishableRewards, an unmet precondition on a locked
+// follow-up reward) is not a dead campaign — the user may want to see it, ease
+// the deadline margin, or (in "priority list only" mode) drag it into their
+// priority list, which is the ONLY way to make such a campaign farmable there.
+// Priority ordering is built from the currently-visible list (prioritiesFromOrder
+// in popup-ui), so hiding a campaign for a reward-timing reason would make it
+// permanently un-prioritizable — a real regression, not a stricter invariant.
+export function campaignEligibleClass(campaign: DropCampaign, settings: EngineSettings): boolean {
   if (campaign.status !== "active") return false;
   if (hasCampaignEnded(campaign)) return false;
   if (campaign.eligibility && campaign.eligibility !== "eligible") return false;
@@ -97,30 +105,44 @@ export function campaignFarmable(campaign: DropCampaign, settings: EngineSetting
   // campaign is never farmable regardless of farmUnlinkedCampaigns. Kick DOES
   // accrue watch progress before linking (the link is only required to claim).
   if (campaign.platform !== "kick" && campaign.accountLinked === false) return false;
+  return campaign.rewards.some((reward) => reward.status !== "claimed");
+}
+
+// The single definition of "is this campaign farmable right now" — everything
+// the engine's isEligible checks EXCEPT settings.priorityMode. Priority-list-only
+// mode is a farming-strategy choice, not a fact about the campaign itself: a
+// campaign the user hasn't prioritized yet must stay eligible-class here (and
+// visible in isCampaignVisible below) so they can add it to the list, which is
+// why the scheduler layers that check on top of this rather than folding it in.
+// Strictly narrower than campaignEligibleClass — see that function for why
+// isCampaignVisible deliberately does NOT use this one.
+export function campaignFarmable(campaign: DropCampaign, settings: EngineSettings): boolean {
+  if (!campaignEligibleClass(campaign, settings)) return false;
   return campaign.rewards.some((reward) => isRewardFarmableNow(campaign, reward, settings));
 }
 
 // What the popup asks. A claimable reward always stays visible so the user can
 // claim it, independent of farmability — claiming doesn't require the engine to
-// be actively farming the campaign. Everything else derives from a single
-// question, "is this campaign farmable right now" (campaignFarmable): if yes,
-// visible (the invariant below); if no, visible only when a display flag
-// explicitly says to show that class of non-farmable campaign anyway.
+// be actively farming the campaign. Everything else derives from
+// campaignEligibleClass (NOT the stricter campaignFarmable — see its comment):
+// if the campaign's class could ever be farmed, it's visible (the invariant
+// below); if not, visible only when a display flag explicitly says to show that
+// class of non-farmable campaign anyway.
 //
-// INVARIANT: a campaign that will be farmed is always visible here. The user
-// must never farm a campaign they cannot see. This holds by construction: the
-// first campaignFarmable(...) check returns true immediately, before any
-// filter flag is consulted, so no flag can hide a farmable campaign. If a
-// future change reorders this, the binding test in campaignFilters.test.ts
-// fails.
+// INVARIANT: a campaign that will be farmed is always visible here. This holds
+// because campaignFarmable is strictly narrower than campaignEligibleClass (same
+// checks, plus a reward-timing requirement) — so campaignFarmable-true implies
+// campaignEligibleClass-true, and the eligible-class check returns visible
+// immediately, before any filter flag is consulted. If a future change breaks
+// that subset relationship, the binding test in campaignFilters.test.ts fails.
 export function isCampaignVisible(
   campaign: DropCampaign,
   settings: ExtensionSettings,
   excludedIds: ReadonlySet<string>,
 ): boolean {
   if (campaign.rewards.some((reward) => reward.status === "claimable")) return true;
-  if (campaignFarmable(campaign, settings)) return true;
-  // Not farmable right now. Bucket by why, and consult that class's display
+  if (campaignEligibleClass(campaign, settings)) return true;
+  // Not in a farmable class. Bucket by why, and consult that class's display
   // flag — the only way a non-farmable campaign can still be shown.
   const filter = settings.dropsListFilter;
   if (excludedIds.has(campaign.id)) return filter.showExcluded;
@@ -129,8 +151,7 @@ export function isCampaignVisible(
   if (isCampaignUpcoming(campaign)) return filter.showUpcoming;
   if (campaign.accountLinked === false) return filter.showNotLinked;
   if (campaignHasSubscriptionRewards(campaign)) return filter.showSubscription;
-  // An ordinary active campaign that campaignFarmable rejected for a reason with
-  // no display flag (category filter, or every reward currently unearnable/
-  // infeasible) has none to fall back on: hidden.
+  // An ordinary active campaign that campaignEligibleClass rejected for a reason
+  // with no display flag (category filter) has none to fall back on: hidden.
   return false;
 }

--- a/packages/shared/src/campaignFilters.ts
+++ b/packages/shared/src/campaignFilters.ts
@@ -142,21 +142,21 @@ export function isCampaignVisible(
 ): boolean {
   if (campaign.rewards.some((reward) => reward.status === "claimable")) return true;
   if (campaignEligibleClass(campaign, settings)) return true;
-  // Not in a farmable class. Bucket by why, and consult that class's display
-  // flag — the only way a non-farmable campaign can still be shown.
+  // The category filter has no display-flag override anywhere, so it is
+  // checked first, ahead of every other bucket below — it wins even over a
+  // campaign that is ALSO excluded/finished/expired/upcoming/not-linked/
+  // subscription-gated with its matching display flag on. "Farm all
+  // categories" off means campaigns outside the list are gone from the Drops
+  // list, full stop, not just gone from farming.
+  const platformSettings = settings.platform[campaign.platform];
+  if (!platformSettings.farmAllCategories && categoryListIndex(campaign, platformSettings.categories) === -1) return false;
+  // Not in a farmable class for some other reason. Bucket by why, and consult
+  // that class's display flag — the only way it can still be shown.
   const filter = settings.dropsListFilter;
   if (excludedIds.has(campaign.id)) return filter.showExcluded;
   if (isCampaignFinished(campaign)) return filter.showFinished;
   if (isCampaignExpired(campaign)) return filter.showExpired;
   if (isCampaignUpcoming(campaign)) return filter.showUpcoming;
-  // The category filter has no display-flag override — checked before the two
-  // class flags below so a not-linked or subscription campaign outside the
-  // selected categories cannot be shown via showNotLinked/showSubscription. A
-  // campaign can be BOTH out-of-category and not-linked/subscription-gated at
-  // once; without this check first, the class bucket below would rescue it and
-  // the category filter would have no effect on that campaign.
-  const platformSettings = settings.platform[campaign.platform];
-  if (!platformSettings.farmAllCategories && categoryListIndex(campaign, platformSettings.categories) === -1) return false;
   if (campaign.accountLinked === false) return filter.showNotLinked;
   if (campaignHasSubscriptionRewards(campaign)) return filter.showSubscription;
   // An ordinary active campaign that campaignEligibleClass rejected for a reason

--- a/packages/shared/src/campaignFilters.ts
+++ b/packages/shared/src/campaignFilters.ts
@@ -149,9 +149,18 @@ export function isCampaignVisible(
   if (isCampaignFinished(campaign)) return filter.showFinished;
   if (isCampaignExpired(campaign)) return filter.showExpired;
   if (isCampaignUpcoming(campaign)) return filter.showUpcoming;
+  // The category filter has no display-flag override — checked before the two
+  // class flags below so a not-linked or subscription campaign outside the
+  // selected categories cannot be shown via showNotLinked/showSubscription. A
+  // campaign can be BOTH out-of-category and not-linked/subscription-gated at
+  // once; without this check first, the class bucket below would rescue it and
+  // the category filter would have no effect on that campaign.
+  const platformSettings = settings.platform[campaign.platform];
+  if (!platformSettings.farmAllCategories && categoryListIndex(campaign, platformSettings.categories) === -1) return false;
   if (campaign.accountLinked === false) return filter.showNotLinked;
   if (campaignHasSubscriptionRewards(campaign)) return filter.showSubscription;
   // An ordinary active campaign that campaignEligibleClass rejected for a reason
-  // with no display flag (category filter) has none to fall back on: hidden.
+  // with no display flag (reward-independent — every branch above is covered)
+  // has none to fall back on: hidden.
   return false;
 }

--- a/packages/shared/src/campaignFilters.ts
+++ b/packages/shared/src/campaignFilters.ts
@@ -1,5 +1,6 @@
-import type { CampaignFilterKey, DropCampaign, EngineSettings, ExtensionSettings } from "./models";
-import { campaignHasSubscriptionRewards } from "./rewards";
+import { categoryListIndex } from "./categories";
+import type { CampaignFilterKey, DropCampaign, DropReward, EngineSettings, ExtensionSettings } from "./models";
+import { campaignHasSubscriptionRewards, canClaimReward, isRewardDeadlineFeasible, isRewardRelevantNow } from "./rewards";
 
 export function isCampaignExpired(campaign: DropCampaign): boolean {
   if (campaign.status === "expired") return true;
@@ -60,39 +61,76 @@ export function campaignPassesFarmingEligibility(
   return true;
 }
 
+// Whether a single reward is farmable right now: not yet claimed, its earn/claim
+// preconditions are met, it is within its claim or earn window, and — for a
+// still-earning watch reward — its deadline is feasible under the user's
+// skip-unfinishable-rewards policy. Shared by campaignFarmable (below) and the
+// scheduler, so "should the engine spend a tick on this reward" has one
+// definition instead of drifting between the two.
+export function isRewardFarmableNow(
+  campaign: Pick<DropCampaign, "endsAt">,
+  reward: DropReward,
+  settings: Pick<EngineSettings, "skipUnfinishableRewards" | "deadlineSafetyMarginMinutes">,
+): boolean {
+  if (reward.status === "claimed") return false;
+  if (reward.preconditionsMet === false) return false;
+  if (!isRewardRelevantNow(reward)) return false;
+  return canClaimReward(reward)
+    || isRewardDeadlineFeasible(campaign, reward, settings.skipUnfinishableRewards, settings.deadlineSafetyMarginMinutes);
+}
+
+// The single definition of "is this campaign farmable right now" — everything
+// the engine's isEligible checks EXCEPT settings.priorityMode. Priority-list-only
+// mode is a farming-strategy choice, not a fact about the campaign itself: a
+// campaign the user hasn't prioritized yet must stay farmable-shaped here (and
+// visible in isCampaignVisible below) so they can add it to the list, which is
+// why the scheduler layers that check on top of this rather than folding it in.
+export function campaignFarmable(campaign: DropCampaign, settings: EngineSettings): boolean {
+  if (campaign.status !== "active") return false;
+  if (hasCampaignEnded(campaign)) return false;
+  if (campaign.eligibility && campaign.eligibility !== "eligible") return false;
+  if (settings.excludedCampaignIds.includes(campaign.id)) return false;
+  if (!campaignPassesFarmingEligibility(campaign, settings.farmingEligibility)) return false;
+  const platformSettings = settings.platform[campaign.platform];
+  if (!platformSettings.farmAllCategories && categoryListIndex(campaign, platformSettings.categories) === -1) return false;
+  // Twitch cannot earn drops until the account is linked, so an unlinked Twitch
+  // campaign is never farmable regardless of farmUnlinkedCampaigns. Kick DOES
+  // accrue watch progress before linking (the link is only required to claim).
+  if (campaign.platform !== "kick" && campaign.accountLinked === false) return false;
+  return campaign.rewards.some((reward) => isRewardFarmableNow(campaign, reward, settings));
+}
+
 // What the popup asks. A claimable reward always stays visible so the user can
-// claim it. The finished/expired/upcoming order mirrors the precedence in
-// campaignFilterCategories. Not-linked and subscription campaigns can be hidden
-// via their display flags, but ONLY when they are not being farmed.
+// claim it, independent of farmability — claiming doesn't require the engine to
+// be actively farming the campaign. Everything else derives from a single
+// question, "is this campaign farmable right now" (campaignFarmable): if yes,
+// visible (the invariant below); if no, visible only when a display flag
+// explicitly says to show that class of non-farmable campaign anyway.
 //
 // INVARIANT: a campaign that will be farmed is always visible here. The user
-// must never farm a campaign they cannot see. For the four lifecycle/excluded
-// states this holds structurally: none of them is farmable — isEligible rejects
-// an inactive/ended campaign and any campaign whose eligibility !== "eligible",
-// and an excluded id is rejected outright — so no farmable campaign can reach
-// those filtered branches. For the two class states (not-linked, subscription)
-// it is enforced explicitly: the hide only fires when farming of that class is
-// OFF, so farming-on forces the campaign visible (farming-on OR show-flag-on).
-// The claimable-reward escape hatch above additionally keeps any campaign the
-// user can still claim visible, covering ended campaigns with an unclaimed
-// reward. If a future change makes a farmable campaign hideable, the binding
-// test in campaignFilters.test.ts fails.
+// must never farm a campaign they cannot see. This holds by construction: the
+// first campaignFarmable(...) check returns true immediately, before any
+// filter flag is consulted, so no flag can hide a farmable campaign. If a
+// future change reorders this, the binding test in campaignFilters.test.ts
+// fails.
 export function isCampaignVisible(
   campaign: DropCampaign,
-  filter: ExtensionSettings["dropsListFilter"],
-  farmingEligibility: EngineSettings["farmingEligibility"],
+  settings: ExtensionSettings,
   excludedIds: ReadonlySet<string>,
 ): boolean {
   if (campaign.rewards.some((reward) => reward.status === "claimable")) return true;
-  if (excludedIds.has(campaign.id) && !filter.showExcluded) return false;
+  if (campaignFarmable(campaign, settings)) return true;
+  // Not farmable right now. Bucket by why, and consult that class's display
+  // flag — the only way a non-farmable campaign can still be shown.
+  const filter = settings.dropsListFilter;
+  if (excludedIds.has(campaign.id)) return filter.showExcluded;
   if (isCampaignFinished(campaign)) return filter.showFinished;
   if (isCampaignExpired(campaign)) return filter.showExpired;
   if (isCampaignUpcoming(campaign)) return filter.showUpcoming;
-  // Active campaign. A not-linked / subscription campaign may be hidden ONLY
-  // when it is not being farmed — the user can never hide something farmed (the
-  // visibility invariant), so farming-on forces it visible regardless of the
-  // display flag.
-  if (campaign.accountLinked === false && !farmingEligibility.farmUnlinkedCampaigns && !filter.showNotLinked) return false;
-  if (campaignHasSubscriptionRewards(campaign) && !farmingEligibility.farmSubscriptionCampaigns && !filter.showSubscription) return false;
-  return true;
+  if (campaign.accountLinked === false) return filter.showNotLinked;
+  if (campaignHasSubscriptionRewards(campaign)) return filter.showSubscription;
+  // An ordinary active campaign that campaignFarmable rejected for a reason with
+  // no display flag (category filter, or every reward currently unearnable/
+  // infeasible) has none to fall back on: hidden.
+  return false;
 }

--- a/packages/shared/src/rewards.ts
+++ b/packages/shared/src/rewards.ts
@@ -54,6 +54,38 @@ export function rewardFeasibility(
   };
 }
 
+// A watch reward not yet claimable but still within its earn window — the
+// scheduler picks these to actively watch. Shared with the popup's farmability
+// check (campaignFarmable) so both agree on what "still earning" means.
+export function isRewardAvailableToEarn(reward: DropReward, now = Date.now()): boolean {
+  if (!isWatchReward(reward)) return false;
+  const startsAt = reward.availableFrom ? Date.parse(reward.availableFrom) : undefined;
+  const endsAt = reward.availableUntil ? Date.parse(reward.availableUntil) : undefined;
+  if (startsAt != null && !Number.isNaN(startsAt) && now < startsAt) return false;
+  if (endsAt != null && !Number.isNaN(endsAt) && now >= endsAt) return false;
+  return reward.status !== "claimed" && reward.status !== "claimable";
+}
+
+export function canClaimReward(reward: DropReward, now = Date.now()): boolean {
+  if (reward.status !== "claimable") return false;
+  if (!reward.claimUntil) return true;
+  const claimUntil = Date.parse(reward.claimUntil);
+  return Number.isNaN(claimUntil) || now < claimUntil;
+}
+
+export function isRewardRelevantNow(reward: DropReward, now = Date.now()): boolean {
+  return canClaimReward(reward, now) || isRewardAvailableToEarn(reward, now);
+}
+
+export function isRewardDeadlineFeasible(
+  campaign: Pick<DropCampaign, "endsAt">,
+  reward: DropReward,
+  enabled: boolean,
+  marginMinutes: number,
+): boolean {
+  return rewardFeasibility(campaign, reward, enabled, marginMinutes).kind !== "insufficient_time";
+}
+
 export function isWaitingSubscriptionReward(reward: DropReward, now = Date.now()): boolean {
   if (!isSubscriptionReward(reward)) return false;
   if (reward.status !== "locked" && reward.status !== "in_progress") return false;


### PR DESCRIPTION
## Summary

- Adds a search box to the popup's campaigns (Drops) view, filtering by campaign title, game/category name, or reward name (closes #306). Drag-and-drop reordering is disabled while a search query is active.
- Fixes a bug where disabling "Farm all categories" and selecting specific categories still showed campaigns from unselected categories in the Drops list, even though they were correctly excluded from farming.
- Centralizes "is this campaign farmable" logic: extracts `campaignEligibleClass`/`campaignFarmable` into `@lurkloot/shared/campaignFilters` as the single definition consumed by both the scheduler's `isEligible` and the popup's `isCampaignVisible`, replacing an independent reimplementation that had drifted from the engine's actual rules.
- Documents the resulting farmability/visibility logic with Mermaid diagrams (`docs/campaign-farmability-visibility.md`), linked from `docs/architecture.md`.

## Details

**Search** (`packages/popup-ui/src/campaignSearch.ts`, `drops.tsx`): reuses the existing diacritic-folded, multi-token `matchesSearch` helper from the settings search. Extracted a shared `SearchBox` primitive (previously settings-only) into `primitives.tsx`.

**Visibility/farmability** (`packages/shared/src/campaignFilters.ts`, `rewards.ts`, `packages/core/src/core/scheduler.ts`):

- `campaignEligibleClass(campaign, settings)` is the shared base: status/lifecycle/exclusion/category/class-eligibility/platform-link checks, ignoring reward timing.
- `campaignFarmable` = `campaignEligibleClass` + a per-reward timing check (deadline feasibility, preconditions). Used by the scheduler's `isEligible` (which layers the `priorityMode` check on top — deliberately excluded from the shared predicate, since a campaign not yet in the priority list must stay eligible-class so the user can add it).
- `isCampaignVisible` uses `campaignEligibleClass` (not the stricter `campaignFarmable`) as its main fast path, so a campaign that's momentarily un-farmable purely for reward-timing reasons stays visible instead of disappearing — that matters most for "priority list only" mode, where `campaignPriorities` is built from the currently-visible list order, so a hidden campaign could never be dragged in to become farmable.
- The category filter has no display-flag override anywhere, so it's checked first in `isCampaignVisible`, ahead of every other bucket (excluded/finished/expired/upcoming/not-linked/subscription) — it wins even for a campaign that's simultaneously in one of those other classes with its flag on.

Also moved the reward-relevance helpers (`isRewardAvailableToEarn`, `canClaimReward`, `isRewardRelevantNow`, `isRewardDeadlineFeasible`) from private functions in `scheduler.ts` into `@lurkloot/shared/rewards`, so engine and popup share one definition.

**Not in scope**: the CLI (`packages/cli/src/runtime/status.ts`) still doesn't apply any visibility filter to its status output — it logs every discovered campaign unconditionally. Left as-is since it changes CLI output and wasn't asked for; happy to follow up if wanted.

## Test plan

- [x] `pnpm --filter @lurkloot/extension test` — 1281 tests pass, including coverage for `filterCampaigns`, `campaignEligibleClass`/`campaignFarmable`, and every visibility-precedence case (category vs. excluded/lifecycle/not-linked/subscription)
- [x] `pnpm --filter @lurkloot/cli test` — 138 tests pass
- [x] `pnpm -r typecheck` — clean across all packages
- [x] `pnpm --filter site build` — site (which embeds the real popup UI) builds
- [ ] Manual popup smoke test (search box feel, category filter, drag-and-drop while searching, priority-list-only mode) not yet done — recommend a `pnpm dev` pass before merging