### PR TITLE
feat(popup): add translation contribution guide

### DIFF
--- a/docs/superpowers/plans/2026-08-01-translation-contribution-guide.md
+++ b/docs/superpowers/plans/2026-08-01-translation-contribution-guide.md
@@ -1,0 +1,231 @@
+# Translation Contribution Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a localized extension-popup tip that links users to an in-repository guide for submitting translation improvements.
+
+**Architecture:** The existing `TipsBanner` receives one more descriptor and consumes a named GitHub guide URL constant. Two new keys are added to every locale catalog. A Markdown guide describes the focused contribution flow; tests assert the action is safe, the guide exists, and localization parity remains complete.
+
+**Tech Stack:** TypeScript, React, Vitest, JSON message catalogs, Markdown, pnpm.
+
+## Global Constraints
+
+- Render the new content only through the existing extension popup `TipsBanner`; do not alter any Astro site page or component.
+- The tip text and its action must be naturally translated in all eleven catalogs.
+- Diagnostics remain English literals and are not translation keys.
+- The guide URL must be `https://github.com/jamezrin/lurkloot/blob/main/docs/translations.md`.
+- The guide is English and must direct pull requests to `develop`.
+- Preserve strict TypeScript, two-space indentation, double quotes, semicolons, and existing safe external-link attributes.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `docs/translations.md` | Contributor-facing process for correcting catalog translations and submitting a PR. |
+| `packages/popup-ui/src/constants.ts` | Stable GitHub URL for the contributor guide. |
+| `packages/popup-ui/src/tips.tsx` | Descriptor that includes the guide tip in popup rotation. |
+| `packages/locales/messages/*.json` | Localized tip text and localized action label. |
+| `packages/extension/tests/tips.test.ts` | Regression coverage for the guide, its safe rendered link, and locale-key parity. |
+
+### Task 1: Guide and regression tests
+
+**Files:**
+- Create: `docs/translations.md`
+- Modify: `packages/extension/tests/tips.test.ts:1-104`
+
+**Interfaces:**
+- Consumes: existing `TipsBanner`, `I18nContext`, and catalog files.
+- Produces: test requirements for `GITHUB_TRANSLATION_GUIDE_URL`, `tipTranslations`, `tipTranslationsAction`, and the guide headings used by contributors.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `readFileSync` expectations after the existing external-action test and add the two keys to `requiredKeys`:
+
+```ts
+it("links the localized translation tip to the contributor guide", () => {
+  const html = renderToStaticMarkup(createElement(
+    I18nContext.Provider,
+    { value: { t: (key: string) => key, dir: "ltr", locale: "en" } },
+    createElement(TipsBanner, { initialIndex: 8 }),
+  ));
+
+  expect(html).toContain("tipTranslations");
+  expect(html).toContain("tipTranslationsAction");
+  expect(html).toContain("https://github.com/jamezrin/lurkloot/blob/main/docs/translations.md");
+  expect(html).toContain('target="_blank"');
+  expect(html).toContain('rel="noreferrer"');
+});
+
+it("documents the translation contribution workflow", () => {
+  const guide = readFileSync(resolve(import.meta.dirname, "../../../docs/translations.md"), "utf8");
+  expect(guide).toContain("# Improving translations");
+  expect(guide).toContain("packages/locales/messages/");
+  expect(guide).toContain("pnpm --filter @lurkloot/extension test -- tips.test.ts");
+  expect(guide).toContain("base branch: `develop`");
+});
+```
+
+Add `"tipTranslations"` and `"tipTranslationsAction"` to the `requiredKeys` array. Update the rotation-boundary assertions from eight tips to nine: `randomTipIndex(9, () => 0.999)` must be `8`, `nextTipIndex(8, 9)` must be `0`, and `nextTipIndex(2, 9)` remains `3`.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run: `pnpm --filter @lurkloot/extension test -- tips.test.ts`
+
+Expected: FAIL because the guide does not exist, the two locale keys are absent, and index `8` falls back to the first tip instead of rendering the translation action.
+
+- [ ] **Step 3: Write the contributor guide**
+
+Create `docs/translations.md` with this content:
+
+```md
+# Improving translations
+
+Lurkloot's translations are maintained automatically with AI. Native speakers are welcome to improve wording, clarity, and accuracy through pull requests.
+
+## Improve an existing translation
+
+1. Find the locale file in `packages/locales/messages/` that you want to improve. Each file is a JSON message catalog; for example, `es.json` contains Spanish copy.
+2. Edit only the message text for the key you are correcting. Keep the key name, JSON structure, placeholders such as `$1`, and product names intact. Do not translate diagnostic messages: diagnostics are English literals by design.
+3. Keep the change focused on the wording you are improving. Add a new locale only when you are prepared to translate every existing message key.
+
+## Submit a pull request
+
+1. Fork the repository and create a branch from `develop`, for example `fix/spanish-tip-wording`.
+2. Make the translation change and run `pnpm --filter @lurkloot/extension test -- tips.test.ts` from the repository root.
+3. Commit using the repository's Conventional Commit format, for example `fix(locales): improve Spanish tip wording`.
+4. Open a pull request from your fork to this repository with base branch: `develop`. Explain which locale and message keys you improved.
+
+Thank you for helping make Lurkloot clearer in every language.
+```
+
+- [ ] **Step 4: Run the focused test to verify the guide assertions now pass while tip assertions still fail**
+
+Run: `pnpm --filter @lurkloot/extension test -- tips.test.ts`
+
+Expected: The guide-workflow test passes; the translation tip render and locale-parity checks still fail because application code and catalog entries are not present.
+
+- [ ] **Step 5: Commit the guide and test expectations**
+
+```bash
+git add docs/translations.md packages/extension/tests/tips.test.ts
+git commit -m "test(popup): cover translation contribution tip"
+```
+
+### Task 2: Localized rotating tip
+
+**Files:**
+- Modify: `packages/popup-ui/src/constants.ts:28-33`
+- Modify: `packages/popup-ui/src/tips.tsx:4-24`
+- Modify: `packages/locales/messages/ar.json`
+- Modify: `packages/locales/messages/de.json`
+- Modify: `packages/locales/messages/en.json`
+- Modify: `packages/locales/messages/es.json`
+- Modify: `packages/locales/messages/fr.json`
+- Modify: `packages/locales/messages/hi.json`
+- Modify: `packages/locales/messages/it.json`
+- Modify: `packages/locales/messages/pt_BR.json`
+- Modify: `packages/locales/messages/ru.json`
+- Modify: `packages/locales/messages/tr.json`
+- Modify: `packages/locales/messages/zh_CN.json`
+
+**Interfaces:**
+- Consumes: `TipDescriptor` (`messageKey`, optional `actionKey`, optional `href`) and existing `TipsBanner` anchor rendering.
+- Produces: `GITHUB_TRANSLATION_GUIDE_URL` and the ninth `TIPS` entry: `{ messageKey: "tipTranslations", actionKey: "tipTranslationsAction", href: GITHUB_TRANSLATION_GUIDE_URL }`.
+
+- [ ] **Step 1: Add the named guide URL and tip descriptor**
+
+In `constants.ts`, add:
+
+```ts
+export const GITHUB_TRANSLATION_GUIDE_URL = "https://github.com/jamezrin/lurkloot/blob/main/docs/translations.md";
+```
+
+In `tips.tsx`, import that constant and append this descriptor after `tipExcludedCampaigns`:
+
+```ts
+{ messageKey: "tipTranslations", actionKey: "tipTranslationsAction", href: GITHUB_TRANSLATION_GUIDE_URL },
+```
+
+- [ ] **Step 2: Add locale messages**
+
+Insert these entries immediately after `tipExcludedCampaigns` in every catalog, preserving the catalog's JSON formatting:
+
+| Catalog | `tipTranslations` | `tipTranslationsAction` |
+| --- | --- | --- |
+| `en` | `Translations are maintained automatically with AI. Help improve them on GitHub.` | `Read the translation guide` |
+| `es` | `Las traducciones se mantienen automáticamente con IA. Ayuda a mejorarlas en GitHub.` | `Leer la guía de traducción` |
+| `fr` | `Les traductions sont maintenues automatiquement par IA. Aidez à les améliorer sur GitHub.` | `Lire le guide de traduction` |
+| `it` | `Le traduzioni vengono gestite automaticamente con l'IA. Aiutaci a migliorarle su GitHub.` | `Leggi la guida alle traduzioni` |
+| `ru` | `Переводы автоматически поддерживаются с помощью ИИ. Помогите улучшить их на GitHub.` | `Открыть руководство по переводу` |
+| `de` | `Übersetzungen werden automatisch mit KI gepflegt. Hilf mit, sie auf GitHub zu verbessern.` | `Übersetzungsleitfaden lesen` |
+| `zh_CN` | `翻译由 AI 自动维护。欢迎在 GitHub 上帮助改进。` | `阅读翻译指南` |
+| `hi` | `अनुवादों का रखरखाव AI द्वारा स्वचालित रूप से किया जाता है। उन्हें बेहतर बनाने में GitHub पर मदद करें।` | `अनुवाद गाइड पढ़ें` |
+| `pt_BR` | `As traduções são mantidas automaticamente com IA. Ajude a melhorá-las no GitHub.` | `Ler o guia de tradução` |
+| `ar` | `تُصان الترجمات تلقائيًا بالذكاء الاصطناعي. ساعد في تحسينها على GitHub.` | `اقرأ دليل الترجمة` |
+| `tr` | `Çeviriler yapay zekâ ile otomatik olarak güncel tutulur. GitHub'da iyileştirmeye yardımcı olun.` | `Çeviri rehberini okuyun` |
+
+Each value has the catalog shape:
+
+```json
+"tipTranslations": { "message": "..." },
+"tipTranslationsAction": { "message": "..." }
+```
+
+- [ ] **Step 3: Run the focused test to verify it passes**
+
+Run: `pnpm --filter @lurkloot/extension test -- tips.test.ts`
+
+Expected: PASS. The rendered ninth tip includes both localized keys, the GitHub guide URL, and the existing `target`/`rel` protections; all eleven catalogs satisfy the required-key test.
+
+- [ ] **Step 4: Commit the implementation and translations**
+
+```bash
+git add packages/popup-ui/src/constants.ts packages/popup-ui/src/tips.tsx packages/locales/messages/*.json
+git commit -m "feat(popup): link translation contribution guide"
+```
+
+### Task 3: Full verification
+
+**Files:**
+- Verify: `docs/translations.md`
+- Verify: `packages/popup-ui/src/constants.ts`
+- Verify: `packages/popup-ui/src/tips.tsx`
+- Verify: `packages/locales/messages/*.json`
+- Verify: `packages/extension/tests/tips.test.ts`
+
+**Interfaces:**
+- Consumes: committed guide, descriptor, URL, and all locale entries from Tasks 1–2.
+- Produces: verified feature branch with no website-source changes.
+
+- [ ] **Step 1: Run the complete extension test suite**
+
+Run: `pnpm test`
+
+Expected: PASS with all workspace tests passing.
+
+- [ ] **Step 2: Run workspace type checking**
+
+Run: `pnpm typecheck`
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 3: Verify scope and catalog JSON**
+
+Run:
+
+```bash
+git diff origin/develop...HEAD --check
+node -e 'for (const file of require("node:fs").readdirSync("packages/locales/messages")) if (file.endsWith(".json")) JSON.parse(require("node:fs").readFileSync(`packages/locales/messages/${file}`, "utf8"));'
+git diff --name-only origin/develop...HEAD
+```
+
+Expected: no whitespace or JSON errors; changed paths are the guide, popup constants/tips, locale catalogs, tip tests, and this feature's design/plan documents — no `packages/site/` source files.
+
+- [ ] **Step 4: Commit the implementation plan if it is not already committed**
+
+```bash
+git add docs/superpowers/plans/2026-08-01-translation-contribution-guide.md
+git commit -m "docs: plan translation contribution guide"
+```

--- a/docs/superpowers/specs/2026-08-01-translation-contribution-guide-design.md
+++ b/docs/superpowers/specs/2026-08-01-translation-contribution-guide-design.md
@@ -16,7 +16,7 @@ Help extension users improve Lurkloot translations by adding one localized rotat
 
 `packages/popup-ui/src/tips.tsx` owns the rotating banner used in the extension popup. Add a descriptor beside the existing external-action tips. Its message communicates that AI maintains translations and that human improvements are welcome; its localized action reads the translation guide. The action opens the GitHub-rendered guide in a new tab with the component's existing safe link attributes.
 
-The new guide URL becomes a named popup constant. It points to `https://github.com/jamezrin/lurkloot/blob/main/docs/translations.md`, so installed extension versions always lead users to the current published instructions. The Astro site does not render `TipsBanner`, and no site source will be changed.
+The new guide URL becomes a named popup constant. It points to `https://github.com/jamezrin/lurkloot/blob/main/docs/translations.md`, so installed extension versions always lead users to the current published instructions. The Astro site renders `TipsBanner` through the shared popup preview, so that preview explicitly filters out the extension-only translation tip without requiring a site source change.
 
 ## Localization
 

--- a/docs/superpowers/specs/2026-08-01-translation-contribution-guide-design.md
+++ b/docs/superpowers/specs/2026-08-01-translation-contribution-guide-design.md
@@ -1,0 +1,35 @@
+# Translation Contribution Guide Design
+
+## Goal
+
+Help extension users improve Lurkloot translations by adding one localized rotating tip that links to a committed GitHub contribution guide. The website must not gain any visible copy or page for this feature.
+
+## Scope
+
+- Add `docs/translations.md`, an English guide for correcting existing translations.
+- Add one rotating popup tip explaining that translations are maintained automatically with AI and inviting people to improve them.
+- Link the tip action to the guide rendered on GitHub's `main` branch.
+- Localize both the tip text and action in every supported message catalog.
+- Extend the existing tip tests to protect the new behavior and catalog parity.
+
+## Popup Behavior
+
+`packages/popup-ui/src/tips.tsx` owns the rotating banner used in the extension popup. Add a descriptor beside the existing external-action tips. Its message communicates that AI maintains translations and that human improvements are welcome; its localized action reads the translation guide. The action opens the GitHub-rendered guide in a new tab with the component's existing safe link attributes.
+
+The new guide URL becomes a named popup constant. It points to `https://github.com/jamezrin/lurkloot/blob/main/docs/translations.md`, so installed extension versions always lead users to the current published instructions. The Astro site does not render `TipsBanner`, and no site source will be changed.
+
+## Localization
+
+Add `tipTranslations` and `tipTranslationsAction` to all eleven JSON catalogs under `packages/locales/messages/`. Every catalog receives natural copy in its own language. The catalogs remain key- and placeholder-compatible, and diagnostic messages remain English literals rather than localized content.
+
+## Contributor Guide
+
+`docs/translations.md` explains that the project uses AI-maintained translations and welcomes human corrections. It describes where the catalog files live; how to make a focused correction while preserving JSON, message keys, and placeholders; how to run the focused test; and how to fork, branch from `develop`, commit, and open a pull request into `develop`. It links back to the repository's contributor and coding conventions where useful.
+
+## Testing
+
+Extend `packages/extension/tests/tips.test.ts` to assert the new descriptor renders its safe external action and to require both new keys in every supported catalog. Existing rotation behavior and the no-site-change boundary remain unchanged. Run the focused test, then the project test suite and relevant typecheck before completion.
+
+## Error Handling
+
+The banner uses the existing catalog fallback behavior. If a future catalog omits either key, the strengthened parity test fails before release. The outbound guide URL is static and opens independently of extension state.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,18 @@
+# Improving translations
+
+Lurkloot's translations are maintained automatically with AI. Native speakers are welcome to improve wording, clarity, and accuracy through pull requests.
+
+## Improve an existing translation
+
+1. Find the locale file in `packages/locales/messages/` that you want to improve. Each file is a JSON message catalog; for example, `es.json` contains Spanish copy.
+2. Edit only the message text for the key you are correcting. Keep the key name, JSON structure, placeholders such as `$1`, and product names intact. Do not translate diagnostic messages: diagnostics are English literals by design.
+3. Keep the change focused on the wording you are improving. Add a new locale only when you are prepared to translate every existing message key.
+
+## Submit a pull request
+
+1. Fork the repository and create a branch from `develop`, for example `fix/spanish-tip-wording`.
+2. Make the translation change and run `pnpm --filter @lurkloot/extension test -- tips.test.ts` from the repository root.
+3. Commit using the repository's Conventional Commit format, for example `fix(locales): improve Spanish tip wording`.
+4. Open a pull request from your fork to this repository with base branch: `develop`. Explain which locale and message keys you improved.
+
+Thank you for helping make Lurkloot clearer in every language.

--- a/packages/extension/tests/tips.test.ts
+++ b/packages/extension/tests/tips.test.ts
@@ -80,6 +80,18 @@ describe("TipsBanner", () => {
     expect(html).toContain('rel="noreferrer"');
   });
 
+  it("excludes the translation tip from the preview variant", () => {
+    const html = renderToStaticMarkup(createElement(
+      I18nContext.Provider,
+      { value: { t: (key: string) => key, dir: "ltr", locale: "en" } },
+      createElement(TipsBanner, { initialIndex: 8, preview: true }),
+    ));
+
+    expect(html).toContain("tipCampaignPriority");
+    expect(html).not.toContain("tipTranslations");
+    expect(html).not.toContain("tipTranslationsAction");
+  });
+
   it("documents the translation contribution workflow", () => {
     const guide = readFileSync(resolve(import.meta.dirname, "../../../docs/translations.md"), "utf8");
     expect(guide).toContain("# Improving translations");
@@ -90,7 +102,7 @@ describe("TipsBanner", () => {
 
   it("is gated by the popup preference and deterministic in previews", () => {
     const popupSource = readFileSync(resolve(import.meta.dirname, "../../popup-ui/src/Popup.tsx"), "utf8");
-    expect(popupSource).toContain("settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} /> : null");
+    expect(popupSource).toContain("settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} preview={preview} /> : null");
   });
 
   it("has a Hide tips control in General settings", () => {

--- a/packages/extension/tests/tips.test.ts
+++ b/packages/extension/tests/tips.test.ts
@@ -14,13 +14,13 @@ import {
 describe("tip rotation", () => {
   it("chooses a bounded random starting tip", () => {
     expect(randomTipIndex(8, () => 0)).toBe(0);
-    expect(randomTipIndex(8, () => 0.999)).toBe(7);
+    expect(randomTipIndex(9, () => 0.999)).toBe(8);
     expect(randomTipIndex(0, () => 0.5)).toBe(0);
   });
 
   it("advances sequentially and wraps without an immediate repeat", () => {
-    expect(nextTipIndex(2, 8)).toBe(3);
-    expect(nextTipIndex(7, 8)).toBe(0);
+    expect(nextTipIndex(2, 9)).toBe(3);
+    expect(nextTipIndex(8, 9)).toBe(0);
     expect(nextTipIndex(0, 1)).toBe(0);
   });
 
@@ -66,6 +66,28 @@ describe("TipsBanner", () => {
     expect(html).toContain("rel=\"noreferrer\"");
   });
 
+  it("links the localized translation tip to the contributor guide", () => {
+    const html = renderToStaticMarkup(createElement(
+      I18nContext.Provider,
+      { value: { t: (key: string) => key, dir: "ltr", locale: "en" } },
+      createElement(TipsBanner, { initialIndex: 8 }),
+    ));
+
+    expect(html).toContain("tipTranslations");
+    expect(html).toContain("tipTranslationsAction");
+    expect(html).toContain("https://github.com/jamezrin/lurkloot/blob/main/docs/translations.md");
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noreferrer"');
+  });
+
+  it("documents the translation contribution workflow", () => {
+    const guide = readFileSync(resolve(import.meta.dirname, "../../../docs/translations.md"), "utf8");
+    expect(guide).toContain("# Improving translations");
+    expect(guide).toContain("packages/locales/messages/");
+    expect(guide).toContain("pnpm --filter @lurkloot/extension test -- tips.test.ts");
+    expect(guide).toContain("base branch: `develop`");
+  });
+
   it("is gated by the popup preference and deterministic in previews", () => {
     const popupSource = readFileSync(resolve(import.meta.dirname, "../../popup-ui/src/Popup.tsx"), "utf8");
     expect(popupSource).toContain("settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} /> : null");
@@ -92,6 +114,8 @@ describe("TipsBanner", () => {
       "tipFeedback",
       "tipFeedbackAction",
       "tipExcludedCampaigns",
+      "tipTranslations",
+      "tipTranslationsAction",
     ];
     const locales = ["en", "es", "fr", "it", "ru", "de", "zh_CN", "hi", "pt_BR", "ar", "tr"];
 

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "استبعدت حملة بالخطأ؟ استعدها من إعدادات Drops."
   },
+  "tipTranslations": {
+    "message": "تُصان الترجمات تلقائيًا بالذكاء الاصطناعي. ساعد في تحسينها على GitHub."
+  },
+  "tipTranslationsAction": {
+    "message": "اقرأ دليل الترجمة"
+  },
   "noCampaigns": {
     "message": "لم يتم اكتشاف أي حملات بعد."
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "Kampagne versehentlich ausgeschlossen? Stelle sie in den Drops-Einstellungen wieder her."
   },
+  "tipTranslations": {
+    "message": "Übersetzungen werden automatisch mit KI gepflegt. Hilf mit, sie auf GitHub zu verbessern."
+  },
+  "tipTranslationsAction": {
+    "message": "Übersetzungsleitfaden lesen"
+  },
   "noCampaigns": {
     "message": "Noch keine Kampagnen gefunden."
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "Excluded a campaign by mistake? Restore excluded campaigns from Drops settings."
   },
+  "tipTranslations": {
+    "message": "Translations are maintained automatically with AI. Help improve them on GitHub."
+  },
+  "tipTranslationsAction": {
+    "message": "Read the translation guide"
+  },
   "noCampaigns": {
     "message": "No campaigns discovered yet."
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "¿Excluiste una campaña por error? Restáurala desde los ajustes de Drops."
   },
+  "tipTranslations": {
+    "message": "Las traducciones se mantienen automáticamente con IA. Ayuda a mejorarlas en GitHub."
+  },
+  "tipTranslationsAction": {
+    "message": "Leer la guía de traducción"
+  },
   "noCampaigns": {
     "message": "Aún no se han descubierto campañas."
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "Campagne exclue par erreur ? Restaurez-la dans les paramètres des Drops."
   },
+  "tipTranslations": {
+    "message": "Les traductions sont maintenues automatiquement par IA. Aidez à les améliorer sur GitHub."
+  },
+  "tipTranslationsAction": {
+    "message": "Lire le guide de traduction"
+  },
   "noCampaigns": {
     "message": "Aucune campagne découverte pour le moment."
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "गलती से कैंपेन हटाया? उसे Drops सेटिंग्स से वापस लाएँ।"
   },
+  "tipTranslations": {
+    "message": "अनुवादों का रखरखाव AI द्वारा स्वचालित रूप से किया जाता है। उन्हें बेहतर बनाने में GitHub पर मदद करें।"
+  },
+  "tipTranslationsAction": {
+    "message": "अनुवाद गाइड पढ़ें"
+  },
   "noCampaigns": {
     "message": "अभी कोई अभियान नहीं मिला।"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "Hai escluso una campagna per errore? Ripristinala dalle impostazioni Drop."
   },
+  "tipTranslations": {
+    "message": "Le traduzioni vengono gestite automaticamente con l'IA. Aiutaci a migliorarle su GitHub."
+  },
+  "tipTranslationsAction": {
+    "message": "Leggi la guida alle traduzioni"
+  },
   "noCampaigns": {
     "message": "Nessuna campagna scoperta finora."
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "Excluiu uma campanha por engano? Restaure-a nas configurações de Drops."
   },
+  "tipTranslations": {
+    "message": "As traduções são mantidas automaticamente com IA. Ajude a melhorá-las no GitHub."
+  },
+  "tipTranslationsAction": {
+    "message": "Ler o guia de tradução"
+  },
   "noCampaigns": {
     "message": "Nenhuma campanha descoberta ainda."
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "Исключили кампанию случайно? Восстановите её в настройках Drops."
   },
+  "tipTranslations": {
+    "message": "Переводы автоматически поддерживаются с помощью ИИ. Помогите улучшить их на GitHub."
+  },
+  "tipTranslationsAction": {
+    "message": "Открыть руководство по переводу"
+  },
   "noCampaigns": {
     "message": "Кампании пока не обнаружены."
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "Geri getirmek istediğiniz kampanyaları Drops ayarlarından düzenleyebilirsiniz."
   },
+  "tipTranslations": {
+    "message": "Çeviriler yapay zekâ ile otomatik olarak güncel tutulur. GitHub'da iyileştirmeye yardımcı olun."
+  },
+  "tipTranslationsAction": {
+    "message": "Çeviri rehberini okuyun"
+  },
   "noCampaigns": {
     "message": "Aktif kampanya yok."
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -185,6 +185,12 @@
   "tipExcludedCampaigns": {
     "message": "误排除了活动？可在 Drops 设置中恢复。"
   },
+  "tipTranslations": {
+    "message": "翻译由 AI 自动维护。欢迎在 GitHub 上帮助改进。"
+  },
+  "tipTranslationsAction": {
+    "message": "阅读翻译指南"
+  },
   "noCampaigns": {
     "message": "尚未发现活动。"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -715,7 +715,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                     />
                   ) : null}
                 </AnimatePresence>
-                {settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} /> : null}
+                {settings.showTips ? <TipsBanner initialIndex={preview ? 0 : undefined} preview={preview} /> : null}
                 {criticalFailureReason ? (
                   <CriticalFailurePanel
                     platform={platform}

--- a/packages/popup-ui/src/constants.ts
+++ b/packages/popup-ui/src/constants.ts
@@ -28,6 +28,7 @@ export const SITE_URL = "https://lurkloot.jamezrin.com";
 export const GITHUB_REPO_URL = "https://github.com/jamezrin/lurkloot";
 export const CLI_DOCS_URL = "https://github.com/jamezrin/lurkloot/tree/main/packages/cli#readme";
 export const GITHUB_NEW_ISSUE_URL = "https://github.com/jamezrin/lurkloot/issues/new/choose";
+export const GITHUB_TRANSLATION_GUIDE_URL = "https://github.com/jamezrin/lurkloot/blob/main/docs/translations.md";
 // The chooser URL cannot carry a prefilled title/body, so the critical-failure
 // prompt targets the raw new-issue form instead.
 export const GITHUB_NEW_ISSUE_URL_BASE = "https://github.com/jamezrin/lurkloot/issues/new";

--- a/packages/popup-ui/src/tips.tsx
+++ b/packages/popup-ui/src/tips.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Info } from "lucide-react";
-import { CLI_DOCS_URL, GITHUB_NEW_ISSUE_URL } from "./constants";
+import { CLI_DOCS_URL, GITHUB_NEW_ISSUE_URL, GITHUB_TRANSLATION_GUIDE_URL } from "./constants";
 import { useT } from "./context";
 
 export const TIP_ROTATION_MS = 10_000;
@@ -21,6 +21,7 @@ const TIPS: TipDescriptor[] = [
   { messageKey: "tipCli", actionKey: "tipCliAction", href: CLI_DOCS_URL },
   { messageKey: "tipFeedback", actionKey: "tipFeedbackAction", href: GITHUB_NEW_ISSUE_URL },
   { messageKey: "tipExcludedCampaigns" },
+  { messageKey: "tipTranslations", actionKey: "tipTranslationsAction", href: GITHUB_TRANSLATION_GUIDE_URL },
 ];
 
 export function randomTipIndex(count: number, random: () => number = Math.random): number {

--- a/packages/popup-ui/src/tips.tsx
+++ b/packages/popup-ui/src/tips.tsx
@@ -24,6 +24,8 @@ const TIPS: TipDescriptor[] = [
   { messageKey: "tipTranslations", actionKey: "tipTranslationsAction", href: GITHUB_TRANSLATION_GUIDE_URL },
 ];
 
+const PREVIEW_TIPS = TIPS.filter((tip) => tip.messageKey !== "tipTranslations");
+
 export function randomTipIndex(count: number, random: () => number = Math.random): number {
   return count > 0 ? Math.floor(random() * count) : 0;
 }
@@ -49,17 +51,18 @@ export function createTipRotator({
   return () => cancel(handle);
 }
 
-export function TipsBanner({ initialIndex }: { initialIndex?: number }): React.ReactElement {
+export function TipsBanner({ initialIndex, preview = false }: { initialIndex?: number; preview?: boolean }): React.ReactElement {
   const t = useT();
   const reduceMotion = useReducedMotion();
-  const [tipIndex, setTipIndex] = React.useState(() => initialIndex ?? randomTipIndex(TIPS.length));
+  const tips = preview ? PREVIEW_TIPS : TIPS;
+  const [tipIndex, setTipIndex] = React.useState(() => initialIndex ?? randomTipIndex(tips.length));
 
   React.useEffect(() => createTipRotator({
-    onAdvance: () => setTipIndex((current) => nextTipIndex(current, TIPS.length)),
+    onAdvance: () => setTipIndex((current) => nextTipIndex(current, tips.length)),
     isVisible: () => typeof document === "undefined" || document.visibilityState === "visible",
-  }), []);
+  }), [tips.length]);
 
-  const tip = TIPS[tipIndex] ?? TIPS[0];
+  const tip = tips[tipIndex] ?? tips[0];
   return (
     <div className="flex items-start gap-2 rounded-xl px-2.5 py-2 text-[11px]" style={{ backgroundColor: "var(--accent-softer)" }}>
       <Info size={13} className="mt-0.5 shrink-0" style={{ color: "var(--accent-text)" }} />


### PR DESCRIPTION
## Summary

- add a localized rotating extension tip that links to a translation contribution guide
- document how contributors can improve locale copy and submit a PR to `develop`
- keep the extension-only tip out of the website popup preview

## Testing

- `pnpm test`
- `pnpm typecheck`
- locale JSON parsing and whitespace validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a rotating popup tip inviting contributors to improve translations.
  * Added a link to the translation contribution guide.
  * The tip is available in 11 supported languages and is excluded from preview mode.

* **Documentation**
  * Added guidance covering translation edits, testing, branching, commits, and pull requests.

* **Bug Fixes**
  * Improved tip rotation and fallback behavior when preview-specific tips are excluded.

* **Tests**
  * Expanded coverage for rotation, localization, preview behavior, and contribution links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->