### PR TITLE
refactor(cli): share TwitchAdapter/KickAdapter construction between transports

### DIFF
--- a/packages/cli/src/transport/common.ts
+++ b/packages/cli/src/transport/common.ts
@@ -1,7 +1,14 @@
 import type { EngineSettings, Platform } from "@lurkloot/shared/models";
 import type { EventEmitter } from "@lurkloot/shared/events";
-import type { PlatformAdapter, WatchTabPort } from "@lurkloot/core/adapter";
-import type { CompatibilityResolution } from "@lurkloot/core";
+import { DEFAULT_ENGINE_SETTINGS } from "@lurkloot/shared/settings";
+import type { PageFetcher, PlatformAdapter, WatchTabPort } from "@lurkloot/core/adapter";
+import type { WebSocketFactory } from "@lurkloot/core/kick/watch";
+import { KickAdapter, KickClaimState, KickDiscoveryState } from "@lurkloot/core/kick";
+import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
+import type { TwitchHeartbeatFetchText, TwitchHeartbeatPost } from "@lurkloot/core/twitch/heartbeat";
+import { resolveCompatibility, type CompatibilityResolution } from "@lurkloot/core";
+import type { PlatformCredentials } from "../authStore";
+import { twitchClientIdentity } from "../twitch";
 
 // A built set of platform adapters plus a teardown hook (e.g. to stop the
 // cycletls subprocess the impersonate transport owns). Every transport returns
@@ -36,6 +43,76 @@ export function createLazyAdapters(
     get kick() {
       return kick ??= createAdapter("kick");
     },
+  };
+}
+
+// What a CLI transport supplies to get the shared TwitchAdapter/KickAdapter
+// construction below: how each platform reaches the network. Everything else
+// (identity resolution, compatibility resolution, discovery/claim state,
+// tabless watch wiring) is identical between the http and impersonate
+// transports and lives here once.
+export interface CliTransportDeps {
+  twitchFetcher(): PageFetcher;
+  twitchHeartbeat(identity: ReturnType<typeof twitchClientIdentity>): {
+    heartbeatFetchText: TwitchHeartbeatFetchText;
+    heartbeatPost: TwitchHeartbeatPost;
+  };
+  kickFetcher(): PageFetcher;
+  // Absent for the http transport: it never opens the viewer WebSocket itself
+  // (Kick's WAF blocks it from a pure-Node origin anyway).
+  kickWebSocketFactory?(): WebSocketFactory;
+}
+
+export function createCliAdapters(
+  creds: PlatformCredentials,
+  deps: CliTransportDeps,
+): Pick<TransportHandle, "adapters" | "createAdapter" | "createAdapters"> {
+  const kickClaimState = new KickClaimState();
+  const kickDiscoveryState = new KickDiscoveryState();
+  const twitchDiscoveryState = new TwitchDiscoveryState();
+  const createAdapter = (platform: Platform, emit: EventEmitter | undefined, settings: EngineSettings = DEFAULT_ENGINE_SETTINGS) => {
+    const identity = twitchClientIdentity(creds);
+    const twitchIdentity = identity.userAgent ? "android" : "web";
+    const resolution = resolveCompatibility(settings.compatibility, { host: "cli", twitchIdentity });
+    const adapter = platform === "twitch"
+      ? new TwitchAdapter(
+        deps.twitchFetcher(),
+        async () => false,
+        tablessWatchPort,
+        {
+          ...identity,
+          compatibility: resolution.compatibility.twitch,
+          discoveryState: twitchDiscoveryState,
+          heartbeatIdentity: twitchIdentity,
+          ...deps.twitchHeartbeat(identity),
+        },
+        emit,
+      )
+      : new KickAdapter(
+        deps.kickFetcher(),
+        tablessWatchPort,
+        deps.kickWebSocketFactory?.(),
+        emit,
+        { compatibility: resolution.compatibility.kick, claimState: kickClaimState, discoveryState: kickDiscoveryState },
+      );
+    return { adapter, ...resolution };
+  };
+  const createAdapters = (emit: EventEmitter | undefined, settings: EngineSettings = DEFAULT_ENGINE_SETTINGS) => {
+    const twitch = createAdapter("twitch", emit, settings);
+    const kick = createAdapter("kick", emit, settings);
+    return {
+      adapters: {
+        twitch: twitch.adapter,
+        kick: kick.adapter,
+      },
+      compatibility: twitch.compatibility,
+      warnings: twitch.warnings,
+    };
+  };
+  return {
+    adapters: createLazyAdapters((platform) => createAdapter(platform, undefined).adapter),
+    createAdapter,
+    createAdapters,
   };
 }
 

--- a/packages/cli/src/transport/http.ts
+++ b/packages/cli/src/transport/http.ts
@@ -1,14 +1,7 @@
 import { fetchKickInBackgroundWith, fetchTwitchInBackgroundWith } from "@lurkloot/core/tabs";
-import { KickAdapter, KickClaimState, KickDiscoveryState } from "@lurkloot/core/kick";
-import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
-import { resolveCompatibility } from "@lurkloot/core";
-import type { EventEmitter } from "@lurkloot/shared/events";
-import { DEFAULT_ENGINE_SETTINGS } from "@lurkloot/shared/settings";
-import type { Platform } from "@lurkloot/shared/models";
 import type { PlatformCredentials } from "../authStore";
-import { twitchClientIdentity } from "../twitch";
 import { kickCookieApi, twitchCookieApi } from "./cookieApi";
-import { createLazyAdapters, tablessWatchPort, withHeartbeatTimeout, type EnabledPlatforms, type TransportHandle } from "./common";
+import { createCliAdapters, withHeartbeatTimeout, type EnabledPlatforms, type TransportHandle } from "./common";
 
 // Plain Node fetch transport. Twitch GQL works (no WAF). Kick's Cloudflare WAF
 // fingerprints the TLS/HTTP-2 stack, so pure-Node requests get HTTP 403 — that
@@ -17,63 +10,28 @@ import { createLazyAdapters, tablessWatchPort, withHeartbeatTimeout, type Enable
 export function createHttpTransport(creds: PlatformCredentials, _enabled: EnabledPlatforms): TransportHandle {
   const twitchApi = twitchCookieApi(creds);
   const kickApi = kickCookieApi(creds);
-  const kickClaimState = new KickClaimState();
-  const kickDiscoveryState = new KickDiscoveryState();
-  const twitchDiscoveryState = new TwitchDiscoveryState();
-  const createAdapter = (platform: Platform, emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
-    const identity = twitchClientIdentity(creds);
-    const twitchIdentity = identity.userAgent ? "android" : "web";
-    const resolution = resolveCompatibility(settings.compatibility, { host: "cli", twitchIdentity });
-    const adapter = platform === "twitch"
-      ? new TwitchAdapter(
-        { fetchJson: (url, init) => fetchTwitchInBackgroundWith(twitchApi, url, init) },
-        async () => false,
-        tablessWatchPort,
-        {
-          ...identity,
-          compatibility: resolution.compatibility.twitch,
-          discoveryState: twitchDiscoveryState,
-          heartbeatIdentity: twitchIdentity,
-          heartbeatFetchText: async (url, init) => {
-            const response = await withHeartbeatTimeout(
-              (signal) => fetch(url, { ...init, signal }),
-              init?.signal,
-            );
-            return response.text();
-          },
-          heartbeatPost: async (url, init) => {
-            const response = await withHeartbeatTimeout(
-              (signal) => fetch(url, { ...init, signal }),
-              init.signal,
-            );
-            return { status: response.status };
-          },
-        },
-        emit,
-      )
-      : new KickAdapter(
-        { fetchJson: (url, init) => fetchKickInBackgroundWith(kickApi, url, init) },
-        tablessWatchPort,
-        undefined,
-        emit,
-        { compatibility: resolution.compatibility.kick, claimState: kickClaimState, discoveryState: kickDiscoveryState },
-      );
-    return { adapter, ...resolution };
-  };
-  const createAdapters = (emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
-    const twitch = createAdapter("twitch", emit, settings);
-    const kick = createAdapter("kick", emit, settings);
-    return {
-      adapters: {
-        twitch: twitch.adapter,
-        kick: kick.adapter,
+  const { adapters, createAdapter, createAdapters } = createCliAdapters(creds, {
+    twitchFetcher: () => ({ fetchJson: (url, init) => fetchTwitchInBackgroundWith(twitchApi, url, init) }),
+    twitchHeartbeat: () => ({
+      heartbeatFetchText: async (url, init) => {
+        const response = await withHeartbeatTimeout(
+          (signal) => fetch(url, { ...init, signal }),
+          init?.signal,
+        );
+        return response.text();
       },
-      compatibility: twitch.compatibility,
-      warnings: twitch.warnings,
-    };
-  };
+      heartbeatPost: async (url, init) => {
+        const response = await withHeartbeatTimeout(
+          (signal) => fetch(url, { ...init, signal }),
+          init.signal,
+        );
+        return { status: response.status };
+      },
+    }),
+    kickFetcher: () => ({ fetchJson: (url, init) => fetchKickInBackgroundWith(kickApi, url, init) }),
+  });
   return {
-    adapters: createLazyAdapters((platform) => createAdapter(platform, undefined).adapter),
+    adapters,
     createAdapter,
     createAdapters,
     async dispose() {

--- a/packages/cli/src/transport/impersonate.ts
+++ b/packages/cli/src/transport/impersonate.ts
@@ -1,15 +1,8 @@
 import { fetchTwitchInBackgroundWith } from "@lurkloot/core/tabs";
-import { KickAdapter, KickClaimState, KickDiscoveryState } from "@lurkloot/core/kick";
-import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
-import { resolveCompatibility } from "@lurkloot/core";
-import type { EventEmitter } from "@lurkloot/shared/events";
-import { DEFAULT_ENGINE_SETTINGS } from "@lurkloot/shared/settings";
-import type { Platform } from "@lurkloot/shared/models";
 import type { PlatformCredentials } from "../authStore";
-import { twitchClientIdentity } from "../twitch";
 import { twitchCookieApi } from "./cookieApi";
 import { createCycleKickFetcher, createCycleKickWebSocketFactory, initCycle, type CycleTLSClient } from "./cycle";
-import { CHROME_HTTP2, CHROME_JA3, createLazyAdapters, headersToObject, tablessWatchPort, withHeartbeatTimeout, type EnabledPlatforms, type TransportHandle } from "./common";
+import { CHROME_HTTP2, CHROME_JA3, createCliAdapters, headersToObject, withHeartbeatTimeout, type EnabledPlatforms, type TransportHandle } from "./common";
 
 export interface ImpersonateDeps {
   // Injectable for tests; defaults to spawning the real cycletls subprocess.
@@ -27,72 +20,38 @@ export async function createImpersonateTransport(
   deps: ImpersonateDeps = {},
 ): Promise<TransportHandle> {
   const cycleTLS = await (deps.initClient ?? initCycle)();
-  const kickClaimState = new KickClaimState();
-  const kickDiscoveryState = new KickDiscoveryState();
-  const twitchDiscoveryState = new TwitchDiscoveryState();
-  const createAdapter = (platform: Platform, emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
-    const identity = twitchClientIdentity(creds);
-    const twitchIdentity = identity.userAgent ? "android" : "web";
-    const resolution = resolveCompatibility(settings.compatibility, { host: "cli", twitchIdentity });
-    const adapter = platform === "twitch"
-      ? new TwitchAdapter(
-        { fetchJson: (url, init) => fetchTwitchInBackgroundWith(twitchCookieApi(creds), url, init) },
-        async () => false,
-        tablessWatchPort,
-        {
-          ...identity,
-          compatibility: resolution.compatibility.twitch,
-          discoveryState: twitchDiscoveryState,
-          heartbeatIdentity: twitchIdentity,
-          heartbeatFetchText: async (url, init) => {
-            const response = await withHeartbeatTimeout(() => cycleTLS(url, {
-              ja3: CHROME_JA3,
-              http2Fingerprint: CHROME_HTTP2,
-              userAgent: identity.userAgent,
-              headers: headersToObject(init?.headers),
-              body: typeof init?.body === "string" ? init.body : undefined,
-              disableRedirect: init?.redirect === "error" || init?.redirect === "manual",
-            }, (init?.method ?? "GET").toLowerCase() as "get" | "post"), init?.signal);
-            return typeof response.data === "string" ? response.data : JSON.stringify(response.data ?? "");
-          },
-          heartbeatPost: async (url, init) => {
-            const response = await withHeartbeatTimeout(() => cycleTLS(url, {
-              ja3: CHROME_JA3,
-              http2Fingerprint: CHROME_HTTP2,
-              userAgent: identity.userAgent,
-              headers: headersToObject(init.headers),
-              body: typeof init.body === "string" ? init.body : undefined,
-              disableRedirect: init.redirect === "error" || init.redirect === "manual",
-            }, "post"), init.signal);
-            return { status: response.status };
-          },
-        },
-        emit,
-      )
-      : new KickAdapter(
-        createCycleKickFetcher(cycleTLS, creds),
-        tablessWatchPort,
-        createCycleKickWebSocketFactory(cycleTLS, creds),
-        emit,
-        { compatibility: resolution.compatibility.kick, claimState: kickClaimState, discoveryState: kickDiscoveryState },
-      );
-    return { adapter, ...resolution };
-  };
-  const createAdapters = (emit: EventEmitter | undefined, settings = DEFAULT_ENGINE_SETTINGS) => {
-    const twitch = createAdapter("twitch", emit, settings);
-    const kick = createAdapter("kick", emit, settings);
-    return {
-      adapters: {
-        twitch: twitch.adapter,
-        kick: kick.adapter,
+  const { adapters, createAdapter, createAdapters } = createCliAdapters(creds, {
+    twitchFetcher: () => ({ fetchJson: (url, init) => fetchTwitchInBackgroundWith(twitchCookieApi(creds), url, init) }),
+    twitchHeartbeat: (identity) => ({
+      heartbeatFetchText: async (url, init) => {
+        const response = await withHeartbeatTimeout(() => cycleTLS(url, {
+          ja3: CHROME_JA3,
+          http2Fingerprint: CHROME_HTTP2,
+          userAgent: identity.userAgent,
+          headers: headersToObject(init?.headers),
+          body: typeof init?.body === "string" ? init.body : undefined,
+          disableRedirect: init?.redirect === "error" || init?.redirect === "manual",
+        }, (init?.method ?? "GET").toLowerCase() as "get" | "post"), init?.signal);
+        return typeof response.data === "string" ? response.data : JSON.stringify(response.data ?? "");
       },
-      compatibility: twitch.compatibility,
-      warnings: twitch.warnings,
-    };
-  };
+      heartbeatPost: async (url, init) => {
+        const response = await withHeartbeatTimeout(() => cycleTLS(url, {
+          ja3: CHROME_JA3,
+          http2Fingerprint: CHROME_HTTP2,
+          userAgent: identity.userAgent,
+          headers: headersToObject(init.headers),
+          body: typeof init.body === "string" ? init.body : undefined,
+          disableRedirect: init.redirect === "error" || init.redirect === "manual",
+        }, "post"), init.signal);
+        return { status: response.status };
+      },
+    }),
+    kickFetcher: () => createCycleKickFetcher(cycleTLS, creds),
+    kickWebSocketFactory: () => createCycleKickWebSocketFactory(cycleTLS, creds),
+  });
 
   return {
-    adapters: createLazyAdapters((platform) => createAdapter(platform, undefined).adapter),
+    adapters,
     createAdapter,
     createAdapters,
     async dispose() {


### PR DESCRIPTION
## Summary

Closes #355.

`packages/cli/src/transport/http.ts` and `packages/cli/src/transport/impersonate.ts` each rebuilt an almost-identical `createAdapter`/`createAdapters` closure: same identity resolution (`twitchClientIdentity`), same `resolveCompatibility` call, same `KickClaimState`/`KickDiscoveryState`/`TwitchDiscoveryState` wiring, same `tablessWatchPort`, same shape of the returned `TransportHandle`. The only real difference between the two transports is *how each platform reaches the network* — plain `fetch`/cookie-backed fetchers for `http.ts`, cycletls-impersonated fetchers/heartbeats for `impersonate.ts`.

## Changes

- Added `createCliAdapters(creds, deps)` to `packages/cli/src/transport/common.ts`: owns the shared skeleton (state, identity/compatibility resolution, `TwitchAdapter`/`KickAdapter` construction, `createLazyAdapters` wiring), parameterized by a small `CliTransportDeps` interface: `twitchFetcher()`, `twitchHeartbeat(identity)`, `kickFetcher()`, and optional `kickWebSocketFactory()`.
- `http.ts` and `impersonate.ts` now only supply their platform-specific fetcher/heartbeat implementations and their own `dispose()` (no-op for `http.ts`, `cycleTLS.exit()` for `impersonate.ts`).
- No behavior change. `common.ts` is now the single construction site for both transports; the resolved identity, compatibility, and per-request plumbing (Chrome JA3/HTTP-2 fingerprint, timeout wrapping, etc.) are unchanged, just relocated.

One pre-existing quirk I deliberately preserved rather than "fixed": `http.ts` builds `twitchApi`/`kickApi` once outside the adapter factory, while `impersonate.ts`'s `twitchFetcher` calls `twitchCookieApi(creds)` fresh on every invocation. Confirmed `twitchCookieApi`/`kickCookieApi` (`cookieApi.ts`) are pure, stateless wrappers over `creds` with no side effects, so this is behaviorally identical either way — not touching it keeps this PR a pure refactor.

## Not in scope

`packages/cli/src/transport/cycle.ts` is Kick-only by design (Twitch has no Cloudflare WAF in front of it) and isn't part of this duplication — it wasn't touched here.

## Testing

- `pnpm --filter @lurkloot/cli typecheck` / `pnpm --filter @lurkloot/cli test` — 149 passed, no test changes needed (confirms the refactor is behavior-preserving under existing coverage)
- `pnpm -r typecheck` and `pnpm test` (full workspace) — all green
- `pnpm verify` (full check + both browser builds) — all green
- Note: existing test coverage exercises the `impersonate` transport's Twitch heartbeat path indirectly but not `http.ts`'s (`bootstrap.test.ts` mocks `TwitchAdapter.checkAuthHealth` directly for both transports) — pre-existing gap, unchanged by this refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified Twitch and Kick connection setup across HTTP and impersonation modes.
  - Improved consistency for compatibility checks, discovery, identity, heartbeat, and event handling.
  - Preserved existing Twitch and Kick connectivity, including cookie, WebSocket, and timeout support.
  - Added compatibility warnings and more flexible adapter initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->