### PR TITLE
fix(core): install captured Twitch integrity outside the platform lock

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -740,25 +740,46 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     noteTwitchGqlRequest(tabId);
     const integrity = integrityFromHeaders(headers);
     if (!integrity) return;
+    // Installed outside withStateLock, and synchronously before the first await.
+    //
+    // A mint waits on setTwitchIntegrity waking its waiters (see core/tabs.ts),
+    // and the two paths that can force a refresh — runTick around
+    // runSchedulerTick, and runPlatformWatchHeartbeat around watcher.tick — both
+    // hold the platform lock across that wait. Installing under the same lock
+    // made the waiter depend on a lock its own holder owns: the token arrived,
+    // sat queued behind the tick, and the wait could only ever time out. Each
+    // timeout then booted another page-context tab, which is what users saw as
+    // twitch.tv/drops/inventory opening and closing every tick.
+    //
+    // The compare and the install must stay in one uninterrupted synchronous
+    // block: webRequest fires on every GQL request, so an await between them
+    // would let two captures interleave and both report themselves as new.
     let isNew = false;
-    await withStateLock(() => withEventCollector(async (emit, events) => {
+    await withEventCollector(async (emit, events) => {
       isNew = integrity.integrity !== installedTwitchIntegrity?.integrity;
       installTwitchIntegrity(integrity, isNew, emit);
-      if (integrity.integrity !== persistedIntegrityToken && deps.saveTwitchIntegrity) {
-        try {
-          await deps.saveTwitchIntegrity(integrity);
-          persistedIntegrityToken = integrity.integrity;
-        } catch {
-          emit({
-            category: "diagnostic",
-            platform: "twitch",
-            level: "warn",
-            message: "Could not persist the captured Twitch integrity token",
-          });
-        }
+      await reportBestEffort(events);
+    });
+    // Persistence still takes the lock: persistedIntegrityToken is read and
+    // written by reconcileStoredTwitchIntegrity under it. Scoped to twitch —
+    // this touches no Kick state, and holding both locks let a busy Kick tick
+    // delay Twitch token bookkeeping. Nothing waits on this, so queueing behind
+    // an in-flight tick is harmless.
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      if (integrity.integrity === persistedIntegrityToken || !deps.saveTwitchIntegrity) return;
+      try {
+        await deps.saveTwitchIntegrity(integrity);
+        persistedIntegrityToken = integrity.integrity;
+      } catch {
+        emit({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "warn",
+          message: "Could not persist the captured Twitch integrity token",
+        });
       }
       await reportBestEffort(events);
-    }));
+    }), ["twitch"]);
     if (!isNew) return;
     const lifecycleGeneration = integrityLifecycleGeneration;
     const settingsTransitionGeneration = twitchSettingsTransitionGeneration;

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -513,6 +513,13 @@ export const TWITCH_PAGE_CONTEXT_URL = "https://www.twitch.tv/drops/inventory";
 // 12s could not cover that, so the wait timed out, the operation degraded to
 // stale data, and the token landed anyway once nobody was waiting for it.
 //
+// Note that "the token landed once nobody was waiting" also had a second, then
+// unknown cause: the capture path installed tokens under the same platform lock
+// the waiting tick held, so a rejection-recovery wait could never be satisfied
+// no matter how long this budget was. That deadlock is fixed in the controller's
+// captureTwitchIntegrity. This budget still covers genuine cold-boot latency on
+// the readiness path, which has always run outside that lock.
+//
 // Raising it is only affordable because a forced refresh is now bounded by
 // rejectedToken (see below): a tick pays this once, not once per rejected
 // operation. Provisional — it covers a single observed sample with margin, and

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1687,6 +1687,88 @@ describe("background controller", () => {
       expect(new Set(integrityAlarmCalls.map(([, options]) => JSON.stringify(options))).size).toBe(1);
     });
 
+    // The invariant both of these guard: installing a captured token must never
+    // need a lock that a waiting mint's own caller is holding. runTick and
+    // runPlatformWatchHeartbeat both hold the platform lock across work that can
+    // force a refresh, so a capture that took that lock could not be installed
+    // until the holder gave up — which it only did by timing out.
+    it("installs a captured token while a tick holds the platform lock", async () => {
+      const replacement = integrityBundle({
+        integrity: "captured-during-locked-tick",
+      });
+      const refreshGate = deferred<void>();
+      const env = harness(undefined, { loadTwitchIntegrity: async () => undefined });
+      await env.controller.settleBackgroundWork();
+      setTwitchIntegrity(undefined);
+
+      // refreshCampaigns runs inside runSchedulerTick, which runTick wraps in
+      // withStateLock for the whole scheduler run.
+      env.twitch.refreshCampaigns = vi.fn(async () => {
+        await refreshGate.promise;
+        return [campaign("twitch")];
+      });
+
+      const ticking = env.controller.tick(["twitch"], "manual_tick");
+      await vi.waitFor(() => expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce());
+
+      // Deliberately not awaited: persistence still queues behind the tick, and
+      // the install must already have happened by the time the call returns.
+      const capturing = env.controller.captureTwitchIntegrity(integrityHeaders(replacement));
+      const installedWhileLocked = currentValidTwitchIntegrity()?.integrity;
+
+      refreshGate.resolve();
+      await Promise.all([capturing, ticking]);
+      setTwitchIntegrity(undefined);
+
+      expect(installedWhileLocked).toBe(replacement.integrity);
+    });
+
+    it("satisfies a rejection-recovery mint raised from inside the platform lock", async () => {
+      const replacement = integrityBundle({
+        integrity: "minted-during-locked-tick",
+      });
+      const browser = {
+        tabs: {
+          get: vi.fn(),
+          update: vi.fn(async () => undefined),
+          remove: vi.fn(async () => undefined),
+          query: vi.fn(async () => []),
+          create: vi.fn(async () => ({ id: 77 })),
+        },
+      } satisfies BrowserTabApi;
+      registerManagedPageContextTabs({});
+      resetTwitchIntegrityRefreshBounds();
+      setTwitchIntegrity(undefined);
+      const env = harness(undefined, { loadTwitchIntegrity: async () => undefined });
+      await env.controller.settleBackgroundWork();
+
+      let mintedInsideLock: boolean | undefined;
+      // Stands in for the adapter forcing a refresh after Twitch rejects a token
+      // it still considers unexpired (platforms/twitch/index.ts). This runs under
+      // the platform lock, so before the fix it could only ever time out.
+      env.twitch.refreshCampaigns = vi.fn(async () => {
+        mintedInsideLock = await ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          1_000,
+          () => undefined,
+          { forceRefresh: true, reason: "rejection_recovery" },
+        );
+        return [campaign("twitch")];
+      });
+
+      const ticking = env.controller.tick(["twitch"], "manual_tick");
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+      const capturing = env.controller.captureTwitchIntegrity(integrityHeaders(replacement));
+
+      await ticking;
+      await capturing;
+      resetTwitchIntegrityRefreshBounds();
+      setTwitchIntegrity(undefined);
+
+      expect(mintedInsideLock).toBe(true);
+    });
+
     it("forces the next normal tick after a proactive refresh is deferred", async () => {
       const integrity = integrityBundle({
         integrity: "deferred-proactive-token",

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -799,24 +799,29 @@ describe("Twitch parsers", () => {
   });
 
   it("does not treat a benefit awarded outside the drop's own window as claiming it", () => {
+    // The campaign has to still be running for the status assertion below to mean
+    // anything, so its window is relative to now rather than a fixed date that
+    // silently turns this into an expired-campaign test once it passes.
+    const day = 24 * 60 * 60 * 1000;
+    const at = (offsetDays: number) => new Date(Date.now() + offsetDays * day).toISOString();
     const campaigns = parseTwitchInventory({
       data: {
         currentUser: {
           inventory: {
             gameEventDrops: [{
               benefit: { id: "shared-benefit" },
-              lastAwardedAt: "2026-05-15T12:00:00.000Z",
+              lastAwardedAt: at(-60),
             }],
             dropCampaignsInProgress: [{
               id: "abc",
               name: "Twitch Drops",
-              startAt: "2026-07-01T00:00:00.000Z",
-              endAt: "2026-08-01T00:00:00.000Z",
+              startAt: at(-15),
+              endAt: at(15),
               timeBasedDrops: [{
                 id: "drop",
                 name: "Cape",
-                startAt: "2026-07-01T00:00:00.000Z",
-                endAt: "2026-08-01T00:00:00.000Z",
+                startAt: at(-15),
+                endAt: at(15),
                 requiredMinutesWatched: 60,
                 benefitEdges: [{ benefit: { id: "shared-benefit", name: "Cape" } }],
               }],

--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.10.1",
+    "changes": [
+      {
+        "kind": "fixed",
+        "text": "Fixed the Twitch inventory page opening and closing in a loop on every check. When Twitch rejected one of its anti-bot verification tokens mid-check, Lurkloot could not take delivery of the replacement it had just asked for, so it waited the full 30 seconds, gave up, and opened another tab to try again. Drop claims and progress could stall for minutes while this repeated."
+      }
+    ],
+    "date": "2026-08-03"
+  },
+  {
     "version": "1.10.0",
     "changes": [
       {


### PR DESCRIPTION
## Summary

Fixes #345 — `twitch.tv/drops/inventory` opening and closing in a loop on every tick.

This is a **lock inversion**, not Kasada latency and not the reporter's VPN/AdGuard.

`runTick` holds the twitch platform lock across the whole scheduler run
(`controller.ts:1504`→`:1576`), and `runPlatformWatchHeartbeat` holds it across
`watcher.tick()` (`:1770`→`:1841`). Both can reach a forced integrity refresh:
`platforms/twitch/index.ts:1527` (claims), `:1720` (safe reads), `:1869` (tabless
`resolveUserId`). That refresh opens a page context and calls
`waitForIntegrityCapture` (`core/tabs.ts:865`), which only settles when
`setTwitchIntegrity` wakes its waiters.

But the only path that installs a captured token — `captureTwitchIntegrity` —
took the *same* lock before installing (`controller.ts:744-746`). So the waiter
depended on a lock its own caller was holding. The page booted fine, minted a
real token, and the capture sat queued until the wait timed out after 30s. Each
timeout opened another tab, because `rejection_recovery` sets
`requireFreshPageContext: true`.

### What the reporter's log shows

- Four mints, each timing out at ~30s, all reporting `tab ready at ~1.4s, first GQL at ~0.35s` — nothing was slow.
- Then ~60 `Captured a fresh Twitch integrity token` lines in one burst, with expiries spanning a ~10 minute range: the queue flushing once the lock drained.
- Eight ticks (`#11`–`#19`, up to 557s of waiting) unblocking in the same window.

The comment at `core/tabs.ts:508-520` already described this symptom ("the token
landed anyway once nobody was waiting for it") and read it as proof-of-work
latency — which is what motivated the 12s → 30s bump. That raise could never have
helped this path. Comment updated rather than removed, since the cold-boot budget
is still right for the readiness path.

### Why it wasn't caught in testing

`prepareTwitchIntegrity` runs *before* the lock (`:1452`), and
`runTwitchIntegrityRefresh` releases both locks (`:673`/`:674`) before calling
`ensureTwitchIntegrity` at `:688`. The readiness and proactive paths were always
fine. Only the mid-tick / mid-heartbeat `rejection_recovery` mint deadlocks — and
once it fires, the tick can never recover, so it repeats every tick.

## Changes

- Install the captured token synchronously, ahead of the lock. The compare and
  the install stay in one uninterrupted block — webRequest fires on every GQL
  request, so an `await` between them would let two captures both report
  themselves as new.
- Persistence keeps the lock (`persistedIntegrityToken` is shared with
  `reconcileStoredTwitchIntegrity`), now scoped to `["twitch"]` so a busy Kick
  tick can't delay Twitch token bookkeeping. Nothing waits on it, so queueing
  behind a tick is harmless. Acquisition order is inversion-proof by
  construction: `withStateLock` always derives targets by filtering the canonical
  `PLATFORMS`, regardless of the caller's argument order.

## Testing

`pnpm verify` passes clean — 1237 extension tests, 132 CLI tests, both browser builds.

Two new regression tests in `backgroundController.test.ts`, both confirmed to
**fail without the fix** (stashed the controller change and re-ran):

- `installs a captured token while a tick holds the platform lock`
- `satisfies a rejection-recovery mint raised from inside the platform lock` — reproduces the exact user-visible failure (`mintedInsideLock === false`, i.e. the timeout)

They guard the invariant rather than one call path: installing a captured token
must never need a lock a waiting mint's own caller is holding.

## Note on the second commit

`main` is currently red on `parsers.test.ts` — a time-bombed fixture whose
campaign window expired on 2026-08-01, unrelated to this change. Cherry-picked
the existing fix `cab7909` from `fix/parser-fixture-expiry` (unmerged, no PR) so
this hotfix is green and mergeable on its own. That branch can be dropped, or it
will merge as a no-op.

## Not addressed here

- What made Twitch reject an unexpired token in the first place. This fix stops a
  single rejection from becoming a permanent loop, but the trigger is separate.
- The reporter has `spade.twitch.tv` DNS-blocked by AdGuard. That's the tabless
  watch heartbeat (`twitch-heartbeat-spade-v1`), so with their watch mode set to
  "Both" their tabless farming can't record watch time at all, and the resulting
  `tablessFallbackFailureLimit` fallback opens a real watch tab — likely their
  "duplicate watch tabs" follow-up. Worth telling them to keep it unblocked.
- Page-context tabs are created without a `windowId` (`core/tabs.ts:1357`), so
  Chrome puts them in whatever window is focused. Separate, smaller issue.