### PR TITLE
perf(twitch): share channel availability cache across ticks

### DIFF
--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -346,6 +346,11 @@ type CampaignAvailabilityCacheLookup =
   | { status: "hit"; available: boolean }
   | { status: "miss" | "expired" };
 
+interface AvailabilityRequestIdentity {
+  userId: string;
+  generation: number;
+}
+
 interface CachedCampaignDetails {
   campaign: unknown;
   freshUntil: number;
@@ -384,6 +389,7 @@ export class TwitchDiscoveryState {
   private readonly availableCampaignsByChannel = new Map<string, CachedAvailableCampaigns>();
   private readonly campaignDetailsByDropId = new Map<string, CachedCampaignDetails>();
   private authenticatedUserId?: string;
+  private identityGeneration = 0;
   private retainedDashboard?: CachedDashboardCampaigns;
 
   setAuthenticatedUser(userId: string): number {
@@ -393,15 +399,25 @@ export class TwitchDiscoveryState {
       this.authenticatedUserId = userId;
       return invalidatedAvailabilityEntries;
     }
+    if (this.authenticatedUserId !== userId) this.identityGeneration += 1;
     this.authenticatedUserId = userId;
     return 0;
   }
 
   clear(): void {
+    this.identityGeneration += 1;
     this.authenticatedUserId = undefined;
     this.retainedDashboard = undefined;
     this.availableCampaignsByChannel.clear();
     this.campaignDetailsByDropId.clear();
+  }
+
+  availabilityRequestIdentity(): AvailabilityRequestIdentity | undefined {
+    if (!this.authenticatedUserId) return undefined;
+    return {
+      userId: this.authenticatedUserId,
+      generation: this.identityGeneration,
+    };
   }
 
   campaignAvailability(channelId: string, campaignId: string): CampaignAvailabilityCacheLookup {
@@ -418,15 +434,23 @@ export class TwitchDiscoveryState {
     return { status: "hit", available: cached.campaignIds.has(campaignId) };
   }
 
-  rememberAvailableCampaigns(channelId: string, campaignIds: Iterable<string>): void {
-    if (!this.authenticatedUserId) return;
+  rememberAvailableCampaigns(
+    channelId: string,
+    campaignIds: Iterable<string>,
+    requestIdentity: AvailabilityRequestIdentity | undefined,
+  ): void {
+    if (
+      !requestIdentity
+      || requestIdentity.userId !== this.authenticatedUserId
+      || requestIdentity.generation !== this.identityGeneration
+    ) return;
     const now = Date.now();
     for (const [cachedChannelId, cached] of this.availableCampaignsByChannel) {
       if (cached.expiresAt <= now) this.availableCampaignsByChannel.delete(cachedChannelId);
     }
     this.availableCampaignsByChannel.delete(channelId);
     this.availableCampaignsByChannel.set(channelId, {
-      userId: this.authenticatedUserId,
+      userId: requestIdentity.userId,
       campaignIds: new Set(campaignIds),
       expiresAt: now + CHANNEL_CAMPAIGN_CACHE_TTL_MS,
     });
@@ -1392,6 +1416,7 @@ export class TwitchAdapter implements PlatformAdapter {
         ),
       );
     };
+    const requestIdentity = this.discoveryState.availabilityRequestIdentity();
     const integrity = this.options.currentIntegrity?.();
     let raw: unknown;
     try {
@@ -1449,7 +1474,11 @@ export class TwitchAdapter implements PlatformAdapter {
         await fallback(candidate);
         continue;
       }
-      this.discoveryState.rememberAvailableCampaigns(candidate.channelId, campaignIds);
+      this.discoveryState.rememberAvailableCampaigns(
+        candidate.channelId,
+        campaignIds,
+        requestIdentity,
+      );
       matches.set(candidate.channelId, campaignIds.has(campaignId));
     }
     return { matches, singleFallbacks };
@@ -1600,6 +1629,7 @@ export class TwitchAdapter implements PlatformAdapter {
       };
     } catch (error) {
       signal?.throwIfAborted();
+      if (authHealthFromError(error)) throw error;
       return this.checkChannelFromPage(channel, campaign, error, signal);
     }
   }
@@ -1617,6 +1647,7 @@ export class TwitchAdapter implements PlatformAdapter {
       if (cached.status === "hit") return cached.available;
     }
 
+    const requestIdentity = this.discoveryState.availabilityRequestIdentity();
     try {
       if (metrics) metrics.checks += 1;
       const response = await this.gqlWithIntegrityRetry<TwitchAvailableDropsData>(
@@ -1634,7 +1665,7 @@ export class TwitchAdapter implements PlatformAdapter {
         return undefined;
       }
 
-      this.discoveryState.rememberAvailableCampaigns(channelId, campaignIds);
+      this.discoveryState.rememberAvailableCampaigns(channelId, campaignIds, requestIdentity);
       return campaignIds.has(campaignId);
     } catch (error) {
       signal?.throwIfAborted();

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -34,7 +34,11 @@ const CURRENT_USER_QUERY = "query CurrentUser { currentUser { id } }";
 // Twitch's web Client-ID — the default identity. It is the one Twitch gates
 // behind Client-Integrity (Kasada); non-web client ids (Android/TV) are not.
 const TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
-const CHANNEL_CAMPAIGN_CACHE_TTL_MS = 60_000;
+// Discovery normally runs once per minute. Keep one full tick of headroom so
+// scheduler-created adapters can reuse an authoritative answer on the next
+// tick without extending channel availability beyond a short-lived window.
+const CHANNEL_CAMPAIGN_CACHE_TTL_MS = 2 * 60_000;
+const CHANNEL_CAMPAIGN_CACHE_MAX_ENTRIES = 128;
 const DISCOVERY_DETAIL_CACHE_TTL_MS = 5 * 60_000;
 // Wider than the default one-minute discovery cadence, so one batch crosses
 // its deadlines over two later ticks while every entry remains fresh for >3m.
@@ -333,9 +337,14 @@ interface TwitchAvailableDropsData {
 }
 
 interface CachedAvailableCampaigns {
+  userId: string;
   campaignIds: Set<string>;
   expiresAt: number;
 }
+
+type CampaignAvailabilityCacheLookup =
+  | { status: "hit"; available: boolean }
+  | { status: "miss" | "expired" };
 
 interface CachedCampaignDetails {
   campaign: unknown;
@@ -372,21 +381,60 @@ function reconcileInventoryCampaignStatuses(
 }
 
 export class TwitchDiscoveryState {
+  private readonly availableCampaignsByChannel = new Map<string, CachedAvailableCampaigns>();
   private readonly campaignDetailsByDropId = new Map<string, CachedCampaignDetails>();
   private authenticatedUserId?: string;
   private retainedDashboard?: CachedDashboardCampaigns;
 
-  setAuthenticatedUser(userId: string): void {
+  setAuthenticatedUser(userId: string): number {
     if (this.authenticatedUserId && this.authenticatedUserId !== userId) {
+      const invalidatedAvailabilityEntries = this.availableCampaignsByChannel.size;
       this.clear();
+      this.authenticatedUserId = userId;
+      return invalidatedAvailabilityEntries;
     }
     this.authenticatedUserId = userId;
+    return 0;
   }
 
   clear(): void {
     this.authenticatedUserId = undefined;
     this.retainedDashboard = undefined;
+    this.availableCampaignsByChannel.clear();
     this.campaignDetailsByDropId.clear();
+  }
+
+  campaignAvailability(channelId: string, campaignId: string): CampaignAvailabilityCacheLookup {
+    const cached = this.availableCampaignsByChannel.get(channelId);
+    if (!cached || !this.authenticatedUserId) return { status: "miss" };
+    if (cached.userId !== this.authenticatedUserId) {
+      this.availableCampaignsByChannel.delete(channelId);
+      return { status: "miss" };
+    }
+    if (cached.expiresAt <= Date.now()) {
+      this.availableCampaignsByChannel.delete(channelId);
+      return { status: "expired" };
+    }
+    return { status: "hit", available: cached.campaignIds.has(campaignId) };
+  }
+
+  rememberAvailableCampaigns(channelId: string, campaignIds: Iterable<string>): void {
+    if (!this.authenticatedUserId) return;
+    const now = Date.now();
+    for (const [cachedChannelId, cached] of this.availableCampaignsByChannel) {
+      if (cached.expiresAt <= now) this.availableCampaignsByChannel.delete(cachedChannelId);
+    }
+    this.availableCampaignsByChannel.delete(channelId);
+    this.availableCampaignsByChannel.set(channelId, {
+      userId: this.authenticatedUserId,
+      campaignIds: new Set(campaignIds),
+      expiresAt: now + CHANNEL_CAMPAIGN_CACHE_TTL_MS,
+    });
+    while (this.availableCampaignsByChannel.size > CHANNEL_CAMPAIGN_CACHE_MAX_ENTRIES) {
+      const oldestChannelId = this.availableCampaignsByChannel.keys().next().value;
+      if (typeof oldestChannelId !== "string") break;
+      this.availableCampaignsByChannel.delete(oldestChannelId);
+    }
   }
 
   snapshot(): TwitchDiscoverySnapshot | undefined {
@@ -673,7 +721,6 @@ export class TwitchAdapter implements PlatformAdapter {
 
   private readonly gqlTransport: TwitchGqlTransport;
   private readonly inventoryCapability: TwitchInventoryCapability;
-  private readonly availableCampaignsByChannel = new Map<string, CachedAvailableCampaigns>();
   private readonly discoveryState: TwitchDiscoveryState;
 
   constructor(
@@ -752,7 +799,18 @@ export class TwitchAdapter implements PlatformAdapter {
     }
 
     const authenticatedUserId = twitchCurrentUserId(inventory) ?? dashboard.data?.currentUser?.id;
-    if (authenticatedUserId) this.discoveryState.setAuthenticatedUser(authenticatedUserId);
+    if (authenticatedUserId) {
+      const invalidatedAvailabilityEntries = this.discoveryState.setAuthenticatedUser(authenticatedUserId);
+      if (invalidatedAvailabilityEntries > 0) {
+        const entryLabel = invalidatedAvailabilityEntries === 1 ? "entry" : "entries";
+        diagnostic(
+          this.emit,
+          "debug",
+          `Twitch availability cache invalidated after authenticated identity changed (${invalidatedAvailabilityEntries} ${entryLabel})`,
+          "twitch",
+        );
+      }
+    }
     const userLogin = authenticatedUserId ?? dashboard.data?.currentUser?.login ?? "";
     const freshCampaignIds = dashboardCampaigns
       .filter((campaign) =>
@@ -1152,15 +1210,22 @@ export class TwitchAdapter implements PlatformAdapter {
           batchRequests: 0,
           singleFallbacks: 0,
           cacheHits: 0,
+          cacheMisses: 0,
+          cacheExpirations: 0,
         };
 
     let checked = 0;
     let winnerFallbacks = 0;
     const reportSelectionFinished = () => {
+      const cacheHitLabel = availabilityResult.cacheHits === 1 ? "hit" : "hits";
+      const cacheMissLabel = availabilityResult.cacheMisses === 1 ? "miss" : "misses";
+      const cacheExpirationLabel = availabilityResult.cacheExpirations === 1
+        ? "expiration"
+        : "expirations";
       diagnostic(
         this.emit,
         "debug",
-        `Twitch ${selectionDescription} finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
+        `Twitch ${selectionDescription} finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache ${cacheHitLabel}, ${availabilityResult.cacheMisses} availability cache ${cacheMissLabel}, ${availabilityResult.cacheExpirations} availability cache ${cacheExpirationLabel}, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
         "twitch",
       );
     };
@@ -1193,6 +1258,22 @@ export class TwitchAdapter implements PlatformAdapter {
     return { checked: candidates.length };
   }
 
+  private cachedCampaignAvailability(
+    channelId: string,
+    campaignId: string,
+    metrics?: { cacheHits: number },
+  ): CampaignAvailabilityCacheLookup {
+    const lookup = this.discoveryState.campaignAvailability(channelId, campaignId);
+    diagnostic(
+      this.emit,
+      "debug",
+      `Twitch availability cache ${lookup.status} for channel ${channelId}`,
+      "twitch",
+    );
+    if (lookup.status === "hit" && metrics) metrics.cacheHits += 1;
+    return lookup;
+  }
+
   private async batchCampaignAvailability(
     candidates: readonly { channelId: string; channelLogin: string }[],
     campaignId: string,
@@ -1202,19 +1283,24 @@ export class TwitchAdapter implements PlatformAdapter {
     batchRequests: number;
     singleFallbacks: number;
     cacheHits: number;
+    cacheMisses: number;
+    cacheExpirations: number;
   }> {
     const matches = new Map<string, boolean | undefined>();
     const uncached: Array<{ channelId: string; channelLogin: string }> = [];
     let cacheHits = 0;
+    let cacheMisses = 0;
+    let cacheExpirations = 0;
     for (const candidate of candidates) {
       if (matches.has(candidate.channelId)) continue;
-      const cached = this.availableCampaignsByChannel.get(candidate.channelId);
-      if (cached && cached.expiresAt > Date.now()) {
+      const cached = this.discoveryState.campaignAvailability(candidate.channelId, campaignId);
+      if (cached.status === "hit") {
         cacheHits += 1;
-        matches.set(candidate.channelId, cached.campaignIds.has(campaignId));
+        matches.set(candidate.channelId, cached.available);
         continue;
       }
-      if (cached) this.availableCampaignsByChannel.delete(candidate.channelId);
+      if (cached.status === "expired") cacheExpirations += 1;
+      else cacheMisses += 1;
       uncached.push(candidate);
     }
     if (uncached.length === 1) {
@@ -1228,6 +1314,7 @@ export class TwitchAdapter implements PlatformAdapter {
           candidate.channelLogin,
           signal,
           metrics,
+          true,
         ),
       );
       return {
@@ -1235,6 +1322,8 @@ export class TwitchAdapter implements PlatformAdapter {
         batchRequests: 0,
         singleFallbacks: metrics.checks,
         cacheHits: cacheHits + metrics.cacheHits,
+        cacheMisses,
+        cacheExpirations,
       };
     }
     const chunks = Array.from(
@@ -1274,6 +1363,8 @@ export class TwitchAdapter implements PlatformAdapter {
       batchRequests: chunks.length,
       singleFallbacks: results.reduce((total, result) => total + result.singleFallbacks, 0),
       cacheHits,
+      cacheMisses,
+      cacheExpirations,
     };
   }
 
@@ -1296,6 +1387,8 @@ export class TwitchAdapter implements PlatformAdapter {
           campaignId,
           candidate.channelLogin,
           signal,
+          undefined,
+          true,
         ),
       );
     };
@@ -1348,19 +1441,15 @@ export class TwitchAdapter implements PlatformAdapter {
     let singleFallbacks = 0;
     for (const [index, candidate] of candidates.entries()) {
       const response = normalizeTwitchGqlResponse<TwitchAvailableDropsData>(responses[index]);
-      const campaigns = response?.data?.channel?.viewerDropCampaigns;
-      if (!Array.isArray(campaigns) || response?.errors?.length || response?.error) {
+      const campaignIds = response
+        ? twitchAvailableCampaignIds(response, candidate.channelId)
+        : undefined;
+      if (!campaignIds) {
         singleFallbacks += 1;
         await fallback(candidate);
         continue;
       }
-      const campaignIds = new Set(
-        campaigns.map((campaign) => campaign.id).filter((id): id is string => Boolean(id)),
-      );
-      this.availableCampaignsByChannel.set(candidate.channelId, {
-        campaignIds,
-        expiresAt: Date.now() + CHANNEL_CAMPAIGN_CACHE_TTL_MS,
-      });
+      this.discoveryState.rememberAvailableCampaigns(candidate.channelId, campaignIds);
       matches.set(candidate.channelId, campaignIds.has(campaignId));
     }
     return { matches, singleFallbacks };
@@ -1521,13 +1610,12 @@ export class TwitchAdapter implements PlatformAdapter {
     channelLogin: string,
     signal?: AbortSignal,
     metrics?: { checks: number; cacheHits: number },
+    cacheAlreadyChecked = false,
   ): Promise<boolean | undefined> {
-    const cached = this.availableCampaignsByChannel.get(channelId);
-    if (cached && cached.expiresAt > Date.now()) {
-      if (metrics) metrics.cacheHits += 1;
-      return cached.campaignIds.has(campaignId);
+    if (!cacheAlreadyChecked) {
+      const cached = this.cachedCampaignAvailability(channelId, campaignId, metrics);
+      if (cached.status === "hit") return cached.available;
     }
-    if (cached) this.availableCampaignsByChannel.delete(channelId);
 
     try {
       if (metrics) metrics.checks += 1;
@@ -1540,19 +1628,13 @@ export class TwitchAdapter implements PlatformAdapter {
         this.emit,
         signal,
       );
-      const campaigns = response.data?.channel?.viewerDropCampaigns;
-      if (!Array.isArray(campaigns)) {
+      const campaignIds = twitchAvailableCampaignIds(response, channelId);
+      if (!campaignIds) {
         diagnostic(this.emit, "debug", `Twitch did not return available campaign data for ${channelLogin}; using live/category validation`, "twitch");
         return undefined;
       }
 
-      const campaignIds = new Set(
-        campaigns.map((campaign) => campaign.id).filter((id): id is string => Boolean(id)),
-      );
-      this.availableCampaignsByChannel.set(channelId, {
-        campaignIds,
-        expiresAt: Date.now() + CHANNEL_CAMPAIGN_CACHE_TTL_MS,
-      });
+      this.discoveryState.rememberAvailableCampaigns(channelId, campaignIds);
       return campaignIds.has(campaignId);
     } catch (error) {
       signal?.throwIfAborted();
@@ -2056,6 +2138,24 @@ function twitchDashboardCampaigns(dashboard: unknown): TwitchDashboardCampaign[]
     && typeof campaign.status === "string"
     && TWITCH_DASHBOARD_CAMPAIGN_STATUSES.has(campaign.status))) return undefined;
   return campaigns as TwitchDashboardCampaign[];
+}
+
+function twitchAvailableCampaignIds(
+  response: TwitchGqlResponse<TwitchAvailableDropsData>,
+  expectedChannelId: string,
+): Set<string> | undefined {
+  if (response.errors?.length || response.error) return undefined;
+  const channel = response.data?.channel;
+  if (!channel || !Array.isArray(channel.viewerDropCampaigns)) return undefined;
+  if (channel.id !== expectedChannelId) return undefined;
+  const campaignIds = new Set<string>();
+  for (const campaign of channel.viewerDropCampaigns) {
+    if (!isRecord(campaign) || typeof campaign.id !== "string" || campaign.id.length === 0) {
+      return undefined;
+    }
+    campaignIds.add(campaign.id);
+  }
+  return campaignIds;
 }
 
 function twitchCurrentUserId(value: unknown): string | undefined {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -1588,8 +1588,9 @@ export class TwitchAdapter implements PlatformAdapter {
     channel: ChannelCandidate,
     { campaign, signal }: AdapterOperationOptions & { campaign?: DropCampaign } = {},
   ): Promise<ChannelCheck> {
+    let response: TwitchGqlResponse<TwitchStreamInfoData>;
     try {
-      const response = await this.gql<TwitchStreamInfoData>(
+      response = await this.gql<TwitchStreamInfoData>(
         "StreamInfo",
         TWITCH_QUERIES.streamInfoHash,
         { channel: channel.username },
@@ -1600,38 +1601,38 @@ export class TwitchAdapter implements PlatformAdapter {
         this.emit,
         signal,
       );
-      const stream = response.data?.user?.stream;
-      const channelId = response.data?.user?.id;
-      const actualCategoryId = stream?.game?.id;
-      const expectedCategoryId = campaign?.categoryId ?? channel.categoryId;
-      const categoryMatches = !expectedCategoryId || actualCategoryId === expectedCategoryId;
-      const campaignMatches = stream && categoryMatches && campaign && channelId
-        ? await this.checkCampaignAvailability(channelId, campaign.id, channel.username, signal)
-        : undefined;
-      return {
-        live: Boolean(stream),
-        categoryMatches,
-        campaignMatches,
-        reason: !stream
-          ? "Twitch channel is offline"
-          : campaignMatches === false
-            ? "Twitch campaign is not available on this channel"
-            : undefined,
-        candidate: {
-          ...channel,
-          displayName: response.data?.user?.displayName ?? channel.displayName,
-          categoryId: actualCategoryId ?? channel.categoryId,
-          categoryName: stream?.game?.name ?? channel.categoryName,
-          viewerCount: stream?.viewersCount ?? channel.viewerCount,
-          channelId: channelId ?? channel.channelId,
-          broadcastId: stream?.id ?? channel.broadcastId,
-        },
-      };
     } catch (error) {
       signal?.throwIfAborted();
-      if (authHealthFromError(error)) throw error;
       return this.checkChannelFromPage(channel, campaign, error, signal);
     }
+
+    const stream = response.data?.user?.stream;
+    const channelId = response.data?.user?.id;
+    const actualCategoryId = stream?.game?.id;
+    const expectedCategoryId = campaign?.categoryId ?? channel.categoryId;
+    const categoryMatches = !expectedCategoryId || actualCategoryId === expectedCategoryId;
+    const campaignMatches = stream && categoryMatches && campaign && channelId
+      ? await this.checkCampaignAvailability(channelId, campaign.id, channel.username, signal)
+      : undefined;
+    return {
+      live: Boolean(stream),
+      categoryMatches,
+      campaignMatches,
+      reason: !stream
+        ? "Twitch channel is offline"
+        : campaignMatches === false
+          ? "Twitch campaign is not available on this channel"
+          : undefined,
+      candidate: {
+        ...channel,
+        displayName: response.data?.user?.displayName ?? channel.displayName,
+        categoryId: actualCategoryId ?? channel.categoryId,
+        categoryName: stream?.game?.name ?? channel.categoryName,
+        viewerCount: stream?.viewersCount ?? channel.viewerCount,
+        channelId: channelId ?? channel.channelId,
+        broadcastId: stream?.id ?? channel.broadcastId,
+      },
+    };
   }
 
   private async checkCampaignAvailability(

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -26,6 +26,14 @@ function requestBody(init?: RequestInit): Record<string, unknown> {
   return JSON.parse(String(init?.body)) as Record<string, unknown>;
 }
 
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
 function twitchInventory(campaignIds: string[], userId = "user-id", watchedMinutes = 20): unknown {
   return {
     data: {
@@ -3447,6 +3455,119 @@ describe("TwitchAdapter", () => {
     expect(availabilityBatchSizes).toEqual([1, 2]);
   });
 
+  it("does not cache a single availability response after the authenticated identity changes", async () => {
+    const firstResponse = deferred<unknown>();
+    const firstRequestStarted = deferred<void>();
+    let availabilityCalls = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        availabilityCalls += 1;
+        if (availabilityCalls === 1) {
+          firstRequestStarted.resolve(undefined);
+          return firstResponse.promise;
+        }
+        return {
+          data: {
+            channel: {
+              id: "channel-id",
+              viewerDropCampaigns: [],
+            },
+          },
+        };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-a");
+    const adapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const check = () => adapter.checkChannel(
+      { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+      { campaign: { id: "campaign", categoryId: "game" } as DropCampaign },
+    );
+
+    const inFlight = check();
+    await firstRequestStarted.promise;
+    discoveryState.setAuthenticatedUser("user-b");
+    firstResponse.resolve({
+      data: {
+        channel: {
+          id: "channel-id",
+          viewerDropCampaigns: [{ id: "campaign" }],
+        },
+      },
+    });
+
+    await expect(inFlight).resolves.toMatchObject({ campaignMatches: true });
+    await expect(check()).resolves.toMatchObject({ campaignMatches: false });
+    await expect(check()).resolves.toMatchObject({ campaignMatches: false });
+    expect(availabilityCalls).toBe(2);
+  });
+
+  it("does not cache a batch availability response after discovery state resets to the same identity", async () => {
+    const firstResponse = deferred<unknown>();
+    const firstRequestStarted = deferred<void>();
+    const availabilityBatches: string[][] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Array<Record<string, unknown>>;
+      const channelIds = body.map((entry) =>
+        String((entry.variables as { channelID?: string }).channelID));
+      availabilityBatches.push(channelIds);
+      if (availabilityBatches.length === 1) {
+        firstRequestStarted.resolve(undefined);
+        return firstResponse.promise;
+      }
+      return channelIds.map((channelId) => ({
+        data: {
+          channel: {
+            id: channelId,
+            viewerDropCampaigns: channelId === "first-id" ? [{ id: "campaign" }] : [],
+          },
+        },
+      }));
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-a");
+    const candidates = ["first", "second"].map((username) => ({
+      platform: "twitch" as const,
+      username,
+      url: `https://www.twitch.tv/${username}`,
+      channelId: `${username}-id`,
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    }));
+    const select = () => new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .selectCandidateChannel(
+        candidates,
+        { id: "campaign", categoryId: "game" } as DropCampaign,
+      );
+
+    const inFlight = select();
+    await firstRequestStarted.promise;
+    discoveryState.clear();
+    discoveryState.setAuthenticatedUser("user-a");
+    firstResponse.resolve(candidates.map((candidate) => ({
+      data: {
+        channel: {
+          id: candidate.channelId,
+          viewerDropCampaigns: candidate.channelId === "first-id" ? [{ id: "campaign" }] : [],
+        },
+      },
+    })));
+
+    await expect(inFlight).resolves.toMatchObject({ channel: { username: "first" } });
+    await expect(select()).resolves.toMatchObject({ channel: { username: "first" } });
+    await expect(select()).resolves.toMatchObject({ channel: { username: "first" } });
+    expect(availabilityBatches).toEqual([
+      ["first-id", "second-id"],
+      ["first-id", "second-id"],
+    ]);
+  });
+
   it("invalidates shared availability on authenticated identity changes and reset", async () => {
     let authenticatedUserId = "user-a";
     let availabilityCalls = 0;
@@ -3583,6 +3704,40 @@ describe("TwitchAdapter", () => {
       .rejects.toBe(failure);
   });
 
+  it("propagates authenticated availability errors through the public single-channel check", async () => {
+    const failure = new SafeFetchError({
+      kind: "authentication_rejected",
+      status: 401,
+      reason: "rejected",
+    });
+    let pageFallbackCalls = 0;
+    const fetcher = jsonFetcher((url, init) => {
+      if (url === "https://gql.twitch.tv/gql") {
+        const op = operation(init);
+        if (op === "StreamInfo") {
+          return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        }
+        if (op === "DropsHighlightService_AvailableDrops") throw failure;
+        throw new Error(`Unexpected op ${op}`);
+      }
+      if (url === "https://www.twitch.tv/creator") {
+        pageFallbackCalls += 1;
+        return { html: '{"isLiveBroadcast":true,"game":{"id":"game","name":"Game"}}' };
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-id");
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .checkChannel(
+        { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+        { campaign: { id: "campaign", categoryId: "game" } as DropCampaign },
+      ))
+      .rejects.toBe(failure);
+    expect(pageFallbackCalls).toBe(0);
+  });
+
   it("lists Twitch drop-enabled streams through the slug directory query", async () => {
     const fetcher = jsonFetcher((_url, init) => {
       expect(operation(init)).toBe("DirectoryPage_Game");
@@ -3715,6 +3870,106 @@ describe("TwitchAdapter", () => {
     expect(events.some((event) =>
       event.category === "diagnostic" &&
       event.message.includes("2 AvailableDrops batch requests, 0 AvailableDrops single fallbacks"))).toBe(true);
+  });
+
+  it("does not cache ambiguous entries from malformed or incomplete multi-candidate availability batches", async () => {
+    const candidates = ["valid", "wrong-channel", "error", "missing"].map((username) => ({
+      platform: "twitch" as const,
+      username,
+      url: `https://www.twitch.tv/${username}`,
+      channelId: `${username}-id`,
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    }));
+    const availabilityBatches: string[][] = [];
+    const singleFallbackChannels: string[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        const channelIds = body.map((entry) =>
+          String((entry.variables as { channelID?: string }).channelID));
+        availabilityBatches.push(channelIds);
+        if (availabilityBatches.length === 1) {
+          return [{
+            data: {
+              channel: {
+                id: "valid-id",
+                viewerDropCampaigns: [],
+              },
+            },
+          }, {
+            data: {
+              channel: {
+                id: "another-channel-id",
+                viewerDropCampaigns: [],
+              },
+            },
+          }, {
+            data: {
+              channel: {
+                id: "error-id",
+                viewerDropCampaigns: [],
+              },
+            },
+            errors: [{ message: "availability failed" }],
+          }];
+        }
+        return channelIds.map((channelId) => ({
+          data: {
+            channel: {
+              id: channelId,
+              viewerDropCampaigns: [],
+            },
+          },
+        }));
+      }
+      const channelId = String((body.variables as { channelID?: string }).channelID);
+      singleFallbackChannels.push(channelId);
+      if (channelId === "wrong-channel-id") {
+        return {
+          data: {
+            channel: {
+              id: "another-channel-id",
+              viewerDropCampaigns: [],
+            },
+          },
+        };
+      }
+      if (channelId === "error-id") {
+        return {
+          data: {
+            channel: {
+              id: channelId,
+              viewerDropCampaigns: [],
+            },
+          },
+          errors: [{ message: "availability failed" }],
+        };
+      }
+      return { data: { channel: { id: channelId } } };
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-id");
+    const select = () => new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .selectCandidateChannel(
+        candidates,
+        { id: "campaign", categoryId: "game" } as DropCampaign,
+      );
+
+    await select();
+    await select();
+    await select();
+
+    expect(availabilityBatches).toEqual([
+      ["valid-id", "wrong-channel-id", "error-id", "missing-id"],
+      ["wrong-channel-id", "error-id", "missing-id"],
+    ]);
+    expect(singleFallbackChannels).toEqual([
+      "wrong-channel-id",
+      "error-id",
+      "missing-id",
+    ]);
   });
 
   it("labels idle channel selection diagnostics when no candidate wins", async () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -4211,6 +4211,36 @@ describe("TwitchAdapter", () => {
     });
   });
 
+  it("falls back to Twitch channel page data when anonymous StreamInfo authentication is rejected", async () => {
+    const failure = new SafeFetchError({
+      kind: "authentication_rejected",
+      status: 401,
+      reason: "rejected",
+    });
+    let pageFallbackCalls = 0;
+    const fetcher = jsonFetcher((url, init) => {
+      if (url === "https://gql.twitch.tv/gql" && operation(init) === "StreamInfo") {
+        throw failure;
+      }
+      if (url === "https://www.twitch.tv/creator") {
+        pageFallbackCalls += 1;
+        return { html: '{"isLiveBroadcast":true,"game":{"id":"game","name":"Game"}}' };
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+
+    await expect(new TwitchAdapter(fetcher).checkChannel(
+      { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+      { campaign: { categoryId: "game" } as DropCampaign },
+    )).resolves.toMatchObject({
+      live: true,
+      categoryMatches: true,
+      reason: "Twitch GQL check failed; used channel page fallback",
+      candidate: { categoryId: "game" },
+    });
+    expect(pageFallbackCalls).toBe(1);
+  });
+
   it("treats Twitch channel validation as invalid when GQL and page fallback both fail", async () => {
     const fetcher = jsonFetcher((url, init) => {
       if (url === "https://gql.twitch.tv/gql" && operation(init) === "StreamInfo") {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -3127,7 +3127,7 @@ describe("TwitchAdapter", () => {
         const body = requestBody(init);
         if (!body.query) return { errors: [{ message: "PersistedQueryNotFound" }] };
         expect(body.query).toContain("viewerDropCampaigns");
-        return { data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } } };
+        return { data: { channel: { id: "channel-id", viewerDropCampaigns: [{ id: "campaign" }] } } };
       }
       throw new Error(`Unexpected op ${op}`);
     });
@@ -3140,43 +3140,447 @@ describe("TwitchAdapter", () => {
     expect(availabilityAttempts).toBe(2);
   });
 
-  it("caches positive and negative Twitch campaign availability for a bounded time", async () => {
-    vi.useFakeTimers();
+  it("shares positive and negative Twitch campaign availability across adapter ticks for two minutes", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
     try {
       vi.setSystemTime(new Date("2026-07-13T12:00:00.000Z"));
       let availabilityCalls = 0;
+      const events: EngineEvent[] = [];
       const fetcher = jsonFetcher((_url, init) => {
         const op = operation(init);
-        if (op === "StreamInfo") {
-          return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
-        }
         if (op === "DropsHighlightService_AvailableDrops") {
           availabilityCalls += 1;
-          return { data: { channel: { viewerDropCampaigns: [{ id: "available" }] } } };
+          return {
+            data: {
+              channel: {
+                id: "channel-id",
+                viewerDropCampaigns: [{ id: "available" }],
+              },
+            },
+          };
         }
         throw new Error(`Unexpected op ${op}`);
       });
-      const adapter = new TwitchAdapter(fetcher);
-      const candidate = { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" } as const;
+      const discoveryState = new TwitchDiscoveryState();
+      discoveryState.setAuthenticatedUser("user-id");
+      const candidate = {
+        platform: "twitch" as const,
+        username: "creator",
+        url: "https://www.twitch.tv/creator",
+        channelId: "channel-id",
+        categoryId: "game",
+        live: true,
+        isAclMatch: false,
+      };
+      const select = (campaignId: string) => new TwitchAdapter(
+        fetcher,
+        undefined,
+        undefined,
+        { discoveryState },
+        (event) => events.push(event),
+      ).selectCandidateChannel(
+        [candidate],
+        { id: campaignId, categoryId: "game" } as DropCampaign,
+      );
 
-      await expect(adapter.checkChannel(candidate, {
-        campaign: { id: "available", categoryId: "game" } as DropCampaign,
-      }))
-        .resolves.toMatchObject({ campaignMatches: true });
-      await expect(adapter.checkChannel(candidate, {
-        campaign: { id: "missing", categoryId: "game" } as DropCampaign,
-      }))
-        .resolves.toMatchObject({ campaignMatches: false });
+      await expect(select("available")).resolves.toMatchObject({
+        channel: { username: "creator" },
+      });
+      vi.advanceTimersByTime(60_000);
+      await expect(select("missing")).resolves.toEqual({ checked: 1 });
       expect(availabilityCalls).toBe(1);
 
-      vi.advanceTimersByTime(60_001);
-      await adapter.checkChannel(candidate, {
-        campaign: { id: "available", categoryId: "game" } as DropCampaign,
+      vi.advanceTimersByTime(60_000);
+      await expect(select("available")).resolves.toMatchObject({
+        channel: { username: "creator" },
       });
       expect(availabilityCalls).toBe(2);
+      expect(events.some((event) =>
+        event.category === "diagnostic"
+        && event.message.includes("0 availability cache hits, 1 availability cache miss, 0 availability cache expirations"))).toBe(true);
+      expect(events.some((event) =>
+        event.category === "diagnostic"
+        && event.message.includes("1 availability cache hit, 0 availability cache misses, 0 availability cache expirations"))).toBe(true);
+      expect(events.some((event) =>
+        event.category === "diagnostic"
+        && event.message.includes("0 availability cache hits, 0 availability cache misses, 1 availability cache expiration"))).toBe(true);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it.each([
+    ["missing campaign collection", { data: { channel: { id: "channel-id" } } }],
+    ["missing channel identity", {
+      data: {
+        channel: {
+          viewerDropCampaigns: [{ id: "campaign" }],
+        },
+      },
+    }],
+    ["mismatched channel identity", {
+      data: {
+        channel: {
+          id: "other-channel",
+          viewerDropCampaigns: [{ id: "campaign" }],
+        },
+      },
+    }],
+    ["campaign entry without an id", {
+      data: {
+        channel: {
+          id: "channel-id",
+          viewerDropCampaigns: [{}],
+        },
+      },
+    }],
+  ])("does not let %s availability data poison later authoritative answers", async (_label, malformed) => {
+    let availabilityCalls = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        availabilityCalls += 1;
+        return availabilityCalls === 1
+          ? malformed
+          : {
+              data: {
+                channel: {
+                  id: "channel-id",
+                  viewerDropCampaigns: [{ id: "campaign" }],
+                },
+              },
+            };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-id");
+    const candidate = {
+      platform: "twitch" as const,
+      username: "creator",
+      url: "https://www.twitch.tv/creator",
+    };
+    const check = () => new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .checkChannel(candidate, {
+        campaign: { id: "campaign", categoryId: "game" } as DropCampaign,
+      });
+
+    await expect(check()).resolves.toMatchObject({ campaignMatches: undefined });
+    await expect(check()).resolves.toMatchObject({ campaignMatches: true });
+    await expect(check()).resolves.toMatchObject({ campaignMatches: true });
+    expect(availabilityCalls).toBe(2);
+  });
+
+  it("does not let an availability request failure poison a later authoritative answer", async () => {
+    let availabilityCalls = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        availabilityCalls += 1;
+        if (availabilityCalls === 1) throw new Error("availability unavailable");
+        return {
+          data: {
+            channel: {
+              id: "channel-id",
+              viewerDropCampaigns: [{ id: "campaign" }],
+            },
+          },
+        };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-id");
+    const candidate = {
+      platform: "twitch" as const,
+      username: "creator",
+      url: "https://www.twitch.tv/creator",
+    };
+    const check = () => new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .checkChannel(candidate, {
+        campaign: { id: "campaign", categoryId: "game" } as DropCampaign,
+      });
+
+    await expect(check()).resolves.toMatchObject({ campaignMatches: undefined });
+    await expect(check()).resolves.toMatchObject({ campaignMatches: true });
+    await expect(check()).resolves.toMatchObject({ campaignMatches: true });
+    expect(availabilityCalls).toBe(2);
+  });
+
+  it.each([
+    ["errors array", { errors: [{ message: "availability rejected" }] }],
+    ["top-level error", { error: "ServiceUnavailable", message: "availability rejected" }],
+  ])("does not cache a valid-looking single availability response with a %s", async (_label, failureEnvelope) => {
+    let availabilityCalls = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        availabilityCalls += 1;
+        const data = {
+          channel: {
+            id: "channel-id",
+            viewerDropCampaigns: [{ id: "campaign" }],
+          },
+        };
+        return availabilityCalls === 1 ? { data, ...failureEnvelope } : { data };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-id");
+    const candidate = {
+      platform: "twitch" as const,
+      username: "creator",
+      url: "https://www.twitch.tv/creator",
+    };
+    const check = () => new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .checkChannel(candidate, {
+        campaign: { id: "campaign", categoryId: "game" } as DropCampaign,
+      });
+
+    await expect(check()).resolves.toMatchObject({ campaignMatches: undefined });
+    await expect(check()).resolves.toMatchObject({ campaignMatches: true });
+    await expect(check()).resolves.toMatchObject({ campaignMatches: true });
+    expect(availabilityCalls).toBe(2);
+  });
+
+  it("reuses authoritative availability from batch checks in later single checks", async () => {
+    const availabilityBatchSizes: number[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      const operations = Array.isArray(body) ? body : [body];
+      availabilityBatchSizes.push(operations.length);
+      return Array.isArray(body)
+        ? operations.map((entry) => {
+            const channelId = String((entry.variables as { channelID?: string }).channelID);
+            return {
+              data: {
+                channel: {
+                  id: channelId,
+                  viewerDropCampaigns: [{ id: "campaign" }],
+                },
+              },
+            };
+          })
+        : {
+            data: {
+              channel: {
+                id: String((body.variables as { channelID?: string }).channelID),
+                viewerDropCampaigns: [{ id: "campaign" }],
+              },
+            },
+          };
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-id");
+    const candidates = ["first", "second"].map((username) => ({
+      platform: "twitch" as const,
+      username,
+      url: `https://www.twitch.tv/${username}`,
+      channelId: `${username}-id`,
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    }));
+
+    await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .selectCandidateChannel(candidates, { id: "campaign", categoryId: "game" } as DropCampaign);
+    await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .selectCandidateChannel([candidates[1]], { id: "campaign", categoryId: "game" } as DropCampaign);
+
+    expect(availabilityBatchSizes).toEqual([2]);
+  });
+
+  it("reuses authoritative availability from single checks in later batches", async () => {
+    const availabilityBatchSizes: number[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      const operations = Array.isArray(body) ? body : [body];
+      availabilityBatchSizes.push(operations.length);
+      return Array.isArray(body)
+        ? operations.map((entry) => {
+            const channelId = String((entry.variables as { channelID?: string }).channelID);
+            return {
+              data: {
+                channel: {
+                  id: channelId,
+                  viewerDropCampaigns: [{ id: "campaign" }],
+                },
+              },
+            };
+          })
+        : {
+            data: {
+              channel: {
+                id: String((body.variables as { channelID?: string }).channelID),
+                viewerDropCampaigns: [{ id: "campaign" }],
+              },
+            },
+          };
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-id");
+    const candidates = ["first", "second", "third"].map((username) => ({
+      platform: "twitch" as const,
+      username,
+      url: `https://www.twitch.tv/${username}`,
+      channelId: `${username}-id`,
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    }));
+
+    await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .selectCandidateChannel([candidates[0]], { id: "campaign", categoryId: "game" } as DropCampaign);
+    await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .selectCandidateChannel(candidates, { id: "campaign", categoryId: "game" } as DropCampaign);
+
+    expect(availabilityBatchSizes).toEqual([1, 2]);
+  });
+
+  it("invalidates shared availability on authenticated identity changes and reset", async () => {
+    let authenticatedUserId = "user-a";
+    let availabilityCalls = 0;
+    const events: EngineEvent[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") return twitchInventory([], authenticatedUserId);
+      if (op === "ViewerDropsDashboard") return twitchDashboard([], authenticatedUserId);
+      if (op === "DropsHighlightService_AvailableDrops") {
+        availabilityCalls += 1;
+        return {
+          data: {
+            channel: {
+              id: "channel-id",
+              viewerDropCampaigns: [{ id: "campaign" }],
+            },
+          },
+        };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser(authenticatedUserId);
+    const candidate = {
+      platform: "twitch" as const,
+      username: "creator",
+      url: "https://www.twitch.tv/creator",
+      channelId: "channel-id",
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    };
+    const adapter = new TwitchAdapter(
+      fetcher,
+      undefined,
+      undefined,
+      { discoveryState },
+      (event) => events.push(event),
+    );
+    const select = () => adapter.selectCandidateChannel(
+      [candidate],
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    await select();
+    authenticatedUserId = "user-b";
+    await new TwitchAdapter(
+      fetcher,
+      undefined,
+      undefined,
+      { discoveryState },
+      (event) => events.push(event),
+    ).refreshCampaigns();
+    await select();
+    expect(availabilityCalls).toBe(2);
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      platform: "twitch",
+      message: expect.stringContaining("Twitch availability cache invalidated after authenticated identity changed"),
+    }));
+
+    discoveryState.clear();
+    discoveryState.setAuthenticatedUser(authenticatedUserId);
+    await select();
+    expect(availabilityCalls).toBe(3);
+  });
+
+  it("bounds shared availability entries with deterministic overflow pruning", async () => {
+    const candidates = Array.from({ length: 129 }, (_, index) => ({
+      platform: "twitch" as const,
+      username: `channel-${index}`,
+      url: `https://www.twitch.tv/channel-${index}`,
+      channelId: `channel-${index}`,
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    }));
+    let availabilityOperations = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      const operations = Array.isArray(body) ? body : [body];
+      availabilityOperations += operations.length;
+      const responses = operations.map((entry) => {
+        const channelId = String((entry.variables as { channelID?: string }).channelID);
+        return {
+          data: {
+            channel: {
+              id: channelId,
+              viewerDropCampaigns: [],
+            },
+          },
+        };
+      });
+      return Array.isArray(body) ? responses : responses[0];
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-id");
+
+    for (const candidate of candidates) {
+      await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+        .selectCandidateChannel([candidate], { id: "campaign", categoryId: "game" } as DropCampaign);
+    }
+    await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .selectCandidateChannel([candidates[0]], { id: "campaign", categoryId: "game" } as DropCampaign);
+    await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .selectCandidateChannel([candidates[128]], { id: "campaign", categoryId: "game" } as DropCampaign);
+
+    expect(availabilityOperations).toBe(130);
+  });
+
+  it("preserves authenticated availability error propagation", async () => {
+    const failure = new SafeFetchError({
+      kind: "authentication_rejected",
+      status: 401,
+      reason: "rejected",
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-id");
+    const fetcher = jsonFetcher((_url, init) => {
+      expect(operation(init)).toBe("DropsHighlightService_AvailableDrops");
+      throw failure;
+    });
+
+    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .selectCandidateChannel([{
+        platform: "twitch",
+        username: "creator",
+        url: "https://www.twitch.tv/creator",
+        channelId: "channel-id",
+        categoryId: "game",
+        live: true,
+        isAclMatch: false,
+      }], { id: "campaign", categoryId: "game" } as DropCampaign))
+      .rejects.toBe(failure);
   });
 
   it("lists Twitch drop-enabled streams through the slug directory query", async () => {
@@ -3239,7 +3643,7 @@ describe("TwitchAdapter", () => {
     const operations: string[] = [];
     const fetcher = jsonFetcher((_url, init) => {
       operations.push(operation(init));
-      return { data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } } };
+      return { data: { channel: { id: "winner-id", viewerDropCampaigns: [{ id: "campaign" }] } } };
     });
     const adapter = new TwitchAdapter(fetcher);
     const candidate = {
@@ -3285,6 +3689,7 @@ describe("TwitchAdapter", () => {
         return {
           data: {
             channel: {
+              id: channelId,
               viewerDropCampaigns: channelId === "channel-23" ? [{ id: "campaign-1" }] : [],
             },
           },
@@ -3359,7 +3764,14 @@ describe("TwitchAdapter", () => {
       maxActiveSingles = Math.max(maxActiveSingles, activeSingles);
       await Promise.resolve();
       activeSingles -= 1;
-      return { data: { channel: { viewerDropCampaigns: [] } } };
+      return {
+        data: {
+          channel: {
+            id: String((body.variables as { channelID?: string }).channelID),
+            viewerDropCampaigns: [],
+          },
+        },
+      };
     });
 
     await new TwitchAdapter(fetcher).selectCandidateChannel?.(
@@ -3386,8 +3798,13 @@ describe("TwitchAdapter", () => {
         const operationName = String(body[0]?.operationName);
         if (operationName === "DropsHighlightService_AvailableDrops") {
           availabilityBatchSizes.push(body.length);
-          return body.map(() => ({
-            data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } },
+          return body.map((entry) => ({
+            data: {
+              channel: {
+                id: String((entry.variables as { channelID?: string }).channelID),
+                viewerDropCampaigns: [{ id: "campaign" }],
+              },
+            },
           }));
         }
         expect(operationName).toBe("StreamInfo");
@@ -3496,6 +3913,7 @@ describe("TwitchAdapter", () => {
         return {
           data: {
             channel: {
+              id: channelId,
               viewerDropCampaigns: channelId === "second-id" ? [{ id: "campaign" }] : [],
             },
           },
@@ -4040,7 +4458,7 @@ describe("TwitchAdapter integrity recovery", () => {
           return { data: { user: { id: "channel-id", displayName: "Creator", stream: { id: "b", game: { id: "game" } } } } };
         }
         if (op === "DropsHighlightService_AvailableDrops") {
-          return { data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } } };
+          return { data: { channel: { id: "channel-id", viewerDropCampaigns: [{ id: "campaign" }] } } };
         }
         throw new Error(`Unexpected op ${op}`);
       });


### PR DESCRIPTION
## Stack

This PR is intentionally stacked on #342 (the finalized #339 campaign-detail cache). Its diff against the #339 branch contains only #338.

## Summary

- Move AvailableDrops caching into TwitchDiscoveryState so adapter instances share it across scheduler ticks.
- Cache complete authoritative positive and negative campaign lists for two minutes with one-minute scheduler headroom.
- Keep the cache bounded to 128 channels, identity-scoped, lazily expired, and FIFO-pruned.
- Reuse results across batch and single checks without increasing request concurrency.
- Preserve undefined for malformed, wrong-channel, incomplete, transport, or ambiguous results; auth failures still propagate.
- Guard in-flight writes with identity generations so user-switch/reset races cannot cross-contaminate results.
- Preserve anonymous StreamInfo page fallback while authenticated availability errors remain observable.

## Verification

- Adapter suite: 190 passed.
- Extension boundary suite: 459 passed.
- CLI isolation suite: 27 passed.
- Full suite: CLI 138, extension 1,367, site 3 passed.
- pnpm typecheck: passed.
- Final task review: clean.

Closes #338