### PR TITLE
feat(popup): search diagnostic history

### DIFF
--- a/docs/superpowers/plans/2026-08-01-diagnostic-history-search.md
+++ b/docs/superpowers/plans/2026-08-01-diagnostic-history-search.md
@@ -61,10 +61,10 @@ Expected: FAIL because `query` is absent and unmatched rows are returned.
 
 - [ ] **Step 3: Implement the contract and storage predicate**
 
-Add `query?: string` to `ActivityQuery`. In `load`, derive `const normalizedQuery = query.query?.trim().toLocaleLowerCase();`; only push a platform-eligible record if the query is empty or its `message` contains the normalized query. Keep the category/time index, cursor encoding, retention, and `limit + 1` pagination untouched.
+Add `query?: string` to `ActivityQuery`. In `load`, derive `const normalizedQuery = query.query?.trim().toLowerCase();`; only push a platform-eligible record if the query is empty or its `message` contains the normalized query. Keep the category/time index, cursor encoding, retention, and `limit + 1` pagination untouched.
 
 ```ts
-const matchesQuery = !normalizedQuery || event.message.toLocaleLowerCase().includes(normalizedQuery);
+const matchesQuery = !normalizedQuery || event.message.toLowerCase().includes(normalizedQuery);
 if (matchesPlatform && matchesQuery) events.push(event);
 ```
 

--- a/docs/superpowers/plans/2026-08-01-diagnostic-history-search.md
+++ b/docs/superpowers/plans/2026-08-01-diagnostic-history-search.md
@@ -1,0 +1,195 @@
+# Diagnostic History Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let popup users search every retained diagnostic message for the selected platform.
+
+**Architecture:** Add an optional case-insensitive message substring to `ActivityQuery`; IndexedDB filters it while scanning the diagnostics index, so existing cursors page matching rows. The popup owns query state and query-scoped requests, while `ActivityLog` renders the control and its empty state.
+
+**Tech Stack:** TypeScript, React, IndexedDB, Vitest, `@lurkloot/shared` contracts, JSON locale catalogs.
+
+## Global Constraints
+
+- Search only diagnostic `message` values; never add diagnostic locale keys or translated diagnostic bodies.
+- Search covers retained history, not merely loaded popup events, and uses a case-insensitive substring match.
+- Preserve current platform filtering, including platform-less global diagnostics.
+- Keep the existing 2,000-record and seven-day diagnostic retention policy and cursor encoding; do not migrate IndexedDB.
+- Match the repository’s two-space TypeScript, double-quote, semicolon style.
+
+## File structure
+
+- `packages/shared/src/messages.ts`: `ActivityQuery` contract.
+- `packages/extension/src/core/activityStorage.ts`: indexed history search.
+- `packages/extension/tests/activityStorage.test.ts`: repository test coverage.
+- `packages/popup-ui/src/Popup.tsx`: query state and requests.
+- `packages/popup-ui/src/activity.tsx`: search input and empty state.
+- `packages/extension/tests/activityLogView.test.tsx`: rendered UI coverage.
+- `packages/locales/messages/*.json`: UI-only labels.
+
+---
+
+### Task 1: Add paginated diagnostic-message matching to activity history
+
+**Files:**
+
+- Modify: `packages/shared/src/messages.ts:61-66`
+- Modify: `packages/extension/src/core/activityStorage.ts:191-230`
+- Test: `packages/extension/tests/activityStorage.test.ts`
+
+**Interfaces:**
+
+- Produces `ActivityQuery.query?: string`; a trimmed empty string does not filter.
+- `ActivityRepository.load(query)` returns at most `query.limit` matching records and a cursor following the final returned match.
+
+- [ ] **Step 1: Write the failing repository test**
+
+Store `"Kick transport failed"`, `"Twitch connected"`, `"kick retry scheduled"`, and platform-less `"Kick global error"`. Request `{ category: "diagnostic", platform: "kick", query: "KICK", limit: 2 }`, then use its cursor for page two.
+
+```ts
+expect(first.events.map((event) => event.message)).toEqual([
+  "Kick global error",
+  "kick retry scheduled",
+]);
+expect(second.events.map((event) => event.message)).toEqual(["Kick transport failed"]);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @lurkloot/extension test -- --run tests/activityStorage.test.ts`
+
+Expected: FAIL because `query` is absent and unmatched rows are returned.
+
+- [ ] **Step 3: Implement the contract and storage predicate**
+
+Add `query?: string` to `ActivityQuery`. In `load`, derive `const normalizedQuery = query.query?.trim().toLocaleLowerCase();`; only push a platform-eligible record if the query is empty or its `message` contains the normalized query. Keep the category/time index, cursor encoding, retention, and `limit + 1` pagination untouched.
+
+```ts
+const matchesQuery = !normalizedQuery || event.message.toLocaleLowerCase().includes(normalizedQuery);
+if (matchesPlatform && matchesQuery) events.push(event);
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `pnpm --filter @lurkloot/extension test -- --run tests/activityStorage.test.ts`
+
+Expected: PASS.
+
+```bash
+git add packages/shared/src/messages.ts packages/extension/src/core/activityStorage.ts packages/extension/tests/activityStorage.test.ts
+git commit -m "feat(activity): search diagnostic history"
+```
+
+### Task 2: Make popup diagnostic requests query-aware
+
+**Files:**
+
+- Modify: `packages/popup-ui/src/Popup.tsx:90-110,260-325,675-700`
+- Modify: `packages/popup-ui/src/activity.logic.ts`
+- Test: `packages/extension/tests/activityView.test.ts`
+
+**Interfaces:**
+
+- Consumes `ActivityQuery.query` from Task 1.
+- Produces `diagnosticSearchQuery: string` state and a stream that represents the latest platform/query combination.
+- Passes `searchQuery`, `onSearchQueryChange`, and `searchingDiagnostics` to `ActivityLog`.
+
+- [ ] **Step 1: Write a failing stale-response test**
+
+Extend `ActivityRequestScope` with `query: string`. Verify a late `"timeout"` page cannot update a scope whose query is `"retry"`.
+
+```ts
+expect(isActivityRequestCurrent(
+  { generation: 2, platform: "kick", query: "timeout" },
+  { generation: 2, platform: "kick", query: "retry" },
+)).toBe(false);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @lurkloot/extension test -- --run tests/activityView.test.ts`
+
+Expected: FAIL because request scopes have no query.
+
+- [ ] **Step 3: Implement scoped query requests**
+
+Keep raw input in `Popup.tsx`, derive a trimmed query, and advance the diagnostic request scope when it changes. Include `query: searchQuery || undefined` in initial and paginated diagnostic requests. Reset query and its stream on platform change, leaving Diagnostics, and a successful clear. Use the existing mutation sequence to discard late responses; do not bulk-load history.
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `pnpm --filter @lurkloot/extension test -- --run tests/activityView.test.ts`
+
+Expected: PASS.
+
+```bash
+git add packages/popup-ui/src/Popup.tsx packages/popup-ui/src/activity.logic.ts packages/extension/tests/activityView.test.ts
+git commit -m "feat(popup): query diagnostic history"
+```
+
+### Task 3: Render and localize Diagnostics search
+
+**Files:**
+
+- Modify: `packages/popup-ui/src/activity.tsx:1-170`
+- Test: `packages/extension/tests/activityLogView.test.tsx`
+- Modify: every `packages/locales/messages/*.json` catalog
+
+**Interfaces:**
+
+- Consumes `searchQuery: string`, `onSearchQueryChange(query: string): void`, and `searchingDiagnostics: boolean`.
+- Uses UI-only `searchDiagnostics` and `noDiagnosticsMatch` locale keys.
+
+- [ ] **Step 1: Write failing view tests**
+
+Extend the mount helper. In Diagnostics, assert an input labelled `"Search diagnostics"`, assert typing invokes the query handler, and assert an empty search result says `No diagnostics match "timeout".`. In Activity, assert no search input and the existing empty state remain.
+
+```ts
+expect(container.querySelector('input[type="search"]')?.getAttribute("aria-label")).toBe("Search diagnostics");
+expect(container.textContent).toContain("No diagnostics match \"timeout\".");
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @lurkloot/extension test -- --run tests/activityLogView.test.tsx`
+
+Expected: FAIL because `ActivityLog` has neither search props nor a search empty state.
+
+- [ ] **Step 3: Implement UI and translated copy**
+
+Use the existing `SearchBox` above the diagnostic list only when `showDiagnostics` is true. When a non-empty trimmed query has no results, render `noDiagnosticsMatch`; otherwise retain `noDiagnostics`. Add translations to every catalog without changing diagnostic text.
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `pnpm --filter @lurkloot/extension test -- --run tests/activityLogView.test.tsx tests/diagnosticsLocale.test.ts`
+
+Expected: PASS.
+
+```bash
+git add packages/popup-ui/src/activity.tsx packages/extension/tests/activityLogView.test.tsx packages/locales/messages
+git commit -m "feat(popup): add diagnostic search field"
+```
+
+### Task 4: Verify the integrated feature
+
+- [ ] **Step 1: Type-check**
+
+Run: `pnpm typecheck`
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 2: Run all extension tests**
+
+Run: `pnpm test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Build the popup-consuming site**
+
+Run: `pnpm build:site`
+
+Expected: PASS; any existing Vite chunk-size advisory remains a warning.
+
+- [ ] **Step 4: Check the final diff**
+
+Run: `git diff origin/develop...HEAD --check && git status --short`
+
+Expected: no whitespace errors and only feature, tests, locales, and approved documentation changes.

--- a/docs/superpowers/specs/2026-08-01-diagnostic-history-search-design.md
+++ b/docs/superpowers/specs/2026-08-01-diagnostic-history-search-design.md
@@ -1,0 +1,31 @@
+# Diagnostic history search design
+
+## Goal
+
+Let users find diagnostic messages across the complete retained diagnostic history from the popup's Diagnostics view.
+
+## Scope and behavior
+
+- The Diagnostics view contains a localized search field.
+- A non-empty query is matched as a case-insensitive substring against each diagnostic message.
+- Results include all retained diagnostics (currently the latest 2,000 records within seven days), not only the page already loaded by the popup.
+- Results retain the selected platform scope, including platform-less global diagnostics as in the current history view.
+- Empty or whitespace-only input uses the ordinary diagnostics stream.
+- A search with no matches shows a dedicated localized empty state.
+- Changing platform, leaving the Diagnostics view, or clearing the history resets the search state.
+
+## Architecture
+
+`ActivityQuery` gains an optional text query. The extension history repository applies it while iterating the existing category/time index. It continues reading until it has one more matching result than the requested limit, allowing the current cursor pagination format to represent the last returned matching record without a schema migration.
+
+The popup owns the search input and debounces request refreshes enough to avoid a request per keystroke. Search requests use a separate activity stream and mutation sequence so late responses cannot replace the ordinary diagnostic stream or a newer search. The ActivityLog receives the query state and displays its search control only when Diagnostics is active; its list and copy action operate on the matching stream.
+
+## Error handling
+
+History-query failures remain non-disruptive, matching the existing activity refresh behavior. A stale response is discarded whenever its platform, query, or history generation no longer matches. Clearing history invalidates every outstanding history request.
+
+## Testing
+
+- Storage tests prove case-insensitive matching, platform/global inclusion, and cursor pagination across unmatched rows.
+- Popup tests prove the search control appears only in Diagnostics, filters visible results, uses the no-results state, and clears when the view or platform changes.
+- Existing activity-history request tests cover stream-mutation ordering; new cases cover query-scoped ordering.

--- a/packages/extension/src/core/activityStorage.ts
+++ b/packages/extension/src/core/activityStorage.ts
@@ -199,7 +199,7 @@ class IndexedDbActivityRepository implements ActivityRepository {
       : IDBKeyRange.bound(lower, [query.category, []]);
     const request = index.openCursor(range, "prev");
     const limit = Math.min(MAX_LIMIT, Math.max(1, query.limit ?? DEFAULT_LIMIT));
-    const normalizedQuery = query.query?.trim().toLocaleLowerCase();
+    const normalizedQuery = query.query?.trim().toLowerCase();
     const events: ActivityHistoryRecord[] = [];
 
     await new Promise<void>((resolve, reject) => {
@@ -212,7 +212,7 @@ class IndexedDbActivityRepository implements ActivityRepository {
         }
         const event = cursor.value as ActivityHistoryRecord;
         const matchesPlatform = !query.platform || !event.platform || event.platform === query.platform;
-        const matchesQuery = !normalizedQuery || event.message?.toLocaleLowerCase().includes(normalizedQuery) === true;
+        const matchesQuery = !normalizedQuery || event.message?.toLowerCase().includes(normalizedQuery) === true;
         if (matchesPlatform && matchesQuery) {
           events.push(event);
           if (events.length === limit + 1) {

--- a/packages/extension/src/core/activityStorage.ts
+++ b/packages/extension/src/core/activityStorage.ts
@@ -199,6 +199,7 @@ class IndexedDbActivityRepository implements ActivityRepository {
       : IDBKeyRange.bound(lower, [query.category, []]);
     const request = index.openCursor(range, "prev");
     const limit = Math.min(MAX_LIMIT, Math.max(1, query.limit ?? DEFAULT_LIMIT));
+    const normalizedQuery = query.query?.trim().toLocaleLowerCase();
     const events: ActivityHistoryRecord[] = [];
 
     await new Promise<void>((resolve, reject) => {
@@ -210,7 +211,9 @@ class IndexedDbActivityRepository implements ActivityRepository {
           return;
         }
         const event = cursor.value as ActivityHistoryRecord;
-        if (!query.platform || !event.platform || event.platform === query.platform) {
+        const matchesPlatform = !query.platform || !event.platform || event.platform === query.platform;
+        const matchesQuery = !normalizedQuery || event.message?.toLocaleLowerCase().includes(normalizedQuery) === true;
+        if (matchesPlatform && matchesQuery) {
           events.push(event);
           if (events.length === limit + 1) {
             resolve();

--- a/packages/extension/tests/activityLogView.test.tsx
+++ b/packages/extension/tests/activityLogView.test.tsx
@@ -44,12 +44,17 @@ function mount(options: {
   diagnosticLogging?: boolean;
   writeClipboard?: (text: string) => Promise<boolean>;
   omitClipboard?: boolean;
+  activityEvents?: ActivityHistoryRecord[];
+  diagnosticEvents?: ActivityHistoryRecord[];
+  searchQuery?: string;
+  searchingDiagnostics?: boolean;
 }) {
   const { document, window } = parseHTML("<div id=app></div>");
   vi.stubGlobal("window", window);
   vi.stubGlobal("document", document);
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   const onShowDiagnosticsChange = vi.fn();
+  const onSearchQueryChange = vi.fn();
   const writeClipboard = options.writeClipboard ?? vi.fn(async () => true);
   const container = document.getElementById("app")!;
 
@@ -65,6 +70,8 @@ function mount(options: {
           diagnosticsViewTab: "Diagnostics",
           noActivity: "No activity recorded yet.",
           noDiagnostics: "No diagnostics recorded yet.",
+          searchDiagnostics: "Search diagnostics",
+          noDiagnosticsMatch: `No diagnostics match \"${String(substitutions)}\".`,
           copyActivityLog: "Copy log",
           copyActivityLogCopied: `Copied ${String(substitutions)} events`,
           copyActivityLogFailed: "Could not copy the log. Try again.",
@@ -73,8 +80,8 @@ function mount(options: {
         locale: "en",
       }}>
         <ActivityLog
-          activityEvents={ACTIVITY}
-          diagnosticEvents={DIAGNOSTICS}
+          activityEvents={options.activityEvents ?? ACTIVITY}
+          diagnosticEvents={options.diagnosticEvents ?? DIAGNOSTICS}
           platform="kick"
           diagnosticLogging={options.diagnosticLogging ?? true}
           showDiagnostics={options.showDiagnostics}
@@ -85,6 +92,9 @@ function mount(options: {
           clearing={false}
           version="1.9.0"
           locale="en"
+          searchQuery={options.searchQuery ?? ""}
+          onSearchQueryChange={onSearchQueryChange}
+          searchingDiagnostics={options.searchingDiagnostics ?? false}
           onShowDiagnosticsChange={onShowDiagnosticsChange}
           onLoadMore={() => undefined}
           onClear={() => undefined}
@@ -94,12 +104,21 @@ function mount(options: {
     );
   });
 
-  return { container, onShowDiagnosticsChange, writeClipboard };
+  return { container, onShowDiagnosticsChange, onSearchQueryChange, writeClipboard };
 }
 
 const copyButton = (container: Element) =>
   [...container.querySelectorAll<HTMLButtonElement>("button")]
     .find((button) => button.textContent?.includes("Copy log") || button.textContent?.includes("Copied"));
+
+function setSearchQuery(input: HTMLInputElement, value: string): void {
+  input.value = value;
+  const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+  const props = propsKey
+    ? (input as unknown as Record<string, { onChange?(event: { target: HTMLInputElement; currentTarget: HTMLInputElement }): void }>)[propsKey]
+    : undefined;
+  props?.onChange?.({ target: input, currentTarget: input });
+}
 
 describe("activity log view", () => {
   it("shows only activity entries while the activity view is selected", () => {
@@ -118,6 +137,33 @@ describe("activity log view", () => {
     expect(container.textContent).not.toContain("Started farming a reward");
     expect(container.textContent).toContain("Kick diagnostics");
     expect(container.querySelectorAll("ul > li")).toHaveLength(1);
+  });
+
+  it("renders the diagnostics search field and forwards typed queries", () => {
+    const { container, onSearchQueryChange } = mount({ showDiagnostics: true });
+    const input = container.querySelector<HTMLInputElement>('input[type="search"]');
+
+    expect(input?.getAttribute("aria-label")).toBe("Search diagnostics");
+    act(() => { if (input) setSearchQuery(input, "timeout"); });
+    expect(onSearchQueryChange).toHaveBeenCalledWith("timeout");
+  });
+
+  it("shows the query-specific empty state when diagnostics search finds no results", () => {
+    const { container } = mount({
+      showDiagnostics: true,
+      diagnosticEvents: [],
+      searchQuery: " timeout ",
+      searchingDiagnostics: true,
+    });
+
+    expect(container.textContent).toContain("No diagnostics match \"timeout\".");
+  });
+
+  it("keeps the activity empty state without a diagnostics search field", () => {
+    const { container } = mount({ showDiagnostics: false, activityEvents: [] });
+
+    expect(container.querySelector('input[type="search"]')).toBeNull();
+    expect(container.textContent).toContain("No activity recorded yet.");
   });
 
   it("marks the selected view on the switch and requests the other one on click", () => {
@@ -176,6 +222,9 @@ describe("activity log view", () => {
             clearing={false}
             version="1.9.0"
             locale="en"
+            searchQuery=""
+            onSearchQueryChange={() => undefined}
+            searchingDiagnostics={false}
             onShowDiagnosticsChange={() => undefined}
             onLoadMore={() => undefined}
             onClear={() => undefined}

--- a/packages/extension/tests/activityStorage.test.ts
+++ b/packages/extension/tests/activityStorage.test.ts
@@ -317,6 +317,31 @@ describe("activity repository", () => {
     expect(second.events.map((event) => event.message)).toEqual(["Kick transport failed"]);
   });
 
+  it("matches English diagnostic text independently of the browser locale", async () => {
+    expect("KICK".toLocaleLowerCase("tr")).not.toBe("kick".toLocaleLowerCase("tr"));
+    const originalToLocaleLowerCase = String.prototype.toLocaleLowerCase;
+    vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(function (
+      this: string,
+      locales?: Intl.LocalesArgument,
+    ) {
+      return originalToLocaleLowerCase.call(this, locales ?? "tr");
+    });
+    await repository.append([{
+      category: "diagnostic",
+      level: "debug",
+      platform: "kick",
+      message: "lowercase kick diagnostic",
+    }]);
+
+    const page = await repository.load({
+      category: "diagnostic",
+      platform: "kick",
+      query: "KICK",
+    });
+
+    expect(page.events.map((event) => event.message)).toEqual(["lowercase kick diagnostic"]);
+  });
+
   it("aborts the entire legacy import when a later value cannot be cloned", async () => {
     const invalid = {
       id: "invalid",

--- a/packages/extension/tests/activityStorage.test.ts
+++ b/packages/extension/tests/activityStorage.test.ts
@@ -293,6 +293,30 @@ describe("activity repository", () => {
     expect(page.events.some((event) => event.platform == null)).toBe(true);
   });
 
+  it("paginates case-insensitive diagnostic message matches within a platform", async () => {
+    await repository.append([
+      { category: "diagnostic", level: "error", platform: "kick", message: "Kick transport failed" },
+      { category: "diagnostic", level: "info", platform: "kick", message: "Twitch connected" },
+      { category: "diagnostic", level: "info", platform: "kick", message: "kick retry scheduled" },
+      { category: "diagnostic", level: "error", message: "Kick global error" },
+    ]);
+
+    const first = await repository.load({ category: "diagnostic", platform: "kick", query: "KICK", limit: 2 });
+    const second = await repository.load({
+      category: "diagnostic",
+      platform: "kick",
+      query: "KICK",
+      limit: 2,
+      cursor: first.nextCursor,
+    });
+
+    expect(first.events.map((event) => event.message)).toEqual([
+      "Kick global error",
+      "kick retry scheduled",
+    ]);
+    expect(second.events.map((event) => event.message)).toEqual(["Kick transport failed"]);
+  });
+
   it("aborts the entire legacy import when a later value cannot be cloned", async () => {
     const invalid = {
       id: "invalid",

--- a/packages/extension/tests/activityStorage.test.ts
+++ b/packages/extension/tests/activityStorage.test.ts
@@ -44,6 +44,7 @@ describe("activity repository", () => {
 
   afterEach(async () => {
     await repository.deleteDatabase();
+    vi.restoreAllMocks();
     vi.useRealTimers();
   }, 30_000);
 
@@ -298,6 +299,7 @@ describe("activity repository", () => {
       { category: "diagnostic", level: "error", platform: "kick", message: "Kick transport failed" },
       { category: "diagnostic", level: "info", platform: "kick", message: "Twitch connected" },
       { category: "diagnostic", level: "info", platform: "kick", message: "kick retry scheduled" },
+      { category: "diagnostic", level: "info", platform: "twitch", message: "KICK connection from Twitch" },
       { category: "diagnostic", level: "error", message: "Kick global error" },
     ]);
 
@@ -315,6 +317,7 @@ describe("activity repository", () => {
       "kick retry scheduled",
     ]);
     expect(second.events.map((event) => event.message)).toEqual(["Kick transport failed"]);
+    expect([...first.events, ...second.events].some((event) => event.message === "KICK connection from Twitch")).toBe(false);
   });
 
   it("matches English diagnostic text independently of the browser locale", async () => {

--- a/packages/extension/tests/activityView.test.ts
+++ b/packages/extension/tests/activityView.test.ts
@@ -228,6 +228,13 @@ describe("activity view model", () => {
     expect(isActivityRequestCurrent(afterClear, afterClear)).toBe(true);
   });
 
+  it("rejects a late diagnostic page after its query changes", () => {
+    expect(isActivityRequestCurrent(
+      { generation: 2, platform: "kick", query: "timeout" },
+      { generation: 2, platform: "kick", query: "retry" },
+    )).toBe(false);
+  });
+
   it("rejects an older refresh response after a newer refresh was issued", () => {
     const sequence = createActivityMutationSequence();
     const scope = createActivityRequestScope("twitch");

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -47,6 +47,15 @@ describe("i18n", () => {
     expect(translateFromCatalogs("fallback", undefined, es, en)).toBe("Fallback");
   });
 
+  it("inserts replacement-pattern characters literally", () => {
+    const catalog: MessageCatalog = {
+      patterns: { message: "$1|$2|$3" },
+    };
+
+    expect(translateFromCatalogs("patterns", ["$&", "$$", "$`"], catalog, catalog))
+      .toBe("$&|$$|$`");
+  });
+
   it("keeps locale catalog keys in sync", () => {
     const locales = localeCodes();
     const english = readCatalog("en");

--- a/packages/extension/tests/popupActivitySearchRequests.test.tsx
+++ b/packages/extension/tests/popupActivitySearchRequests.test.tsx
@@ -1,0 +1,167 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActivityPage, RuntimeMessage } from "@lurkloot/shared/messages";
+import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
+import { resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
+
+vi.mock("motion/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("motion/react")>()),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
+
+let root: Root | undefined;
+
+afterEach(() => {
+  resetCatalogTracking();
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+function setSearchQuery(input: HTMLInputElement, value: string): void {
+  input.value = value;
+  const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+  const props = propsKey
+    ? (input as unknown as Record<string, { onChange?(event: { target: HTMLInputElement; currentTarget: HTMLInputElement }): void }>)[propsKey]
+    : undefined;
+  props?.onChange?.({ target: input, currentTarget: input });
+}
+
+async function waitForMessage(
+  sent: RuntimeMessage[],
+  predicate: (message: RuntimeMessage) => boolean,
+): Promise<RuntimeMessage> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const message = sent.find(predicate);
+    if (message) return message;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  throw new Error("Popup did not send the expected message");
+}
+
+async function waitForElement<T extends Element>(find: () => T | undefined): Promise<T> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const element = find();
+    if (element) return element;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error("Popup did not render the expected element");
+}
+
+async function mount(): Promise<{ container: HTMLElement; sent: RuntimeMessage[] }> {
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(Date.now());
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+
+  const demo = createDemoPopupAdapter();
+  const sent: RuntimeMessage[] = [];
+  const adapter: PopupAdapter = {
+    ...demo,
+    getStorage: async () => ({ "popup:selectedPlatform": "twitch" }),
+    send: async <T,>(message: RuntimeMessage): Promise<T> => {
+      sent.push(message);
+      if (message.type === "getActivity" && message.category === "diagnostic") {
+        const page: ActivityPage = message.cursor
+          ? { events: [] }
+          : {
+              events: [{
+                id: "diagnostic-1",
+                at: "2026-08-01T12:00:00.000Z",
+                category: "diagnostic",
+                level: "warn",
+                platform: "twitch",
+                message: "timeout while fetching inventory",
+              }],
+              nextCursor: "diagnostic-next",
+            };
+        return page as T;
+      }
+      return demo.send<T>(message);
+    },
+  };
+  const container = document.getElementById("app")!;
+
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} />);
+  });
+  await waitForCatalog();
+
+  const openActivity = container.querySelector<HTMLButtonElement>('button[aria-label="Open activity"]');
+  if (!openActivity) throw new Error("Missing activity button");
+  await act(async () => openActivity.click());
+
+  const diagnosticsTab = await waitForElement(() =>
+    container.querySelector<HTMLButtonElement>('[role="tab"][aria-selected="false"]') ?? undefined);
+  await act(async () => diagnosticsTab.click());
+
+  return { container, sent };
+}
+
+describe("popup diagnostic search requests", () => {
+  it("trims the query in the initial diagnostic request", async () => {
+    const { container, sent } = await mount();
+    sent.splice(0);
+    const input = container.querySelector<HTMLInputElement>('input[type="search"]');
+    if (!input) throw new Error("Missing diagnostics search input");
+
+    act(() => setSearchQuery(input, " timeout "));
+
+    const request = await waitForMessage(sent, (message) =>
+      message.type === "getActivity" && message.category === "diagnostic" && message.query != null);
+    expect(request).toEqual({
+      type: "getActivity",
+      platform: "twitch",
+      category: "diagnostic",
+      query: "timeout",
+      limit: 80,
+    });
+  });
+
+  it("trims the query in a cursor diagnostic request", async () => {
+    const { container, sent } = await mount();
+    const input = container.querySelector<HTMLInputElement>('input[type="search"]');
+    if (!input) throw new Error("Missing diagnostics search input");
+    act(() => setSearchQuery(input, " timeout "));
+    await waitForMessage(sent, (message) =>
+      message.type === "getActivity"
+      && message.category === "diagnostic"
+      && message.query != null
+      && !message.cursor);
+    sent.splice(0);
+
+    const loadMore = await waitForElement(() =>
+      [...container.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent === "Load more")
+      ?? [...container.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent === "loadMoreActivity"));
+    await act(async () => loadMore.click());
+
+    const request = await waitForMessage(sent, (message) =>
+      message.type === "getActivity" && message.category === "diagnostic" && message.cursor != null);
+    expect(request).toEqual({
+      type: "getActivity",
+      platform: "twitch",
+      category: "diagnostic",
+      query: "timeout",
+      cursor: "diagnostic-next",
+      limit: 80,
+    });
+  });
+});

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "لم يتم تسجيل أي تشخيصات بعد. تظهر أثناء عمل الإضافة."
   },
+  "searchDiagnostics": {
+    "message": "البحث في التشخيصات"
+  },
+  "noDiagnosticsMatch": {
+    "message": "لا توجد تشخيصات تطابق \"$1\"."
+  },
   "platformActivity": {
     "message": "نشاط $1"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "Noch keine Diagnosen aufgezeichnet. Sie erscheinen, während die Erweiterung arbeitet."
   },
+  "searchDiagnostics": {
+    "message": "Diagnosen suchen"
+  },
+  "noDiagnosticsMatch": {
+    "message": "Keine Diagnose stimmt mit \"$1\" überein."
+  },
   "platformActivity": {
     "message": "$1-Aktivität"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "No diagnostics recorded yet. They appear as the extension works."
   },
+  "searchDiagnostics": {
+    "message": "Search diagnostics"
+  },
+  "noDiagnosticsMatch": {
+    "message": "No diagnostics match \"$1\"."
+  },
   "platformActivity": {
     "message": "$1 activity"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "Aún no hay diagnósticos registrados. Aparecen mientras la extensión trabaja."
   },
+  "searchDiagnostics": {
+    "message": "Buscar diagnósticos"
+  },
+  "noDiagnosticsMatch": {
+    "message": "Ningún diagnóstico coincide con \"$1\"."
+  },
   "platformActivity": {
     "message": "Actividad de $1"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "Aucun diagnostic enregistré. Ils apparaissent au fil du travail de l'extension."
   },
+  "searchDiagnostics": {
+    "message": "Rechercher des diagnostics"
+  },
+  "noDiagnosticsMatch": {
+    "message": "Aucun diagnostic ne correspond à \"$1\"."
+  },
   "platformActivity": {
     "message": "Activité $1"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "अभी कोई डायग्नोस्टिक रिकॉर्ड नहीं हुआ। एक्सटेंशन के काम करते ही ये दिखेंगे।"
   },
+  "searchDiagnostics": {
+    "message": "डायग्नोस्टिक खोजें"
+  },
+  "noDiagnosticsMatch": {
+    "message": "\"$1\" से मेल खाने वाला कोई डायग्नोस्टिक नहीं है।"
+  },
   "platformActivity": {
     "message": "$1 गतिविधि"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "Nessuna diagnostica registrata. Compare mentre l'estensione lavora."
   },
+  "searchDiagnostics": {
+    "message": "Cerca diagnostica"
+  },
+  "noDiagnosticsMatch": {
+    "message": "Nessuna diagnostica corrisponde a \"$1\"."
+  },
   "platformActivity": {
     "message": "Attività $1"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "Nenhum diagnóstico registrado ainda. Eles aparecem conforme a extensão trabalha."
   },
+  "searchDiagnostics": {
+    "message": "Pesquisar diagnósticos"
+  },
+  "noDiagnosticsMatch": {
+    "message": "Nenhum diagnóstico corresponde a \"$1\"."
+  },
   "platformActivity": {
     "message": "Atividade de $1"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "Диагностика пока не записана. Она появляется по мере работы расширения."
   },
+  "searchDiagnostics": {
+    "message": "Искать диагностику"
+  },
+  "noDiagnosticsMatch": {
+    "message": "Нет диагностических записей, соответствующих \"$1\"."
+  },
   "platformActivity": {
     "message": "Активность $1"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "Henüz teknik kayıt yok. Uzantı çalıştıkça görünür."
   },
+  "searchDiagnostics": {
+    "message": "Teknik kayıtları ara"
+  },
+  "noDiagnosticsMatch": {
+    "message": "\"$1\" ile eşleşen teknik kayıt yok."
+  },
   "platformActivity": {
     "message": "$1 geçmişi"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -212,6 +212,12 @@
   "noDiagnostics": {
     "message": "尚未记录诊断信息。扩展运行时会出现。"
   },
+  "searchDiagnostics": {
+    "message": "搜索诊断信息"
+  },
+  "noDiagnosticsMatch": {
+    "message": "没有与“$1”匹配的诊断信息。"
+  },
   "platformActivity": {
     "message": "$1 活动"
   },

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -90,6 +90,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const [diagnosticStream, setDiagnosticStream] = useState<ActivityStream>(createActivityStream);
   const [reportEvents, setReportEvents] = useState<ActivityHistoryRecord[]>([]);
   const [showDiagnostics, setShowDiagnostics] = useState(false);
+  const [diagnosticSearchQuery, setDiagnosticSearchQuery] = useState("");
   const [loadingMoreActivity, setLoadingMoreActivity] = useState(false);
   const [clearActivityArmed, setClearActivityArmed] = useState(false);
   const [clearingActivity, setClearingActivity] = useState(false);
@@ -109,6 +110,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const diagnosticMutationSequenceRef = useRef(createActivityMutationSequence());
   const activityClearInFlightRef = useRef(false);
   const [activityRequestGeneration, setActivityRequestGeneration] = useState(0);
+  const trimmedDiagnosticSearchQuery = diagnosticSearchQuery.trim();
   const languageOverride = initialState?.locale ?? snapshot?.settings.languageOverride ?? DEFAULT_SETTINGS.languageOverride;
   const locale = effectiveLocale(languageOverride, adapter.getUiLanguage());
   const dir = isRtlLocale(locale) ? "rtl" : "ltr";
@@ -121,8 +123,11 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
     return message === key ? adapter.getMessage(key, substitutions) || message : message;
   };
 
-  function invalidateActivityRequests(nextPlatform: Platform = activityRequestScopeRef.current.platform): ActivityRequestScope {
-    const nextScope = advanceActivityRequestScope(activityRequestScopeRef.current, nextPlatform);
+  function invalidateActivityRequests(
+    nextPlatform: Platform = activityRequestScopeRef.current.platform,
+    nextQuery: string = activityRequestScopeRef.current.query,
+  ): ActivityRequestScope {
+    const nextScope = advanceActivityRequestScope(activityRequestScopeRef.current, nextPlatform, nextQuery);
     activityRequestScopeRef.current = nextScope;
     setActivityRequestGeneration(nextScope.generation);
     setLoadingMoreActivity(false);
@@ -226,16 +231,25 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   }, [activityOpen, activityRequestGeneration, adapter, clearingActivity, preview]);
 
   useEffect(() => {
-    if (activityRequestScopeRef.current.platform !== platform) invalidateActivityRequests(platform);
+    if (activityRequestScopeRef.current.platform !== platform || activityRequestScopeRef.current.query) {
+      invalidateActivityRequests(platform, "");
+    }
     setActivityStream(createActivityStream());
     setDiagnosticStream(createActivityStream());
+    setDiagnosticSearchQuery("");
     setShowDiagnostics(false);
     setClearActivityArmed(false);
     setClearActivityFailed(false);
   }, [platform]);
 
   useEffect(() => {
-    if (!snapshot?.settings.diagnosticLogging) setShowDiagnostics(false);
+    if (activityRequestScopeRef.current.query === trimmedDiagnosticSearchQuery) return;
+    invalidateActivityRequests(platform, trimmedDiagnosticSearchQuery);
+    setDiagnosticStream(createActivityStream());
+  }, [platform, trimmedDiagnosticSearchQuery]);
+
+  useEffect(() => {
+    if (!snapshot?.settings.diagnosticLogging) handleShowDiagnosticsChange(false);
   }, [snapshot?.settings.diagnosticLogging]);
 
   // The failure report needs recent activity, but the Activity view's stream is
@@ -263,7 +277,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
     const refresh = () => {
       if (activityClearInFlightRef.current || !isActivityRequestCurrent(requestScope, activityRequestScopeRef.current)) return;
       const refreshRequest = beginActivityMutation(diagnosticMutationSequenceRef.current);
-      void adapter.send<ActivityPage>({ type: "getActivity", platform: requestScope.platform, category: "diagnostic", limit: 80 }).then((page) => {
+      void adapter.send<ActivityPage>({ type: "getActivity", platform: requestScope.platform, category: "diagnostic", query: requestScope.query || undefined, limit: 80 }).then((page) => {
         if (!cancelled) {
           setDiagnosticStream((current) => applyActivityMutationForRequest(
             current,
@@ -310,7 +324,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
     if (showDiagnostics && snapshot?.settings.diagnosticLogging && diagnosticStream.nextCursor) {
       const cursor = diagnosticStream.nextCursor;
       const pageRequest = beginActivityMutation(diagnosticMutationSequenceRef.current);
-      requests.push(adapter.send<ActivityPage>({ type: "getActivity", platform: requestScope.platform, category: "diagnostic", cursor, limit: 80 })
+      requests.push(adapter.send<ActivityPage>({ type: "getActivity", platform: requestScope.platform, category: "diagnostic", query: requestScope.query || undefined, cursor, limit: 80 })
         .then((page) => {
           setDiagnosticStream((current) => applyActivityMutationForRequest(
             current,
@@ -346,6 +360,8 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
       invalidateActivityRequests();
       setActivityStream(createActivityStream());
       setDiagnosticStream(createActivityStream());
+      setDiagnosticSearchQuery("");
+      invalidateActivityRequests(platform, "");
       setClearActivityArmed(false);
       setClearingActivity(false);
     }).catch(() => {
@@ -386,7 +402,8 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   }, [adapter, preview]);
 
   function selectPlatform(nextPlatform: Platform): void {
-    if (nextPlatform !== activityRequestScopeRef.current.platform) invalidateActivityRequests(nextPlatform);
+    if (nextPlatform !== activityRequestScopeRef.current.platform) invalidateActivityRequests(nextPlatform, "");
+    setDiagnosticSearchQuery("");
     setPlatform(nextPlatform);
     // The watchlist add form belongs to the platform it was opened on: leaving
     // it open would submit a name typed for one platform into the other's list.
@@ -395,10 +412,21 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   }
 
   function closeActivityView(): void {
-    if (activityOpen) invalidateActivityRequests();
+    if (activityOpen) invalidateActivityRequests(platform, "");
     setClearActivityArmed(false);
     setClearActivityFailed(false);
+    setDiagnosticSearchQuery("");
+    setDiagnosticStream(createActivityStream());
     setActivityOpen(false);
+  }
+
+  function handleShowDiagnosticsChange(nextShowDiagnostics: boolean): void {
+    if (showDiagnostics && !nextShowDiagnostics) {
+      invalidateActivityRequests(platform, "");
+      setDiagnosticSearchQuery("");
+      setDiagnosticStream(createActivityStream());
+    }
+    setShowDiagnostics(nextShowDiagnostics);
   }
 
   async function updateSettings(patch: SettingsPatch, options?: { tickAfterSave?: boolean; tickAfterSavePlatforms?: Platform[] }): Promise<void> {
@@ -690,7 +718,10 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                   clearing={clearingActivity}
                   version={adapter.version}
                   locale={locale}
-                  onShowDiagnosticsChange={setShowDiagnostics}
+                  searchQuery={diagnosticSearchQuery}
+                  onSearchQueryChange={setDiagnosticSearchQuery}
+                  searchingDiagnostics={Boolean(trimmedDiagnosticSearchQuery)}
+                  onShowDiagnosticsChange={handleShowDiagnosticsChange}
                   onLoadMore={loadMoreActivity}
                   onClear={clearActivityHistory}
                   writeClipboard={adapter.writeClipboard}

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -19,6 +19,7 @@ export type ActivityStream = {
 export type ActivityRequestScope = {
   generation: number;
   platform: Platform;
+  query: string;
 };
 
 export type ActivityMutationSequence = { latest: number };
@@ -57,22 +58,25 @@ export function applyActivityPage(
   };
 }
 
-export function createActivityRequestScope(platform: Platform): ActivityRequestScope {
-  return { generation: 0, platform };
+export function createActivityRequestScope(platform: Platform, query = ""): ActivityRequestScope {
+  return { generation: 0, platform, query };
 }
 
 export function advanceActivityRequestScope(
   current: ActivityRequestScope,
   platform: Platform = current.platform,
+  query: string = current.query,
 ): ActivityRequestScope {
-  return { generation: current.generation + 1, platform };
+  return { generation: current.generation + 1, platform, query };
 }
 
 export function isActivityRequestCurrent(
   request: ActivityRequestScope,
   current: ActivityRequestScope,
 ): boolean {
-  return request.generation === current.generation && request.platform === current.platform;
+  return request.generation === current.generation
+    && request.platform === current.platform
+    && request.query === current.query;
 }
 
 export function applyActivityPageForRequest(

--- a/packages/popup-ui/src/activity.tsx
+++ b/packages/popup-ui/src/activity.tsx
@@ -24,6 +24,9 @@ export function ActivityLog({
   clearing,
   version,
   locale,
+  searchQuery: _searchQuery,
+  onSearchQueryChange: _onSearchQueryChange,
+  searchingDiagnostics: _searchingDiagnostics,
   onShowDiagnosticsChange,
   onLoadMore,
   onClear,
@@ -42,6 +45,9 @@ export function ActivityLog({
   clearing: boolean;
   version: string;
   locale: string;
+  searchQuery: string;
+  onSearchQueryChange(query: string): void;
+  searchingDiagnostics: boolean;
   onShowDiagnosticsChange(show: boolean): void;
   onLoadMore(): void;
   onClear(): void;

--- a/packages/popup-ui/src/activity.tsx
+++ b/packages/popup-ui/src/activity.tsx
@@ -6,6 +6,7 @@ import { EVENT_LEVEL_COLOR, PLATFORMS } from "./constants";
 import { useT } from "./context";
 import { formatEventTime } from "./format";
 import { buildActivityExport, formatActivityEvent } from "./activity.logic";
+import { SearchBox } from "./primitives";
 
 // How long the button stays in its confirmation state after a successful copy.
 const COPY_FEEDBACK_MS = 2500;
@@ -24,9 +25,9 @@ export function ActivityLog({
   clearing,
   version,
   locale,
-  searchQuery: _searchQuery,
-  onSearchQueryChange: _onSearchQueryChange,
-  searchingDiagnostics: _searchingDiagnostics,
+  searchQuery,
+  onSearchQueryChange,
+  searchingDiagnostics,
   onShowDiagnosticsChange,
   onLoadMore,
   onClear,
@@ -68,6 +69,7 @@ export function ActivityLog({
   // activity entry now has a diagnostic counterpart, so a merged list showed the
   // same thing twice and buried the high-level story in plumbing detail.
   const visible = showDiagnostics ? diagnosticsForPlatform : forPlatform;
+  const trimmedSearchQuery = searchQuery.trim();
   const errorCount = visible.filter((event) => event.level === "error").length;
   const [copied, setCopied] = useState<number | null>(null);
   const [copyFailed, setCopyFailed] = useState(false);
@@ -162,9 +164,12 @@ export function ActivityLog({
       {copyFailed ? (
         <p role="alert" className="px-0.5 text-[10px] font-medium text-red-500">{t("copyActivityLogFailed")}</p>
       ) : null}
+      {showDiagnostics ? (
+        <SearchBox compact value={searchQuery} onChange={onSearchQueryChange} placeholder={t("searchDiagnostics")} />
+      ) : null}
       <div className="overflow-hidden rounded-xl border border-zinc-200/70 bg-white/70 dark:border-zinc-800 dark:bg-zinc-900/50">
         {visible.length === 0 ? (
-          <p className="px-2.5 py-6 text-center text-[11px] text-zinc-400">{t(showDiagnostics ? "noDiagnostics" : "noActivity")}</p>
+          <p className="px-2.5 py-6 text-center text-[11px] text-zinc-400">{showDiagnostics && searchingDiagnostics && trimmedSearchQuery ? t("noDiagnosticsMatch", trimmedSearchQuery) : t(showDiagnostics ? "noDiagnostics" : "noActivity")}</p>
         ) : (
           <ul className="divide-y divide-zinc-100 dark:divide-zinc-800/70">
             {visible.map((event) => (

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -53,5 +53,5 @@ export function translateFromCatalogs(
     : substitutions == null
       ? []
       : [substitutions];
-  return values.reduce((text, value, index) => text.replaceAll(`$${index + 1}`, value), template);
+  return values.reduce((text, value, index) => text.replaceAll(`$${index + 1}`, () => value), template);
 }

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -60,6 +60,7 @@ export interface PlaybackControl {
 export interface ActivityQuery {
   platform?: Platform;
   category: EventCategory;
+  query?: string;
   cursor?: string;
   limit?: number;
 }


### PR DESCRIPTION
## Summary

- add a Diagnostics search field backed by the complete retained history
- preserve platform/global scoping and matching-result pagination
- add locale-safe text matching and literal interpolation regressions

Closes #300.

## Validation

- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search to the Diagnostics view for case-insensitive matching across retained diagnostic messages.
  * Search works with platform filters and paginated results.
  * Added localized search labels and no-match messages across supported languages.
  * Search state resets when leaving Diagnostics, changing platforms, or clearing history.

* **Bug Fixes**
  * Prevented outdated search results from replacing newer queries.
  * Preserved literal replacement characters in localized messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->