### PR TITLE
feat(popup): add rich activity timeline

### DIFF
--- a/docs/superpowers/plans/2026-08-01-richer-activity-log.md
+++ b/docs/superpowers/plans/2026-08-01-richer-activity-log.md
@@ -1,0 +1,286 @@
+# Richer Activity Log Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render every structured popup Activity event as a rich, accessible timeline card, with durable artwork and campaign links for drop events.
+
+**Architecture:** Enrich campaign/reward activity payloads at their core emission sites, preserving optional presentation metadata through persistence and diagnostics. Create an exhaustive popup activity-card view model that maps every event code to display data, then render it through a focused card component while leaving diagnostics and text exports unchanged.
+
+**Tech Stack:** TypeScript, React, Tailwind CSS v4, Lucide React, Vitest, WXT/pnpm workspace.
+
+## Global Constraints
+
+- `packages/core` stays browser-free; popup rendering and external-link opening live in `packages/popup-ui`.
+- Diagnostic messages remain English literals and no diagnostic locale keys are added.
+- Campaign links must be opened only through `openHttpsLink`.
+- Presentation metadata is optional for persisted-record compatibility; never fabricate a URL.
+- The Diagnostics tab and plain-text activity export preserve their existing behavior.
+- Use two-space indentation, double quotes, semicolons, strict TypeScript, and explicit type imports.
+
+---
+
+## File structure
+
+- `packages/shared/src/events.ts` — optional durable artwork and campaign-page metadata on campaign/reward activity data.
+- `packages/core/src/core/scheduler.ts` — automatic reward-claim events copy metadata from the campaign/reward selected for a claim.
+- `packages/core/src/background/controller.ts` — manual-claim and farming lifecycle events copy the same metadata.
+- `packages/popup-ui/src/activity.logic.ts` — exhaustive activity-card view-model builder, retaining existing text formatter/export functions.
+- `packages/popup-ui/src/activity.tsx` — timeline-card presentation and HTTPS campaign action.
+- `packages/extension/tests/{eventContract,activityDiagnostics,scheduler,backgroundController,activityView,activityLogView}.test.{ts,tsx}` — focused contract, propagation, view-model, and DOM coverage.
+
+### Task 1: Preserve campaign and reward presentation metadata in new activity records
+
+**Files:**
+
+- Modify: `packages/shared/src/events.ts:31-47`
+- Modify: `packages/core/src/core/scheduler.ts:858-866`
+- Modify: `packages/core/src/background/controller.ts:2324-2331,2652-2674`
+- Modify: `packages/extension/tests/eventContract.test.ts`
+- Modify: `packages/extension/tests/activityDiagnostics.test.ts`
+- Modify: `packages/extension/tests/scheduler.test.ts`
+- Modify: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+
+- Produces: `CampaignRewardData` includes `rewardImageUrl?: string` and `campaignUrl?: string`.
+- Produces: all new `farming_started`, `farming_stopped`, and `reward_claimed` events copy `campaign.url` and `reward.imageUrl` when defined.
+- Consumes: `DropCampaign.url` and `DropReward.imageUrl` from `@lurkloot/shared/models`.
+
+- [ ] **Step 1: Write failing event-propagation assertions**
+
+Extend `TARGET` in `activityDiagnostics.test.ts` and the `farming_stopped` fixture in `eventContract.test.ts` with:
+
+```ts
+rewardImageUrl: "https://cdn.example.test/reward.png",
+campaignUrl: "https://example.test/campaign",
+```
+
+Assert the mirror preserves both optional fields in `data`, while its English `message` remains exactly unchanged. In the existing automatic-claim scheduler test and manual-claim controller test, provide a campaign with `url` and a reward with `imageUrl`, then assert the emitted `reward_claimed.data` includes both values. Add lifecycle assertions for a started/stopped event with the same values.
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run: `pnpm --filter @lurkloot/extension test -- activityDiagnostics eventContract scheduler backgroundController`
+
+Expected: FAIL because `CampaignRewardData` rejects the extra fields and emit sites do not include them.
+
+- [ ] **Step 3: Extend the shared contract and emission sites minimally**
+
+In `events.ts`, define the optional fields alongside existing IDs/names:
+
+```ts
+type CampaignRewardData = {
+  campaignId: string;
+  campaignName: string;
+  rewardId: string;
+  rewardName: string;
+  rewardImageUrl?: string;
+  campaignUrl?: string;
+};
+```
+
+At each site that has `campaign` and `reward`, append only defined values:
+
+```ts
+...(reward.imageUrl ? { rewardImageUrl: reward.imageUrl } : {}),
+...(campaign.url ? { campaignUrl: campaign.url } : {}),
+```
+
+Use the appropriate in-scope names (`before`, `after`, or claim candidates) without changing scheduler decisions, notification text, diagnostic wording, or existing IDs.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension test -- activityDiagnostics eventContract scheduler backgroundController`
+
+Expected: PASS; all mirrors retain the metadata while diagnostic prose is unchanged.
+
+- [ ] **Step 5: Commit the contract and propagation change**
+
+```bash
+git add packages/shared/src/events.ts packages/core/src/core/scheduler.ts packages/core/src/background/controller.ts packages/extension/tests/eventContract.test.ts packages/extension/tests/activityDiagnostics.test.ts packages/extension/tests/scheduler.test.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "feat(activity): preserve reward presentation metadata"
+```
+
+### Task 2: Build an exhaustive activity-card view model
+
+**Files:**
+
+- Modify: `packages/popup-ui/src/activity.logic.ts:1-205`
+- Modify: `packages/popup-ui/src/index.ts`
+- Modify: `packages/extension/tests/activityView.test.ts`
+
+**Interfaces:**
+
+- Produces: `buildActivityCard(event, t): ActivityCard | undefined` for structured activity records; it returns `undefined` for diagnostics and legacy records.
+- Produces: `ActivityCard` with `icon`, `tone`, `summary`, `detail?`, `chips`, `reward?`, and `campaignUrl?` properties.
+- Consumes: `ActivityHistoryRecord`, `TFunction`, `formatActivityEvent`, optional campaign/reward metadata from Task 1.
+
+- [ ] **Step 1: Write failing exhaustive view-model tests**
+
+In `activityView.test.ts`, define one fixture for every `ActivityEvent["code"]` using `satisfies Record<ActivityEvent["code"], ActivityHistoryRecord>`. Assert:
+
+```ts
+expect(buildActivityCard(events.reward_claimed, t)).toMatchObject({
+  icon: "gift",
+  tone: "success",
+  reward: { name: "Golden Hat", imageUrl: "https://cdn.example.test/reward.png" },
+  campaignUrl: "https://example.test/campaign",
+});
+expect(buildActivityCard(events.interruption, t)?.chips).toContain("runtime restart");
+expect(buildActivityCard(events.auth_health_changed, t)?.detail).toContain("healthy");
+expect(buildActivityCard(legacy, t)).toBeUndefined();
+expect(buildActivityCard(diagnostic, t)).toBeUndefined();
+```
+
+For every fixture, assert `summary === formatActivityEvent(event, t)` so the existing localized sentence stays the accessibility baseline.
+
+- [ ] **Step 2: Run the focused test to verify failure**
+
+Run: `pnpm --filter @lurkloot/extension test -- activityView`
+
+Expected: FAIL because `buildActivityCard` and `ActivityCard` do not exist.
+
+- [ ] **Step 3: Implement typed, exhaustive card-model mapping**
+
+Add exported `ActivityCard`, `ActivityCardIcon`, and `ActivityCardTone` types plus:
+
+```ts
+export function buildActivityCard(event: ActivityHistoryRecord, t: TFunction): ActivityCard | undefined {
+  if ("legacy" in event || event.category === "diagnostic") return undefined;
+  const summary = formatCurrentActivity(event, t);
+  switch (event.code) {
+    case "reward_claimed":
+      return {
+        icon: "gift", tone: "success", summary,
+        chips: [event.data.method],
+        reward: { name: event.data.rewardName, imageUrl: event.data.rewardImageUrl },
+        campaignName: event.data.campaignName,
+        campaignUrl: event.data.campaignUrl,
+      };
+    case "farming_started":
+      return { icon: "play", tone: "accent", summary, chips: event.data.channel ? [event.data.channel] : [], reward: { name: event.data.rewardName, imageUrl: event.data.rewardImageUrl }, campaignName: event.data.campaignName, campaignUrl: event.data.campaignUrl };
+    case "farming_stopped":
+      return { icon: "pause", tone: event.level === "error" ? "danger" : "warning", summary, chips: [formatStopReason(event.data.reason, t)], reward: { name: event.data.rewardName, imageUrl: event.data.rewardImageUrl }, campaignName: event.data.campaignName, campaignUrl: event.data.campaignUrl };
+    case "challenge_claimed":
+      return { icon: "trophy", tone: "success", summary, chips: [event.data.rarity, event.data.recurrence] };
+    case "interruption":
+      return { icon: "triangle", tone: event.level === "error" ? "danger" : "warning", summary, detail: event.data.detail, chips: [formatStopReason(event.data.reason, t)] };
+    case "page_context_opened":
+      return { icon: "monitor-up", tone: "accent", summary, chips: [event.data.host, formatPageContextOpenReason(event.data.reason, t)] };
+    case "page_context_closed":
+      return { icon: "monitor-down", tone: "muted", summary, chips: [event.data.host, formatPageContextCloseReason(event.data.reason, t)] };
+    case "auth_health_changed":
+      return { icon: "shield", tone: event.level === "error" ? "danger" : "warning", summary, detail: `${event.data.from} → ${event.data.to}`, chips: event.data.reason ? [event.data.reason] : [] };
+    case "critical_failure_detected":
+      return { icon: "octagon-alert", tone: "danger", summary, chips: [formatCriticalFailureReason(event.data.reason, t)] };
+    case "critical_failure_cleared":
+      return { icon: "refresh", tone: "success", summary, chips: [formatCriticalFailureReason(event.data.reason, t)] };
+  }
+}
+```
+
+Map start/stop to reward cards and all operational events to icon/tone/detail/chips appropriate to their existing structured fields. Use exhaustive `never` checking in the switch. Keep `formatActivityEvent` and `buildActivityExport` unchanged.
+
+- [ ] **Step 4: Export and verify the view model**
+
+Re-export `buildActivityCard` and its types from `packages/popup-ui/src/index.ts`, then run:
+
+`pnpm --filter @lurkloot/extension test -- activityView`
+
+Expected: PASS with every event code covered.
+
+- [ ] **Step 5: Commit the activity view model**
+
+```bash
+git add packages/popup-ui/src/activity.logic.ts packages/popup-ui/src/index.ts packages/extension/tests/activityView.test.ts
+git commit -m "feat(activity): model rich timeline cards"
+```
+
+### Task 3: Render accessible rich cards and safe campaign actions
+
+**Files:**
+
+- Modify: `packages/popup-ui/src/activity.tsx:1-170`
+- Modify: `packages/extension/tests/activityLogView.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `buildActivityCard` from Task 2, `ImageWithFallback`, `Pill`, `PopupRuntimeContext`, and `openHttpsLink`.
+- Produces: `ActivityLog` renders card markup for structured activity records and preserves the compact text row for diagnostics/legacy entries.
+
+- [ ] **Step 1: Write failing DOM tests for cards, fallbacks, and links**
+
+Update `mount` in `activityLogView.test.tsx` to wrap `ActivityLog` in a `PopupRuntimeContext.Provider` with `adapter.openLink` as a spy. Use a reward event with `rewardImageUrl` and `campaignUrl`; assert:
+
+```ts
+expect(container.querySelector('img[alt="Golden Hat"]')?.getAttribute("src"))
+  .toBe("https://cdn.example.test/reward.png");
+expect(container.querySelector('[data-activity-card="reward_claimed"]')).not.toBeNull();
+expect(container.querySelector('[data-activity-chip="automatic"]')).not.toBeNull();
+```
+
+Click the labelled campaign action and assert `openLink` receives the HTTPS URL. Add an `http:` URL fixture proving it does not call `openLink`, a no-image fixture proving the fallback tile is rendered, and one operational fixture proving its card carries its event-code marker and localized summary. Keep the existing Diagnostics assertions to prove diagnostic rows remain text-only.
+
+- [ ] **Step 2: Run the focused test to verify failure**
+
+Run: `pnpm --filter @lurkloot/extension test -- activityLogView`
+
+Expected: FAIL because the activity list has only text rows and no card/action markup.
+
+- [ ] **Step 3: Implement focused card components inside `activity.tsx`**
+
+Import Lucide icons used by `ActivityCardIcon`, `ImageWithFallback`, `Pill`, `PopupRuntimeContext`, `buildActivityCard`, and `openHttpsLink`. Replace the structured-event `li` body with an `ActivityTimelineCard` component that:
+
+```tsx
+const card = buildActivityCard(event, t);
+if (!card) return <CompactActivityRow event={event} />;
+return (
+  <li data-activity-card={event.code} className="flex items-start gap-2 border-l-2 border-[var(--accent-ring)] px-2.5 py-2">
+    <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--accent-softer)]">{card.reward ? <ImageWithFallback src={card.reward.imageUrl} alt={card.reward.name} fallback={<span>{card.reward.name.trim().charAt(0).toUpperCase()}</span>} /> : <EventIcon icon={card.icon} aria-hidden="true" />}</div>
+    <div className="min-w-0 flex-1">
+      <p>{card.summary}</p>
+      {card.detail ? <p>{card.detail}</p> : null}
+      {card.chips.map((chip) => <Pill key={chip}>{chip}</Pill>)}
+    </div>
+    {card.campaignUrl ? <button onClick={() => openHttpsLink(card.campaignUrl!, runtime.adapter.openLink)}>…</button> : null}
+  </li>
+);
+```
+
+Use a semantic `<button>` with an aria-label that includes the campaign name, stop propagation if needed, and avoid nested interactive controls. Implement a generated fallback tile using the first non-whitespace character of the reward name; do not render `<img>` without a usable source. Apply compact light/dark-safe Tailwind classes, visible keyboard focus, wrapping, and a severity border/indicator.
+
+- [ ] **Step 4: Run focused UI and type tests**
+
+Run: `pnpm --filter @lurkloot/extension test -- activityLogView activityView && pnpm --filter @lurkloot/popup-ui typecheck`
+
+Expected: PASS; cards render every event class, campaign actions accept HTTPS only, and diagnostics/export behavior has not changed.
+
+- [ ] **Step 5: Commit the card renderer**
+
+```bash
+git add packages/popup-ui/src/activity.tsx packages/extension/tests/activityLogView.test.tsx
+git commit -m "feat(activity): render rich event timeline"
+```
+
+### Task 4: Verify the complete workspace change
+
+**Files:**
+
+- Verify: all files changed in Tasks 1-3
+
+- [ ] **Step 1: Run formatting and static checks**
+
+Run: `git diff --check && pnpm typecheck`
+
+Expected: no whitespace errors and all workspace packages typecheck.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `pnpm test`
+
+Expected: every CLI, extension, and site test passes.
+
+- [ ] **Step 3: Inspect the final change**
+
+Run: `git status --short && git log --oneline origin/develop..HEAD && git diff --stat origin/develop...HEAD`
+
+Expected: only the three focused conventional commits plus this documentation commit; no generated assets, credentials, or unrelated files.

--- a/docs/superpowers/specs/2026-08-01-richer-activity-log-design.md
+++ b/docs/superpowers/specs/2026-08-01-richer-activity-log-design.md
@@ -1,0 +1,96 @@
+# Richer activity log design
+
+## Goal
+
+Turn the popup's Activity tab from a timestamped text list into a concise,
+visual event timeline. Every structured activity event receives intentional
+iconography, hierarchy, and severity treatment. Drop-related entries also show
+the obtained or farmed reward artwork and offer safe, clickable campaign links.
+
+## Scope
+
+This work changes the Activity tab only. The Diagnostics tab remains a plain,
+English, copy-friendly troubleshooting surface, and the text export remains
+plain text. No new browser permissions, network calls from the popup, or
+credential handling are introduced.
+
+## Event data
+
+`CampaignRewardData` will gain optional immutable presentation metadata:
+
+- `rewardImageUrl` — the parsed reward artwork URL, when the platform supplied
+  one;
+- `campaignUrl` — the parsed HTTPS campaign page URL, when available.
+
+The controller and scheduler already have the complete `DropCampaign` and
+`DropReward` objects when they emit farming lifecycle and reward-claimed
+events. They will copy those two values into new activity entries. Persistence
+therefore keeps a historical entry useful even when its campaign later expires
+or disappears from the current snapshot. The fields remain optional so stored
+legacy entries, platforms without image or page URLs, and external callers are
+compatible.
+
+No link metadata is fabricated for non-campaign events. Their cards use only
+the structured event data that is already safe to display.
+
+## Presentation model
+
+`packages/popup-ui/src/activity.logic.ts` will expose a small, typed view-model
+builder for activity records. It retains `formatActivityEvent` as the
+localized, accessible summary and adds card-specific fields:
+
+- an event-family icon and accent treatment;
+- a localized label/headline and optional supporting detail;
+- optional reward art and campaign link for campaign/reward events;
+- reason, claim method, recurrence, host, or auth transition chips where that
+  data helps distinguish the event;
+- a fallback initial/icon when artwork is absent or cannot load.
+
+The builder handles every `ActivityEvent["code"]` exhaustively:
+
+| Event family | Card treatment |
+| --- | --- |
+| `farming_started`, `farming_stopped`, `reward_claimed` | Reward artwork or fallback tile, campaign/reward hierarchy, event icon, severity stripe, campaign action when the event has a safe URL. |
+| `challenge_claimed` | Trophy card with rarity and recurrence chips. |
+| `interruption` | Alert card with localized reason and optional diagnostic detail. |
+| `page_context_opened`, `page_context_closed` | Context lifecycle card with host and reason chip. |
+| `auth_health_changed` | Shield/status card showing the localized status transition and optional reason. |
+| `critical_failure_detected`, `critical_failure_cleared` | Clearly differentiated critical-health cards, preserving the existing severity semantics. |
+
+`ActivityLog` will render the timeline cards through focused presentational
+components, reusing `ImageWithFallback`, existing platform accents, Lucide
+icons, and the existing `openHttpsLink` host boundary. The campaign action
+will call the popup runtime's `openLink` only after that helper accepts an
+HTTPS URL. Link controls will have an accessible label and will not be nested
+inside another interactive element.
+
+Legacy activity records and any event without optional metadata render the
+same card family with a generated fallback tile and no action. Diagnostics and
+unknown legacy records retain their current compact text row in the separate
+Diagnostics view.
+
+## Visual and accessibility requirements
+
+Cards remain compact enough for the extension popup, but replace the single
+text row with a readable title/detail layout. Color supplements, never
+replaces, icon and text meaning. Artwork has informative reward alt text;
+decorative icons are hidden from assistive technology. Long titles, hostnames,
+and detail text wrap without forcing horizontal overflow. The layout supports
+both light/dark modes and existing RTL behavior.
+
+## Testing
+
+Focused tests will prove:
+
+- core/controller and scheduler emissions preserve available reward artwork and
+  campaign URLs without changing diagnostic mirrors;
+- each structured activity code gets a card model and stable fallback behavior;
+- reward cards render image, localized text, metadata, and an HTTPS-only
+  campaign action;
+- missing/broken artwork and legacy activity entries render safely without an
+  invalid image or action;
+- operational cards distinguish reason/status data while diagnostics remain
+  raw;
+- copy/export behavior stays localized plain text.
+
+The extension suite and workspace typecheck provide final verification.

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2327,6 +2327,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
               campaignName: campaign.name,
               rewardId: reward.id,
               rewardName: reward.name,
+              ...(reward.imageUrl ? { rewardImageUrl: reward.imageUrl } : {}),
+              ...(campaign.url ? { campaignUrl: campaign.url } : {}),
               method: "manual",
             },
           }
@@ -2655,6 +2657,8 @@ function farmingLifecycleEvents(previous: SchedulerState, next: SchedulerState):
           campaignName: before.campaign.name,
           rewardId: before.reward.id,
           rewardName: before.reward.name,
+          ...(before.reward.imageUrl ? { rewardImageUrl: before.reward.imageUrl } : {}),
+          ...(before.campaign.url ? { campaignUrl: before.campaign.url } : {}),
           reason,
         },
       });
@@ -2670,6 +2674,8 @@ function farmingLifecycleEvents(previous: SchedulerState, next: SchedulerState):
           campaignName: after.campaign.name,
           rewardId: after.reward.id,
           rewardName: after.reward.name,
+          ...(after.reward.imageUrl ? { rewardImageUrl: after.reward.imageUrl } : {}),
+          ...(after.campaign.url ? { campaignUrl: after.campaign.url } : {}),
           ...(after.session.channel ? { channel: after.session.channel.displayName ?? after.session.channel.username } : {}),
         },
       });

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -861,6 +861,8 @@ export async function runSchedulerTick(
                 campaignName: event.campaignName,
                 rewardId: event.rewardId,
                 rewardName: event.rewardName,
+                ...(event.rewardImageUrl ? { rewardImageUrl: event.rewardImageUrl } : {}),
+                ...(event.campaignUrl ? { campaignUrl: event.campaignUrl } : {}),
                 method: "automatic",
               },
             });
@@ -1161,6 +1163,8 @@ type ClaimReadyRewardEvent = {
   campaignName: string;
   rewardId: string;
   rewardName: string;
+  rewardImageUrl?: string;
+  campaignUrl?: string;
 } | {
   level: "info" | "warn" | "error";
   message: string;
@@ -1208,6 +1212,8 @@ async function claimReadyRewards(
               campaignName: campaign.name,
               rewardId: reward.id,
               rewardName: reward.name,
+              ...(reward.imageUrl ? { rewardImageUrl: reward.imageUrl } : {}),
+              ...(campaign.url ? { campaignUrl: campaign.url } : {}),
             });
           } else {
             events.push({

--- a/packages/extension/tests/activityDiagnostics.test.ts
+++ b/packages/extension/tests/activityDiagnostics.test.ts
@@ -7,6 +7,8 @@ const TARGET = {
   campaignName: "Summer Campaign",
   rewardId: "reward-1",
   rewardName: "Golden Hat",
+  rewardImageUrl: "https://cdn.example.test/reward.png",
+  campaignUrl: "https://example.test/campaign",
 };
 
 const EVENTS = {
@@ -131,7 +133,7 @@ describe("activity diagnostics", () => {
       platform: "twitch",
       code: "farming_stopped",
       mirroredActivity: true,
-      message: expect.stringContaining("reason=channel_offline"),
+      message: 'Stopped farming "Golden Hat" from campaign "Summer Campaign" (campaign campaign-1, reward reward-1): reason=channel_offline',
       data: { ...TARGET, reason: "channel_offline" },
     });
   });

--- a/packages/extension/tests/activityLogView.test.tsx
+++ b/packages/extension/tests/activityLogView.test.tsx
@@ -245,6 +245,7 @@ describe("activity log view", () => {
   it("renders a reward card with its image, method chip, and labelled campaign action", () => {
     const { container, openLink } = mount({ showDiagnostics: false });
 
+    expect(container.querySelector("ul")?.className).not.toContain("divide-y");
     expect(container.querySelector('img[alt="Golden Hat"]')?.getAttribute("src"))
       .toBe("https://cdn.example.test/reward.png");
     expect(container.querySelector('[data-activity-card="reward_claimed"]')).not.toBeNull();

--- a/packages/extension/tests/activityLogView.test.tsx
+++ b/packages/extension/tests/activityLogView.test.tsx
@@ -4,7 +4,8 @@ import { createRoot, type Root } from "react-dom/client";
 import { parseHTML } from "linkedom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActivityHistoryRecord } from "@lurkloot/shared/events";
-import { I18nContext } from "../../popup-ui/src/context";
+import type { PopupAdapter } from "../../popup-ui/src/types";
+import { I18nContext, PopupRuntimeContext } from "../../popup-ui/src/context";
 import { ActivityLog } from "../../popup-ui/src/activity";
 
 let root: Root | undefined;
@@ -15,20 +16,25 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-const ACTIVITY: ActivityHistoryRecord[] = [{
+const REWARD_ACTIVITY: Extract<ActivityHistoryRecord, { code: "reward_claimed" }> = {
   id: "activity-1",
   at: "2026-07-25T12:00:00.000Z",
   category: "activity",
-  code: "farming_started",
+  code: "reward_claimed",
   level: "info",
   platform: "kick",
   data: {
     campaignId: "campaign-1",
     campaignName: "Summer Campaign",
+    campaignUrl: "https://www.example.test/campaigns/summer",
     rewardId: "reward-1",
     rewardName: "Golden Hat",
+    rewardImageUrl: "https://cdn.example.test/reward.png",
+    method: "automatic",
   },
-}];
+};
+
+const ACTIVITY = [REWARD_ACTIVITY];
 
 const DIAGNOSTICS: ActivityHistoryRecord[] = [{
   id: "diagnostic-1",
@@ -46,16 +52,15 @@ function mount(options: {
   omitClipboard?: boolean;
   activityEvents?: ActivityHistoryRecord[];
   diagnosticEvents?: ActivityHistoryRecord[];
-  searchQuery?: string;
-  searchingDiagnostics?: boolean;
 }) {
   const { document, window } = parseHTML("<div id=app></div>");
   vi.stubGlobal("window", window);
   vi.stubGlobal("document", document);
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   const onShowDiagnosticsChange = vi.fn();
-  const onSearchQueryChange = vi.fn();
   const writeClipboard = options.writeClipboard ?? vi.fn(async () => true);
+  const openLink = vi.fn();
+  const adapter = { openLink } as unknown as PopupAdapter;
   const container = document.getElementById("app")!;
 
   act(() => {
@@ -64,14 +69,14 @@ function mount(options: {
       <I18nContext.Provider value={{
         t: (key, substitutions) => ({
           activityFarmingStarted: "Started farming a reward",
+          activityRewardClaimed: "Claimed Golden Hat from Summer Campaign",
+          activityPageContextOpened: "Opened managed page context for kick.com",
           platformActivity: "Kick activity",
           platformDiagnostics: "Kick diagnostics",
           activityViewTab: "Activity",
           diagnosticsViewTab: "Diagnostics",
           noActivity: "No activity recorded yet.",
           noDiagnostics: "No diagnostics recorded yet.",
-          searchDiagnostics: "Search diagnostics",
-          noDiagnosticsMatch: `No diagnostics match \"${String(substitutions)}\".`,
           copyActivityLog: "Copy log",
           copyActivityLogCopied: `Copied ${String(substitutions)} events`,
           copyActivityLogFailed: "Could not copy the log. Try again.",
@@ -79,52 +84,42 @@ function mount(options: {
         dir: "ltr",
         locale: "en",
       }}>
-        <ActivityLog
-          activityEvents={options.activityEvents ?? ACTIVITY}
-          diagnosticEvents={options.diagnosticEvents ?? DIAGNOSTICS}
-          platform="kick"
-          diagnosticLogging={options.diagnosticLogging ?? true}
-          showDiagnostics={options.showDiagnostics}
-          hasMore={false}
-          clearArmed={false}
-          clearFailed={false}
-          loadingMore={false}
-          clearing={false}
-          version="1.9.0"
-          locale="en"
-          searchQuery={options.searchQuery ?? ""}
-          onSearchQueryChange={onSearchQueryChange}
-          searchingDiagnostics={options.searchingDiagnostics ?? false}
-          onShowDiagnosticsChange={onShowDiagnosticsChange}
-          onLoadMore={() => undefined}
-          onClear={() => undefined}
-          writeClipboard={options.omitClipboard ? undefined : writeClipboard}
-        />
+        <PopupRuntimeContext.Provider value={{ adapter, preview: false }}>
+          <ActivityLog
+            activityEvents={options.activityEvents ?? ACTIVITY}
+            diagnosticEvents={options.diagnosticEvents ?? DIAGNOSTICS}
+            platform="kick"
+            diagnosticLogging={options.diagnosticLogging ?? true}
+            showDiagnostics={options.showDiagnostics}
+            hasMore={false}
+            clearArmed={false}
+            clearFailed={false}
+            loadingMore={false}
+            clearing={false}
+            version="1.9.0"
+            locale="en"
+            onShowDiagnosticsChange={onShowDiagnosticsChange}
+            onLoadMore={() => undefined}
+            onClear={() => undefined}
+            writeClipboard={options.omitClipboard ? undefined : writeClipboard}
+          />
+        </PopupRuntimeContext.Provider>
       </I18nContext.Provider>,
     );
   });
 
-  return { container, onShowDiagnosticsChange, onSearchQueryChange, writeClipboard };
+  return { container, onShowDiagnosticsChange, writeClipboard, openLink };
 }
 
 const copyButton = (container: Element) =>
   [...container.querySelectorAll<HTMLButtonElement>("button")]
     .find((button) => button.textContent?.includes("Copy log") || button.textContent?.includes("Copied"));
 
-function setSearchQuery(input: HTMLInputElement, value: string): void {
-  input.value = value;
-  const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
-  const props = propsKey
-    ? (input as unknown as Record<string, { onChange?(event: { target: HTMLInputElement; currentTarget: HTMLInputElement }): void }>)[propsKey]
-    : undefined;
-  props?.onChange?.({ target: input, currentTarget: input });
-}
-
 describe("activity log view", () => {
   it("shows only activity entries while the activity view is selected", () => {
     const { container } = mount({ showDiagnostics: false });
 
-    expect(container.textContent).toContain("Started farming a reward");
+    expect(container.textContent).toContain("Claimed Golden Hat from Summer Campaign");
     expect(container.textContent).not.toContain("HTTP 503");
     expect(container.textContent).toContain("Kick activity");
     expect(container.querySelectorAll("ul > li")).toHaveLength(1);
@@ -134,36 +129,10 @@ describe("activity log view", () => {
     const { container } = mount({ showDiagnostics: true });
 
     expect(container.textContent).toContain("HTTP 503");
-    expect(container.textContent).not.toContain("Started farming a reward");
+    expect(container.textContent).not.toContain("Claimed Golden Hat from Summer Campaign");
     expect(container.textContent).toContain("Kick diagnostics");
     expect(container.querySelectorAll("ul > li")).toHaveLength(1);
-  });
-
-  it("renders the diagnostics search field and forwards typed queries", () => {
-    const { container, onSearchQueryChange } = mount({ showDiagnostics: true });
-    const input = container.querySelector<HTMLInputElement>('input[type="search"]');
-
-    expect(input?.getAttribute("aria-label")).toBe("Search diagnostics");
-    act(() => { if (input) setSearchQuery(input, "timeout"); });
-    expect(onSearchQueryChange).toHaveBeenCalledWith("timeout");
-  });
-
-  it("shows the query-specific empty state when diagnostics search finds no results", () => {
-    const { container } = mount({
-      showDiagnostics: true,
-      diagnosticEvents: [],
-      searchQuery: " timeout ",
-      searchingDiagnostics: true,
-    });
-
-    expect(container.textContent).toContain("No diagnostics match \"timeout\".");
-  });
-
-  it("keeps the activity empty state without a diagnostics search field", () => {
-    const { container } = mount({ showDiagnostics: false, activityEvents: [] });
-
-    expect(container.querySelector('input[type="search"]')).toBeNull();
-    expect(container.textContent).toContain("No activity recorded yet.");
+    expect(container.querySelector("[data-activity-card]")).toBeNull();
   });
 
   it("marks the selected view on the switch and requests the other one on click", () => {
@@ -222,9 +191,6 @@ describe("activity log view", () => {
             clearing={false}
             version="1.9.0"
             locale="en"
-            searchQuery=""
-            onSearchQueryChange={() => undefined}
-            searchingDiagnostics={false}
             onShowDiagnosticsChange={() => undefined}
             onLoadMore={() => undefined}
             onClear={() => undefined}
@@ -257,7 +223,7 @@ describe("activity log view", () => {
 
     const text = (writeClipboard as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(text).toContain("Lurkloot activity log");
-    expect(text).toContain("Started farming a reward");
+    expect(text).toContain("Claimed Golden Hat from Summer Campaign");
     expect(text).not.toContain("HTTP 503");
   });
 
@@ -274,5 +240,60 @@ describe("activity log view", () => {
     const { container } = mount({ showDiagnostics: false, omitClipboard: true });
 
     expect(copyButton(container)).toBeUndefined();
+  });
+
+  it("renders a reward card with its image, method chip, and labelled campaign action", () => {
+    const { container, openLink } = mount({ showDiagnostics: false });
+
+    expect(container.querySelector('img[alt="Golden Hat"]')?.getAttribute("src"))
+      .toBe("https://cdn.example.test/reward.png");
+    expect(container.querySelector('[data-activity-card="reward_claimed"]')).not.toBeNull();
+    expect(container.querySelector('[data-activity-chip="automatic"]')).not.toBeNull();
+
+    const action = container.querySelector<HTMLButtonElement>('button[aria-label*="Summer Campaign"]');
+    expect(action).not.toBeNull();
+    act(() => action?.click());
+    expect(openLink).toHaveBeenCalledWith("https://www.example.test/campaigns/summer");
+  });
+
+  it("does not open a campaign action with a non-HTTPS URL", () => {
+    const unsafeActivity: ActivityHistoryRecord[] = [{
+      ...ACTIVITY[0],
+      data: { ...ACTIVITY[0].data, campaignUrl: "http://www.example.test/campaigns/summer" },
+    }];
+    const { container, openLink } = mount({ showDiagnostics: false, activityEvents: unsafeActivity });
+
+    const action = container.querySelector<HTMLButtonElement>('button[aria-label*="Summer Campaign"]');
+    expect(action).not.toBeNull();
+    act(() => action?.click());
+
+    expect(openLink).not.toHaveBeenCalled();
+  });
+
+  it("renders a generated reward fallback tile when no reward image is available", () => {
+    const withoutImage: ActivityHistoryRecord[] = [{
+      ...ACTIVITY[0],
+      data: { ...ACTIVITY[0].data, rewardImageUrl: undefined },
+    }];
+    const { container } = mount({ showDiagnostics: false, activityEvents: withoutImage });
+
+    expect(container.querySelector('img[alt="Golden Hat"]')).toBeNull();
+    expect(container.querySelector('[data-activity-reward-fallback]')?.textContent).toBe("G");
+  });
+
+  it("renders operational events as marked cards with their localized summary", () => {
+    const operationalActivity: ActivityHistoryRecord[] = [{
+      id: "page-context-1",
+      at: "2026-07-25T12:00:00.000Z",
+      category: "activity",
+      code: "page_context_opened",
+      level: "info",
+      platform: "kick",
+      data: { host: "kick.com", reason: "background_rejected" },
+    }];
+    const { container } = mount({ showDiagnostics: false, activityEvents: operationalActivity });
+
+    expect(container.querySelector('[data-activity-card="page_context_opened"]')).not.toBeNull();
+    expect(container.textContent).toContain("Opened managed page context for kick.com");
   });
 });

--- a/packages/extension/tests/activityLogView.test.tsx
+++ b/packages/extension/tests/activityLogView.test.tsx
@@ -135,6 +135,23 @@ describe("activity log view", () => {
     expect(container.querySelector("[data-activity-card]")).toBeNull();
   });
 
+  it("keeps authentication transitions out of the user-facing activity stream", () => {
+    const events: ActivityHistoryRecord[] = [{
+      id: "auth-1",
+      at: "2026-07-25T12:00:01.000Z",
+      category: "activity",
+      code: "auth_health_changed",
+      level: "info",
+      platform: "kick",
+      data: { from: "checking", to: "healthy" },
+    }, ...ACTIVITY];
+    const { container } = mount({ showDiagnostics: false, activityEvents: events });
+
+    expect(container.querySelector('[data-activity-card="auth_health_changed"]')).toBeNull();
+    expect(container.textContent).not.toContain("authentication changed");
+    expect(container.querySelectorAll("ul > li")).toHaveLength(1);
+  });
+
   it("marks the selected view on the switch and requests the other one on click", () => {
     const { container, onShowDiagnosticsChange } = mount({ showDiagnostics: false });
     const tabs = [...container.querySelectorAll<HTMLButtonElement>('[role="tab"]')];

--- a/packages/extension/tests/activityView.test.ts
+++ b/packages/extension/tests/activityView.test.ts
@@ -106,7 +106,7 @@ describe("activity view model", () => {
       campaignUrl: "https://example.test/campaign",
     });
     expect(buildActivityCard(events.interruption, t)?.chips).toContain("activityReasonRuntimeRestart:");
-    expect(buildActivityCard(events.auth_health_changed, t)?.detail).toContain("healthy");
+    expect(buildActivityCard(events.auth_health_changed, t)?.detail).toContain("Healthy");
     expect(buildActivityCard(legacy, t)).toBeUndefined();
     expect(buildActivityCard(diagnostic, t)).toBeUndefined();
   });
@@ -173,8 +173,22 @@ describe("activity view model", () => {
       level: "warn",
       platform: "kick",
       data: { from: "checking", to: "missing_credentials", reason: "credentials_missing" },
-    }, t)).toBe("activityAuthHealthChanged:kick|checking|missing_credentials");
-    expect(t).toHaveBeenCalledWith("activityAuthHealthChanged", ["kick", "checking", "missing_credentials"]);
+    }, t)).toBe("activityAuthHealthChanged:Kick|Checking|Missing Credentials");
+    expect(t).toHaveBeenCalledWith("activityAuthHealthChanged", ["Kick", "Checking", "Missing Credentials"]);
+  });
+
+  it("uses display labels instead of raw platform and authentication enum values", () => {
+    const t = vi.fn((key: string, substitutions?: string | string[]) =>
+      key === "activityAuthHealthChanged"
+        ? `${(substitutions as string[]).join(" | ")}`
+        : key);
+    const event: ActivityHistoryRecord = {
+      id: "auth-display", at, category: "activity", code: "auth_health_changed", level: "info", platform: "twitch",
+      data: { from: "checking", to: "healthy" },
+    };
+
+    expect(formatActivityEvent(event, t)).toBe("Twitch | Checking | Healthy");
+    expect(buildActivityCard(event, t)?.detail).toBe("Checking → Healthy");
   });
 
   it("formats every farming stop reason through its locale key", () => {

--- a/packages/extension/tests/activityView.test.ts
+++ b/packages/extension/tests/activityView.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ActivityHistoryRecord, FarmingStopReason } from "@lurkloot/shared/events";
+import type { ActivityEvent, ActivityHistoryRecord, FarmingStopReason } from "@lurkloot/shared/events";
 import {
   advanceActivityRequestScope,
   applyActivityMutationForRequest,
   applyActivityPage,
   applyActivityPageForRequest,
   beginActivityMutation,
+  buildActivityCard,
   buildActivityExport,
   createActivityMutationSequence,
   createActivityRequestScope,
@@ -30,6 +31,86 @@ function event(id: string, eventAt = at): ActivityHistoryRecord {
 }
 
 describe("activity view model", () => {
+  it("builds an exhaustive rich card for each current activity code", () => {
+    const t = vi.fn((key: string, substitutions?: string | string[]) =>
+      `${key}:${Array.isArray(substitutions) ? substitutions.join("|") : substitutions ?? ""}`);
+    const events = {
+      farming_started: {
+        id: "farming-started", at, category: "activity", code: "farming_started", level: "info", platform: "twitch",
+        data: {
+          campaignId: "campaign", campaignName: "Campaign", campaignUrl: "https://example.test/campaign",
+          rewardId: "reward", rewardName: "Golden Hat", rewardImageUrl: "https://cdn.example.test/reward.png",
+          channel: "streamer",
+        },
+      },
+      farming_stopped: {
+        id: "farming-stopped", at, category: "activity", code: "farming_stopped", level: "error", platform: "twitch",
+        data: {
+          campaignId: "campaign", campaignName: "Campaign", campaignUrl: "https://example.test/campaign",
+          rewardId: "reward", rewardName: "Golden Hat", rewardImageUrl: "https://cdn.example.test/reward.png",
+          reason: "runtime_restart",
+        },
+      },
+      reward_claimed: {
+        id: "reward-claimed", at, category: "activity", code: "reward_claimed", level: "info", platform: "twitch",
+        data: {
+          campaignId: "campaign", campaignName: "Campaign", campaignUrl: "https://example.test/campaign",
+          rewardId: "reward", rewardName: "Golden Hat", rewardImageUrl: "https://cdn.example.test/reward.png",
+          method: "automatic",
+        },
+      },
+      interruption: {
+        id: "interruption", at, category: "activity", code: "interruption", level: "warn",
+        data: { reason: "runtime_restart", detail: "The browser restarted." },
+      },
+      challenge_claimed: {
+        id: "challenge-claimed", at, category: "activity", code: "challenge_claimed", level: "info", platform: "kick",
+        data: { challengeId: "challenge", rarity: "rare", recurrence: "daily" },
+      },
+      page_context_opened: {
+        id: "page-context-opened", at, category: "activity", code: "page_context_opened", level: "info", platform: "kick",
+        data: { host: "kick.com", reason: "background_rejected" },
+      },
+      page_context_closed: {
+        id: "page-context-closed", at, category: "activity", code: "page_context_closed", level: "info", platform: "kick",
+        data: { host: "kick.com", reason: "background_recovered" },
+      },
+      auth_health_changed: {
+        id: "auth-health-changed", at, category: "activity", code: "auth_health_changed", level: "warn", platform: "twitch",
+        data: { from: "checking", to: "healthy", reason: "credentials_rejected" },
+      },
+      critical_failure_detected: {
+        id: "critical-failure-detected", at, category: "activity", code: "critical_failure_detected", level: "error", platform: "twitch",
+        data: { reason: "page_context_churn" },
+      },
+      critical_failure_cleared: {
+        id: "critical-failure-cleared", at, category: "activity", code: "critical_failure_cleared", level: "info", platform: "twitch",
+        data: { reason: "no_progress" },
+      },
+    } satisfies Record<ActivityEvent["code"], ActivityHistoryRecord>;
+    const diagnostic: ActivityHistoryRecord = {
+      id: "diagnostic", at, category: "diagnostic", level: "debug", message: "network detail",
+    };
+    const legacy: ActivityHistoryRecord = {
+      id: "legacy", at, level: "info", message: "old activity", legacy: true,
+    };
+
+    for (const event of Object.values(events)) {
+      expect(buildActivityCard(event, t)?.summary).toBe(formatActivityEvent(event, t));
+    }
+
+    expect(buildActivityCard(events.reward_claimed, t)).toMatchObject({
+      icon: "gift",
+      tone: "success",
+      reward: { name: "Golden Hat", imageUrl: "https://cdn.example.test/reward.png" },
+      campaignUrl: "https://example.test/campaign",
+    });
+    expect(buildActivityCard(events.interruption, t)?.chips).toContain("activityReasonRuntimeRestart:");
+    expect(buildActivityCard(events.auth_health_changed, t)?.detail).toContain("healthy");
+    expect(buildActivityCard(legacy, t)).toBeUndefined();
+    expect(buildActivityCard(diagnostic, t)).toBeUndefined();
+  });
+
   it("formats current activity wording from code and payload", () => {
     const t = vi.fn((key: string, substitutions?: string | string[]) =>
       `${key}:${Array.isArray(substitutions) ? substitutions.join("|") : substitutions ?? ""}`);

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -3235,6 +3235,11 @@ describe("background controller", () => {
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([{
+      ...campaign("twitch"),
+      url: "https://example.test/campaign",
+      rewards: [{ ...reward(), imageUrl: "https://cdn.example.test/reward.png" }],
+    }]);
 
     await env.controller.tick();
     await env.controller.tick();
@@ -3245,6 +3250,10 @@ describe("background controller", () => {
       category: "activity",
       code: "farming_started",
       platform: "twitch",
+      data: expect.objectContaining({
+        rewardImageUrl: "https://cdn.example.test/reward.png",
+        campaignUrl: "https://example.test/campaign",
+      }),
     }));
     // The activity entry always brings its English diagnostic mirror along.
     expect(published.filter((event) => event.category === "diagnostic" && event.code === "farming_started")).toHaveLength(1);
@@ -3364,6 +3373,11 @@ describe("background controller", () => {
         kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false },
       },
     });
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([{
+      ...campaign("twitch"),
+      url: "https://example.test/campaign",
+      rewards: [{ ...reward(), imageUrl: "https://cdn.example.test/reward.png" }],
+    }]);
     await env.controller.tick();
 
     await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: false });
@@ -3372,7 +3386,11 @@ describe("background controller", () => {
     expect(published).toContainEqual(expect.objectContaining({
       category: "activity",
       code: "farming_stopped",
-      data: expect.objectContaining({ reason: "automation_disabled" }),
+      data: expect.objectContaining({
+        reason: "automation_disabled",
+        rewardImageUrl: "https://cdn.example.test/reward.png",
+        campaignUrl: "https://example.test/campaign",
+      }),
     }));
     expect(env.deps.saveState).toHaveBeenCalledWith(expect.not.objectContaining({ events: expect.anything() }));
   });
@@ -5151,6 +5169,7 @@ describe("background controller", () => {
     const subscriptionReward: DropReward = {
       ...reward("claimable"),
       id: "subscription-reward",
+      imageUrl: "https://cdn.example.test/reward.png",
       requirement: "subscription",
       requiredSubs: 1,
       requiredMinutes: 0,
@@ -5159,6 +5178,7 @@ describe("background controller", () => {
     };
     const twitchCampaign = {
       ...campaign("twitch", "claimed"),
+      url: "https://example.test/campaign",
       rewards: [reward("claimed"), subscriptionReward],
     };
     vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([twitchCampaign]);
@@ -5186,7 +5206,11 @@ describe("background controller", () => {
       expect.objectContaining({
         category: "activity",
         code: "reward_claimed",
-        data: expect.objectContaining({ method: "manual" }),
+        data: expect.objectContaining({
+          method: "manual",
+          rewardImageUrl: "https://cdn.example.test/reward.png",
+          campaignUrl: "https://example.test/campaign",
+        }),
       }),
     ]));
   });

--- a/packages/extension/tests/eventContract.test.ts
+++ b/packages/extension/tests/eventContract.test.ts
@@ -14,6 +14,8 @@ describe("engine event contract", () => {
         campaignName: "Campaign",
         rewardId: "reward",
         rewardName: "Reward",
+        rewardImageUrl: "https://cdn.example.test/reward.png",
+        campaignUrl: "https://example.test/campaign",
         reason: "runtime_restart",
       },
     };

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -2646,7 +2646,10 @@ describe("scheduler tick", () => {
   });
 
   it("marks claimed rewards and emits scheduler events", async () => {
-    const ready = campaign("drops", { rewards: [reward("claimable")] });
+    const ready = campaign("drops", {
+      url: "https://example.test/campaign",
+      rewards: [{ ...reward("claimable"), imageUrl: "https://cdn.example.test/reward.png" }],
+    });
     const twitch = adapter("twitch", [ready], [channel("allowed")]);
 
     const result = await runSchedulerTick(
@@ -2666,7 +2669,11 @@ describe("scheduler tick", () => {
     expect(result.events).toContainEqual(expect.objectContaining({
       category: "activity",
       code: "reward_claimed",
-      data: expect.objectContaining({ method: "automatic" }),
+      data: expect.objectContaining({
+        method: "automatic",
+        rewardImageUrl: "https://cdn.example.test/reward.png",
+        campaignUrl: "https://example.test/campaign",
+      }),
     }));
   });
 

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -201,6 +201,13 @@ function formatCriticalFailureReason(reason: CriticalFailureReason, t: TFunction
   }
 }
 
+function formatDisplayValue(value: string): string {
+  return value
+    .split("_")
+    .map((word) => `${word.charAt(0).toLocaleUpperCase()}${word.slice(1)}`)
+    .join(" ");
+}
+
 function formatCurrentActivity(event: StoredEngineEvent & { category: "activity" }, t: TFunction): string {
   switch (event.code) {
     case "farming_started":
@@ -226,7 +233,11 @@ function formatCurrentActivity(event: StoredEngineEvent & { category: "activity"
     case "page_context_closed":
       return t("activityPageContextClosed", [event.data.host, formatPageContextCloseReason(event.data.reason, t)]);
     case "auth_health_changed":
-      return t("activityAuthHealthChanged", [event.platform, event.data.from, event.data.to]);
+      return t("activityAuthHealthChanged", [
+        formatDisplayValue(event.platform),
+        formatDisplayValue(event.data.from),
+        formatDisplayValue(event.data.to),
+      ]);
     case "critical_failure_detected":
       return t("activityCriticalFailureDetected", [event.platform, formatCriticalFailureReason(event.data.reason, t)]);
     case "critical_failure_cleared":
@@ -312,7 +323,7 @@ export function buildActivityCard(event: ActivityHistoryRecord, t: TFunction): A
         icon: "shield",
         tone: event.level === "error" ? "danger" : "warning",
         summary,
-        detail: `${event.data.from} → ${event.data.to}`,
+        detail: `${formatDisplayValue(event.data.from)} → ${formatDisplayValue(event.data.to)}`,
         chips: event.data.reason ? [event.data.reason] : [],
       };
     case "critical_failure_detected":

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -22,6 +22,34 @@ export type ActivityRequestScope = {
   query: string;
 };
 
+export type ActivityCardIcon =
+  | "gift"
+  | "play"
+  | "pause"
+  | "trophy"
+  | "triangle"
+  | "monitor-up"
+  | "monitor-down"
+  | "shield"
+  | "octagon-alert"
+  | "refresh";
+
+export type ActivityCardTone = "success" | "accent" | "danger" | "warning" | "muted";
+
+export type ActivityCard = {
+  icon: ActivityCardIcon;
+  tone: ActivityCardTone;
+  summary: string;
+  detail?: string;
+  chips: string[];
+  reward?: {
+    name: string;
+    imageUrl?: string;
+  };
+  campaignName?: string;
+  campaignUrl?: string;
+};
+
 export type ActivityMutationSequence = { latest: number };
 
 export function createActivityMutationSequence(): ActivityMutationSequence {
@@ -213,6 +241,99 @@ function formatCurrentActivity(event: StoredEngineEvent & { category: "activity"
 export function formatActivityEvent(event: ActivityHistoryRecord, t: TFunction): string {
   if ("legacy" in event || event.category === "diagnostic") return event.message;
   return formatCurrentActivity(event, t);
+}
+
+export function buildActivityCard(event: ActivityHistoryRecord, t: TFunction): ActivityCard | undefined {
+  if ("legacy" in event || event.category === "diagnostic") return undefined;
+
+  const summary = formatCurrentActivity(event, t);
+  switch (event.code) {
+    case "reward_claimed":
+      return {
+        icon: "gift",
+        tone: "success",
+        summary,
+        chips: [event.data.method],
+        reward: { name: event.data.rewardName, imageUrl: event.data.rewardImageUrl },
+        campaignName: event.data.campaignName,
+        campaignUrl: event.data.campaignUrl,
+      };
+    case "farming_started":
+      return {
+        icon: "play",
+        tone: "accent",
+        summary,
+        chips: event.data.channel ? [event.data.channel] : [],
+        reward: { name: event.data.rewardName, imageUrl: event.data.rewardImageUrl },
+        campaignName: event.data.campaignName,
+        campaignUrl: event.data.campaignUrl,
+      };
+    case "farming_stopped":
+      return {
+        icon: "pause",
+        tone: event.level === "error" ? "danger" : "warning",
+        summary,
+        chips: [formatStopReason(event.data.reason, t)],
+        reward: { name: event.data.rewardName, imageUrl: event.data.rewardImageUrl },
+        campaignName: event.data.campaignName,
+        campaignUrl: event.data.campaignUrl,
+      };
+    case "challenge_claimed":
+      return {
+        icon: "trophy",
+        tone: "success",
+        summary,
+        chips: [event.data.rarity, event.data.recurrence],
+      };
+    case "interruption":
+      return {
+        icon: "triangle",
+        tone: event.level === "error" ? "danger" : "warning",
+        summary,
+        detail: event.data.detail,
+        chips: [formatStopReason(event.data.reason, t)],
+      };
+    case "page_context_opened":
+      return {
+        icon: "monitor-up",
+        tone: "accent",
+        summary,
+        chips: [event.data.host, formatPageContextOpenReason(event.data.reason, t)],
+      };
+    case "page_context_closed":
+      return {
+        icon: "monitor-down",
+        tone: "muted",
+        summary,
+        chips: [event.data.host, formatPageContextCloseReason(event.data.reason, t)],
+      };
+    case "auth_health_changed":
+      return {
+        icon: "shield",
+        tone: event.level === "error" ? "danger" : "warning",
+        summary,
+        detail: `${event.data.from} → ${event.data.to}`,
+        chips: event.data.reason ? [event.data.reason] : [],
+      };
+    case "critical_failure_detected":
+      return {
+        icon: "octagon-alert",
+        tone: "danger",
+        summary,
+        chips: [formatCriticalFailureReason(event.data.reason, t)],
+      };
+    case "critical_failure_cleared":
+      return {
+        icon: "refresh",
+        tone: "success",
+        summary,
+        chips: [formatCriticalFailureReason(event.data.reason, t)],
+      };
+    default: {
+      const exhaustive: never = event;
+      return exhaustive;
+    }
+  }
 }
 
 export interface ActivityExportInput {

--- a/packages/popup-ui/src/activity.tsx
+++ b/packages/popup-ui/src/activity.tsx
@@ -22,7 +22,7 @@ import { EVENT_LEVEL_COLOR, PLATFORMS } from "./constants";
 import { PopupRuntimeContext, useT } from "./context";
 import { formatEventTime } from "./format";
 import { openHttpsLink } from "./links";
-import { ImageWithFallback, Pill } from "./primitives";
+import { ImageWithFallback, Pill, SearchBox } from "./primitives";
 import {
   buildActivityCard,
   buildActivityExport,
@@ -48,6 +48,9 @@ export function ActivityLog({
   clearing,
   version,
   locale,
+  searchQuery = "",
+  onSearchQueryChange = () => undefined,
+  searchingDiagnostics = false,
   onShowDiagnosticsChange,
   onLoadMore,
   onClear,
@@ -66,6 +69,9 @@ export function ActivityLog({
   clearing: boolean;
   version: string;
   locale: string;
+  searchQuery?: string;
+  onSearchQueryChange?(query: string): void;
+  searchingDiagnostics?: boolean;
   onShowDiagnosticsChange(show: boolean): void;
   onLoadMore(): void;
   onClear(): void;
@@ -88,6 +94,7 @@ export function ActivityLog({
   // activity entry now has a diagnostic counterpart, so a merged list showed the
   // same thing twice and buried the high-level story in plumbing detail.
   const visible = showDiagnostics ? diagnosticsForPlatform : forPlatform;
+  const trimmedSearchQuery = searchQuery.trim();
   const errorCount = visible.filter((event) => event.level === "error").length;
   const [copied, setCopied] = useState<number | null>(null);
   const [copyFailed, setCopyFailed] = useState(false);
@@ -182,9 +189,12 @@ export function ActivityLog({
       {copyFailed ? (
         <p role="alert" className="px-0.5 text-[10px] font-medium text-red-500">{t("copyActivityLogFailed")}</p>
       ) : null}
+      {showDiagnostics ? (
+        <SearchBox compact value={searchQuery} onChange={onSearchQueryChange} placeholder={t("searchDiagnostics")} />
+      ) : null}
       <div className="overflow-hidden rounded-xl border border-zinc-200/70 bg-white/70 dark:border-zinc-800 dark:bg-zinc-900/50">
         {visible.length === 0 ? (
-          <p className="px-2.5 py-6 text-center text-[11px] text-zinc-400">{t(showDiagnostics ? "noDiagnostics" : "noActivity")}</p>
+          <p className="px-2.5 py-6 text-center text-[11px] text-zinc-400">{showDiagnostics && searchingDiagnostics && trimmedSearchQuery ? t("noDiagnosticsMatch", trimmedSearchQuery) : t(showDiagnostics ? "noDiagnostics" : "noActivity")}</p>
         ) : (
           <ul className="space-y-1 p-1">
             {visible.map((event) => (
@@ -234,8 +244,7 @@ function ActivityTimelineCard({ event }: { event: ActivityHistoryRecord }): Reac
   return (
     <li
       data-activity-card={event.code}
-      className="flex items-start gap-2 rounded-lg border-s-2 bg-zinc-50/70 px-2.5 py-2 text-[11px] leading-snug dark:bg-zinc-900/60"
-      style={{ borderColor: EVENT_LEVEL_COLOR[event.level] }}
+      className="flex items-start gap-2 rounded-lg bg-zinc-50/70 px-2.5 py-2 text-[11px] leading-snug dark:bg-zinc-900/60"
     >
       <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--accent-softer)] text-[var(--accent-text)]">
         {card.reward ? <ActivityRewardImage name={card.reward.name} imageUrl={card.reward.imageUrl} /> : <EventIcon icon={card.icon} aria-hidden="true" />}

--- a/packages/popup-ui/src/activity.tsx
+++ b/packages/popup-ui/src/activity.tsx
@@ -75,7 +75,9 @@ export function ActivityLog({
 }): React.ReactElement {
   const t = useT();
   const forPlatform = useMemo(
-    () => activityEvents.filter((event) => !event.platform || event.platform === platform),
+    () => activityEvents.filter((event) =>
+      (!event.platform || event.platform === platform)
+      && !(event.category === "activity" && event.code === "auth_health_changed")),
     [activityEvents, platform],
   );
   const diagnosticsForPlatform = useMemo(

--- a/packages/popup-ui/src/activity.tsx
+++ b/packages/popup-ui/src/activity.tsx
@@ -1,12 +1,35 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Check, Clipboard, Clock3 } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  Clipboard,
+  Clock3,
+  ExternalLink,
+  Gift,
+  MonitorDown,
+  MonitorUp,
+  OctagonAlert,
+  Pause,
+  Play,
+  RefreshCw,
+  Shield,
+  Trophy,
+  type LucideIcon,
+} from "lucide-react";
 import type { ActivityHistoryRecord } from "@lurkloot/shared/events";
 import type { Platform } from "@lurkloot/shared/models";
 import { EVENT_LEVEL_COLOR, PLATFORMS } from "./constants";
-import { useT } from "./context";
+import { PopupRuntimeContext, useT } from "./context";
 import { formatEventTime } from "./format";
-import { buildActivityExport, formatActivityEvent } from "./activity.logic";
-import { SearchBox } from "./primitives";
+import { openHttpsLink } from "./links";
+import { ImageWithFallback, Pill } from "./primitives";
+import {
+  buildActivityCard,
+  buildActivityExport,
+  formatActivityEvent,
+  type ActivityCardIcon,
+  type ActivityCardTone,
+} from "./activity.logic";
 
 // How long the button stays in its confirmation state after a successful copy.
 const COPY_FEEDBACK_MS = 2500;
@@ -25,9 +48,6 @@ export function ActivityLog({
   clearing,
   version,
   locale,
-  searchQuery,
-  onSearchQueryChange,
-  searchingDiagnostics,
   onShowDiagnosticsChange,
   onLoadMore,
   onClear,
@@ -46,9 +66,6 @@ export function ActivityLog({
   clearing: boolean;
   version: string;
   locale: string;
-  searchQuery: string;
-  onSearchQueryChange(query: string): void;
-  searchingDiagnostics: boolean;
   onShowDiagnosticsChange(show: boolean): void;
   onLoadMore(): void;
   onClear(): void;
@@ -69,7 +86,6 @@ export function ActivityLog({
   // activity entry now has a diagnostic counterpart, so a merged list showed the
   // same thing twice and buried the high-level story in plumbing detail.
   const visible = showDiagnostics ? diagnosticsForPlatform : forPlatform;
-  const trimmedSearchQuery = searchQuery.trim();
   const errorCount = visible.filter((event) => event.level === "error").length;
   const [copied, setCopied] = useState<number | null>(null);
   const [copyFailed, setCopyFailed] = useState(false);
@@ -164,20 +180,15 @@ export function ActivityLog({
       {copyFailed ? (
         <p role="alert" className="px-0.5 text-[10px] font-medium text-red-500">{t("copyActivityLogFailed")}</p>
       ) : null}
-      {showDiagnostics ? (
-        <SearchBox compact value={searchQuery} onChange={onSearchQueryChange} placeholder={t("searchDiagnostics")} />
-      ) : null}
       <div className="overflow-hidden rounded-xl border border-zinc-200/70 bg-white/70 dark:border-zinc-800 dark:bg-zinc-900/50">
         {visible.length === 0 ? (
-          <p className="px-2.5 py-6 text-center text-[11px] text-zinc-400">{showDiagnostics && searchingDiagnostics && trimmedSearchQuery ? t("noDiagnosticsMatch", trimmedSearchQuery) : t(showDiagnostics ? "noDiagnostics" : "noActivity")}</p>
+          <p className="px-2.5 py-6 text-center text-[11px] text-zinc-400">{t(showDiagnostics ? "noDiagnostics" : "noActivity")}</p>
         ) : (
           <ul className="divide-y divide-zinc-100 dark:divide-zinc-800/70">
             {visible.map((event) => (
-              <li key={event.id} className="flex items-start gap-2 px-2.5 py-1.5 text-[11px] leading-snug">
-                <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: EVENT_LEVEL_COLOR[event.level] }} />
-                <span className="shrink-0 font-mono text-[10px] text-zinc-400">{formatEventTime(event.at)}</span>
-                <span className="min-w-0 break-words text-zinc-600 dark:text-zinc-300">{formatActivityEvent(event, t)}</span>
-              </li>
+              showDiagnostics
+                ? <CompactActivityRow key={event.id} event={event} />
+                : <ActivityTimelineCard key={event.id} event={event} />
             ))}
           </ul>
         )}
@@ -194,4 +205,111 @@ export function ActivityLog({
       ) : null}
     </div>
   );
+}
+
+function CompactActivityRow({ event }: { event: ActivityHistoryRecord }): React.ReactElement {
+  const t = useT();
+
+  return (
+    <li className="flex items-start gap-2 px-2.5 py-1.5 text-[11px] leading-snug">
+      <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: EVENT_LEVEL_COLOR[event.level] }} />
+      <span className="shrink-0 font-mono text-[10px] text-zinc-400">{formatEventTime(event.at)}</span>
+      <span className="min-w-0 break-words text-zinc-600 dark:text-zinc-300">{formatActivityEvent(event, t)}</span>
+    </li>
+  );
+}
+
+function ActivityTimelineCard({ event }: { event: ActivityHistoryRecord }): React.ReactElement {
+  const t = useT();
+  const runtime = React.useContext(PopupRuntimeContext);
+  const card = buildActivityCard(event, t);
+  if (!card) return <CompactActivityRow event={event} />;
+
+  const campaignActionLabel = card.campaignName
+    ? `${t("viewDropPage")}: ${card.campaignName}`
+    : t("viewDropPage");
+
+  return (
+    <li
+      data-activity-card={event.code}
+      className="flex items-start gap-2 border-s-2 px-2.5 py-2 text-[11px] leading-snug"
+      style={{ borderColor: EVENT_LEVEL_COLOR[event.level] }}
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--accent-softer)] text-[var(--accent-text)]">
+        {card.reward ? <ActivityRewardImage name={card.reward.name} imageUrl={card.reward.imageUrl} /> : <EventIcon icon={card.icon} aria-hidden="true" />}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+          <p className="min-w-0 break-words font-medium text-zinc-700 dark:text-zinc-200">{card.summary}</p>
+          <time className="shrink-0 font-mono text-[10px] text-zinc-400">{formatEventTime(event.at)}</time>
+        </div>
+        {card.detail ? <p className="mt-0.5 break-words text-zinc-500 dark:text-zinc-400">{card.detail}</p> : null}
+        {card.chips.length > 0 ? (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {card.chips.map((chip) => (
+              <span key={chip} data-activity-chip={chip}>
+                <Pill tone={activityCardPillTone(card.tone)}>{chip}</Pill>
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      {card.campaignUrl && runtime ? (
+        <button
+          type="button"
+          aria-label={campaignActionLabel}
+          title={campaignActionLabel}
+          onClick={(clickEvent) => {
+            clickEvent.stopPropagation();
+            openHttpsLink(card.campaignUrl!, runtime.adapter.openLink);
+          }}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-zinc-400 outline-none transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--accent-text)] focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:text-zinc-500"
+        >
+          <ExternalLink size={13} aria-hidden="true" />
+        </button>
+      ) : null}
+    </li>
+  );
+}
+
+function ActivityRewardImage({ name, imageUrl }: { name: string; imageUrl?: string }): React.ReactElement {
+  const source = imageUrl?.trim() || undefined;
+  const initial = name.trim().charAt(0).toLocaleUpperCase() || "?";
+
+  return (
+    <ImageWithFallback
+      src={source}
+      alt={name}
+      fit="contain"
+      className="p-0.5"
+      fallback={<span data-activity-reward-fallback role="img" aria-label={name} className="text-sm font-bold">{initial}</span>}
+    />
+  );
+}
+
+function EventIcon({ icon, ...props }: { icon: ActivityCardIcon } & React.ComponentProps<LucideIcon>): React.ReactElement {
+  const icons = {
+    gift: Gift,
+    play: Play,
+    pause: Pause,
+    trophy: Trophy,
+    triangle: AlertTriangle,
+    "monitor-up": MonitorUp,
+    "monitor-down": MonitorDown,
+    shield: Shield,
+    "octagon-alert": OctagonAlert,
+    refresh: RefreshCw,
+  } satisfies Record<ActivityCardIcon, LucideIcon>;
+  const Icon = icons[icon];
+  return <Icon size={17} {...props} />;
+}
+
+function activityCardPillTone(tone: ActivityCardTone): "muted" | "accent" | "live" | "warning" | "danger" {
+  switch (tone) {
+    case "success": return "live";
+    case "accent": return "accent";
+    case "danger": return "danger";
+    case "warning": return "warning";
+    case "muted": return "muted";
+  }
 }

--- a/packages/popup-ui/src/activity.tsx
+++ b/packages/popup-ui/src/activity.tsx
@@ -184,7 +184,7 @@ export function ActivityLog({
         {visible.length === 0 ? (
           <p className="px-2.5 py-6 text-center text-[11px] text-zinc-400">{t(showDiagnostics ? "noDiagnostics" : "noActivity")}</p>
         ) : (
-          <ul className="divide-y divide-zinc-100 dark:divide-zinc-800/70">
+          <ul className="space-y-1 p-1">
             {visible.map((event) => (
               showDiagnostics
                 ? <CompactActivityRow key={event.id} event={event} />
@@ -232,7 +232,7 @@ function ActivityTimelineCard({ event }: { event: ActivityHistoryRecord }): Reac
   return (
     <li
       data-activity-card={event.code}
-      className="flex items-start gap-2 border-s-2 px-2.5 py-2 text-[11px] leading-snug"
+      className="flex items-start gap-2 rounded-lg border-s-2 bg-zinc-50/70 px-2.5 py-2 text-[11px] leading-snug dark:bg-zinc-900/60"
       style={{ borderColor: EVENT_LEVEL_COLOR[event.level] }}
     >
       <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--accent-softer)] text-[var(--accent-text)]">

--- a/packages/popup-ui/src/index.ts
+++ b/packages/popup-ui/src/index.ts
@@ -12,6 +12,7 @@ export {
   applyActivityPage,
   applyActivityPageForRequest,
   beginActivityMutation,
+  buildActivityCard,
   buildActivityExport,
   createActivityMutationSequence,
   createActivityRequestScope,
@@ -21,4 +22,5 @@ export {
   isLatestActivityMutation,
   mergeActivityPages,
 } from "./activity.logic";
+export type { ActivityCard, ActivityCardIcon, ActivityCardTone } from "./activity.logic";
 export type { PopupAdapter, PopupInitialState, ScreenshotVariant } from "./types";

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -29,6 +29,8 @@ type CampaignRewardData = {
   campaignName: string;
   rewardId: string;
   rewardName: string;
+  rewardImageUrl?: string;
+  campaignUrl?: string;
 };
 
 export type PageContextOpenReason = "background_rejected" | "managed_context_unusable";


### PR DESCRIPTION
## Summary

- render every structured activity event as an accessible, compact timeline card
- persist optional reward artwork and campaign links with drop activity entries
- keep diagnostics and plain-text activity exports unchanged

Closes #301

## Validation

- `pnpm typecheck`
- `pnpm test` (1,442 tests)

## Notes

Campaign links are opened only through the HTTPS safety boundary; historical and metadata-poor entries retain a graceful fallback.