### PR TITLE
perf(twitch): stop refetching every campaign's details on each tick

### DIFF
--- a/packages/core/src/background/platformState.ts
+++ b/packages/core/src/background/platformState.ts
@@ -79,6 +79,9 @@ export function mergePlatformState(
       source.deadlineInfeasibleRewardIds,
       platform,
     ),
+    twitchDiscovery: platform === "twitch"
+      ? source.twitchDiscovery
+      : destination.twitchDiscovery,
     lastTickAt: newestTimestamp(destination.lastTickAt, source.lastTickAt),
   };
 }

--- a/packages/core/src/core/defaults.ts
+++ b/packages/core/src/core/defaults.ts
@@ -58,12 +58,104 @@ function normalizedIsoTimestamp(value: unknown): string | undefined {
   }
 }
 
+function isOptionalString(value: unknown): boolean {
+  return value == null || typeof value === "string";
+}
+
+function isOptionalNumber(value: unknown): boolean {
+  return value == null || (typeof value === "number" && Number.isFinite(value));
+}
+
+function isOptionalBoolean(value: unknown): boolean {
+  return value == null || typeof value === "boolean";
+}
+
+function isTwitchBenefitEdge(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const benefit = value.benefit;
+  return benefit == null || (
+    isRecord(benefit)
+    && isOptionalString(benefit.id)
+    && isOptionalString(benefit.name)
+    && isOptionalString(benefit.imageAssetURL)
+    && isOptionalString(benefit.distributionType)
+  );
+}
+
+function isTwitchCampaignReward(value: unknown): boolean {
+  if (!isRecord(value) || typeof value.id !== "string" || value.id.length === 0) return false;
+  const benefitEdges = value.benefitEdges;
+  const preconditionDrops = value.preconditionDrops;
+  const self = value.self;
+  return isOptionalString(value.name)
+    && isOptionalString(value.startAt)
+    && isOptionalString(value.endAt)
+    && isOptionalNumber(value.requiredMinutesWatched)
+    && isOptionalNumber(value.requiredSubs)
+    && (benefitEdges == null || (Array.isArray(benefitEdges) && benefitEdges.every(isTwitchBenefitEdge)))
+    && (preconditionDrops == null || (
+      Array.isArray(preconditionDrops)
+      && preconditionDrops.every((drop) => isRecord(drop) && typeof drop.id === "string")
+    ))
+    && (self == null || (
+      isRecord(self)
+      && isOptionalNumber(self.currentMinutesWatched)
+      && isOptionalBoolean(self.isClaimed)
+      && isOptionalString(self.dropInstanceID)
+    ));
+}
+
+function isTwitchAllowedChannel(value: unknown): boolean {
+  return typeof value === "string" || (
+    isRecord(value)
+    && isOptionalString(value.name)
+    && isOptionalString(value.login)
+  );
+}
+
+function isTwitchCampaignGame(value: unknown): boolean {
+  return value == null || (
+    isRecord(value)
+    && isOptionalString(value.id)
+    && isOptionalString(value.name)
+    && isOptionalString(value.displayName)
+    && isOptionalString(value.slug)
+    && isOptionalString(value.boxArtURL)
+  );
+}
+
 export function isTwitchCampaignDetailPayload(value: unknown, dropID: string): value is Record<string, unknown> {
-  return isRecord(value)
-    && value.id === dropID
-    && typeof value.name === "string"
-    && value.name.length > 0
-    && Array.isArray(value.timeBasedDrops);
+  if (
+    !isRecord(value)
+    || value.id !== dropID
+    || typeof value.name !== "string"
+    || value.name.length === 0
+    || !Array.isArray(value.timeBasedDrops)
+    || !value.timeBasedDrops.every(isTwitchCampaignReward)
+  ) return false;
+  const game = value.game;
+  const self = value.self;
+  const allow = value.allow;
+  const allowedChannels = value.allowedChannels;
+  return isTwitchCampaignGame(game)
+    && isOptionalString(value.imageURL)
+    && isOptionalString(value.startAt)
+    && isOptionalString(value.endAt)
+    && isOptionalString(value.status)
+    && isOptionalString(value.accountLinkURL)
+    && isOptionalString(value.detailsURL)
+    && (self == null || (isRecord(self) && isOptionalBoolean(self.isAccountConnected)))
+    && (allow == null || (
+      isRecord(allow)
+      && (allow.channels == null || (
+        Array.isArray(allow.channels)
+        && allow.channels.every(isTwitchAllowedChannel)
+      ))
+    ))
+    && (allowedChannels == null || (
+      Array.isArray(allowedChannels)
+      && allowedChannels.every(isTwitchAllowedChannel)
+    ));
 }
 
 export function normalizeTwitchDiscoverySnapshot(value: unknown): TwitchDiscoverySnapshot | undefined {

--- a/packages/core/src/core/defaults.ts
+++ b/packages/core/src/core/defaults.ts
@@ -45,6 +45,9 @@ const AUTH_MESSAGE_KEYS: Record<PlatformAuthStatus | PlatformAuthReasonCode, Pla
   network_unavailable: "authNetworkUnavailable",
 };
 
+const TWITCH_DISCOVERY_SNAPSHOT_FRESH_HORIZON_MS = 5 * 60_000;
+const TWITCH_DISCOVERY_SNAPSHOT_RETENTION_HORIZON_MS = 30 * 60_000;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -182,7 +185,12 @@ export function normalizeTwitchDiscoverySnapshot(value: unknown): TwitchDiscover
     if (!freshUntil || !retainedUntil) return undefined;
     const freshUntilTime = Date.parse(freshUntil);
     const retainedUntilTime = Date.parse(retainedUntil);
-    if (freshUntilTime <= now || retainedUntilTime < freshUntilTime) return undefined;
+    if (
+      freshUntilTime <= now
+      || freshUntilTime > now + TWITCH_DISCOVERY_SNAPSHOT_FRESH_HORIZON_MS
+      || retainedUntilTime < freshUntilTime
+      || retainedUntilTime > now + TWITCH_DISCOVERY_SNAPSHOT_RETENTION_HORIZON_MS
+    ) return undefined;
     seen.add(dropID);
     entries.push({
       dropID,

--- a/packages/core/src/core/defaults.ts
+++ b/packages/core/src/core/defaults.ts
@@ -1,4 +1,15 @@
-import type { Platform, PlatformAuthHealth, PlatformAuthMessageKey, PlatformAuthReasonCode, PlatformAuthStatus, SchedulerState } from "@lurkloot/shared/models";
+import {
+  TWITCH_DISCOVERY_SNAPSHOT_MAX_ENTRIES,
+  TWITCH_DISCOVERY_SNAPSHOT_VERSION,
+  type Platform,
+  type PlatformAuthHealth,
+  type PlatformAuthMessageKey,
+  type PlatformAuthReasonCode,
+  type PlatformAuthStatus,
+  type SchedulerState,
+  type TwitchDiscoverySnapshot,
+  type TwitchDiscoverySnapshotEntry,
+} from "@lurkloot/shared/models";
 import { normalizeCriticalHealth } from "@lurkloot/shared/criticalHealth";
 
 const AUTH_STATUSES = new Set<PlatformAuthStatus>([
@@ -45,6 +56,55 @@ function normalizedIsoTimestamp(value: unknown): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+export function isTwitchCampaignDetailPayload(value: unknown, dropID: string): value is Record<string, unknown> {
+  return isRecord(value)
+    && value.id === dropID
+    && typeof value.name === "string"
+    && value.name.length > 0
+    && Array.isArray(value.timeBasedDrops);
+}
+
+export function normalizeTwitchDiscoverySnapshot(value: unknown): TwitchDiscoverySnapshot | undefined {
+  if (!isRecord(value) || value.version !== TWITCH_DISCOVERY_SNAPSHOT_VERSION) return undefined;
+  if (typeof value.userId !== "string" || value.userId.length === 0 || value.userId.length > 128) return undefined;
+  if (
+    !Array.isArray(value.entries)
+    || value.entries.length === 0
+    || value.entries.length > TWITCH_DISCOVERY_SNAPSHOT_MAX_ENTRIES
+  ) return undefined;
+
+  const now = Date.now();
+  const seen = new Set<string>();
+  const entries: TwitchDiscoverySnapshotEntry[] = [];
+  for (const rawEntry of value.entries) {
+    if (!isRecord(rawEntry)) return undefined;
+    const dropID = rawEntry.dropID;
+    if (typeof dropID !== "string" || dropID.length === 0 || dropID.length > 256 || seen.has(dropID)) {
+      return undefined;
+    }
+    if (!isTwitchCampaignDetailPayload(rawEntry.campaign, dropID)) return undefined;
+    const freshUntil = normalizedIsoTimestamp(rawEntry.freshUntil);
+    const retainedUntil = normalizedIsoTimestamp(rawEntry.retainedUntil);
+    if (!freshUntil || !retainedUntil) return undefined;
+    const freshUntilTime = Date.parse(freshUntil);
+    const retainedUntilTime = Date.parse(retainedUntil);
+    if (freshUntilTime <= now || retainedUntilTime < freshUntilTime) return undefined;
+    seen.add(dropID);
+    entries.push({
+      dropID,
+      campaign: rawEntry.campaign,
+      freshUntil,
+      retainedUntil,
+    });
+  }
+
+  return {
+    version: TWITCH_DISCOVERY_SNAPSHOT_VERSION,
+    userId: value.userId,
+    entries,
+  };
 }
 
 export function normalizePlatformAuthHealth(value: unknown): PlatformAuthHealth {
@@ -113,7 +173,12 @@ export const DEFAULT_STATE: SchedulerState = {
 // layer and any file-backed storage so a new top-level slice only has to be
 // added in one place.
 export function mergeSchedulerState(stored: Partial<SchedulerState> | undefined): SchedulerState {
-  const { events: _legacyEvents, criticalHealth: _rawCriticalHealth, ...operationalState } = stored as (Partial<SchedulerState> & { events?: unknown }) ?? {};
+  const {
+    events: _legacyEvents,
+    criticalHealth: _rawCriticalHealth,
+    twitchDiscovery: rawTwitchDiscovery,
+    ...operationalState
+  } = stored as (Partial<SchedulerState> & { events?: unknown }) ?? {};
   const normalizedCriticalHealth = stored?.criticalHealth
     ? (Object.fromEntries(
         (Object.entries(stored.criticalHealth) as [Platform, unknown][]).map(([platform, value]) => [
@@ -125,6 +190,7 @@ export function mergeSchedulerState(stored: Partial<SchedulerState> | undefined)
   const criticalHealth = normalizedCriticalHealth && Object.keys(normalizedCriticalHealth).length > 0
     ? normalizedCriticalHealth
     : undefined;
+  const twitchDiscovery = normalizeTwitchDiscoverySnapshot(rawTwitchDiscovery);
   return {
     ...DEFAULT_STATE,
     ...operationalState,
@@ -138,5 +204,6 @@ export function mergeSchedulerState(stored: Partial<SchedulerState> | undefined)
     manualWatch: { ...stored?.manualWatch },
     campaigns: { ...DEFAULT_STATE.campaigns, ...stored?.campaigns },
     ...(criticalHealth ? { criticalHealth } : {}),
+    ...(twitchDiscovery ? { twitchDiscovery } : {}),
   };
 }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -231,14 +231,20 @@ function isCredentialRejection(message: string | undefined): boolean {
   return message != null && /unauthenticated|unauthorized|(?:the )?oauth token (?:(?:is|was) )?invalid|invalid oauth token|token (?:has )?expired/i.test(message);
 }
 
+interface TwitchDashboardCampaign {
+  id?: string;
+  status?: string;
+  self?: { isAccountConnected?: boolean };
+}
+
 interface TwitchDashboardData {
   currentUser?: {
     id?: string;
     login?: string;
     inventory?: {
-      dropCampaigns?: Array<{ id?: string; status?: string; self?: { isAccountConnected?: boolean } }>;
+      dropCampaigns?: TwitchDashboardCampaign[];
     };
-    dropCampaigns?: Array<{ id?: string; status?: string; self?: { isAccountConnected?: boolean } }>;
+    dropCampaigns?: TwitchDashboardCampaign[];
   };
 }
 
@@ -422,6 +428,7 @@ export class TwitchDiscoveryState {
   }
 
   rememberCampaignDetails(dropID: string, campaign: unknown): void {
+    if (!isTwitchCampaignDetailPayload(campaign, dropID)) return;
     const now = Date.now();
     for (const [cachedDropID, cached] of this.campaignDetailsByDropId) {
       if (cached.retainedUntil <= now) this.campaignDetailsByDropId.delete(cachedDropID);
@@ -693,7 +700,7 @@ export class TwitchAdapter implements PlatformAdapter {
       this.fetchDashboard(TWITCH_QUERIES.dashboard.variables, signal),
     ]);
     let inventoryCampaigns = this.inventoryCapability.parse(inventory);
-    let dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
+    let dashboardCampaigns = dashboardResult.campaigns;
 
     if (inventoryCampaigns.length === 0 && dashboardCampaigns.length === 0) {
       try {
@@ -708,7 +715,7 @@ export class TwitchAdapter implements PlatformAdapter {
         inventoryCampaigns = this.inventoryCapability.parse(inventory);
         if (fallbackDashboardResult.ok || !dashboardResult.ok) {
           dashboardResult = fallbackDashboardResult;
-          dashboardCampaigns = twitchDashboardCampaigns(dashboardResult.response);
+          dashboardCampaigns = dashboardResult.campaigns;
         }
       } catch (error) {
         signal?.throwIfAborted();
@@ -740,12 +747,15 @@ export class TwitchAdapter implements PlatformAdapter {
         && (campaign.status === "ACTIVE" || campaign.status === "UPCOMING")
       )
       .map((campaign) => campaign.id as string);
+    const activeCampaignId = session?.status === "watching" || session?.status === "starting"
+      ? session.campaignId ?? session.channel?.campaignId
+      : undefined;
 
-    // A failed dashboard parses to the same empty list as a dashboard with no
-    // active drops, and the Inventory payload only carries campaigns the user
-    // already started — so falling back to it hides every campaign they have
-    // not. Reuse the last dashboard we did get instead. `dashboardResponded`
-    // stays false so the expiry stamping below never fires off a stale list.
+    // Only a validated dashboard collection is authoritative. A failed or
+    // malformed dashboard leaves `ok` false, and the Inventory payload only
+    // carries campaigns the user already started — so falling back to it hides
+    // every campaign they have not. Reuse the last valid dashboard instead.
+    // `dashboardResponded` stays false so expiry stamping never uses stale data.
     let invalidatedDetails = 0;
     if (dashboardResult.ok && authenticatedUserId) {
       this.discoveryState.rememberDashboardCampaignIds(freshCampaignIds);
@@ -757,8 +767,11 @@ export class TwitchAdapter implements PlatformAdapter {
         ? this.discoveryState.retainedDashboardCampaignIds()
         : [];
     const dashboardResponded = dashboardResult.ok && dashboardCampaigns.length > 0;
+    const detailCampaignIds = activeCampaignId && !discoverableCampaignIds.includes(activeCampaignId)
+      ? [...discoverableCampaignIds, activeCampaignId]
+      : discoverableCampaignIds;
 
-    if (discoverableCampaignIds.length === 0) {
+    if (detailCampaignIds.length === 0) {
       return reconcileInventoryCampaignStatuses(
         inventoryCampaigns,
         new Set(discoverableCampaignIds),
@@ -766,14 +779,11 @@ export class TwitchAdapter implements PlatformAdapter {
       );
     }
 
-    const activeCampaignId = session?.status === "watching" || session?.status === "starting"
-      ? session.campaignId ?? session.channel?.campaignId
-      : undefined;
     const detailByDropID = new Map<string, unknown>();
     const detailFetchIds: string[] = [];
     let cachedDetails = 0;
     let staleDetails = 0;
-    for (const dropID of discoverableCampaignIds) {
+    for (const dropID of detailCampaignIds) {
       const fresh = dropID === activeCampaignId
         ? undefined
         : this.discoveryState.freshCampaignDetails(dropID);
@@ -834,14 +844,14 @@ export class TwitchAdapter implements PlatformAdapter {
       }
       useRetainedDetails(dropID, result.reason);
     });
-    const operationLabel = discoverableCampaignIds.length === 1 ? "operation" : "operations";
+    const operationLabel = detailCampaignIds.length === 1 ? "operation" : "operations";
     diagnostic(
       this.emit,
       "debug",
-      `Twitch campaign details finished in ${Date.now() - detailsStartedAt}ms (${discoverableCampaignIds.length} ${operationLabel}: ${detailFetchIds.length} fetched, ${cachedDetails} served from cache, ${staleDetails} stale, ${invalidatedDetails} invalidated, ${detailFetch.batchRequests} batch requests, ${detailFetch.singleFallbacks} single fallbacks)`,
+      `Twitch campaign details finished in ${Date.now() - detailsStartedAt}ms (${detailCampaignIds.length} ${operationLabel}: ${detailFetchIds.length} fetched, ${cachedDetails} served from cache, ${staleDetails} stale, ${invalidatedDetails} invalidated, ${detailFetch.batchRequests} batch requests, ${detailFetch.singleFallbacks} single fallbacks)`,
       "twitch",
     );
-    const detailedCampaigns = discoverableCampaignIds
+    const detailedCampaigns = detailCampaignIds
       .map((dropID) => detailByDropID.get(dropID))
       .filter((campaign) => campaign !== undefined);
     if (detailedCampaigns.length === 0) {
@@ -1581,7 +1591,11 @@ export class TwitchAdapter implements PlatformAdapter {
   private async fetchDashboard(
     variables: Record<string, unknown>,
     signal?: AbortSignal,
-  ): Promise<{ response: TwitchGqlResponse<TwitchDashboardData>; ok: boolean }> {
+  ): Promise<{
+    response: TwitchGqlResponse<TwitchDashboardData>;
+    campaigns: TwitchDashboardCampaign[];
+    ok: boolean;
+  }> {
     try {
       const response = await this.gqlWithIntegrityRetry<TwitchDashboardData>(
         TWITCH_QUERIES.dashboard.operationName,
@@ -1592,13 +1606,23 @@ export class TwitchAdapter implements PlatformAdapter {
         this.emit,
         signal,
       );
-      return { response, ok: true };
+      const campaigns = twitchDashboardCampaigns(response);
+      if (!campaigns) {
+        diagnostic(
+          this.emit,
+          "warn",
+          "Twitch drops dashboard response did not contain a valid campaign collection; reusing the last campaign list it returned",
+          "twitch",
+        );
+        return { response, campaigns: [], ok: false };
+      }
+      return { response, campaigns, ok: true };
     } catch (error) {
       signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
       const message = error instanceof Error ? error.message : String(error);
       diagnostic(this.emit, "warn", `Twitch drops dashboard request failed; reusing the last campaign list it returned: ${message}`, "twitch");
-      return { response: {}, ok: false };
+      return { response: {}, campaigns: [], ok: false };
     }
   }
 
@@ -1999,10 +2023,24 @@ class TwitchWatcher implements TablessWatchController {
   }
 }
 
-function twitchDashboardCampaigns(dashboard: TwitchGqlResponse<TwitchDashboardData>) {
-  return dashboard.data?.currentUser?.dropCampaigns
-    ?? dashboard.data?.currentUser?.inventory?.dropCampaigns
-    ?? [];
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function twitchDashboardCampaigns(dashboard: unknown): TwitchDashboardCampaign[] | undefined {
+  if (!isRecord(dashboard) || !isRecord(dashboard.data)) return undefined;
+  const currentUser = dashboard.data.currentUser;
+  if (!isRecord(currentUser)) return undefined;
+  const inventory = currentUser.inventory;
+  const campaigns = currentUser.dropCampaigns
+    ?? (isRecord(inventory) ? inventory.dropCampaigns : undefined);
+  if (!Array.isArray(campaigns)) return undefined;
+  if (!campaigns.every((campaign) =>
+    isRecord(campaign)
+    && typeof campaign.id === "string"
+    && campaign.id.length > 0
+    && typeof campaign.status === "string")) return undefined;
+  return campaigns as TwitchDashboardCampaign[];
 }
 
 function twitchCurrentUserId(value: unknown): string | undefined {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -1,4 +1,15 @@
-import type { CategorySelection, ChannelCandidate, ChannelCheck, DropCampaign, DropReward, PlatformAuthHealth, WatchSession } from "@lurkloot/shared/models";
+import {
+  TWITCH_DISCOVERY_SNAPSHOT_MAX_ENTRIES,
+  TWITCH_DISCOVERY_SNAPSHOT_VERSION,
+  type CategorySelection,
+  type ChannelCandidate,
+  type ChannelCheck,
+  type DropCampaign,
+  type DropReward,
+  type PlatformAuthHealth,
+  type TwitchDiscoverySnapshot,
+  type WatchSession,
+} from "@lurkloot/shared/models";
 import type { EventEmitter } from "@lurkloot/shared/events";
 import type { LogLevel } from "@lurkloot/shared/logging";
 import { authHealthFromError, SafeFetchError } from "../../core/fetchError";
@@ -12,6 +23,7 @@ import { createTwitchHeartbeat } from "./heartbeat/factory";
 import type { TwitchHeartbeatFetchText, TwitchHeartbeatPost, TwitchHeartbeatStrategy } from "./heartbeat/types";
 import { createTwitchInventory } from "./inventory/factory";
 import type { TwitchInventoryCapability } from "./inventory/types";
+import { isTwitchCampaignDetailPayload, normalizeTwitchDiscoverySnapshot } from "../../core/defaults";
 
 export { createTwitchInventory } from "./inventory/factory";
 export type { TwitchInventoryCapability } from "./inventory/types";
@@ -23,7 +35,7 @@ const CURRENT_USER_QUERY = "query CurrentUser { currentUser { id } }";
 // behind Client-Integrity (Kasada); non-web client ids (Android/TV) are not.
 const TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 const CHANNEL_CAMPAIGN_CACHE_TTL_MS = 60_000;
-const DISCOVERY_DETAIL_PRUNE_LIMIT = 32;
+const DISCOVERY_DETAIL_CACHE_TTL_MS = 5 * 60_000;
 const GQL_BATCH_OPERATION_LIMIT = 20;
 const GQL_BATCH_CONCURRENCY = 2;
 // How long a discovery result stays usable when Twitch stops answering. Long
@@ -317,7 +329,8 @@ interface CachedAvailableCampaigns {
 
 interface CachedCampaignDetails {
   campaign: unknown;
-  expiresAt: number;
+  freshUntil: number;
+  retainedUntil: number;
 }
 
 interface CachedDashboardCampaigns {
@@ -346,10 +359,50 @@ export class TwitchDiscoveryState {
 
   setAuthenticatedUser(userId: string): void {
     if (this.authenticatedUserId && this.authenticatedUserId !== userId) {
-      this.retainedDashboard = undefined;
-      this.campaignDetailsByDropId.clear();
+      this.clear();
     }
     this.authenticatedUserId = userId;
+  }
+
+  clear(): void {
+    this.authenticatedUserId = undefined;
+    this.retainedDashboard = undefined;
+    this.campaignDetailsByDropId.clear();
+  }
+
+  snapshot(): TwitchDiscoverySnapshot | undefined {
+    if (!this.authenticatedUserId) return undefined;
+    const now = Date.now();
+    const entries = [...this.campaignDetailsByDropId.entries()]
+      .filter(([, cached]) => cached.freshUntil > now && cached.retainedUntil > now)
+      .sort(([leftID], [rightID]) => leftID.localeCompare(rightID))
+      .slice(0, TWITCH_DISCOVERY_SNAPSHOT_MAX_ENTRIES)
+      .map(([dropID, cached]) => ({
+        dropID,
+        campaign: cached.campaign,
+        freshUntil: new Date(cached.freshUntil).toISOString(),
+        retainedUntil: new Date(cached.retainedUntil).toISOString(),
+      }));
+    if (entries.length === 0) return undefined;
+    return {
+      version: TWITCH_DISCOVERY_SNAPSHOT_VERSION,
+      userId: this.authenticatedUserId,
+      entries,
+    };
+  }
+
+  restore(snapshot: unknown): void {
+    const normalized = normalizeTwitchDiscoverySnapshot(snapshot);
+    this.clear();
+    if (!normalized) return;
+    this.authenticatedUserId = normalized.userId;
+    for (const entry of normalized.entries) {
+      this.campaignDetailsByDropId.set(entry.dropID, {
+        campaign: entry.campaign,
+        freshUntil: Date.parse(entry.freshUntil),
+        retainedUntil: Date.parse(entry.retainedUntil),
+      });
+    }
   }
 
   rememberDashboardCampaignIds(campaignIds: string[]): void {
@@ -370,26 +423,54 @@ export class TwitchDiscoveryState {
 
   rememberCampaignDetails(dropID: string, campaign: unknown): void {
     const now = Date.now();
-    let inspected = 0;
     for (const [cachedDropID, cached] of this.campaignDetailsByDropId) {
-      if (inspected >= DISCOVERY_DETAIL_PRUNE_LIMIT) break;
-      inspected += 1;
-      if (cached.expiresAt <= now) this.campaignDetailsByDropId.delete(cachedDropID);
+      if (cached.retainedUntil <= now) this.campaignDetailsByDropId.delete(cachedDropID);
     }
     this.campaignDetailsByDropId.set(dropID, {
       campaign,
-      expiresAt: now + DISCOVERY_RETENTION_TTL_MS,
+      freshUntil: now + DISCOVERY_DETAIL_CACHE_TTL_MS,
+      retainedUntil: now + DISCOVERY_RETENTION_TTL_MS,
     });
+    const overflow = this.campaignDetailsByDropId.size - TWITCH_DISCOVERY_SNAPSHOT_MAX_ENTRIES;
+    if (overflow <= 0) return;
+    const oldest = [...this.campaignDetailsByDropId.entries()]
+      .sort(([leftID, left], [rightID, right]) =>
+        left.retainedUntil - right.retainedUntil || leftID.localeCompare(rightID));
+    for (const [cachedDropID] of oldest.slice(0, overflow)) {
+      this.campaignDetailsByDropId.delete(cachedDropID);
+    }
   }
 
   forgetCampaignDetails(dropID: string): void {
     this.campaignDetailsByDropId.delete(dropID);
   }
 
+  forgetCampaignDetailsAbsentFrom(campaignIds: readonly string[]): number {
+    const retainedIds = new Set(campaignIds);
+    let forgotten = 0;
+    for (const dropID of this.campaignDetailsByDropId.keys()) {
+      if (retainedIds.has(dropID)) continue;
+      this.campaignDetailsByDropId.delete(dropID);
+      forgotten += 1;
+    }
+    return forgotten;
+  }
+
+  freshCampaignDetails(dropID: string): unknown {
+    const cached = this.campaignDetailsByDropId.get(dropID);
+    if (!cached) return undefined;
+    const now = Date.now();
+    if (cached.retainedUntil <= now) {
+      this.campaignDetailsByDropId.delete(dropID);
+      return undefined;
+    }
+    return cached.freshUntil > now ? cached.campaign : undefined;
+  }
+
   retainedCampaignDetails(dropID: string): unknown {
     const cached = this.campaignDetailsByDropId.get(dropID);
     if (!cached) return undefined;
-    if (cached.expiresAt <= Date.now()) {
+    if (cached.retainedUntil <= Date.now()) {
       this.campaignDetailsByDropId.delete(dropID);
       return undefined;
     }
@@ -604,6 +685,7 @@ export class TwitchAdapter implements PlatformAdapter {
   }
 
   private async discoverCampaignSnapshot(
+    session?: WatchSession,
     { signal }: AdapterOperationOptions = {},
   ): Promise<DropCampaign[]> {
     let [inventory, dashboardResult] = await Promise.all([
@@ -664,8 +746,10 @@ export class TwitchAdapter implements PlatformAdapter {
     // already started — so falling back to it hides every campaign they have
     // not. Reuse the last dashboard we did get instead. `dashboardResponded`
     // stays false so the expiry stamping below never fires off a stale list.
+    let invalidatedDetails = 0;
     if (dashboardResult.ok && authenticatedUserId) {
       this.discoveryState.rememberDashboardCampaignIds(freshCampaignIds);
+      invalidatedDetails = this.discoveryState.forgetCampaignDetailsAbsentFrom(freshCampaignIds);
     }
     const discoverableCampaignIds = dashboardResult.ok
       ? freshCampaignIds
@@ -682,15 +766,31 @@ export class TwitchAdapter implements PlatformAdapter {
       );
     }
 
+    const activeCampaignId = session?.status === "watching" || session?.status === "starting"
+      ? session.campaignId ?? session.channel?.campaignId
+      : undefined;
+    const detailByDropID = new Map<string, unknown>();
+    const detailFetchIds: string[] = [];
+    let cachedDetails = 0;
+    let staleDetails = 0;
+    for (const dropID of discoverableCampaignIds) {
+      const fresh = dropID === activeCampaignId
+        ? undefined
+        : this.discoveryState.freshCampaignDetails(dropID);
+      if (fresh !== undefined) {
+        detailByDropID.set(dropID, fresh);
+        cachedDetails += 1;
+        continue;
+      }
+      if (dropID !== activeCampaignId && this.discoveryState.retainedCampaignDetails(dropID) !== undefined) {
+        staleDetails += 1;
+      }
+      detailFetchIds.push(dropID);
+    }
+
     const detailsStartedAt = Date.now();
-    const detailFetch = await this.fetchCampaignDetails(discoverableCampaignIds, userLogin, signal);
+    const detailFetch = await this.fetchCampaignDetails(detailFetchIds, userLogin, signal);
     const details = detailFetch.results;
-    diagnostic(
-      this.emit,
-      "debug",
-      `Twitch campaign details finished in ${Date.now() - detailsStartedAt}ms (${discoverableCampaignIds.length} operations: ${detailFetch.batchRequests} batch requests, ${detailFetch.singleFallbacks} single fallbacks)`,
-      "twitch",
-    );
     signal?.throwIfAborted();
     for (const result of details) {
       if (result.status === "rejected" && authHealthFromError(result.reason)) throw result.reason;
@@ -698,48 +798,58 @@ export class TwitchAdapter implements PlatformAdapter {
     // A campaign the user has not started is only ever described by its detail
     // request, so dropping a rejection loses the campaign entirely. Serve the
     // last details we saw for it instead, and never lose the failure silently.
-    const detailedCampaigns: unknown[] = [];
-    details.forEach((result, index) => {
-      const dropID = discoverableCampaignIds[index];
-      if (result.status === "fulfilled") {
-        const data = result.value.data;
-        const campaign = data?.dropCampaign ?? data?.user?.dropCampaign;
-        if (!campaign) {
-          const campaignWasAuthoritativelyMissing = Boolean(
-            data
-            && (
-              Object.prototype.hasOwnProperty.call(data, "dropCampaign")
-              || (
-                data.user
-                && Object.prototype.hasOwnProperty.call(data.user, "dropCampaign")
-              )
-            ),
-          );
-          if (authenticatedUserId && campaignWasAuthoritativelyMissing) {
-            this.discoveryState.forgetCampaignDetails(dropID);
-          }
-          return;
-        }
-        if (authenticatedUserId) this.discoveryState.rememberCampaignDetails(dropID, campaign);
-        detailedCampaigns.push(campaign);
-        return;
-      }
+    const useRetainedDetails = (dropID: string, reason: unknown): void => {
       const retained = authenticatedUserId
         ? this.discoveryState.retainedCampaignDetails(dropID)
         : undefined;
-      const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      const message = reason instanceof Error ? reason.message : String(reason);
       diagnostic(
         this.emit,
         "warn",
         `Twitch campaign details for ${dropID} failed; ${retained ? "reusing the last known details" : "leaving the campaign out of this refresh"}: ${message}`,
         "twitch",
       );
-      if (retained) detailedCampaigns.push(retained);
+      if (retained !== undefined) detailByDropID.set(dropID, retained);
+    };
+    details.forEach((result, index) => {
+      const dropID = detailFetchIds[index];
+      if (result.status === "fulfilled") {
+        const data = result.value.data;
+        const campaign = data?.dropCampaign ?? data?.user?.dropCampaign;
+        const campaignMatchesDropID = isTwitchCampaignDetailPayload(campaign, dropID);
+        if (!campaignMatchesDropID) {
+          const campaignWasAuthoritativelyMissing = data?.dropCampaign === null
+            || data?.user?.dropCampaign === null;
+          if (authenticatedUserId && campaignWasAuthoritativelyMissing) {
+            this.discoveryState.forgetCampaignDetails(dropID);
+            invalidatedDetails += 1;
+          } else {
+            useRetainedDetails(dropID, "Twitch returned ambiguous campaign details");
+          }
+          return;
+        }
+        if (authenticatedUserId) this.discoveryState.rememberCampaignDetails(dropID, campaign);
+        detailByDropID.set(dropID, campaign);
+        return;
+      }
+      useRetainedDetails(dropID, result.reason);
     });
+    const operationLabel = discoverableCampaignIds.length === 1 ? "operation" : "operations";
+    diagnostic(
+      this.emit,
+      "debug",
+      `Twitch campaign details finished in ${Date.now() - detailsStartedAt}ms (${discoverableCampaignIds.length} ${operationLabel}: ${detailFetchIds.length} fetched, ${cachedDetails} served from cache, ${staleDetails} stale, ${invalidatedDetails} invalidated, ${detailFetch.batchRequests} batch requests, ${detailFetch.singleFallbacks} single fallbacks)`,
+      "twitch",
+    );
+    const detailedCampaigns = discoverableCampaignIds
+      .map((dropID) => detailByDropID.get(dropID))
+      .filter((campaign) => campaign !== undefined);
     if (detailedCampaigns.length === 0) {
       return inventoryCampaigns;
     }
-    const parsedDetails = parseTwitchCampaigns(detailedCampaigns as Parameters<typeof parseTwitchCampaigns>[0]);
+    const parsedDetails = parseTwitchCampaigns(
+      detailedCampaigns as unknown as Parameters<typeof parseTwitchCampaigns>[0],
+    );
     const mergedDetails = mergeTwitchCampaignProgress(parsedDetails, inventory as Parameters<typeof mergeTwitchCampaignProgress>[1]);
     const detailedIds = new Set(mergedDetails.map((campaign) => campaign.id));
     // The Inventory payload omits campaign/reward end dates, so an ended
@@ -761,7 +871,7 @@ export class TwitchAdapter implements PlatformAdapter {
     session?: WatchSession,
     options: AdapterOperationOptions = {},
   ): Promise<DropCampaign[]> {
-    const campaigns = await this.discoverCampaignSnapshot(options);
+    const campaigns = await this.discoverCampaignSnapshot(session, options);
     if (!session?.channel || session.status !== "watching") return campaigns;
     return this.mergeCurrentSessionProgress(campaigns, session.channel, options.signal);
   }
@@ -1513,7 +1623,9 @@ export class TwitchAdapter implements PlatformAdapter {
     await this.ensureIntegrity({ signal });
 
     try {
-      return await this.runClaim(reward, signal);
+      const claimed = await this.runClaim(reward, signal);
+      if (claimed) this.discoveryState.forgetCampaignDetails(campaign.id);
+      return claimed;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // Only integrity rejections are worth a refresh + retry; everything else
@@ -1530,7 +1642,11 @@ export class TwitchAdapter implements PlatformAdapter {
         rejectedToken,
         signal,
       });
-      if (refreshed) return await this.runClaim(reward, signal);
+      if (refreshed) {
+        const claimed = await this.runClaim(reward, signal);
+        if (claimed) this.discoveryState.forgetCampaignDetails(campaign.id);
+        return claimed;
+      }
       throw new Error(`Twitch rejected the claim for ${reward.name} (${message}). Keep a logged-in twitch.tv tab open so the extension can capture a valid integrity token, then retry.`);
     }
   }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -36,8 +36,12 @@ const CURRENT_USER_QUERY = "query CurrentUser { currentUser { id } }";
 const TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 const CHANNEL_CAMPAIGN_CACHE_TTL_MS = 60_000;
 const DISCOVERY_DETAIL_CACHE_TTL_MS = 5 * 60_000;
+// Wider than the default one-minute discovery cadence, so one batch crosses
+// its deadlines over two later ticks while every entry remains fresh for >3m.
+const DISCOVERY_DETAIL_CACHE_STAGGER_WINDOW_MS = 2 * 60_000;
 const GQL_BATCH_OPERATION_LIMIT = 20;
 const GQL_BATCH_CONCURRENCY = 2;
+const TWITCH_DASHBOARD_CAMPAIGN_STATUSES = new Set(["ACTIVE", "UPCOMING", "EXPIRED"]);
 // How long a discovery result stays usable when Twitch stops answering. Long
 // enough to ride out an outage of many ticks, short enough that a campaign
 // Twitch quietly stopped serving does not linger for a whole session.
@@ -344,6 +348,15 @@ interface CachedDashboardCampaigns {
   expiresAt: number;
 }
 
+function campaignDetailFreshTtlMs(dropID: string): number {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < dropID.length; index += 1) {
+    hash = Math.imul(hash ^ dropID.charCodeAt(index), 16_777_619);
+  }
+  return DISCOVERY_DETAIL_CACHE_TTL_MS
+    - (hash >>> 0) % DISCOVERY_DETAIL_CACHE_STAGGER_WINDOW_MS;
+}
+
 function reconcileInventoryCampaignStatuses(
   campaigns: DropCampaign[],
   activeDashboardIds: ReadonlySet<string>,
@@ -435,7 +448,7 @@ export class TwitchDiscoveryState {
     }
     this.campaignDetailsByDropId.set(dropID, {
       campaign,
-      freshUntil: now + DISCOVERY_DETAIL_CACHE_TTL_MS,
+      freshUntil: now + campaignDetailFreshTtlMs(dropID),
       retainedUntil: now + DISCOVERY_RETENTION_TTL_MS,
     });
     const overflow = this.campaignDetailsByDropId.size - TWITCH_DISCOVERY_SNAPSHOT_MAX_ENTRIES;
@@ -825,11 +838,12 @@ export class TwitchAdapter implements PlatformAdapter {
       const dropID = detailFetchIds[index];
       if (result.status === "fulfilled") {
         const data = result.value.data;
-        const campaign = data?.dropCampaign ?? data?.user?.dropCampaign;
-        const campaignMatchesDropID = isTwitchCampaignDetailPayload(campaign, dropID);
-        if (!campaignMatchesDropID) {
-          const campaignWasAuthoritativelyMissing = data?.dropCampaign === null
-            || data?.user?.dropCampaign === null;
+        const campaignCandidates = [data?.dropCampaign, data?.user?.dropCampaign];
+        const campaign = campaignCandidates.find((candidate) =>
+          isTwitchCampaignDetailPayload(candidate, dropID));
+        if (!campaign) {
+          const campaignWasAuthoritativelyMissing = campaignCandidates.some((candidate) => candidate === null)
+            && campaignCandidates.every((candidate) => candidate == null);
           if (authenticatedUserId && campaignWasAuthoritativelyMissing) {
             this.discoveryState.forgetCampaignDetails(dropID);
             invalidatedDetails += 1;
@@ -2039,7 +2053,8 @@ function twitchDashboardCampaigns(dashboard: unknown): TwitchDashboardCampaign[]
     isRecord(campaign)
     && typeof campaign.id === "string"
     && campaign.id.length > 0
-    && typeof campaign.status === "string")) return undefined;
+    && typeof campaign.status === "string"
+    && TWITCH_DASHBOARD_CAMPAIGN_STATUSES.has(campaign.status))) return undefined;
   return campaigns as TwitchDashboardCampaign[];
 }
 

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -1,5 +1,5 @@
 import { browser } from "wxt/browser";
-import { loadSettings, loadState, loadTwitchIntegrity, resetStorage, saveSettings, saveState, saveTwitchIntegrity } from "../src/core/storage";
+import { createTwitchDiscoveryStateStorage, loadSettings, loadTwitchIntegrity, saveSettings, saveTwitchIntegrity } from "../src/core/storage";
 import type { CliCredentialBlob, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import {
   applyAdFocus,
@@ -49,6 +49,7 @@ const reportEvents = createActivityEventReporter({
 });
 const kickClaimState = new KickClaimState();
 const twitchDiscoveryState = new TwitchDiscoveryState();
+const twitchDiscoveryStorage = createTwitchDiscoveryStateStorage(twitchDiscoveryState);
 const KICK_PAGE_CONTEXT_URL = "https://kick.com/drops/inventory";
 const checkCredentialAvailability = createCredentialAvailabilityProvider({
   get: (details) => browser.cookies.get(details),
@@ -130,8 +131,8 @@ function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings
 const controller = createBackgroundController<ExtensionSettings>({
   loadSettings,
   saveSettings,
-  loadState,
-  saveState,
+  loadState: twitchDiscoveryStorage.loadState,
+  saveState: twitchDiscoveryStorage.saveState,
   reportEvents,
   checkCredentialAvailability,
   createAlarm: (name, options) => browser.alarms.create(name, options),
@@ -212,7 +213,7 @@ function resetExtension(): Promise<RuntimeSnapshot<ExtensionSettings>> {
   resetMutation = (async () => {
     await controller.prepareForHostReset(async () => {
       kickClaimState.clear();
-      await resetStorage();
+      await twitchDiscoveryStorage.resetStorage();
     });
     return await controller.handleMessage({ type: "getSnapshot" }) as RuntimeSnapshot<ExtensionSettings>;
   })().finally(() => {

--- a/packages/extension/src/core/storage.ts
+++ b/packages/extension/src/core/storage.ts
@@ -126,3 +126,45 @@ export async function resetStorage(): Promise<void> {
   });
   await clearActivityEvents();
 }
+
+interface PersistedTwitchDiscoveryState {
+  restore(snapshot: unknown): void;
+  snapshot(): SchedulerState["twitchDiscovery"];
+  clear(): void;
+}
+
+// Binds the browser-free Twitch cache lifecycle to the extension's existing
+// scheduler-state document. Hydration happens once per MV3 worker evaluation;
+// later state reads cannot restore an older snapshot over fresher in-memory
+// details, while every state save carries the latest bounded snapshot.
+export function createTwitchDiscoveryStateStorage(discoveryState: PersistedTwitchDiscoveryState) {
+  let hydrated = false;
+  let hydration: Promise<SchedulerState> | undefined;
+  const ensureHydrated = (): Promise<SchedulerState> => {
+    hydration ??= loadState().then((state) => {
+      discoveryState.restore(state.twitchDiscovery);
+      hydrated = true;
+      return state;
+    });
+    return hydration;
+  };
+
+  return {
+    async loadState(): Promise<SchedulerState> {
+      if (!hydrated) return ensureHydrated();
+      return loadState();
+    },
+    async saveState(state: SchedulerState): Promise<void> {
+      await ensureHydrated();
+      const snapshot = discoveryState.snapshot();
+      const nextState = { ...state, twitchDiscovery: snapshot };
+      if (!snapshot) delete nextState.twitchDiscovery;
+      await saveState(nextState);
+    },
+    async resetStorage(): Promise<void> {
+      await ensureHydrated();
+      discoveryState.clear();
+      await resetStorage();
+    },
+  };
+}

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -26,7 +26,7 @@ function requestBody(init?: RequestInit): Record<string, unknown> {
   return JSON.parse(String(init?.body)) as Record<string, unknown>;
 }
 
-function twitchInventory(campaignIds: string[], userId = "user-id"): unknown {
+function twitchInventory(campaignIds: string[], userId = "user-id", watchedMinutes = 20): unknown {
   return {
     data: {
       currentUser: {
@@ -39,7 +39,7 @@ function twitchInventory(campaignIds: string[], userId = "user-id"): unknown {
             timeBasedDrops: [{
               id: `${id}-drop`,
               requiredMinutesWatched: 60,
-              self: { currentMinutesWatched: 20, isClaimed: false },
+              self: { currentMinutesWatched: watchedMinutes, isClaimed: false },
               benefitEdges: [{ benefit: { id: "benefit", name: "Reward" } }],
             }],
           })),
@@ -1398,8 +1398,336 @@ describe("TwitchAdapter", () => {
     expect(emit).toHaveBeenCalledWith(expect.objectContaining({
       category: "diagnostic",
       platform: "twitch",
-      message: expect.stringMatching(/^Twitch campaign details finished in \d+ms \(41 operations: 3 batch requests, 0 single fallbacks\)$/),
+      message: expect.stringMatching(/^Twitch campaign details finished in \d+ms \(41 operations: 41 fetched, 0 served from cache, 0 stale, 0 invalidated, 3 batch requests, 0 single fallbacks\)$/),
     }));
+  });
+
+  it("reuses unchanged non-current campaign details while merging fresh inventory progress", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      let watchedMinutes = 20;
+      let detailRequests = 0;
+      const events: EngineEvent[] = [];
+      const fetcher = jsonFetcher((_url, init) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+        if (Array.isArray(body)) {
+          detailRequests += body.length;
+          return body.map((entry) => twitchCampaignDetails(String(
+            (entry.variables as { dropID?: string }).dropID,
+          )));
+        }
+        if (body.operationName === "Inventory") return twitchInventory(["campaign"], "user-id", watchedMinutes);
+        if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+        throw new Error(`Unexpected operation ${String(body.operationName)}`);
+      });
+      const discoveryState = new TwitchDiscoveryState();
+
+      const first = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+        .refreshCampaigns();
+      watchedMinutes = 35;
+      vi.advanceTimersByTime(60_000);
+      const second = await new TwitchAdapter(
+        fetcher,
+        undefined,
+        undefined,
+        { discoveryState },
+        (event) => events.push(event),
+      ).refreshCampaigns();
+
+      expect(first[0]?.rewards[0]?.watchedMinutes).toBe(20);
+      expect(second[0]?.rewards[0]?.watchedMinutes).toBe(35);
+      expect(detailRequests).toBe(1);
+      expect(events).toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        platform: "twitch",
+        message: expect.stringMatching(/^Twitch campaign details finished in \d+ms \(1 operation: 0 fetched, 1 served from cache, 0 stale, 0 invalidated, 0 batch requests, 0 single fallbacks\)$/),
+      }));
+      vi.advanceTimersByTime(4 * 60_000 + 1);
+      await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+      expect(detailRequests).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["starting", "watching"] as const)("fetches the currently farmed campaign details on every refresh while %s", async (status) => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      let detailRequests = 0;
+      const fetcher = jsonFetcher((_url, init) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+        if (Array.isArray(body)) {
+          detailRequests += body.length;
+          return body.map((entry) => twitchCampaignDetails(String(
+            (entry.variables as { dropID?: string }).dropID,
+          )));
+        }
+        if (body.operationName === "Inventory") return twitchInventory([]);
+        if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+        throw new Error(`Unexpected operation ${String(body.operationName)}`);
+      });
+      const discoveryState = new TwitchDiscoveryState();
+      const session = {
+        platform: "twitch" as const,
+        status,
+        campaignId: "campaign",
+        offlineChecks: 0,
+      };
+
+      await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(session);
+      vi.advanceTimersByTime(60_000);
+      await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(session);
+
+      expect(detailRequests).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reuses fresh campaign details after discovery-state reconstruction", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      let detailRequests = 0;
+      const fetcher = jsonFetcher((_url, init) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+        if (Array.isArray(body)) {
+          detailRequests += body.length;
+          return body.map((entry) => twitchCampaignDetails(String(
+            (entry.variables as { dropID?: string }).dropID,
+          )));
+        }
+        if (body.operationName === "Inventory") return twitchInventory([]);
+        if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+        throw new Error(`Unexpected operation ${String(body.operationName)}`);
+      });
+      const firstDiscoveryState = new TwitchDiscoveryState();
+
+      await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState: firstDiscoveryState })
+        .refreshCampaigns();
+      const persisted = JSON.parse(JSON.stringify(firstDiscoveryState.snapshot())) as unknown;
+      vi.advanceTimersByTime(60_000);
+      const reconstructedDiscoveryState = new TwitchDiscoveryState();
+      reconstructedDiscoveryState.restore(persisted);
+      const campaigns = await new TwitchAdapter(
+        fetcher,
+        undefined,
+        undefined,
+        { discoveryState: reconstructedDiscoveryState },
+      ).refreshCampaigns();
+
+      expect(campaigns.map((campaign) => campaign.id)).toEqual(["campaign"]);
+      expect(detailRequests).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not reuse reconstructed campaign details after authenticated identity changes", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      let userId = "user-a";
+      let detailRequests = 0;
+      const fetcher = jsonFetcher((_url, init) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+        if (Array.isArray(body)) {
+          detailRequests += body.length;
+          return body.map((entry) => twitchCampaignDetails(String(
+            (entry.variables as { dropID?: string }).dropID,
+          )));
+        }
+        if (body.operationName === "Inventory") return twitchInventory([], userId);
+        if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"], userId);
+        throw new Error(`Unexpected operation ${String(body.operationName)}`);
+      });
+      const firstDiscoveryState = new TwitchDiscoveryState();
+
+      await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState: firstDiscoveryState })
+        .refreshCampaigns();
+      const persisted = firstDiscoveryState.snapshot();
+      userId = "user-b";
+      const reconstructedDiscoveryState = new TwitchDiscoveryState();
+      reconstructedDiscoveryState.restore(persisted);
+      await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState: reconstructedDiscoveryState })
+        .refreshCampaigns();
+
+      expect(detailRequests).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fetches a newly dashboard-listed campaign immediately while reusing known details", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      let dashboardIds = ["known"];
+      const detailRequests = new Map<string, number>();
+      const fetcher = jsonFetcher((_url, init) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+        if (Array.isArray(body)) {
+          return body.map((entry) => {
+            const dropID = String((entry.variables as { dropID?: string }).dropID);
+            detailRequests.set(dropID, (detailRequests.get(dropID) ?? 0) + 1);
+            return twitchCampaignDetails(dropID);
+          });
+        }
+        if (body.operationName === "Inventory") return twitchInventory([]);
+        if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(dashboardIds);
+        throw new Error(`Unexpected operation ${String(body.operationName)}`);
+      });
+      const discoveryState = new TwitchDiscoveryState();
+
+      await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+      dashboardIds = ["known", "new"];
+      vi.advanceTimersByTime(60_000);
+      const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+
+      expect(campaigns.map((campaign) => campaign.id)).toEqual(["known", "new"]);
+      expect(Object.fromEntries(detailRequests)).toEqual({ known: 1, new: 1 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("forgets details when a successful dashboard no longer lists the campaign", async () => {
+    let dashboardIds = ["campaign"];
+    let detailRequests = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        detailRequests += body.length;
+        return body.map((entry) => twitchCampaignDetails(String(
+          (entry.variables as { dropID?: string }).dropID,
+        )));
+      }
+      if (body.operationName === "Inventory") return twitchInventory([]);
+      if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(dashboardIds);
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+
+    await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+    dashboardIds = [];
+    await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+
+    expect(discoveryState.retainedCampaignDetails("campaign")).toBeUndefined();
+
+    dashboardIds = ["campaign"];
+    await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+    expect(detailRequests).toBe(2);
+  });
+
+  it("forgets campaign details after a successful claim", async () => {
+    let detailRequests = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        detailRequests += body.length;
+        return body.map((entry) => twitchCampaignDetails(String(
+          (entry.variables as { dropID?: string }).dropID,
+        )));
+      }
+      if (body.operationName === "Inventory") return twitchInventory([]);
+      if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+      if (body.operationName === "DropsPage_ClaimDropRewards") {
+        return { data: { claimDropRewards: { status: "ELIGIBLE_FOR_ALL" } } };
+      }
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    const adapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const campaign: DropCampaign = {
+      id: "campaign",
+      platform: "twitch",
+      name: "Campaign",
+      status: "active",
+      rewards: [],
+    };
+    const reward: DropReward = {
+      id: "reward",
+      name: "Reward",
+      requiredMinutes: 60,
+      watchedMinutes: 60,
+      status: "claimable",
+      claimId: "instance",
+    };
+
+    await adapter.refreshCampaigns();
+    await expect(adapter.claimReward(campaign, reward)).resolves.toBe(true);
+
+    expect(discoveryState.retainedCampaignDetails("campaign")).toBeUndefined();
+    await adapter.refreshCampaigns();
+    expect(detailRequests).toBe(2);
+  });
+
+  it("falls back to retained details when a fresh response is ambiguous without poisoning the cache", async () => {
+    let detailResponse: "campaign" | "ambiguous" = "campaign";
+    let detailRequests = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        detailRequests += body.length;
+        return body.map((entry) => detailResponse === "ambiguous"
+          ? { data: {} }
+          : twitchCampaignDetails(String((entry.variables as { dropID?: string }).dropID)));
+      }
+      if (body.operationName === "Inventory") return twitchInventory([]);
+      if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    const activeSession = {
+      platform: "twitch" as const,
+      status: "watching" as const,
+      campaignId: "campaign",
+      offlineChecks: 0,
+    };
+
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+      .map((campaign) => campaign.id)).toEqual(["campaign"]);
+    detailResponse = "ambiguous";
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(activeSession))
+      .map((campaign) => campaign.id)).toEqual(["campaign"]);
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+      .map((campaign) => campaign.id)).toEqual(["campaign"]);
+    expect(detailRequests).toBe(2);
+  });
+
+  it("falls back to retained details when a fresh response is malformed without poisoning the cache", async () => {
+    let malformed = false;
+    let detailRequests = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        detailRequests += body.length;
+        return body.map((entry) => malformed
+          ? { data: { dropCampaign: { id: "campaign" } } }
+          : twitchCampaignDetails(String((entry.variables as { dropID?: string }).dropID)));
+      }
+      if (body.operationName === "Inventory") return twitchInventory([]);
+      if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    const activeSession = {
+      platform: "twitch" as const,
+      status: "watching" as const,
+      campaignId: "campaign",
+      offlineChecks: 0,
+    };
+
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())[0]?.name)
+      .toBe("Campaign campaign");
+    malformed = true;
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(activeSession))[0]?.name)
+      .toBe("Campaign campaign");
+    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())[0]?.name)
+      .toBe("Campaign campaign");
+    expect(detailRequests).toBe(2);
   });
 
   it("starts Twitch inventory and dashboard discovery requests concurrently", async () => {
@@ -1464,29 +1792,40 @@ describe("TwitchAdapter", () => {
   });
 
   it("keeps a campaign whose details request fails once it has been seen successfully", async () => {
-    let failing: string | undefined;
-    const fetcher = jsonFetcher((_url, init) => {
-      const op = operation(init);
-      if (op === "Inventory") return twitchInventory([]);
-      if (op === "ViewerDropsDashboard") return twitchDashboard(["a", "b"]);
-      if (op === "DropCampaignDetails") {
-        const dropID = String((requestBody(init).variables as Record<string, unknown>).dropID);
-        if (dropID === failing) throw new Error("service unavailable");
-        return twitchCampaignDetails(dropID);
-      }
-      throw new Error(`Unexpected op ${op}`);
-    });
-    const events: EngineEvent[] = [];
-    const discoveryState = new TwitchDiscoveryState();
-    const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      let failing: string | undefined;
+      const fetcher = jsonFetcher((_url, init) => {
+        const op = operation(init);
+        if (op === "Inventory") return twitchInventory([]);
+        if (op === "ViewerDropsDashboard") return twitchDashboard(["a", "b"]);
+        if (op === "DropCampaignDetails") {
+          const dropID = String((requestBody(init).variables as Record<string, unknown>).dropID);
+          if (dropID === failing) throw new Error("service unavailable");
+          return twitchCampaignDetails(dropID);
+        }
+        throw new Error(`Unexpected op ${op}`);
+      });
+      const events: EngineEvent[] = [];
+      const discoveryState = new TwitchDiscoveryState();
+      const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
-    expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
-    failing = "b";
-    const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
-    const campaigns = await secondAdapter.refreshCampaigns();
+      expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
+      failing = "b";
+      vi.advanceTimersByTime(6 * 60_000);
+      const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
+      const campaigns = await secondAdapter.refreshCampaigns();
 
-    expect(campaigns.map((campaign) => campaign.id)).toEqual(["a", "b"]);
-    expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("b"))).toBe(true);
+      expect(campaigns.map((campaign) => campaign.id)).toEqual(["a", "b"]);
+      expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("b"))).toBe(true);
+      expect(events).toContainEqual(expect.objectContaining({
+        category: "diagnostic",
+        message: expect.stringMatching(/\(2 operations: 2 fetched, 0 served from cache, 2 stale,/),
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("omits a campaign whose details request fails before it was ever seen, but records it", async () => {
@@ -1764,11 +2103,17 @@ describe("TwitchAdapter", () => {
     expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["campaign"]);
     detailResponse = "missing";
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    const activeSession = {
+      platform: "twitch" as const,
+      status: "watching" as const,
+      campaignId: "campaign",
+      offlineChecks: 0,
+    };
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(activeSession))
       .resolves.toEqual([]);
     detailResponse = "failure";
 
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(activeSession))
       .resolves.toEqual([]);
   });
 
@@ -1786,6 +2131,28 @@ describe("TwitchAdapter", () => {
       discoveryState.rememberCampaignDetails("fresh", { id: "fresh" });
 
       expect([...details.keys()]).toEqual(["fresh"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds retained campaign details with deterministic oldest-id pruning", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      const discoveryState = new TwitchDiscoveryState();
+      const details = (discoveryState as unknown as {
+        campaignDetailsByDropId: Map<string, unknown>;
+      }).campaignDetailsByDropId;
+
+      for (let index = 0; index < 129; index += 1) {
+        const id = `campaign-${index.toString().padStart(3, "0")}`;
+        discoveryState.rememberCampaignDetails(id, { id });
+      }
+
+      expect(details).toHaveLength(128);
+      expect(details.has("campaign-000")).toBe(false);
+      expect(details.has("campaign-128")).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -1574,6 +1574,30 @@ describe("TwitchAdapter", () => {
     }
   });
 
+  it("rejects campaign details restored with malicious 24-hour deadlines", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      const discoveryState = new TwitchDiscoveryState();
+
+      discoveryState.restore({
+        version: 1,
+        userId: "user-id",
+        entries: [{
+          dropID: "campaign",
+          campaign: { id: "campaign", name: "Campaign", timeBasedDrops: [] },
+          freshUntil: "2026-08-02T12:00:00.000Z",
+          retainedUntil: "2026-08-02T12:30:00.000Z",
+        }],
+      });
+
+      expect(discoveryState.freshCampaignDetails("campaign")).toBeUndefined();
+      expect(discoveryState.retainedCampaignDetails("campaign")).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not reuse reconstructed campaign details after authenticated identity changes", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     try {
@@ -1777,6 +1801,51 @@ describe("TwitchAdapter", () => {
     expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())[0]?.name)
       .toBe("Campaign campaign");
     expect(detailRequests).toBe(2);
+  });
+
+  it.each([
+    ["a malformed same-ID candidate", { id: "campaign" }],
+    ["a valid wrong-ID candidate", {
+      id: "other-campaign",
+      name: "Other Campaign",
+      timeBasedDrops: [],
+    }],
+  ])("preserves known-good details when an explicit null conflicts with %s", async (_label, conflictingCampaign) => {
+    let conflicting = false;
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        return body.map((entry) => conflicting
+          ? {
+              data: {
+                dropCampaign: null,
+                user: { dropCampaign: conflictingCampaign },
+              },
+            }
+          : twitchCampaignDetails(String((entry.variables as { dropID?: string }).dropID)));
+      }
+      if (body.operationName === "Inventory") return twitchInventory([]);
+      if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    const activeSession = {
+      platform: "twitch" as const,
+      status: "watching" as const,
+      campaignId: "campaign",
+      offlineChecks: 0,
+    };
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+      .resolves.toEqual([expect.objectContaining({ id: "campaign", name: "Campaign campaign" })]);
+    conflicting = true;
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(activeSession))
+      .resolves.toEqual([expect.objectContaining({ id: "campaign", name: "Campaign campaign" })]);
+    expect(discoveryState.retainedCampaignDetails("campaign")).toMatchObject({
+      id: "campaign",
+      name: "Campaign campaign",
+    });
   });
 
   it.each([
@@ -2005,6 +2074,24 @@ describe("TwitchAdapter", () => {
           id: "user-id",
           login: "viewer",
           dropCampaigns: { campaign: { id: "campaign", status: "ACTIVE" } },
+        },
+      },
+    }],
+    ["has an empty campaign status", {
+      data: {
+        currentUser: {
+          id: "user-id",
+          login: "viewer",
+          dropCampaigns: [{ id: "campaign", status: "" }],
+        },
+      },
+    }],
+    ["has an unknown campaign status", {
+      data: {
+        currentUser: {
+          id: "user-id",
+          login: "viewer",
+          dropCampaigns: [{ id: "campaign", status: "UNKNOWN" }],
         },
       },
     }],
@@ -2278,6 +2365,45 @@ describe("TwitchAdapter", () => {
       name: "Known Good",
       timeBasedDrops: [],
     });
+  });
+
+  it("stagger successful detail deadlines deterministically by campaign ID within five minutes", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      const now = Date.parse("2026-08-01T12:00:00.000Z");
+      vi.setSystemTime(now);
+      const campaignIds = ["campaign-alpha", "campaign-bravo", "campaign-charlie", "campaign-delta"];
+      const deadlinesFor = (ids: readonly string[]): Record<string, number> => {
+        const discoveryState = new TwitchDiscoveryState();
+        discoveryState.setAuthenticatedUser("user-id");
+        for (const id of ids) {
+          discoveryState.rememberCampaignDetails(id, {
+            id,
+            name: `Campaign ${id}`,
+            timeBasedDrops: [],
+          });
+        }
+        return Object.fromEntries(
+          discoveryState.snapshot()?.entries.map((entry) => [entry.dropID, Date.parse(entry.freshUntil)]) ?? [],
+        );
+      };
+
+      const forwardDeadlines = deadlinesFor(campaignIds);
+      const reverseDeadlines = deadlinesFor([...campaignIds].reverse());
+      const deadlines = Object.values(forwardDeadlines);
+
+      expect(reverseDeadlines).toEqual(forwardDeadlines);
+      expect(new Set(deadlines).size).toBeGreaterThan(1);
+      expect(deadlines).toHaveLength(campaignIds.length);
+      expect(deadlines.some((deadline) => deadline <= now + 4 * 60_000)).toBe(true);
+      expect(deadlines.some((deadline) => deadline > now + 4 * 60_000)).toBe(true);
+      for (const deadline of deadlines) {
+        expect(deadline).toBeGreaterThan(now);
+        expect(deadline).toBeLessThanOrEqual(now + 5 * 60_000);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("prunes expired retained campaign details during a later write", () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -1486,6 +1486,55 @@ describe("TwitchAdapter", () => {
     }
   });
 
+  it.each(["starting", "watching"] as const)("fetches reconstructed current campaign details when a valid dashboard omits them while %s", async (status) => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      let dashboardIds = ["campaign"];
+      const detailRequests: string[] = [];
+      const fetcher = jsonFetcher((_url, init) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+        if (Array.isArray(body)) {
+          return body.map((entry) => {
+            const dropID = String((entry.variables as { dropID?: string }).dropID);
+            detailRequests.push(dropID);
+            return twitchCampaignDetails(dropID);
+          });
+        }
+        if (body.operationName === "Inventory") return twitchInventory([]);
+        if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(dashboardIds);
+        throw new Error(`Unexpected operation ${String(body.operationName)}`);
+      });
+      const session = {
+        platform: "twitch" as const,
+        status,
+        campaignId: "campaign",
+        offlineChecks: 0,
+      };
+      const initialDiscoveryState = new TwitchDiscoveryState();
+
+      await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState: initialDiscoveryState })
+        .refreshCampaigns(session);
+      const persisted = JSON.parse(JSON.stringify(initialDiscoveryState.snapshot())) as unknown;
+      const reconstructedDiscoveryState = new TwitchDiscoveryState();
+      reconstructedDiscoveryState.restore(persisted);
+      dashboardIds = [];
+
+      const first = await new TwitchAdapter(fetcher, undefined, undefined, {
+        discoveryState: reconstructedDiscoveryState,
+      }).refreshCampaigns(session);
+      const second = await new TwitchAdapter(fetcher, undefined, undefined, {
+        discoveryState: reconstructedDiscoveryState,
+      }).refreshCampaigns(session);
+
+      expect(first.map((campaign) => campaign.id)).toEqual(["campaign"]);
+      expect(second.map((campaign) => campaign.id)).toEqual(["campaign"]);
+      expect(detailRequests).toEqual(["campaign", "campaign", "campaign"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reuses fresh campaign details after discovery-state reconstruction", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     try {
@@ -1730,6 +1779,61 @@ describe("TwitchAdapter", () => {
     expect(detailRequests).toBe(2);
   });
 
+  it.each([
+    ["a null reward", {
+      id: "campaign",
+      name: "Malformed Campaign",
+      timeBasedDrops: [null],
+    }],
+    ["a null benefit edge", {
+      id: "campaign",
+      name: "Malformed Campaign",
+      timeBasedDrops: [{
+        id: "campaign-drop",
+        requiredMinutesWatched: 60,
+        benefitEdges: [null],
+      }],
+    }],
+    ["a malformed game", {
+      id: "campaign",
+      name: "Malformed Campaign",
+      game: { id: "game", slug: 42 },
+      timeBasedDrops: [],
+    }],
+  ])("rejects nested malformed details with %s and preserves the known-good cache", async (_label, malformedCampaign) => {
+    let malformed = false;
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        return body.map((entry) => malformed
+          ? { data: { dropCampaign: malformedCampaign } }
+          : twitchCampaignDetails(String((entry.variables as { dropID?: string }).dropID)));
+      }
+      if (body.operationName === "Inventory") return twitchInventory([]);
+      if (body.operationName === "ViewerDropsDashboard") return twitchDashboard(["campaign"]);
+      throw new Error(`Unexpected operation ${String(body.operationName)}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    const activeSession = {
+      platform: "twitch" as const,
+      status: "watching" as const,
+      campaignId: "campaign",
+      offlineChecks: 0,
+    };
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+      .resolves.toEqual([expect.objectContaining({ id: "campaign", name: "Campaign campaign" })]);
+    malformed = true;
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(activeSession))
+      .resolves.toEqual([expect.objectContaining({ id: "campaign", name: "Campaign campaign" })]);
+    expect(discoveryState.retainedCampaignDetails("campaign")).toMatchObject({
+      id: "campaign",
+      name: "Campaign campaign",
+      timeBasedDrops: [{ id: "campaign-drop" }],
+    });
+  });
+
   it("starts Twitch inventory and dashboard discovery requests concurrently", async () => {
     let releaseInventory!: () => void;
     const inventoryGate = new Promise<void>((resolve) => {
@@ -1891,6 +1995,44 @@ describe("TwitchAdapter", () => {
 
     dashboardFails = false;
     expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+  });
+
+  it.each([
+    ["is absent", { data: { currentUser: { id: "user-id", login: "viewer" } } }],
+    ["has the wrong shape", {
+      data: {
+        currentUser: {
+          id: "user-id",
+          login: "viewer",
+          dropCampaigns: { campaign: { id: "campaign", status: "ACTIVE" } },
+        },
+      },
+    }],
+  ])("retains cached campaigns when the dashboard campaign collection %s", async (_label, malformedDashboard) => {
+    let malformed = false;
+    let detailRequests = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([]);
+      if (op === "ViewerDropsDashboard") {
+        return malformed ? malformedDashboard : twitchDashboard(["campaign"]);
+      }
+      if (op === "DropCampaignDetails") {
+        detailRequests += 1;
+        return twitchCampaignDetails("campaign");
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+      .resolves.toEqual([expect.objectContaining({ id: "campaign" })]);
+    malformed = true;
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+      .resolves.toEqual([expect.objectContaining({ id: "campaign" })]);
+    expect(discoveryState.retainedCampaignDetails("campaign")).toBeDefined();
+    expect(detailRequests).toBe(1);
   });
 
   it("does not retain dashboard campaigns when the dashboard genuinely returns none", async () => {
@@ -2117,6 +2259,27 @@ describe("TwitchAdapter", () => {
       .resolves.toEqual([]);
   });
 
+  it("does not replace known-good details through a malformed cache write", () => {
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.rememberCampaignDetails("campaign", {
+      id: "campaign",
+      name: "Known Good",
+      timeBasedDrops: [],
+    });
+
+    discoveryState.rememberCampaignDetails("campaign", {
+      id: "campaign",
+      name: "Malformed",
+      timeBasedDrops: [null],
+    });
+
+    expect(discoveryState.retainedCampaignDetails("campaign")).toEqual({
+      id: "campaign",
+      name: "Known Good",
+      timeBasedDrops: [],
+    });
+  });
+
   it("prunes expired retained campaign details during a later write", () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     try {
@@ -2126,9 +2289,17 @@ describe("TwitchAdapter", () => {
         campaignDetailsByDropId: Map<string, unknown>;
       }).campaignDetailsByDropId;
 
-      discoveryState.rememberCampaignDetails("expired", { id: "expired" });
+      discoveryState.rememberCampaignDetails("expired", {
+        id: "expired",
+        name: "Expired",
+        timeBasedDrops: [],
+      });
       vi.setSystemTime("2026-07-26T12:31:00.000Z");
-      discoveryState.rememberCampaignDetails("fresh", { id: "fresh" });
+      discoveryState.rememberCampaignDetails("fresh", {
+        id: "fresh",
+        name: "Fresh",
+        timeBasedDrops: [],
+      });
 
       expect([...details.keys()]).toEqual(["fresh"]);
     } finally {
@@ -2147,7 +2318,11 @@ describe("TwitchAdapter", () => {
 
       for (let index = 0; index < 129; index += 1) {
         const id = `campaign-${index.toString().padStart(3, "0")}`;
-        discoveryState.rememberCampaignDetails(id, { id });
+        discoveryState.rememberCampaignDetails(id, {
+          id,
+          name: `Campaign ${index}`,
+          timeBasedDrops: [],
+        });
       }
 
       expect(details).toHaveLength(128);

--- a/packages/extension/tests/platformState.test.ts
+++ b/packages/extension/tests/platformState.test.ts
@@ -1,6 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Platform, SchedulerState } from "@lurkloot/shared/models";
 import { mergePlatformState } from "@lurkloot/core/background/platformState";
+import { mergeSchedulerState } from "@lurkloot/core/defaults";
+
+function discoverySnapshot(
+  overrides: Record<string, unknown> = {},
+  entryOverrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    version: 1,
+    userId: "user-id",
+    entries: [{
+      dropID: "campaign",
+      campaign: { id: "campaign", name: "Campaign", timeBasedDrops: [] },
+      freshUntil: "2026-08-01T12:05:00.000Z",
+      retainedUntil: "2026-08-01T12:30:00.000Z",
+      ...entryOverrides,
+    }],
+    ...overrides,
+  };
+}
 
 function state(label: string, lastTickAt: string): SchedulerState {
   const session = (platform: Platform) => ({
@@ -81,5 +100,70 @@ describe("mergePlatformState", () => {
       destination.deadlineInfeasibleRewardIds?.kick,
     );
     expect(merged.lastTickAt).toBe("2026-07-29T12:00:00.000Z");
+  });
+
+  it("replaces Twitch discovery only with the Twitch platform slice", () => {
+    const destination = state("destination", "2026-07-29T11:00:00.000Z") as SchedulerState & {
+      twitchDiscovery?: unknown;
+    };
+    const source = state("source", "2026-07-29T12:00:00.000Z") as SchedulerState & {
+      twitchDiscovery?: unknown;
+    };
+    destination.twitchDiscovery = discoverySnapshot({ userId: "destination-user" }) as unknown as SchedulerState["twitchDiscovery"];
+    source.twitchDiscovery = discoverySnapshot({ userId: "source-user" }) as unknown as SchedulerState["twitchDiscovery"];
+
+    expect((mergePlatformState(destination, source, "twitch") as SchedulerState & { twitchDiscovery?: unknown })
+      .twitchDiscovery).toEqual(source.twitchDiscovery);
+    expect((mergePlatformState(destination, source, "kick") as SchedulerState & { twitchDiscovery?: unknown })
+      .twitchDiscovery).toEqual(destination.twitchDiscovery);
+  });
+});
+
+describe("mergeSchedulerState Twitch discovery", () => {
+  it("keeps a valid versioned fresh snapshot", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      const snapshot = discoverySnapshot() as unknown as NonNullable<SchedulerState["twitchDiscovery"]>;
+
+      const merged = mergeSchedulerState({ twitchDiscovery: snapshot });
+
+      expect((merged as SchedulerState & { twitchDiscovery?: unknown }).twitchDiscovery).toEqual(snapshot);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    ["unknown version", discoverySnapshot({ version: 2 })],
+    ["missing identity", discoverySnapshot({ userId: "" })],
+    ["expired entry", discoverySnapshot({}, { freshUntil: "2026-08-01T12:00:00.000Z" })],
+    ["mismatched campaign identity", discoverySnapshot({}, { campaign: { id: "other" } })],
+    ["malformed campaign payload", discoverySnapshot({}, { campaign: { id: "campaign", name: "Campaign" } })],
+    ["duplicate campaign identity", discoverySnapshot({
+      entries: [
+        (discoverySnapshot().entries as unknown[])[0],
+        (discoverySnapshot().entries as unknown[])[0],
+      ],
+    })],
+    ["oversized entry set", discoverySnapshot({
+      entries: Array.from({ length: 129 }, (_, index) => ({
+        dropID: `campaign-${index}`,
+        campaign: { id: `campaign-${index}`, name: `Campaign ${index}`, timeBasedDrops: [] },
+        freshUntil: "2026-08-01T12:05:00.000Z",
+        retainedUntil: "2026-08-01T12:30:00.000Z",
+      })),
+    })],
+  ])("discards a snapshot with %s", (_label, snapshot) => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+
+      const merged = mergeSchedulerState({ twitchDiscovery: snapshot } as unknown as Partial<SchedulerState>);
+
+      expect((merged as SchedulerState & { twitchDiscovery?: unknown }).twitchDiscovery).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/extension/tests/platformState.test.ts
+++ b/packages/extension/tests/platformState.test.ts
@@ -140,6 +140,24 @@ describe("mergeSchedulerState Twitch discovery", () => {
     ["expired entry", discoverySnapshot({}, { freshUntil: "2026-08-01T12:00:00.000Z" })],
     ["mismatched campaign identity", discoverySnapshot({}, { campaign: { id: "other" } })],
     ["malformed campaign payload", discoverySnapshot({}, { campaign: { id: "campaign", name: "Campaign" } })],
+    ["null campaign reward", discoverySnapshot({}, {
+      campaign: { id: "campaign", name: "Campaign", timeBasedDrops: [null] },
+    })],
+    ["null campaign benefit edge", discoverySnapshot({}, {
+      campaign: {
+        id: "campaign",
+        name: "Campaign",
+        timeBasedDrops: [{ id: "drop", benefitEdges: [null] }],
+      },
+    })],
+    ["malformed campaign game", discoverySnapshot({}, {
+      campaign: {
+        id: "campaign",
+        name: "Campaign",
+        game: { id: "game", slug: 42 },
+        timeBasedDrops: [],
+      },
+    })],
     ["duplicate campaign identity", discoverySnapshot({
       entries: [
         (discoverySnapshot().entries as unknown[])[0],

--- a/packages/extension/tests/platformState.test.ts
+++ b/packages/extension/tests/platformState.test.ts
@@ -138,6 +138,12 @@ describe("mergeSchedulerState Twitch discovery", () => {
     ["unknown version", discoverySnapshot({ version: 2 })],
     ["missing identity", discoverySnapshot({ userId: "" })],
     ["expired entry", discoverySnapshot({}, { freshUntil: "2026-08-01T12:00:00.000Z" })],
+    ["fresh deadline beyond the five-minute restore horizon", discoverySnapshot({}, {
+      freshUntil: "2026-08-01T12:05:00.001Z",
+    })],
+    ["24-hour retained deadline", discoverySnapshot({}, {
+      retainedUntil: "2026-08-02T12:00:00.000Z",
+    })],
     ["mismatched campaign identity", discoverySnapshot({}, { campaign: { id: "other" } })],
     ["malformed campaign payload", discoverySnapshot({}, { campaign: { id: "campaign", name: "Campaign" } })],
     ["null campaign reward", discoverySnapshot({}, {

--- a/packages/extension/tests/storageMigration.test.ts
+++ b/packages/extension/tests/storageMigration.test.ts
@@ -25,7 +25,8 @@ vi.mock("../src/core/activityStorage", () => ({
   importLegacyActivityEvents: mocks.importLegacyActivityEvents,
 }));
 
-import { DEFAULT_STATE, loadState, resetStorage, saveState } from "../src/core/storage";
+import { createTwitchDiscoveryStateStorage, DEFAULT_STATE, loadState, resetStorage, saveState } from "../src/core/storage";
+import { TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
 import { withSchemaVersion } from "@lurkloot/shared/settingsSchema";
 
@@ -140,5 +141,56 @@ describe("legacy activity migration", () => {
     await expect(resetStorage()).resolves.toBeUndefined();
 
     expect(mocks.values.schedulerState).toEqual(DEFAULT_STATE);
+  });
+
+  it("restores fresh Twitch details across a reconstructed state-storage boundary", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      mocks.values.schedulerState = DEFAULT_STATE;
+      const firstDiscoveryState = new TwitchDiscoveryState();
+      const firstStorage = createTwitchDiscoveryStateStorage(firstDiscoveryState);
+      await firstStorage.loadState();
+      firstDiscoveryState.setAuthenticatedUser("user-id");
+      firstDiscoveryState.rememberCampaignDetails("campaign", {
+        id: "campaign",
+        name: "Campaign",
+        timeBasedDrops: [],
+      });
+      await firstStorage.saveState(DEFAULT_STATE);
+
+      vi.advanceTimersByTime(60_000);
+      const reconstructedDiscoveryState = new TwitchDiscoveryState();
+      const reconstructedStorage = createTwitchDiscoveryStateStorage(reconstructedDiscoveryState);
+      await reconstructedStorage.loadState();
+
+      expect(reconstructedDiscoveryState.freshCampaignDetails("campaign"))
+        .toEqual({ id: "campaign", name: "Campaign", timeBasedDrops: [] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears restored Twitch details during an extension storage reset", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-01T12:00:00.000Z");
+      const discoveryState = new TwitchDiscoveryState();
+      const stateStorage = createTwitchDiscoveryStateStorage(discoveryState);
+      await stateStorage.loadState();
+      discoveryState.setAuthenticatedUser("user-id");
+      discoveryState.rememberCampaignDetails("campaign", {
+        id: "campaign",
+        name: "Campaign",
+        timeBasedDrops: [],
+      });
+
+      await stateStorage.resetStorage();
+
+      expect(discoveryState.freshCampaignDetails("campaign")).toBeUndefined();
+      expect(mocks.values.schedulerState).toEqual(DEFAULT_STATE);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -385,6 +385,22 @@ export interface ExtensionSettings extends EngineSettings {
   diagnosticLogging: boolean;
 }
 
+export const TWITCH_DISCOVERY_SNAPSHOT_VERSION = 1;
+export const TWITCH_DISCOVERY_SNAPSHOT_MAX_ENTRIES = 128;
+
+export interface TwitchDiscoverySnapshotEntry {
+  dropID: string;
+  campaign: unknown;
+  freshUntil: string;
+  retainedUntil: string;
+}
+
+export interface TwitchDiscoverySnapshot {
+  version: typeof TWITCH_DISCOVERY_SNAPSHOT_VERSION;
+  userId: string;
+  entries: TwitchDiscoverySnapshotEntry[];
+}
+
 export interface SchedulerState {
   sessions: Record<Platform, WatchSession>;
   authHealth: Record<Platform, PlatformAuthHealth>;
@@ -401,6 +417,10 @@ export interface SchedulerState {
   // Persisted because adapters are rebuilt every tick, so an in-memory throttle
   // would never survive to the next one.
   gamification?: Partial<Record<Platform, { lastCheckedAt: string }>>;
+  // Versioned, bounded raw Twitch campaign details that are still inside the
+  // short read-through window. The host may persist this browser-free snapshot
+  // so an MV3 service-worker reconstruction does not force a cold details pass.
+  twitchDiscovery?: TwitchDiscoverySnapshot;
   campaigns: Record<Platform, DropCampaign[]>;
   deadlineInfeasibleRewardIds?: Partial<Record<Platform, string[]>>;
   lastTickAt?: string;


### PR DESCRIPTION
## Summary

- Reuse successful Twitch campaign detail reads with a bounded, identity-scoped discovery cache.
- Keep the current watched/starting campaign fresh on every discovery, including after service-worker reconstruction.
- Use deterministic per-campaign freshness spread (just over three to five minutes) to avoid synchronized large-batch expiry.
- Preserve the existing thirty-minute outage fallback, dashboard reconciliation, claim invalidation, and progress merging.
- Persist only validated fresh entries at the extension storage boundary; CLI transports remain process-local.

## Reliability hardening

- Reject malformed nested detail payloads before they can poison live, retained, or persisted cache state.
- Bound restored fresh/retained deadlines to the five-minute/30-minute horizons.
- Treat conflicting detail envelopes and malformed or absent dashboard campaign collections as ambiguous.
- Keep explicit campaign absence and valid empty dashboard collections authoritative.

## Verification

- Focused boundary suite: 442 tests passed.
- Full suite: CLI 138, extension 1,350, site 3 passed.
- pnpm typecheck: all workspace packages passed.
- git diff --check: clean.
- Final task review: clean.

Closes #339