### PR TITLE
fix(cli): classify Kick cycletls 403s the same way checkAuthHealth expects

### DIFF
--- a/packages/cli/src/transport/cycle.ts
+++ b/packages/cli/src/transport/cycle.ts
@@ -1,5 +1,6 @@
 import initCycleTLS, { type CycleTLSClient, type CycleTLSWebSocketResponse } from "cycletls";
-import { KickWafBlockedError } from "@lurkloot/core/tabs";
+import { KickWafBlockedError, safeKickFailure } from "@lurkloot/core/tabs";
+import { SafeFetchError } from "@lurkloot/core/fetchError";
 import type { PageFetcher } from "@lurkloot/core/adapter";
 import type { WebSocketFactory, WebSocketLike } from "@lurkloot/core/kick/watch";
 import type { PlatformCredentials } from "../authStore";
@@ -62,11 +63,24 @@ export function createCycleKickFetcher(cycleTLS: CycleTLSClient, creds: Platform
         body: typeof init?.body === "string" ? init.body : undefined,
       }, method);
 
-      if (response.status === 403) {
-        throw new KickWafBlockedError(`HTTP 403 from ${new URL(url).host} (Cloudflare blocked the impersonated request)`);
-      }
       if (response.status >= 400) {
-        throw new Error(`HTTP ${response.status} from ${new URL(url).host}`);
+        // Mirrors fetchKickInBackgroundWith's classification so checkAuthHealth sees the
+        // same failure kinds (WAF challenge vs. rejected credentials) over this transport
+        // as it does over the extension's page-context fetcher. safeKickFailure only
+        // recognizes Cloudflare's block by matching Kick's JSON error envelope; against
+        // this impersonated session a 401/403 is just as likely to come back as an HTML
+        // challenge page (see tabs.ts's own "likely a challenge page" handling), which
+        // would otherwise silently fall through to "authentication_rejected" and could
+        // suspend farming on what was actually a WAF block, not a bad session token.
+        const text = typeof response.data === "string" ? response.data : JSON.stringify(response.data ?? "");
+        const isJsonBody = (typeof response.data === "object" && response.data !== null) || safeJsonParse(text) !== undefined;
+        if (!isJsonBody && (response.status === 401 || response.status === 403)) {
+          throw new KickWafBlockedError(`HTTP ${response.status} from ${new URL(url).host} — non-JSON body (likely a Cloudflare challenge page)`);
+        }
+        const failure = safeKickFailure(response.status, text);
+        throw failure.kind === "security_policy_blocked"
+          ? new KickWafBlockedError(failure)
+          : new SafeFetchError(failure);
       }
 
       const data = response.data;

--- a/packages/cli/tests/impersonate.test.ts
+++ b/packages/cli/tests/impersonate.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { KickWafBlockedError } from "@lurkloot/core/tabs";
+import { isSafeFetchError } from "@lurkloot/core/fetchError";
 import { createImpersonateTransport } from "../src/transport/impersonate";
 import { createTvLinkAuthenticator } from "../src/transport/cycle";
 import { CHROME_JA3 } from "../src/transport/common";
@@ -96,7 +97,32 @@ describe("impersonate transport", () => {
   });
 
   it("surfaces a Cloudflare 403 as KickWafBlockedError", async () => {
-    const client = fakeClient(() => Promise.resolve({ status: 403, data: "blocked" }));
+    const client = fakeClient(() => Promise.resolve({
+      status: 403,
+      data: { error: "Request blocked by security policy.", reference: "9e4db7e3" },
+    }));
+    const handle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
+    await expect(handle.adapters.kick.refreshCampaigns()).rejects.toBeInstanceOf(KickWafBlockedError);
+    await handle.dispose();
+  });
+
+  it("surfaces a non-WAF Kick 403 as a plain auth rejection, not KickWafBlockedError", async () => {
+    const client = fakeClient(() => Promise.resolve({
+      status: 403,
+      data: { error: "Invalid session" },
+    }));
+    const handle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
+    const error = await handle.adapters.kick.refreshCampaigns().catch((caught: unknown) => caught);
+    expect(error).not.toBeInstanceOf(KickWafBlockedError);
+    expect(isSafeFetchError(error) && error.failure.kind).toBe("authentication_rejected");
+    await handle.dispose();
+  });
+
+  it("surfaces a non-JSON 403 body (HTML challenge page) as KickWafBlockedError", async () => {
+    const client = fakeClient(() => Promise.resolve({
+      status: 403,
+      data: "<html><body>Attention Required! | Cloudflare</body></html>",
+    }));
     const handle = await createImpersonateTransport({}, ENABLED, { initClient: async () => client });
     await expect(handle.adapters.kick.refreshCampaigns()).rejects.toBeInstanceOf(KickWafBlockedError);
     await handle.dispose();

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -1013,7 +1013,10 @@ export class KickWafBlockedError extends SafeFetchError {
   }
 }
 
-function safeKickFailure(status: number, text: string): SafeFetchFailure {
+// Exported so headless transports outside the extension (e.g. the CLI's
+// cycletls-backed Kick fetcher) classify Kick's HTTP failures the same way
+// checkAuthHealth does, instead of guessing from the status code alone.
+export function safeKickFailure(status: number, text: string): SafeFetchFailure {
   let body: Record<string, unknown> = {};
   try {
     const parsed = JSON.parse(text) as unknown;


### PR DESCRIPTION
## Summary

Closes #354.

`createCycleKickFetcher` (the Kick `PageFetcher` used by the CLI's `impersonate` transport) treated **every** HTTP 403 from Kick as `KickWafBlockedError`, and every other `>=400` status as a plain `Error`. This diverged from the classification core already uses for the same decision.

`fetchKickInBackgroundWith` (`packages/core/src/core/tabs.ts`, used by the extension's page-context fetcher) instead calls `safeKickFailure(status, text)`, which inspects the response body to distinguish `security_policy_blocked` (Cloudflare WAF challenge) from `authentication_rejected` (bad/expired session). `KickAdapter.checkAuthHealth()` depends on this distinction to report `invalid_credentials` vs `blocked` vs `unavailable`. Because the CLI's cycletls fetcher only ever threw a string-constructed `KickWafBlockedError` (which always resolves to `failure.kind: "network_error"`), `checkAuthHealth()` could never surface `invalid_credentials` or `blocked` over the `impersonate` transport — every failure showed up as the generic "unavailable" state, regardless of whether the real problem was a WAF block or a genuinely bad/expired Kick session token.

## Changes

- Export `safeKickFailure` from `packages/core/src/core/tabs.ts` (mirrors the existing `KickWafBlockedError` export, same rationale: reused by the CLI's headless transport).
- `cycle.ts`'s `createCycleKickFetcher` now classifies `>=400` responses the same way `fetchKickInBackgroundWith` does.
- Added a guard for the case where Cloudflare's block against the impersonated cycletls session comes back as a non-JSON HTML challenge page rather than Kick's JSON error envelope (which `safeKickFailure`'s body-regex match alone wouldn't catch): a 401/403 with an unparseable body is treated as `KickWafBlockedError` directly.

## Not in scope

The other architecture-review finding from the same pass (`KICK_AUTH_HOSTS`/session-bearer predicate duplication, #353) was independently fixed by #351 before this branch was rebased on top of it, so it's not part of this diff. A milder, separate finding (Twitch cycletls plumbing duplicated between `impersonate.ts`/`http.ts`) is tracked as #355, also not addressed here.

## Testing

- `pnpm --filter @lurkloot/core --filter @lurkloot/cli typecheck`
- `pnpm --filter @lurkloot/cli test` — 149 passed, including 3 new cases (WAF-blocked JSON envelope, non-WAF 403 → `authentication_rejected`, non-JSON HTML challenge page → `KickWafBlockedError`)
- `pnpm -r typecheck` and `pnpm test` (full workspace) — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Kick HTTP errors, including authentication failures and access-blocking security challenges.
  * Added clearer detection of Cloudflare-style challenge responses.
  * Prevented regular “Invalid session” responses from being misidentified as security blocks.
* **Tests**
  * Expanded coverage for blocked-access and authentication error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->