### PR TITLE
ci: automerge non-major Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,28 @@
   ],
   "extends": [
     "config:recommended"
+  ],
+  "ignoreTests": false,
+  "lockFileMaintenance": {
+    "automerge": true,
+    "automergeType": "pr",
+    "platformAutomerge": true,
+    "automergeStrategy": "squash"
+  },
+  "packageRules": [
+    {
+      "description": "Automerge non-major dependency updates after CI passes",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest",
+        "rollback"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "automergeStrategy": "squash"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Enable Renovate auto-merge for non-major dependency updates and lockfile maintenance.
- Keep major updates manual and require checks before merging.
- Use GitHub native auto-merge with squash commits.

## Validation

- Validated `renovate.json` with Renovate’s configuration validator.
- Confirmed the `develop` ruleset requires verification, extension, and Docker build checks.

The full workspace test baseline has one unrelated existing parser failure in `packages/extension/tests/parsers.test.ts`.