### PR TITLE
fix(extension): bound Twitch heartbeat requests with a timeout

### DIFF
--- a/packages/cli/src/transport/common.ts
+++ b/packages/cli/src/transport/common.ts
@@ -39,34 +39,15 @@ export function createLazyAdapters(
   };
 }
 
-export const HEARTBEAT_REQUEST_TIMEOUT_MS = 15_000;
-
-export async function withHeartbeatTimeout<T>(
-  operation: (signal: AbortSignal) => Promise<T>,
-  callerSignal?: AbortSignal | null,
-  timeoutMs = HEARTBEAT_REQUEST_TIMEOUT_MS,
-): Promise<T> {
-  const controller = new AbortController();
-  const abortFromCaller = () => controller.abort(callerSignal?.reason);
-  if (callerSignal?.aborted) abortFromCaller();
-  else callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
-  const timeout = setTimeout(() => {
-    controller.abort(new Error(`Twitch heartbeat request timed out after ${timeoutMs}ms`));
-  }, timeoutMs);
-
-  const aborted = new Promise<never>((_resolve, reject) => {
-    const rejectAbort = () => reject(controller.signal.reason);
-    if (controller.signal.aborted) rejectAbort();
-    else controller.signal.addEventListener("abort", rejectAbort, { once: true });
-  });
-
-  try {
-    return await Promise.race([operation(controller.signal), aborted]);
-  } finally {
-    clearTimeout(timeout);
-    callerSignal?.removeEventListener("abort", abortFromCaller);
-  }
-}
+// Shared engine code, so it lives in core alongside the heartbeat strategies it
+// bounds — the extension's transport uses the same helper. Re-exported here so
+// both CLI transports keep importing their transport helpers from one place.
+export {
+  HEARTBEAT_REQUEST_TIMEOUT_MS,
+  HeartbeatTimeoutError,
+  isHeartbeatTimeoutError,
+  withHeartbeatTimeout,
+} from "@lurkloot/core/twitch/heartbeat";
 
 // Watch port for the headless transports, which never open a tab: opening fails
 // clearly (the CLI farms tabless only — keep tablessMode on), while stopping is

--- a/packages/core/src/platforms/twitch/heartbeat/index.ts
+++ b/packages/core/src/platforms/twitch/heartbeat/index.ts
@@ -10,3 +10,9 @@ export { isAllowedTwitchUrl } from "./hosts";
 export { createSpadeHeartbeat, type SpadeHeartbeatOptions } from "./spade";
 export { createTrowelHeartbeat, type TrowelHeartbeatOptions } from "./trowel";
 export { createTwitchHeartbeat, type TwitchHeartbeatFactoryOptions } from "./factory";
+export {
+  HEARTBEAT_REQUEST_TIMEOUT_MS,
+  HeartbeatTimeoutError,
+  isHeartbeatTimeoutError,
+  withHeartbeatTimeout,
+} from "./timeout";

--- a/packages/core/src/platforms/twitch/heartbeat/timeout.ts
+++ b/packages/core/src/platforms/twitch/heartbeat/timeout.ts
@@ -1,0 +1,57 @@
+// Every heartbeat request runs inside runPlatformWatchHeartbeat, which holds the
+// platform state lock across watcher.tick(). An unbounded request therefore does
+// not merely fail the heartbeat — it head-blocks that platform's lock, and every
+// tick, auth refresh and token install queued behind it waits for the network to
+// give up on its own.
+//
+// That is not hypothetical: spade.twitch.tv ships blocked in AdGuard's DNS filter
+// and most adblock lists, and a blackholed host stalls on TCP connect rather than
+// failing fast. Bounding each request keeps a blocked domain a heartbeat problem
+// instead of a whole-platform stall, and makes the cause visible in diagnostics
+// rather than surfacing as a generic network error minutes later.
+export const HEARTBEAT_REQUEST_TIMEOUT_MS = 15_000;
+
+// Thrown so callers can tell "we gave up waiting" apart from a network error the
+// host actually reported. Transports redact request URLs from heartbeat failures,
+// so this message deliberately carries no URL and is safe to surface verbatim.
+export class HeartbeatTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`Twitch heartbeat request timed out after ${timeoutMs}ms`);
+    this.name = "HeartbeatTimeoutError";
+  }
+}
+
+export function isHeartbeatTimeoutError(error: unknown): error is HeartbeatTimeoutError {
+  return error instanceof HeartbeatTimeoutError;
+}
+
+// Races the operation against the deadline rather than relying on the operation
+// honouring the signal: the CLI's impersonate transport hands work to cycleTLS,
+// which ignores AbortSignal entirely. A caller signal still wins with its own
+// reason, so stopping a platform is not reported as a timeout.
+export async function withHeartbeatTimeout<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  callerSignal?: AbortSignal | null,
+  timeoutMs = HEARTBEAT_REQUEST_TIMEOUT_MS,
+): Promise<T> {
+  const controller = new AbortController();
+  const abortFromCaller = () => controller.abort(callerSignal?.reason);
+  if (callerSignal?.aborted) abortFromCaller();
+  else callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+  const timeout = setTimeout(() => {
+    controller.abort(new HeartbeatTimeoutError(timeoutMs));
+  }, timeoutMs);
+
+  const aborted = new Promise<never>((_resolve, reject) => {
+    const rejectAbort = () => reject(controller.signal.reason);
+    if (controller.signal.aborted) rejectAbort();
+    else controller.signal.addEventListener("abort", rejectAbort, { once: true });
+  });
+
+  try {
+    return await Promise.race([operation(controller.signal), aborted]);
+  } finally {
+    clearTimeout(timeout);
+    callerSignal?.removeEventListener("abort", abortFromCaller);
+  }
+}

--- a/packages/extension/src/core/twitchHeartbeatTransport.ts
+++ b/packages/extension/src/core/twitchHeartbeatTransport.ts
@@ -1,3 +1,5 @@
+import { isHeartbeatTimeoutError, withHeartbeatTimeout } from "@lurkloot/core/twitch/heartbeat";
+
 function safeHostname(url: string): string {
   try {
     return new URL(url).hostname || "unknown Twitch host";
@@ -7,6 +9,10 @@ function safeHostname(url: string): string {
 }
 
 function safeErrorCause(error: unknown): string {
+  // Reported verbatim: it names no URL, and "we gave up after 15s" is the one
+  // cause a user can act on — a DNS filter blackholing the host looks like an
+  // ordinary network failure otherwise.
+  if (isHeartbeatTimeoutError(error)) return error.message;
   if (!(error instanceof Error)) return "unknown network error";
   if (error.message === "Failed to fetch" || /^HTTP \d{3}$/.test(error.message)) {
     return error.message;
@@ -17,7 +23,10 @@ function safeErrorCause(error: unknown): string {
 export async function twitchHeartbeatFetchText(url: string, init?: RequestInit): Promise<string> {
   const hostname = safeHostname(url);
   try {
-    const response = await fetch(url, init);
+    const response = await withHeartbeatTimeout(
+      (signal) => fetch(url, { ...init, signal }),
+      init?.signal,
+    );
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return await response.text();
   } catch (error) {
@@ -28,7 +37,10 @@ export async function twitchHeartbeatFetchText(url: string, init?: RequestInit):
 export async function twitchHeartbeatPost(url: string, init: RequestInit): Promise<{ status: number }> {
   const hostname = safeHostname(url);
   try {
-    const response = await fetch(url, init);
+    const response = await withHeartbeatTimeout(
+      (signal) => fetch(url, { ...init, signal }),
+      init.signal,
+    );
     return { status: response.status };
   } catch (error) {
     throw new Error(`Twitch Spade heartbeat POST failed for ${hostname}: ${safeErrorCause(error)}`);

--- a/packages/extension/src/core/twitchHeartbeatTransport.ts
+++ b/packages/extension/src/core/twitchHeartbeatTransport.ts
@@ -23,12 +23,17 @@ function safeErrorCause(error: unknown): string {
 export async function twitchHeartbeatFetchText(url: string, init?: RequestInit): Promise<string> {
   const hostname = safeHostname(url);
   try {
-    const response = await withHeartbeatTimeout(
-      (signal) => fetch(url, { ...init, signal }),
+    // Body read included: the timer is cleared as soon as withHeartbeatTimeout
+    // returns, so reading outside it leaves a host that sends headers and then
+    // stalls the body unbounded — the same lock-holding hang, one step later.
+    return await withHeartbeatTimeout(
+      async (signal) => {
+        const response = await fetch(url, { ...init, signal });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.text();
+      },
       init?.signal,
     );
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    return await response.text();
   } catch (error) {
     throw new Error(`Twitch Spade destination fetch failed for ${hostname}: ${safeErrorCause(error)}`);
   }

--- a/packages/extension/tests/heartbeatTransport.test.ts
+++ b/packages/extension/tests/heartbeatTransport.test.ts
@@ -63,6 +63,26 @@ describe("Twitch heartbeat extension transport", () => {
     expect(String(error)).not.toMatch(/do-not-log|settings\.js/);
   });
 
+  it("gives up on a response whose body never arrives", async () => {
+    vi.useFakeTimers();
+    // Headers land, the body stalls. The timeout has to span the whole request,
+    // not just the fetch: the timer is cleared the moment withHeartbeatTimeout
+    // returns, so a body read outside it is unbounded again.
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: () => new Promise<string>(() => {}),
+    })));
+    const pending = twitchHeartbeatFetchText("https://assets.twitch.tv/config/settings.js")
+      .catch((caught: unknown) => caught);
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_REQUEST_TIMEOUT_MS);
+
+    expect(String(await pending)).toBe(
+      `Error: Twitch Spade destination fetch failed for assets.twitch.tv: Twitch heartbeat request timed out after ${HEARTBEAT_REQUEST_TIMEOUT_MS}ms`,
+    );
+  });
+
   it("gives up on a stalled heartbeat POST and names the timeout as the cause", async () => {
     vi.useFakeTimers();
     stubHangingFetch();

--- a/packages/extension/tests/heartbeatTransport.test.ts
+++ b/packages/extension/tests/heartbeatTransport.test.ts
@@ -1,7 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_REQUEST_TIMEOUT_MS } from "@lurkloot/core/twitch/heartbeat";
 import { twitchHeartbeatFetchText, twitchHeartbeatPost } from "../src/core/twitchHeartbeatTransport";
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+// A request that never settles is what a DNS-blackholed host actually produces:
+// it stalls on connect instead of failing. These run inside the platform state
+// lock (runPlatformWatchHeartbeat holds it across watcher.tick), so "eventually
+// rejects" is the property that keeps a blocked domain from head-blocking every
+// tick queued behind it.
+function stubHangingFetch(): void {
+  vi.stubGlobal("fetch", vi.fn(() => new Promise<never>(() => {})));
+}
 
 describe("Twitch heartbeat extension transport", () => {
   it("identifies destination-fetch failures without leaking URL details", async () => {
@@ -33,5 +46,54 @@ describe("Twitch heartbeat extension transport", () => {
 
     await expect(twitchHeartbeatFetchText("https://assets.twitch.tv/config/settings.js"))
       .rejects.toThrow("Twitch Spade destination fetch failed for assets.twitch.tv: HTTP 403");
+  });
+
+  it("gives up on a stalled destination fetch instead of hanging", async () => {
+    vi.useFakeTimers();
+    stubHangingFetch();
+    const pending = twitchHeartbeatFetchText("https://assets.twitch.tv/config/settings.js?token=do-not-log")
+      .catch((caught: unknown) => caught);
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_REQUEST_TIMEOUT_MS);
+
+    const error = await pending;
+    expect(error).toEqual(new Error(
+      `Twitch Spade destination fetch failed for assets.twitch.tv: Twitch heartbeat request timed out after ${HEARTBEAT_REQUEST_TIMEOUT_MS}ms`,
+    ));
+    expect(String(error)).not.toMatch(/do-not-log|settings\.js/);
+  });
+
+  it("gives up on a stalled heartbeat POST and names the timeout as the cause", async () => {
+    vi.useFakeTimers();
+    stubHangingFetch();
+    const pending = twitchHeartbeatPost("https://spade.twitch.tv/track?token=do-not-log", { method: "POST" })
+      .catch((caught: unknown) => caught);
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_REQUEST_TIMEOUT_MS);
+
+    const error = await pending;
+    // The hostname plus "timed out" is what tells an AdGuard user their DNS
+    // filter is the cause; a generic network error would not.
+    expect(error).toEqual(new Error(
+      `Twitch Spade heartbeat POST failed for spade.twitch.tv: Twitch heartbeat request timed out after ${HEARTBEAT_REQUEST_TIMEOUT_MS}ms`,
+    ));
+    expect(String(error)).not.toMatch(/track|do-not-log/);
+  });
+
+  it("does not report a caller-cancelled heartbeat as a timeout", async () => {
+    stubHangingFetch();
+    const caller = new AbortController();
+    const pending = twitchHeartbeatPost("https://spade.twitch.tv/track", {
+      method: "POST",
+      signal: caller.signal,
+    }).catch((caught: unknown) => caught);
+
+    caller.abort(new Error("Twitch stopped"));
+
+    // Stopping a platform must not be reported as the host timing out, or a
+    // deliberate shutdown reads in diagnostics as a blocked spade.twitch.tv.
+    const error = await pending;
+    expect(String(error)).not.toMatch(/timed out/);
+    expect(String(error)).toBe("Error: Twitch Spade heartbeat POST failed for spade.twitch.tv: network request failed");
   });
 });


### PR DESCRIPTION
## Summary

The extension's Twitch heartbeat transport called `fetch` with no signal. The CLI
transport already wrapped both of its heartbeat calls in `withHeartbeatTimeout`
(`cli/src/transport/common.ts`), so this was a gap in one transport rather than a
core design decision.

It matters more than "a heartbeat can hang" suggests. Every heartbeat request runs
inside `runPlatformWatchHeartbeat`, which holds the platform state lock across
`watcher.tick()` (`core/src/background/controller.ts:1770`→`:1841`). An unbounded
request does not just fail the heartbeat — it head-blocks that platform's lock
until the network gives up on its own, and every tick, auth refresh and integrity
install queued behind it waits. `runPlatformWatchHeartbeat` also only logs on the
*first* failure (`:1826`), so repeats are silent.

`spade.twitch.tv` ships blocked in AdGuard's DNS filter and most adblock lists, and
a blackholed host stalls on TCP connect rather than failing fast — so this is the
common case, not an edge one. A blocked domain should cost a failed heartbeat, not
a stalled platform.

### Where this came from

Investigating #345. That issue is fixed by #346 (a lock inversion in
`captureTwitchIntegrity`), but one fact in the reporter's diagnostics is not
explained by it: a silent 129s gap between tick #7 releasing the twitch lock at
`23:05:49` and the token queue flushing at `23:07:58`. Two blocked spade POSTs
under the lock fits that window, and the reporter has spade DNS-blocked. **I have
not proven that is what happened** — hence `Refs #345` rather than `Fixes`. The bug
here is real and worth fixing regardless of whether it caused that particular gap.

The reporter also made the general point directly: relying on a domain that
adblockers filter by default will keep producing reports like this.

## Changes

- **`core/src/platforms/twitch/heartbeat/timeout.ts`** (new) — `withHeartbeatTimeout`
  moved here so both transports share one implementation, plus a
  `HeartbeatTimeoutError` so callers can tell "we gave up waiting" from a network
  error the host actually reported. It races the deadline rather than relying on the
  operation honouring the signal, because the CLI's impersonate transport hands work
  to cycleTLS, which ignores `AbortSignal` entirely.
- **`cli/src/transport/common.ts`** — re-exports from core. Both CLI transports and
  `cli/tests/transport.test.ts` import it unchanged.
- **`extension/src/core/twitchHeartbeatTransport.ts`** — both `fetch` calls bounded,
  and `safeErrorCause` now recognises the timeout. That second part carries as much
  of the value as the first: without it the timeout collapsed into the generic
  `"network request failed"`, which tells an AdGuard user nothing. It now reads
  `Twitch Spade heartbeat POST failed for spade.twitch.tv: Twitch heartbeat request
  timed out after 15000ms` — hostname and cause, still no URL, so the existing
  redaction guarantee holds.

## Testing

`pnpm check` passes clean — 1312 extension tests, 138 CLI tests, workspace
typechecks, site build.

Three new tests in `heartbeatTransport.test.ts`, all confirmed to **fail without the
fix** (reverted only the transport file and re-ran): each one hung until vitest
killed it at 4s, which is the production failure mode exactly.

- `gives up on a stalled destination fetch instead of hanging`
- `gives up on a stalled heartbeat POST and names the timeout as the cause`
- `does not report a caller-cancelled heartbeat as a timeout` — asserts the message
  does *not* contain "timed out", so a deliberate platform stop cannot be misread in
  diagnostics as a blocked domain

## Not addressed here

This bounds the lock hold; it does not remove network I/O from under the lock. A
blocked spade still costs ~30s per heartbeat tick (POST, delete, re-resolve, POST)
against a ~60s alarm cadence. `runPlatformWatchHeartbeat` holding `withStateLock`
across `watcher.tick()` is the structural issue and is untouched — worth its own
issue.

Refs #345


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 15-second timeout for Twitch heartbeat requests.
  * Heartbeat requests now support cancellation and abort automatically when they time out.
  * Timeout errors are clearly identified and reported with the affected destination.

* **Bug Fixes**
  * Prevented stalled heartbeat requests from hanging indefinitely.
  * Preserved distinct handling for user-initiated cancellations and network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->