### PR TITLE
ci: restrict automerge to Renovate

### DIFF
--- a/docs/superpowers/plans/2026-08-01-renovate-only-automerge.md
+++ b/docs/superpowers/plans/2026-08-01-renovate-only-automerge.md
@@ -1,0 +1,187 @@
+# Renovate-Only Auto-Merge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restrict automatic pull-request merging to eligible Renovate updates while preserving squash-only history for ordinary `develop` PRs.
+
+**Architecture:** The repository configuration reconciliation API explicitly disables GitHub's global auto-merge setting. Renovate merges eligible non-major PRs itself with the squash strategy, avoiding the global GitHub feature. Existing `main` and `develop` rulesets are unchanged.
+
+**Tech Stack:** Node.js built-in test runner, GitHub REST repository settings API, Renovate JSON configuration.
+
+## Global Constraints
+
+- Ordinary PRs into `develop` use squash merge only.
+- Release and hotfix PRs into `main` use merge commits only.
+- GitHub repository-wide auto-merge must be disabled.
+- Only Renovate may automatically merge eligible non-major dependency updates, using squash commits after checks pass.
+- Do not add bypass actors or alter required status checks.
+
+---
+
+### Task 1: Disable GitHub-Wide Auto-Merge in Reconciliation
+
+**Files:**
+- Modify: `scripts/release/repository-config.test.mjs:24-37`
+- Modify: `scripts/release/repository-config.mjs:7-17`
+
+**Interfaces:**
+- Consumes: `repositoryPatch(): Record<string, boolean | string>` used by `applyRepositoryConfig()` to PATCH `/repos/{owner}/{repo}`.
+- Produces: a repository patch containing `allow_auto_merge: false` alongside existing merge-method settings.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the expected object in the `enables merge and squash while disabling repository-wide rebase` test:
+
+```js
+assert.deepEqual(repositoryPatch(), {
+  allow_merge_commit: true,
+  allow_squash_merge: true,
+  allow_rebase_merge: false,
+  allow_auto_merge: false,
+  merge_commit_title: "PR_TITLE",
+  merge_commit_message: "PR_BODY",
+  squash_merge_commit_title: "PR_TITLE",
+  squash_merge_commit_message: "PR_BODY",
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test scripts/release/repository-config.test.mjs`
+
+Expected: FAIL because `repositoryPatch()` lacks `allow_auto_merge`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add this property to `repositoryPatch()`:
+
+```js
+allow_auto_merge: false,
+```
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run: `node --test scripts/release/repository-config.test.mjs`
+
+Expected: PASS with all repository configuration tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release/repository-config.mjs scripts/release/repository-config.test.mjs
+git commit -m "ci: disable repository-wide automerge"
+```
+
+### Task 2: Make Renovate Own Eligible Auto-Merges
+
+**Files:**
+- Modify: `renovate.json:1-9`
+
+**Interfaces:**
+- Consumes: Renovate's `packageRules` configuration schema.
+- Produces: a rule that excludes major updates and uses Renovate-managed PR squash auto-merge.
+
+- [ ] **Step 1: Validate the existing configuration**
+
+Run: `pnpm exec renovate-config-validator renovate.json`
+
+Expected: PASS for the current syntactically valid configuration; this records the validator used for the change.
+
+- [ ] **Step 2: Add the Renovate-only auto-merge rule**
+
+Add this `packageRules` entry after `extends`:
+
+```json
+"packageRules": [
+  {
+    "description": "Automerge non-major dependency updates after CI passes",
+    "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
+    "automerge": true,
+    "automergeType": "pr",
+    "platformAutomerge": false,
+    "automergeStrategy": "squash"
+  }
+]
+```
+
+- [ ] **Step 3: Validate the changed configuration**
+
+Run: `pnpm exec renovate-config-validator renovate.json`
+
+Expected: PASS and report that `renovate.json` is valid.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add renovate.json
+git commit -m "ci: let Renovate manage dependency automerge"
+```
+
+### Task 3: Apply and Read Back the Live Repository Setting
+
+**Files:**
+- Modify: no further tracked files.
+
+**Interfaces:**
+- Consumes: authenticated `gh` CLI access with repository administration permission.
+- Produces: the `allow_auto_merge` repository setting set to `false`.
+
+- [ ] **Step 1: Confirm the current live setting**
+
+Run: `gh api repos/jamezrin/lurkloot --jq '.allow_auto_merge'`
+
+Expected: `true` before the update.
+
+- [ ] **Step 2: Disable the setting**
+
+Run: `gh api --method PATCH repos/jamezrin/lurkloot -f allow_auto_merge=false --jq '.allow_auto_merge'`
+
+Expected: `false` in the response.
+
+- [ ] **Step 3: Read back the setting**
+
+Run: `gh api repos/jamezrin/lurkloot --jq '.allow_auto_merge'`
+
+Expected: `false`.
+
+### Task 4: Verify the Complete Change
+
+**Files:**
+- Modify: no further tracked files.
+
+**Interfaces:**
+- Consumes: the changed repository configuration code and `renovate.json`.
+- Produces: evidence that repository configuration tests and workspace tests pass.
+
+- [ ] **Step 1: Run release configuration tests**
+
+Run: `pnpm release:test`
+
+Expected: PASS with no failing release-script tests.
+
+- [ ] **Step 2: Run the workspace test suite**
+
+Run: `pnpm test`
+
+Expected: PASS across CLI, extension, and site packages.
+
+- [ ] **Step 3: Inspect the final diff and live setting**
+
+Run:
+```bash
+git diff origin/develop...HEAD -- scripts/release/repository-config.mjs scripts/release/repository-config.test.mjs renovate.json
+gh api repos/jamezrin/lurkloot --jq '.allow_auto_merge'
+```
+
+Expected: the diff disables global auto-merge and makes Renovate use `platformAutomerge: false`; the live setting is `false`.
+
+- [ ] **Step 4: Commit any remaining tracked changes**
+
+Run:
+```bash
+git status --short
+git add renovate.json scripts/release/repository-config.mjs scripts/release/repository-config.test.mjs
+git commit -m "ci: restrict automerge to Renovate"
+```
+
+Expected: no tracked implementation changes remain uncommitted. Do not create an empty commit if Tasks 1 and 2 already committed all implementation changes.

--- a/docs/superpowers/specs/2026-08-01-renovate-only-automerge-design.md
+++ b/docs/superpowers/specs/2026-08-01-renovate-only-automerge-design.md
@@ -1,0 +1,19 @@
+# Renovate-Only Auto-Merge Design
+
+## Goal
+
+Allow eligible non-major Renovate dependency pull requests to merge automatically after required checks pass, while preventing GitHub from auto-merging any other pull request.
+
+## Current issue
+
+Renovate was configured with `platformAutomerge: true`. That setting relies on the repository-wide GitHub auto-merge option. GitHub then allowed ordinary pull requests to opt into auto-merge, which could create merge commits despite the `develop` ruleset requiring squash merges for ordinary actors.
+
+## Design
+
+GitHub repository auto-merge will be disabled through the repository configuration script and applied to the live repository. `renovate.json` will configure only non-major updates to use Renovate-managed pull-request auto-merge with a squash strategy; it will not ask GitHub to manage the auto-merge queue.
+
+The existing branch rulesets remain unchanged: ordinary PRs into `develop` are squash-only, release PRs into `main` are merge-commit-only, and only the release-sync App bypasses the `develop` rule.
+
+## Verification
+
+Repository-configuration tests will assert `allow_auto_merge: false`. Renovate configuration will be parsed by the existing configuration checks, and the live repository will be read back after updating the setting to confirm auto-merge is disabled. The full workspace test suite will be run after the change.

--- a/renovate.json
+++ b/renovate.json
@@ -6,27 +6,15 @@
   "extends": [
     "config:recommended"
   ],
-  "ignoreTests": false,
-  "lockFileMaintenance": {
-    "automerge": true,
-    "automergeType": "pr",
-    "platformAutomerge": true,
-    "automergeStrategy": "squash"
-  },
   "packageRules": [
     {
       "description": "Automerge non-major dependency updates after CI passes",
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest",
-        "rollback"
-      ],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true,
+      "platformAutomerge": false,
       "automergeStrategy": "squash"
     }
-  ]
+  ],
+  "ignoreTests": false
 }

--- a/scripts/release/repository-config.mjs
+++ b/scripts/release/repository-config.mjs
@@ -8,6 +8,7 @@ export function repositoryPatch() {
     allow_merge_commit: true,
     allow_squash_merge: true,
     allow_rebase_merge: false,
+    allow_auto_merge: false,
     merge_commit_title: "PR_TITLE",
     merge_commit_message: "PR_BODY",
     squash_merge_commit_title: "PR_TITLE",

--- a/scripts/release/repository-config.test.mjs
+++ b/scripts/release/repository-config.test.mjs
@@ -26,6 +26,7 @@ test("enables merge and squash while disabling repository-wide rebase", () => {
     allow_merge_commit: true,
     allow_squash_merge: true,
     allow_rebase_merge: false,
+    allow_auto_merge: false,
     merge_commit_title: "PR_TITLE",
     merge_commit_message: "PR_BODY",
     squash_merge_commit_title: "PR_TITLE",


### PR DESCRIPTION
## Summary

- disable GitHub's repository-wide auto-merge setting through the reconciliation configuration
- let Renovate squash-merge eligible non-major dependency updates without platform auto-merge
- preserve the existing squash-only policy for ordinary `develop` pull requests

## Root cause

Renovate's platform auto-merge mode required GitHub's repository-wide auto-merge setting, which also allowed ordinary pull requests to auto-merge with merge commits.

## Validation

- `pnpm release:test`
- `pnpm test` (CLI 138, site 3, extension 1293)
- live GitHub setting read-back: `allow_auto_merge: false`
