### PR TITLE
refactor(core): require resolved compatibility on adapter options

### DIFF
--- a/packages/cli/src/transport/http.ts
+++ b/packages/cli/src/transport/http.ts
@@ -55,8 +55,8 @@ export function createHttpTransport(creds: PlatformCredentials, _enabled: Enable
         { fetchJson: (url, init) => fetchKickInBackgroundWith(kickApi, url, init) },
         tablessWatchPort,
         undefined,
-        emit,
         { compatibility: resolution.compatibility.kick, claimState: kickClaimState, discoveryState: kickDiscoveryState },
+        emit,
       );
     return { adapter, ...resolution };
   };

--- a/packages/cli/src/transport/impersonate.ts
+++ b/packages/cli/src/transport/impersonate.ts
@@ -73,8 +73,8 @@ export async function createImpersonateTransport(
         createCycleKickFetcher(cycleTLS, creds),
         tablessWatchPort,
         createCycleKickWebSocketFactory(cycleTLS, creds),
-        emit,
         { compatibility: resolution.compatibility.kick, claimState: kickClaimState, discoveryState: kickDiscoveryState },
+        emit,
       );
     return { adapter, ...resolution };
   };

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -4,7 +4,7 @@ import type { TablessWatchController } from "../../core/tablessWatch";
 import { KickWafBlockedError } from "../../core/tabs";
 import { authHealthFromError } from "../../core/fetchError";
 import { StaleWhileRevalidateCache } from "../../core/staleCache";
-import { diagnostic, ignoreEvent, unavailableWatchTabPort, type AdapterOperationOptions, type ClaimedChallenge, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
+import { diagnostic, ignoreEvent, type AdapterOperationOptions, type ClaimedChallenge, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { kickCandidatesFromCampaign, mergeKickProgress, parseKickCampaigns } from "./parser";
 import { KICK_CLIENT_TOKEN, KickWatcher, type WebSocketFactory } from "./watch";
 import type { ResolvedCompatibility } from "../../compatibility/types";
@@ -36,8 +36,10 @@ export class KickDiscoveryState {
 export interface KickAdapterOptions {
   // Resolved metadata is injected by the host and fixed for this adapter's
   // lifetime. Settings changes construct a fresh adapter rather than switching
-  // claim behavior after a request failure.
-  compatibility?: ResolvedCompatibility["kick"];
+  // claim behavior after a request failure. Required: resolveCompatibility()
+  // is the only thing that may decide which capability an adapter gets — no
+  // construction site restates a default.
+  compatibility: ResolvedCompatibility["kick"];
   claimState?: KickClaimState;
   discoveryState?: KickDiscoveryState;
 }
@@ -288,20 +290,26 @@ export class KickAdapter implements PlatformAdapter {
 
   constructor(
     private readonly fetcher: PageFetcher,
-    // Tab-based watch is browser-bound, so it is injected (see WatchTabPort).
-    private readonly watchTabPort: WatchTabPort = unavailableWatchTabPort,
-    // Optional factory for the tabless viewer WebSocket. The extension leaves it
-    // unset (the watcher uses the platform WebSocket from the service worker); a
+    // Tab-based watch is browser-bound, so it is injected (see WatchTabPort). No
+    // default: a required options.compatibility below would follow an optional
+    // parameter, which TypeScript rejects (a required parameter cannot follow an
+    // optional one), so this and webSocketFactory lost their defaults too. emit
+    // moved after options (instead of before) so it could keep its default.
+    private readonly watchTabPort: WatchTabPort,
+    // Factory for the tabless viewer WebSocket. The extension passes undefined
+    // (the watcher uses the platform WebSocket from the service worker); a
     // headless runtime injects one that rides its impersonated session so the
     // handshake clears Kick's WAF.
-    private readonly webSocketFactory?: WebSocketFactory,
+    private readonly webSocketFactory: WebSocketFactory | undefined,
+    // No default: options.compatibility is required, so every construction
+    // site must resolve it via resolveCompatibility() rather than get one implied.
+    options: KickAdapterOptions,
     private readonly emit: EventEmitter = ignoreEvent,
-    options: KickAdapterOptions = {},
   ) {
     this.compatibility = options.compatibility;
     this.discoveryState = options.discoveryState ?? new KickDiscoveryState();
     this.claimCapability = createKickClaimCapability(
-      options.compatibility?.claim ?? "kick-claim-v2",
+      options.compatibility.claim,
       options.claimState,
     );
   }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -6,7 +6,7 @@ import type { TwitchIntegrityRequest } from "../../core/tabs";
 import type { TwitchIntegrity } from "../../core/twitchIntegrity";
 import { PendingWatcherDiagnostics, type HeartbeatResult, type TablessWatchController, type WatchContext } from "../../core/tablessWatch";
 import { StaleWhileRevalidateCache } from "../../core/staleCache";
-import { diagnostic, ignoreEvent, unavailableWatchTabPort, type AdapterOperationOptions, type CandidateChannelSelection, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
+import { diagnostic, ignoreEvent, type AdapterOperationOptions, type CandidateChannelSelection, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { campaignHasClaimableReward, mergeTwitchCampaignProgress, parseTwitchCampaigns, twitchCandidatesFromCampaign, withCampaignStatus } from "./parser";
 import type { ResolvedCompatibility, TwitchIdentity } from "../../compatibility/types";
 import { createTwitchHeartbeat } from "./heartbeat/factory";
@@ -46,7 +46,9 @@ export interface TwitchAdapterOptions {
   // non-browser runtimes — browsers forbid overriding User-Agent on fetch.
   userAgent?: string;
   // Resolved metadata selects the registered heartbeat and inventory versions.
-  compatibility?: ResolvedCompatibility["twitch"];
+  // Required: resolveCompatibility() is the only thing that may decide which
+  // capability an adapter gets — no construction site restates a default.
+  compatibility: ResolvedCompatibility["twitch"];
   heartbeatStrategy?: TwitchHeartbeatStrategy;
   heartbeatIdentity?: TwitchIdentity;
   heartbeatFetchText?: TwitchHeartbeatFetchText;
@@ -456,7 +458,7 @@ export type TwitchGqlTransport = <T>(
 // so a persistent watcher never retains an operation-scoped adapter/emitter.
 export function createTwitchGqlTransport(
   fetcher: PageFetcher,
-  options: TwitchAdapterOptions = {},
+  options: TwitchAdapterOptions,
 ): TwitchGqlTransport {
   const clientId = options.clientId ?? TWITCH_CLIENT_ID;
   const userAgent = options.userAgent;
@@ -627,24 +629,27 @@ export class TwitchAdapter implements PlatformAdapter {
     private readonly fetcher: PageFetcher,
     // Twitch only enforces Client-Integrity (Kasada) for the WEB client id, so
     // this is only meaningful under that id (the extension, which captures the
-    // page-minted token). A runtime using a non-web client id never needs it, so
-    // it defaults to "no integrity available".
-    private readonly ensureIntegrity: (request?: TwitchIntegrityRequest) => Promise<boolean> = async () => false,
+    // page-minted token). A runtime using a non-web client id never needs it —
+    // pass `async () => false` for "no integrity available". No default: a
+    // required options.compatibility below would follow an optional parameter,
+    // which TypeScript rejects (a required parameter cannot follow an optional
+    // one), so this and watchTabPort lost their defaults too.
+    private readonly ensureIntegrity: (request?: TwitchIntegrityRequest) => Promise<boolean>,
     // Tab-based watch is browser-bound, so it is injected (see WatchTabPort).
-    private readonly watchTabPort: WatchTabPort = unavailableWatchTabPort,
+    private readonly watchTabPort: WatchTabPort,
     // Identity the GQL requests present. Defaults to the WEB client (what the
     // extension uses). A headless runtime can pass a non-web client id + matching
     // user agent (e.g. the Android app) so Twitch never gates it behind integrity
     // — the persisted-query hashes are client-agnostic, so claims work unchanged.
-    private readonly options: TwitchAdapterOptions = {},
+    // No default: options.compatibility is required, so every construction site
+    // must resolve it via resolveCompatibility() rather than get one implied.
+    private readonly options: TwitchAdapterOptions,
     private readonly emit: EventEmitter = ignoreEvent,
   ) {
     this.compatibility = options.compatibility;
     this.discoveryState = options.discoveryState ?? new TwitchDiscoveryState();
     this.gqlTransport = createTwitchGqlTransport(fetcher, options);
-    this.inventoryCapability = createTwitchInventory(
-      options.compatibility?.inventory ?? "twitch-inventory-v1",
-    );
+    this.inventoryCapability = createTwitchInventory(options.compatibility.inventory);
   }
 
   private async discoverCampaignSnapshot(
@@ -1894,7 +1899,7 @@ class TwitchWatcher implements TablessWatchController {
     private readonly ensureIntegrity: (request?: TwitchIntegrityRequest) => Promise<boolean> = async () => false,
   ) {
     this.heartbeatStrategy = options.heartbeatStrategy ?? createTwitchHeartbeat(
-      options.compatibility?.heartbeat ?? "twitch-heartbeat-gql-v1",
+      options.compatibility.heartbeat,
       {
         gql,
         emit: this.diagnostics.emit,

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -122,8 +122,8 @@ function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings
       }),
       watchTabPort,
       undefined,
-      emit,
       { compatibility: resolution.compatibility.kick, claimState: kickClaimState, discoveryState: kickDiscoveryState },
+      emit,
     );
   return { adapter, ...resolution };
 }

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -10,6 +10,7 @@ import { chooseCampaignDecision } from "@lurkloot/core/scheduler";
 import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
 import { resolveCompatibility } from "@lurkloot/core";
 import { SafeFetchError, type SafeFetchFailureKind } from "@lurkloot/core/fetchError";
+import { kickAdapter, twitchAdapter, TWITCH_COMPAT } from "./helpers/adapters";
 
 function jsonFetcher(handler: (url: string, init?: RequestInit) => unknown): PageFetcher {
   const fetchJson = vi.fn(async (url: string, init?: RequestInit): Promise<unknown> => handler(url, init));
@@ -97,7 +98,7 @@ describe("KickAdapter", () => {
   it("starts Kick campaign and progress requests concurrently", async () => {
     let campaignStarted = false;
     let progressStarted = false;
-    const adapter = new KickAdapter(jsonFetcher(async (url) => {
+    const adapter = kickAdapter(jsonFetcher(async (url) => {
       if (url.endsWith("/drops/campaigns")) {
         campaignStarted = true;
         await vi.waitFor(() => expect(progressStarted).toBe(true));
@@ -132,7 +133,7 @@ describe("KickAdapter", () => {
 
   it("keeps Kick campaigns when concurrent progress refresh fails", async () => {
     const events: EngineEvent[] = [];
-    const adapter = new KickAdapter(jsonFetcher((url) => {
+    const adapter = kickAdapter(jsonFetcher((url) => {
       if (url.endsWith("/drops/campaigns")) {
         return {
           data: [{
@@ -158,7 +159,7 @@ describe("KickAdapter", () => {
 
   it("propagates Kick progress authentication failures during refresh", async () => {
     const failure = new SafeFetchError({ kind: "authentication_rejected", status: 401 });
-    const adapter = new KickAdapter(jsonFetcher((url) => {
+    const adapter = kickAdapter(jsonFetcher((url) => {
       if (url.endsWith("/drops/campaigns")) return { data: [] };
       throw failure;
     }));
@@ -168,7 +169,7 @@ describe("KickAdapter", () => {
 
   it("propagates Kick campaign discovery failures during refresh", async () => {
     const failure = new Error("campaigns unavailable");
-    const adapter = new KickAdapter(jsonFetcher((url) => {
+    const adapter = kickAdapter(jsonFetcher((url) => {
       if (url.endsWith("/drops/progress")) return { data: [] };
       throw failure;
     }));
@@ -179,7 +180,7 @@ describe("KickAdapter", () => {
   it("propagates Kick refresh cancellation without reporting a progress fallback", async () => {
     const abort = new AbortController();
     const events: EngineEvent[] = [];
-    const adapter = new KickAdapter(jsonFetcher((url, init) => {
+    const adapter = kickAdapter(jsonFetcher((url, init) => {
       if (url.endsWith("/drops/campaigns")) return { data: [] };
       return new Promise((_, reject) => {
         init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
@@ -204,7 +205,7 @@ describe("KickAdapter", () => {
     const fetchJson = vi.fn(async () => ({ id: 42 }));
     const fetcher = { fetchJson: fetchJson as PageFetcher["fetchJson"] };
 
-    await new KickAdapter(fetcher, undefined, undefined, emit).checkAuthHealth(abort.signal);
+    await kickAdapter(fetcher, undefined, undefined, emit).checkAuthHealth(abort.signal);
 
     expect(fetchJson).toHaveBeenCalledWith(
       "https://kick.com/api/v1/user",
@@ -215,7 +216,7 @@ describe("KickAdapter", () => {
 
   it("does not swallow authentication failures while refreshing progress", async () => {
     const failure = new SafeFetchError({ kind: "authentication_rejected", status: 401 });
-    const adapter = new KickAdapter(jsonFetcher((url) => {
+    const adapter = kickAdapter(jsonFetcher((url) => {
       if (url.endsWith("/drops/campaigns")) return { data: [] };
       throw failure;
     }));
@@ -225,7 +226,7 @@ describe("KickAdapter", () => {
 
   it("does not swallow security-policy failures while claiming challenges", async () => {
     const failure = new SafeFetchError({ kind: "security_policy_blocked", status: 403, reference: "safe-ref" });
-    const adapter = new KickAdapter(jsonFetcher((url) => {
+    const adapter = kickAdapter(jsonFetcher((url) => {
       if (url.endsWith("/gamification/challenges")) {
         return { data: [{ id: "daily", claimed_at: null, recurrence: "daily", condition: { progress: 1, threshold: 1 } }] };
       }
@@ -250,7 +251,7 @@ describe("KickAdapter", () => {
       });
     });
 
-    const health = await new KickAdapter(fetcher).checkAuthHealth();
+    const health = await kickAdapter(fetcher).checkAuthHealth();
 
     expect(health).toMatchObject({ status, reasonCode, message: { key } });
     expect(health.message?.values?.reference).toBe(kind === "security_policy_blocked" ? "9e4db7e3" : undefined);
@@ -260,7 +261,7 @@ describe("KickAdapter", () => {
   it("does not copy unknown account probe errors into health state", async () => {
     const fetcher = jsonFetcher(() => { throw new Error("token=secret-value"); });
 
-    const health = await new KickAdapter(fetcher).checkAuthHealth();
+    const health = await kickAdapter(fetcher).checkAuthHealth();
 
     expect(health).toMatchObject({
       status: "unavailable",
@@ -283,7 +284,7 @@ describe("KickAdapter", () => {
       host: "extension",
       twitchIdentity: "web",
     }).compatibility.kick;
-    const adapter = new KickAdapter(fetcher, undefined, undefined, undefined, { compatibility });
+    const adapter = kickAdapter(fetcher, undefined, undefined, undefined, { compatibility });
     const campaign = { id: "campaign" } as DropCampaign;
     const reward = { id: "reward", status: "claimable", requiredMinutes: 1, watchedMinutes: 1 } as DropReward;
 
@@ -308,7 +309,7 @@ describe("KickAdapter", () => {
       ...DEFAULT_SETTINGS.compatibility,
       kick: { ...DEFAULT_SETTINGS.compatibility.kick, claimLinkHandling: "kick-claim-v1" },
     }, { host: "extension", twitchIdentity: "web" }).compatibility.kick;
-    const adapter = new KickAdapter(fetcher, undefined, undefined, undefined, { compatibility });
+    const adapter = kickAdapter(fetcher, undefined, undefined, undefined, { compatibility });
     const campaign = { id: "campaign", accountLinked: true } as DropCampaign;
     const reward = { id: "reward", status: "claimable", requiredMinutes: 1, watchedMinutes: 1 } as DropReward;
 
@@ -328,8 +329,8 @@ describe("KickAdapter", () => {
     });
     const first: EngineEvent[] = [];
     const second: EngineEvent[] = [];
-    const firstAdapter = new KickAdapter(failingFetcher, undefined, undefined, (event) => first.push(event));
-    const secondAdapter = new KickAdapter(failingFetcher, undefined, undefined, (event) => second.push(event));
+    const firstAdapter = kickAdapter(failingFetcher, undefined, undefined, (event) => first.push(event));
+    const secondAdapter = kickAdapter(failingFetcher, undefined, undefined, (event) => second.push(event));
 
     await firstAdapter.refreshCampaigns();
     await secondAdapter.refreshCampaigns();
@@ -378,7 +379,7 @@ describe("KickAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new KickAdapter(fetcher);
+    const adapter = kickAdapter(fetcher);
 
     const campaigns = await adapter.refreshCampaigns();
     const candidates = await adapter.listCandidateChannels(campaigns[0]);
@@ -391,7 +392,7 @@ describe("KickAdapter", () => {
   it("lists followed live channels from the Kick user livestreams endpoint and caches them", async () => {
     let calls = 0;
     let requestedUrl = "";
-    const adapter = new KickAdapter(jsonFetcher((url) => {
+    const adapter = kickAdapter(jsonFetcher((url) => {
       requestedUrl = url;
       calls += 1;
       return [
@@ -410,7 +411,7 @@ describe("KickAdapter", () => {
 
   it("reports no followed channels for a signed-out session or a failed lookup", async () => {
     const emit = vi.fn();
-    const adapter = new KickAdapter(jsonFetcher(() => {
+    const adapter = kickAdapter(jsonFetcher(() => {
       throw new SafeFetchError({ kind: "authentication_rejected", status: 401 });
     }), undefined, undefined, emit);
 
@@ -432,8 +433,8 @@ describe("KickAdapter", () => {
       return [{ channel: { slug: "friend" } }];
     });
     const discoveryState = new KickDiscoveryState();
-    const firstTick = new KickAdapter(fetcher, undefined, undefined, undefined, { discoveryState });
-    const secondTick = new KickAdapter(fetcher, undefined, undefined, undefined, { discoveryState });
+    const firstTick = kickAdapter(fetcher, undefined, undefined, undefined, { discoveryState });
+    const secondTick = kickAdapter(fetcher, undefined, undefined, undefined, { discoveryState });
 
     await expect(firstTick.listFollowedChannels()).resolves.toEqual(["friend"]);
     await expect(secondTick.listFollowedChannels()).resolves.toEqual(["friend"]);
@@ -456,13 +457,13 @@ describe("KickAdapter", () => {
         });
       });
       const discoveryState = new KickDiscoveryState();
-      const firstTick = new KickAdapter(fetcher, undefined, undefined, undefined, { discoveryState });
+      const firstTick = kickAdapter(fetcher, undefined, undefined, undefined, { discoveryState });
 
       await expect(firstTick.listFollowedChannels()).resolves.toEqual(["stale-friend"]);
       expect(calls).toBe(1);
 
       vi.advanceTimersByTime(6 * 60_000); // past the 5-minute cache TTL
-      const secondTick = new KickAdapter(fetcher, undefined, undefined, undefined, { discoveryState });
+      const secondTick = kickAdapter(fetcher, undefined, undefined, undefined, { discoveryState });
 
       // Resolves with the stale value without waiting on the (still-pending)
       // background refresh.
@@ -470,7 +471,7 @@ describe("KickAdapter", () => {
       expect(calls).toBe(2);
 
       resolveSecondFetch?.();
-      await vi.waitFor(() => expect(new KickAdapter(fetcher, undefined, undefined, undefined, { discoveryState }).listFollowedChannels())
+      await vi.waitFor(() => expect(kickAdapter(fetcher, undefined, undefined, undefined, { discoveryState }).listFollowedChannels())
         .resolves.toEqual(["fresh-friend"]));
     } finally {
       vi.useRealTimers();
@@ -495,7 +496,7 @@ describe("KickAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new KickAdapter(fetcher);
+    const adapter = kickAdapter(fetcher);
 
     const candidates = await adapter.listCandidateChannels({
       id: "site-wide",
@@ -525,7 +526,7 @@ describe("KickAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new KickAdapter(fetcher);
+    const adapter = kickAdapter(fetcher);
     const settings: ExtensionSettings = {
       ...DEFAULT_SETTINGS,
       platform: {
@@ -562,7 +563,7 @@ describe("KickAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new KickAdapter(fetcher);
+    const adapter = kickAdapter(fetcher);
 
     const decision = await chooseCampaignDecision(
       "kick",
@@ -594,7 +595,7 @@ describe("KickAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new KickAdapter(fetcher);
+    const adapter = kickAdapter(fetcher);
     const campaign = { id: "campaign", categoryId: "99" } as DropCampaign;
     const reward = { id: "reward", status: "claimable", requiredMinutes: 1, watchedMinutes: 1 } as DropReward;
 
@@ -613,7 +614,7 @@ describe("KickAdapter", () => {
   it("treats a Kick claim as successful only on a positive response signal", async () => {
     const campaign = { id: "campaign" } as DropCampaign;
     const reward = { id: "reward", status: "claimable", requiredMinutes: 1, watchedMinutes: 1 } as DropReward;
-    const claimWith = (body: unknown) => new KickAdapter(jsonFetcher((url) => {
+    const claimWith = (body: unknown) => kickAdapter(jsonFetcher((url) => {
       if (url === "https://web.kick.com/api/v1/drops/claim") return body;
       throw new Error(`Unexpected URL ${url}`);
     })).claimReward(campaign, reward);
@@ -678,7 +679,7 @@ describe("KickAdapter", () => {
       if (url === "https://web.kick.com/api/v1/drops/progress") return progress;
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new KickAdapter(fetcher, undefined, undefined, (event) => events.push(event));
+    const adapter = kickAdapter(fetcher, undefined, undefined, (event) => events.push(event));
     const campaign = {
       id: "campaign",
       platform: "kick",
@@ -736,7 +737,7 @@ describe("KickAdapter", () => {
   it("clears v2 suppression from a bare-array affirmative progress response", async () => {
     let claimPosts = 0;
     let progress: unknown = [{ campaign_id: "campaign" }];
-    const adapter = new KickAdapter(jsonFetcher((url) => {
+    const adapter = kickAdapter(jsonFetcher((url) => {
       if (url === "https://web.kick.com/api/v1/drops/claim") {
         claimPosts += 1;
         return { connect_url: "https://accounts.example/link" };
@@ -771,17 +772,17 @@ describe("KickAdapter", () => {
     const reward = { id: "reward", name: "Reward", status: "claimable", requiredMinutes: 1, watchedMinutes: 1 } as DropReward;
 
     const state = new KickClaimState();
-    await new KickAdapter(fetcher, undefined, undefined, undefined, { claimState: state }).claimReward(campaign, reward);
-    await new KickAdapter(fetcher, undefined, undefined, undefined, { claimState: state }).claimReward(campaign, reward);
+    await kickAdapter(fetcher, undefined, undefined, undefined, { claimState: state }).claimReward(campaign, reward);
+    await kickAdapter(fetcher, undefined, undefined, undefined, { claimState: state }).claimReward(campaign, reward);
 
     expect(claimPosts).toBe(1);
 
     state.clear();
-    await new KickAdapter(fetcher, undefined, undefined, undefined, { claimState: state }).claimReward(campaign, reward);
+    await kickAdapter(fetcher, undefined, undefined, undefined, { claimState: state }).claimReward(campaign, reward);
 
     expect(claimPosts).toBe(2);
 
-    await new KickAdapter(fetcher, undefined, undefined, undefined, { claimState: new KickClaimState() }).claimReward(campaign, reward);
+    await kickAdapter(fetcher, undefined, undefined, undefined, { claimState: new KickClaimState() }).claimReward(campaign, reward);
 
     expect(claimPosts).toBe(3);
   });
@@ -806,7 +807,7 @@ describe("KickAdapter", () => {
   it("guides the user to link instead of erroring when an unlinked Kick claim is rejected", async () => {
     const reward = { id: "reward", name: "Spray", status: "claimable", requiredMinutes: 1, watchedMinutes: 1 } as DropReward;
     let rejectionPosts = 0;
-    const rejecting = () => new KickAdapter(jsonFetcher((url) => {
+    const rejecting = () => kickAdapter(jsonFetcher((url) => {
       if (url === "https://web.kick.com/api/v1/drops/claim") {
         rejectionPosts += 1;
         throw new Error("403 Forbidden");
@@ -838,7 +839,7 @@ describe("KickAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const check = await new KickAdapter(fetcher).checkChannel({ platform: "kick", username: "creator", url: "https://kick.com/creator" });
+    const check = await kickAdapter(fetcher).checkChannel({ platform: "kick", username: "creator", url: "https://kick.com/creator" });
     expect(check.live).toBe(true);
     expect(check.candidate.viewerCount).toBe(164);
     expect(check.candidate.categoryName).toBe("Rust");
@@ -856,7 +857,7 @@ describe("KickAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new KickAdapter(fetcher);
+    const adapter = kickAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "kick", username: "creator", url: "https://kick.com/creator" },
@@ -879,7 +880,7 @@ describe("KickAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new KickAdapter(fetcher);
+    const adapter = kickAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "kick", username: "creator", url: "https://kick.com/creator" },
@@ -906,14 +907,14 @@ describe("KickAdapter", () => {
       };
     });
 
-    await expect(new KickAdapter(fetcher).searchCategories("rust")).resolves.toEqual([
+    await expect(kickAdapter(fetcher).searchCategories("rust")).resolves.toEqual([
       { id: "13", name: "Rust", imageUrl: "https://files.kick.com/rust.webp" },
     ]);
   });
 
   it("returns no categories for a blank query without fetching", async () => {
     const fetcher = jsonFetcher(() => { throw new Error("should not fetch"); });
-    await expect(new KickAdapter(fetcher).searchCategories("   ")).resolves.toEqual([]);
+    await expect(kickAdapter(fetcher).searchCategories("   ")).resolves.toEqual([]);
   });
 
   it("claims only completed, unclaimed Kick challenges", async () => {
@@ -936,7 +937,7 @@ describe("KickAdapter", () => {
       throw new Error(`Unexpected URL ${url}`);
     });
 
-    const adapter = new KickAdapter(fetcher);
+    const adapter = kickAdapter(fetcher);
 
     await expect(adapter.claimChallenges!()).resolves.toEqual([
       { id: "done", rarity: "legendary", recurrence: "daily" },
@@ -953,7 +954,7 @@ describe("KickAdapter", () => {
       throw new Error(`Unexpected URL ${url}`);
     });
 
-    await expect(new KickAdapter(fetcher).claimChallenges!()).resolves.toEqual([
+    await expect(kickAdapter(fetcher).claimChallenges!()).resolves.toEqual([
       { id: "done", rarity: "unknown", recurrence: "weekly" },
     ]);
   });
@@ -975,14 +976,14 @@ describe("KickAdapter", () => {
       throw new Error(`Unexpected URL ${url}`);
     });
 
-    await expect(new KickAdapter(fetcher).claimChallenges!()).resolves.toEqual([
+    await expect(kickAdapter(fetcher).claimChallenges!()).resolves.toEqual([
       { id: "good", rarity: "common", recurrence: "daily" },
     ]);
   });
 
   it("returns nothing when Kick reports no challenges", async () => {
     const fetcher = jsonFetcher(() => ({}));
-    await expect(new KickAdapter(fetcher).claimChallenges!()).resolves.toEqual([]);
+    await expect(kickAdapter(fetcher).claimChallenges!()).resolves.toEqual([]);
   });
 });
 
@@ -1138,7 +1139,7 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
 describe("TwitchAdapter", () => {
   it("refreshes Twitch campaigns with one inventory request", async () => {
     let inventoryCalls = 0;
-    const adapter = new TwitchAdapter(jsonFetcher((_url, init) => {
+    const adapter = twitchAdapter(jsonFetcher((_url, init) => {
       const body = JSON.parse(String(init?.body)) as
         | Record<string, unknown>
         | Array<Record<string, unknown>>;
@@ -1161,7 +1162,7 @@ describe("TwitchAdapter", () => {
   it("merges active Twitch session progress without repeating inventory", async () => {
     let inventoryCalls = 0;
     let currentDropCalls = 0;
-    const adapter = new TwitchAdapter(jsonFetcher((_url, init) => {
+    const adapter = twitchAdapter(jsonFetcher((_url, init) => {
       const body = JSON.parse(String(init?.body)) as
         | Record<string, unknown>
         | Array<Record<string, unknown>>;
@@ -1211,7 +1212,7 @@ describe("TwitchAdapter", () => {
 
   it("lists followed live channels and caches them across calls", async () => {
     let calls = 0;
-    const adapter = new TwitchAdapter(jsonFetcher((_url, init) => {
+    const adapter = twitchAdapter(jsonFetcher((_url, init) => {
       const body = requestBody(init);
       if (body.operationName !== "FollowedLiveChannels") throw new Error(`Unexpected operation ${String(body.operationName)}`);
       calls += 1;
@@ -1240,7 +1241,7 @@ describe("TwitchAdapter", () => {
     const emit = vi.fn();
     // Schema drift answers 200 with an errors body rather than throwing, so it
     // must not be mistaken for a signed-out account with no live follows.
-    const adapter = new TwitchAdapter(
+    const adapter = twitchAdapter(
       jsonFetcher(() => ({ errors: [{ message: "Cannot query field followedLiveUsers" }] })),
       undefined,
       undefined,
@@ -1256,7 +1257,7 @@ describe("TwitchAdapter", () => {
   });
 
   it("returns no followed channels for a signed-out session", async () => {
-    const adapter = new TwitchAdapter(jsonFetcher(() => ({ data: { currentUser: null } })));
+    const adapter = twitchAdapter(jsonFetcher(() => ({ data: { currentUser: null } })));
 
     await expect(adapter.listFollowedChannels()).resolves.toEqual([]);
   });
@@ -1272,8 +1273,8 @@ describe("TwitchAdapter", () => {
       return { data: { currentUser: { followedLiveUsers: { edges: [{ node: { login: "friend" } }] } } } };
     });
     const discoveryState = new TwitchDiscoveryState();
-    const firstTick = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
-    const secondTick = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const firstTick = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const secondTick = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
     await expect(firstTick.listFollowedChannels()).resolves.toEqual(["friend"]);
     await expect(secondTick.listFollowedChannels()).resolves.toEqual(["friend"]);
@@ -1294,11 +1295,11 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
     discoveryState.setAuthenticatedUser("user-1");
-    const firstTick = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const firstTick = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
     await expect(firstTick.listFollowedChannels()).resolves.toEqual(["first-account-friend"]);
 
     discoveryState.setAuthenticatedUser("user-2");
-    const secondTick = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const secondTick = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
     await expect(secondTick.listFollowedChannels()).resolves.toEqual(["second-account-friend"]);
     expect(calls).toBe(2);
@@ -1312,12 +1313,12 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
     discoveryState.setAuthenticatedUser("user-1");
-    const firstTick = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const firstTick = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
     await expect(firstTick.listFollowedChannels()).resolves.toEqual(["friend"]);
 
     // Discovery re-reports the same id every tick; that must not cost a refetch.
     discoveryState.setAuthenticatedUser("user-1");
-    const secondTick = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const secondTick = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
     await expect(secondTick.listFollowedChannels()).resolves.toEqual(["friend"]);
     expect(calls).toBe(1);
@@ -1340,13 +1341,13 @@ describe("TwitchAdapter", () => {
         });
       });
       const discoveryState = new TwitchDiscoveryState();
-      const firstTick = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+      const firstTick = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
       await expect(firstTick.listFollowedChannels()).resolves.toEqual(["stale-friend"]);
       expect(calls).toBe(1);
 
       vi.advanceTimersByTime(6 * 60_000); // past the 5-minute cache TTL
-      const secondTick = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+      const secondTick = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
       // Resolves with the stale value without waiting on the (still-pending)
       // background refresh.
@@ -1354,7 +1355,7 @@ describe("TwitchAdapter", () => {
       expect(calls).toBe(2);
 
       resolveSecondFetch?.();
-      await vi.waitFor(() => expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).listFollowedChannels())
+      await vi.waitFor(() => expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).listFollowedChannels())
         .resolves.toEqual(["fresh-friend"]));
     } finally {
       vi.useRealTimers();
@@ -1367,7 +1368,7 @@ describe("TwitchAdapter", () => {
     const fetchJson = vi.fn(async () => ({ data: { currentUser: { id: "u" } } }));
     const fetcher = { fetchJson: fetchJson as PageFetcher["fetchJson"] };
 
-    await new TwitchAdapter(fetcher, undefined, undefined, undefined, emit).checkAuthHealth(abort.signal);
+    await twitchAdapter(fetcher, undefined, undefined, undefined, emit).checkAuthHealth(abort.signal);
 
     expect(fetchJson).toHaveBeenCalledWith(
       "https://gql.twitch.tv/gql",
@@ -1384,7 +1385,7 @@ describe("TwitchAdapter", () => {
       return { data: { currentUser: { id: "private-user-id" } } };
     });
 
-    await expect(new TwitchAdapter(fetcher, ensureIntegrity).checkAuthHealth()).resolves.toEqual({
+    await expect(twitchAdapter(fetcher, ensureIntegrity).checkAuthHealth()).resolves.toEqual({
       status: "healthy",
       checkedAt: expect.any(String),
       message: { key: "authHealthy" },
@@ -1399,7 +1400,7 @@ describe("TwitchAdapter", () => {
   ])("rejects a completed response without authenticated identity: %j", async (response) => {
     const fetcher = jsonFetcher(() => response);
 
-    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+    await expect(twitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
       status: "invalid_credentials",
       checkedAt: expect.any(String),
       reasonCode: "credentials_rejected",
@@ -1414,7 +1415,7 @@ describe("TwitchAdapter", () => {
   ])("classifies explicit Twitch credential rejection as invalid: %j", async (response) => {
     const fetcher = jsonFetcher(() => response);
 
-    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+    await expect(twitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
       status: "invalid_credentials",
       checkedAt: expect.any(String),
       reasonCode: "credentials_rejected",
@@ -1439,7 +1440,7 @@ describe("TwitchAdapter", () => {
     };
 
     try {
-      await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+      await expect(twitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
         status: healthStatus,
         checkedAt: expect.any(String),
         reasonCode,
@@ -1455,7 +1456,7 @@ describe("TwitchAdapter", () => {
       throw new TypeError("Failed to fetch secret-url");
     });
 
-    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+    await expect(twitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
       status: "unavailable",
       checkedAt: expect.any(String),
       reasonCode: "network_unavailable",
@@ -1470,7 +1471,7 @@ describe("TwitchAdapter", () => {
   ])("classifies Twitch response failure as platform unavailability: %j", async (response) => {
     const fetcher = jsonFetcher(() => response);
 
-    await expect(new TwitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
+    await expect(twitchAdapter(fetcher).checkAuthHealth()).resolves.toEqual({
       status: "unavailable",
       checkedAt: expect.any(String),
       reasonCode: "platform_unavailable",
@@ -1486,8 +1487,8 @@ describe("TwitchAdapter", () => {
 
     // Read through the interface: the capability is optional there, and Kick's
     // concrete class deliberately does not declare it at all.
-    const twitch: PlatformAdapter = new TwitchAdapter(fetcher);
-    const kick: PlatformAdapter = new KickAdapter(fetcher);
+    const twitch: PlatformAdapter = twitchAdapter(fetcher);
+    const kick: PlatformAdapter = kickAdapter(fetcher);
 
     expect(twitch.supportsPostClaimHandoff).toBe(true);
     expect(kick.supportsPostClaimHandoff).toBeUndefined();
@@ -1547,7 +1548,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     const campaigns = await adapter.refreshCampaigns();
 
@@ -1595,7 +1596,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns).toHaveLength(1);
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Inventory Campaign", status: "active" });
@@ -1625,7 +1626,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected operation ${String(body.operationName)}`);
     });
 
-    const campaigns = await new TwitchAdapter(
+    const campaigns = await twitchAdapter(
       fetcher,
       undefined,
       undefined,
@@ -1661,7 +1662,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected operation ${op}`);
     });
-    const discovery = new TwitchAdapter(fetcher).refreshCampaigns();
+    const discovery = twitchAdapter(fetcher).refreshCampaigns();
 
     try {
       await vi.waitFor(() => expect(dashboardStarted).toBe(true));
@@ -1699,7 +1700,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Inventory Campaign", eligibility: "eligible" });
   });
@@ -1719,11 +1720,11 @@ describe("TwitchAdapter", () => {
     });
     const events: EngineEvent[] = [];
     const discoveryState = new TwitchDiscoveryState();
-    const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const firstAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
     expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
     failing = "b";
-    const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
+    const secondAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
     const campaigns = await secondAdapter.refreshCampaigns();
 
     expect(campaigns.map((campaign) => campaign.id)).toEqual(["a", "b"]);
@@ -1743,7 +1744,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
     const events: EngineEvent[] = [];
-    const adapter = new TwitchAdapter(fetcher, undefined, undefined, undefined, (event) => events.push(event));
+    const adapter = twitchAdapter(fetcher, undefined, undefined, undefined, (event) => events.push(event));
 
     const campaigns = await adapter.refreshCampaigns();
 
@@ -1762,7 +1763,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).refreshCampaigns()).rejects.toThrow(SafeFetchError);
+    await expect(twitchAdapter(fetcher).refreshCampaigns()).rejects.toThrow(SafeFetchError);
   });
 
   it("keeps not-yet-started campaigns when the dashboard request fails after a successful one", async () => {
@@ -1781,18 +1782,18 @@ describe("TwitchAdapter", () => {
     });
     const events: EngineEvent[] = [];
     const discoveryState = new TwitchDiscoveryState();
-    const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const firstAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
     expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
     dashboardFails = true;
-    const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
+    const secondAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
     const campaigns = await secondAdapter.refreshCampaigns();
 
     expect(campaigns.map((campaign) => campaign.id)).toEqual(["a"]);
     expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("dashboard"))).toBe(true);
 
     dashboardFails = false;
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
+    expect((await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a"]);
   });
 
   it("does not retain dashboard campaigns when the dashboard genuinely returns none", async () => {
@@ -1811,17 +1812,17 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
     const discoveryState = new TwitchDiscoveryState();
-    const firstAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const firstAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
     expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["campaign"]);
     dashboardIds = [];
-    const secondAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const secondAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
     const campaigns = await secondAdapter.refreshCampaigns();
 
     expect(campaigns).toEqual([]);
 
     dashboardFails = true;
-    const thirdAdapter = new TwitchAdapter(fetcher, undefined, undefined, { discoveryState });
+    const thirdAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
     const failedCampaigns = await thirdAdapter.refreshCampaigns();
 
     expect(failedCampaigns).toEqual([]);
@@ -1846,11 +1847,11 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    expect((await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["retained"]);
     refresh = 2;
 
-    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
 
     expect(campaigns).toEqual([]);
   });
@@ -1879,17 +1880,17 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    expect((await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["retained"]);
     refresh = 2;
     fallbackInventoryFails = true;
 
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .resolves.toEqual([]);
 
     fallbackInventoryFails = false;
     dashboardFails = true;
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .resolves.toEqual([]);
   });
 
@@ -1907,7 +1908,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).refreshCampaigns()).rejects.toThrow(SafeFetchError);
+    await expect(twitchAdapter(fetcher).refreshCampaigns()).rejects.toThrow(SafeFetchError);
   });
 
   it("does not reuse discovery retained for another authenticated Twitch user", async () => {
@@ -1928,12 +1929,12 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    expect((await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["user-a-campaign"]);
     userId = "user-b";
     dashboardFails = true;
 
-    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
 
     expect(campaigns).toEqual([]);
   });
@@ -1953,12 +1954,12 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    expect((await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["shared-campaign-id"]);
     userId = "user-b";
     detailsFail = true;
 
-    const campaigns = await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
 
     expect(campaigns).toEqual([]);
   });
@@ -1981,7 +1982,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns).toHaveLength(1);
     expect(campaigns[0]).toMatchObject({ id: "ended", status: "expired", eligibility: "expired" });
@@ -2002,14 +2003,14 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    expect((await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .map((campaign) => campaign.id)).toEqual(["campaign"]);
     detailResponse = "missing";
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .resolves.toEqual([]);
     detailResponse = "failure";
 
-    await expect(new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
       .resolves.toEqual([]);
   });
 
@@ -2083,7 +2084,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns.find((campaign) => campaign.id === "active")).toMatchObject({ status: "active", eligibility: "eligible" });
     expect(campaigns.find((campaign) => campaign.id === "ended")).toMatchObject({ status: "expired", eligibility: "expired" });
@@ -2140,7 +2141,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     const ended = campaigns.find((campaign) => campaign.id === "ended");
     expect(ended).toMatchObject({ status: "active", eligibility: "eligible" });
@@ -2188,7 +2189,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({
       id: "campaign",
@@ -2232,7 +2233,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Fallback Campaign", eligibility: "eligible" });
   });
@@ -2280,7 +2281,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({
       id: "future",
@@ -2314,7 +2315,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.claimChannelPoints({ platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" }))
       .resolves.toBe(true);
@@ -2350,7 +2351,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Array Campaign", eligibility: "eligible" });
   });
@@ -2390,7 +2391,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    const campaigns = await twitchAdapter(fetcher).refreshCampaigns();
 
     expect(inventoryAttempts).toBe(2);
     expect(campaigns[0]).toMatchObject({ id: "campaign", name: "Inline Campaign", eligibility: "eligible" });
@@ -2407,7 +2408,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).refreshCampaigns()).rejects.toThrow("permission denied");
+    await expect(twitchAdapter(fetcher).refreshCampaigns()).rejects.toThrow("permission denied");
     expect(inventoryAttempts).toBe(1);
   });
 
@@ -2436,7 +2437,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).claimChannelPoints({ platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" }))
+    await expect(twitchAdapter(fetcher).claimChannelPoints({ platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" }))
       .resolves.toBe(true);
     expect(contextAttempts).toBe(2);
   });
@@ -2457,7 +2458,11 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const campaigns = await new TwitchAdapter(fetcher).refreshCampaigns();
+    // Explicit v1 override: the recommended/automatic profile resolves to
+    // inventory v2, but this test exercises v1's hash/fallback/parser pairing.
+    const campaigns = await twitchAdapter(fetcher, undefined, undefined, {
+      compatibility: { ...TWITCH_COMPAT, inventory: "twitch-inventory-v1" },
+    }).refreshCampaigns();
 
     expect(inventoryBodies).toHaveLength(2);
     expect(inventoryBodies[0]).toMatchObject({
@@ -2496,7 +2501,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    const adapter = new TwitchAdapter(
+    const adapter = twitchAdapter(
       fetcher,
       undefined,
       undefined,
@@ -2519,7 +2524,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${operation(init)}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).refreshCampaigns())
+    await expect(twitchAdapter(fetcher).refreshCampaigns())
       .rejects.toMatchObject({
         failure: { kind: "authentication_rejected", status: 401 },
       });
@@ -2534,13 +2539,13 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${op}`);
     });
 
-    await expect(new TwitchAdapter(fetcher).refreshCampaigns())
+    await expect(twitchAdapter(fetcher).refreshCampaigns())
       .rejects.toThrow("Twitch did not return a logged-in current user; open twitch.tv and confirm you are signed in");
   });
 
   it("reports unusable array-wrapped Twitch GQL responses as empty", async () => {
     for (const empty of [[], [null]] as const) {
-      const adapter = new TwitchAdapter(jsonFetcher((_url, init) => {
+      const adapter = twitchAdapter(jsonFetcher((_url, init) => {
         if (operation(init) === "ChannelPointsContext") return empty;
         throw new Error(`Unexpected op ${operation(init)}`);
       }));
@@ -2551,7 +2556,7 @@ describe("TwitchAdapter", () => {
   });
 
   it("surfaces the page fetcher's __twitchGqlError diagnostic envelope", async () => {
-    const adapter = new TwitchAdapter(jsonFetcher((_url, init) => {
+    const adapter = twitchAdapter(jsonFetcher((_url, init) => {
       if (operation(init) === "Inventory") {
         return { __twitchGqlError: "returned an unusable response; status=200; body=null" };
       }
@@ -2563,7 +2568,7 @@ describe("TwitchAdapter", () => {
   });
 
   it("reports null Twitch GQL responses with the operation name", async () => {
-    const adapter = new TwitchAdapter(jsonFetcher((_url, init) => {
+    const adapter = twitchAdapter(jsonFetcher((_url, init) => {
       if (operation(init) === "ChannelPointsContext") return null;
       throw new Error(`Unexpected op ${operation(init)}`);
     }));
@@ -2583,7 +2588,7 @@ describe("TwitchAdapter", () => {
       expect(init?.credentials).toBe("omit");
       return { data: { user: { displayName: "Creator", stream: { viewersCount: 789, game: { id: "game", name: "Game" } } } } };
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
@@ -2607,7 +2612,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator", isAclMatch: true },
@@ -2631,7 +2636,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
@@ -2653,7 +2658,7 @@ describe("TwitchAdapter", () => {
       if (op === "DropsHighlightService_AvailableDrops") throw new Error("availability unavailable");
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
@@ -2676,7 +2681,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
@@ -2704,7 +2709,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
@@ -2729,7 +2734,7 @@ describe("TwitchAdapter", () => {
         }
         throw new Error(`Unexpected op ${op}`);
       });
-      const adapter = new TwitchAdapter(fetcher);
+      const adapter = twitchAdapter(fetcher);
       const candidate = { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" } as const;
 
       await expect(adapter.checkChannel(candidate, {
@@ -2784,7 +2789,7 @@ describe("TwitchAdapter", () => {
         },
       };
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     const candidates = await adapter.listCandidateChannels({
       id: "campaign",
@@ -2814,7 +2819,7 @@ describe("TwitchAdapter", () => {
       operations.push(operation(init));
       return { data: { channel: { viewerDropCampaigns: [{ id: "campaign" }] } } };
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
     const candidate = {
       platform: "twitch" as const,
       username: "directory-winner",
@@ -2865,7 +2870,7 @@ describe("TwitchAdapter", () => {
       });
     });
 
-    const selection = await new TwitchAdapter(fetcher, undefined, undefined, {}, (event) => {
+    const selection = await twitchAdapter(fetcher, undefined, undefined, {}, (event) => {
       events.push(event);
     }).selectCandidateChannel?.(
       candidates,
@@ -2894,7 +2899,7 @@ describe("TwitchAdapter", () => {
       return [{ data: { user: { stream: null } } }];
     });
 
-    const selection = await new TwitchAdapter(fetcher, undefined, undefined, {}, (event) => {
+    const selection = await twitchAdapter(fetcher, undefined, undefined, {}, (event) => {
       events.push(event);
     }).selectCandidateChannel?.([{
       platform: "twitch",
@@ -2935,7 +2940,7 @@ describe("TwitchAdapter", () => {
       return { data: { channel: { viewerDropCampaigns: [] } } };
     });
 
-    await new TwitchAdapter(fetcher).selectCandidateChannel?.(
+    await twitchAdapter(fetcher).selectCandidateChannel?.(
       candidates,
       { id: "campaign", categoryId: "game" } as DropCampaign,
     );
@@ -2981,7 +2986,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected operation ${String(body.operationName)}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     const selection = await adapter.selectCandidateChannel?.(
       candidates,
@@ -3025,7 +3030,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected operation ${String(body.operationName)}`);
     });
-    const adapter = new TwitchAdapter(fetcher, undefined, undefined, {}, (event) => {
+    const adapter = twitchAdapter(fetcher, undefined, undefined, {}, (event) => {
       if (event.category === "diagnostic") diagnostics.push(event.message);
     });
 
@@ -3077,7 +3082,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected operation ${String(body.operationName)}`);
     });
 
-    const selection = await new TwitchAdapter(fetcher).selectCandidateChannel?.(
+    const selection = await twitchAdapter(fetcher).selectCandidateChannel?.(
       candidates,
       { id: "campaign", categoryId: "game" } as DropCampaign,
     );
@@ -3098,7 +3103,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
@@ -3121,7 +3126,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
@@ -3143,7 +3148,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected URL ${url}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     await expect(adapter.checkChannel(
       { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
@@ -3183,7 +3188,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     const progress = await adapter.refreshCampaigns({
       platform: "twitch",
@@ -3208,7 +3213,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${operation(init)}`);
     });
     const ensureIntegrity = vi.fn(async () => true);
-    const adapter = new TwitchAdapter(fetcher, ensureIntegrity);
+    const adapter = twitchAdapter(fetcher, ensureIntegrity);
     const reward = { id: "drop", name: "Reward", requiredMinutes: 60, watchedMinutes: 60, status: "claimable", claimId: "instance-id" } as DropReward;
 
     await expect(adapter.claimReward({ id: "campaign" } as DropCampaign, reward)).resolves.toBe(true);
@@ -3221,7 +3226,7 @@ describe("TwitchAdapter", () => {
       throw new Error("should not fetch without a claim id");
     });
     const ensureIntegrity = vi.fn(async () => true);
-    const adapter = new TwitchAdapter(fetcher, ensureIntegrity);
+    const adapter = twitchAdapter(fetcher, ensureIntegrity);
     const reward = { id: "drop", name: "Reward", requiredMinutes: 60, watchedMinutes: 60, status: "claimable" } as DropReward;
 
     expect(adapter.isClaimReady(reward)).toBe(false);
@@ -3238,7 +3243,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${operation(init)}`);
     });
     const ensureIntegrity = vi.fn(async () => true);
-    const adapter = new TwitchAdapter(fetcher, ensureIntegrity);
+    const adapter = twitchAdapter(fetcher, ensureIntegrity);
     const reward = { id: "drop", name: "Reward", requiredMinutes: 60, watchedMinutes: 60, status: "claimable", claimId: "instance-id" } as DropReward;
 
     await expect(adapter.claimReward({ id: "campaign" } as DropCampaign, reward)).rejects.toThrow(/status=INELIGIBLE/);
@@ -3257,7 +3262,7 @@ describe("TwitchAdapter", () => {
       throw new Error(`Unexpected op ${operation(init)}`);
     });
     const ensureIntegrity = vi.fn(async () => true);
-    const adapter = new TwitchAdapter(fetcher, ensureIntegrity);
+    const adapter = twitchAdapter(fetcher, ensureIntegrity);
     const reward = { id: "drop", name: "Reward", requiredMinutes: 60, watchedMinutes: 60, status: "claimable", claimId: "instance-id" } as DropReward;
 
     await expect(adapter.claimReward({ id: "campaign" } as DropCampaign, reward)).resolves.toBe(true);
@@ -3275,7 +3280,7 @@ describe("TwitchAdapter", () => {
     });
     // No token can be captured (e.g. logged out / no tab can be opened).
     const ensureIntegrity = vi.fn(async () => false);
-    const adapter = new TwitchAdapter(fetcher, ensureIntegrity);
+    const adapter = twitchAdapter(fetcher, ensureIntegrity);
     const reward = { id: "drop", name: "Reward", requiredMinutes: 60, watchedMinutes: 60, status: "claimable", claimId: "instance-id" } as DropReward;
 
     await expect(adapter.claimReward({ id: "campaign" } as DropCampaign, reward))
@@ -3313,7 +3318,7 @@ describe("TwitchAdapter", () => {
       }
       throw new Error(`Unexpected op ${op}`);
     });
-    const adapter = new TwitchAdapter(fetcher);
+    const adapter = twitchAdapter(fetcher);
 
     const progress = await adapter.refreshCampaigns({
       platform: "twitch",
@@ -3348,7 +3353,7 @@ describe("TwitchAdapter", () => {
       };
     });
 
-    await expect(new TwitchAdapter(fetcher).searchCategories("fort")).resolves.toEqual([
+    await expect(twitchAdapter(fetcher).searchCategories("fort")).resolves.toEqual([
       { id: "33214", name: "Fortnite", imageUrl: "https://art/fortnite-144x192.jpg" },
     ]);
   });
@@ -3359,7 +3364,7 @@ describe("TwitchAdapter client identity", () => {
 
   it("sends an injected non-web Client-ID + matching User-Agent on GQL requests", async () => {
     let captured: RequestInit | undefined;
-    const adapter = new TwitchAdapter(
+    const adapter = twitchAdapter(
       jsonFetcher((_url, init) => { captured = init; return emptyCategories; }),
       undefined,
       undefined,
@@ -3373,7 +3378,7 @@ describe("TwitchAdapter client identity", () => {
 
   it("defaults to the web Client-ID and omits the User-Agent (extension behavior)", async () => {
     let captured: RequestInit | undefined;
-    await new TwitchAdapter(jsonFetcher((_url, init) => { captured = init; return emptyCategories; })).searchCategories("rust");
+    await twitchAdapter(jsonFetcher((_url, init) => { captured = init; return emptyCategories; })).searchCategories("rust");
     const headers = captured?.headers as Record<string, string>;
     expect(headers["Client-ID"]).toBe("kimne78kx3ncx6brgo4mv6wki5h1ko");
     expect(headers["User-Agent"]).toBeUndefined();
@@ -3428,7 +3433,7 @@ describe("TwitchAdapter integrity recovery", () => {
       return attempts === 1 ? INTEGRITY_REJECTION : { data: { currentUser: { id: "u" } } };
     });
 
-    await new TwitchAdapter(fetcher, ensureIntegrity, undefined, { currentIntegrity }).checkAuthHealth();
+    await twitchAdapter(fetcher, ensureIntegrity, undefined, { currentIntegrity }).checkAuthHealth();
 
     expect(sent[0]).toBe("token-1");
     expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
@@ -3451,7 +3456,7 @@ describe("TwitchAdapter integrity recovery", () => {
       return { data: { currentUser: { id: "u" } } };
     });
 
-    await new TwitchAdapter(fetcher, undefined, undefined, { currentIntegrity }).checkAuthHealth();
+    await twitchAdapter(fetcher, undefined, undefined, { currentIntegrity }).checkAuthHealth();
 
     expect(seen?.get("client-integrity")).toBe("bound-token");
     expect(seen?.get("x-device-id")).toBe("bound-device");
@@ -3476,7 +3481,7 @@ describe("TwitchAdapter integrity recovery", () => {
         const ensureIntegrity = integrityCallback();
         const { fetcher, attempts } = rejectFirst(target, discoveryPayload);
 
-        const campaigns = await new TwitchAdapter(fetcher, ensureIntegrity).refreshCampaigns();
+        const campaigns = await twitchAdapter(fetcher, ensureIntegrity).refreshCampaigns();
 
         expect(campaigns.map((campaign) => campaign.id)).toEqual(["campaign"]);
         expect(ensureIntegrity).toHaveBeenCalledOnce();
@@ -3493,7 +3498,7 @@ describe("TwitchAdapter integrity recovery", () => {
       const ensureIntegrity = integrityCallback();
       const { fetcher } = rejectFirst("ViewerDropsDashboard", discoveryPayload);
 
-      const campaigns = await new TwitchAdapter(
+      const campaigns = await twitchAdapter(
         fetcher,
         ensureIntegrity,
         undefined,
@@ -3522,7 +3527,7 @@ describe("TwitchAdapter integrity recovery", () => {
         throw new Error(`Unexpected op ${op}`);
       });
 
-      await new TwitchAdapter(fetcher, ensureIntegrity, undefined, {}, (event) => events.push(event))
+      await twitchAdapter(fetcher, ensureIntegrity, undefined, {}, (event) => events.push(event))
         .refreshCampaigns();
 
       // Discovery makes two dashboard requests when both lists come back empty
@@ -3553,7 +3558,7 @@ describe("TwitchAdapter integrity recovery", () => {
         throw new Error(`Unexpected op ${op}`);
       });
 
-      await new TwitchAdapter(fetcher, ensureIntegrity).refreshCampaigns();
+      await twitchAdapter(fetcher, ensureIntegrity).refreshCampaigns();
 
       // Two dashboard requests, each bounded to exactly one refresh and one
       // retry — the second rejection is never refreshed or replayed again.
@@ -3574,7 +3579,7 @@ describe("TwitchAdapter integrity recovery", () => {
         throw new Error(`Unexpected op ${op}`);
       });
 
-      await new TwitchAdapter(fetcher, ensureIntegrity).refreshCampaigns();
+      await twitchAdapter(fetcher, ensureIntegrity).refreshCampaigns();
 
       // Both dashboard requests fail generically: no refresh, and no replay of
       // either request.
@@ -3594,7 +3599,7 @@ describe("TwitchAdapter integrity recovery", () => {
         },
       }));
 
-      const candidates = await new TwitchAdapter(fetcher, ensureIntegrity)
+      const candidates = await twitchAdapter(fetcher, ensureIntegrity)
         .listCandidateChannels({ id: "campaign", slug: "game-slug" } as DropCampaign);
 
       expect(candidates.map((candidate) => candidate.username)).toEqual(["creator"]);
@@ -3618,7 +3623,7 @@ describe("TwitchAdapter integrity recovery", () => {
         throw new Error(`Unexpected op ${op}`);
       });
 
-      const check = await new TwitchAdapter(fetcher, ensureIntegrity).checkChannel(
+      const check = await twitchAdapter(fetcher, ensureIntegrity).checkChannel(
         { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
         { campaign: { id: "campaign", categoryId: "game" } as DropCampaign },
       );
@@ -3645,7 +3650,7 @@ describe("TwitchAdapter integrity recovery", () => {
           }
           throw new Error(`Unexpected op ${op}`);
         });
-        const progressed = await new TwitchAdapter(fetcher, ensureIntegrity).refreshCampaigns({
+        const progressed = await twitchAdapter(fetcher, ensureIntegrity).refreshCampaigns({
           platform: "twitch",
           status: "watching",
           offlineChecks: 0,
@@ -3667,7 +3672,7 @@ describe("TwitchAdapter integrity recovery", () => {
         data: { currentUser: { id: "user-id" } },
       }));
 
-      const health = await new TwitchAdapter(fetcher, ensureIntegrity).checkAuthHealth();
+      const health = await twitchAdapter(fetcher, ensureIntegrity).checkAuthHealth();
 
       expect(health.status).toBe("healthy");
       expect(ensureIntegrity).toHaveBeenCalledWith(expect.objectContaining({
@@ -3693,7 +3698,7 @@ describe("TwitchAdapter integrity recovery", () => {
         return INTEGRITY_REJECTION;
       });
 
-      await run(new TwitchAdapter(fetcher, ensureIntegrity)).catch(() => undefined);
+      await run(twitchAdapter(fetcher, ensureIntegrity)).catch(() => undefined);
 
       expect(captured?.credentials).toBe("omit");
       expect(ensureIntegrity).not.toHaveBeenCalled();
@@ -3718,7 +3723,7 @@ describe("TwitchAdapter integrity recovery", () => {
         data: { claimDropRewards: { status: "ELIGIBLE_FOR_ALL" } },
       }));
 
-      await expect(new TwitchAdapter(fetcher, ensureIntegrity)
+      await expect(twitchAdapter(fetcher, ensureIntegrity)
         .claimReward({ id: "campaign" } as DropCampaign, reward)).resolves.toBe(true);
 
       expect(attempts.get("DropsPage_ClaimDropRewards")).toBe(2);
@@ -3745,7 +3750,7 @@ describe("TwitchAdapter integrity recovery", () => {
         throw new Error(`Unexpected op ${op}`);
       });
 
-      await expect(new TwitchAdapter(fetcher, ensureIntegrity).claimChannelPoints({
+      await expect(twitchAdapter(fetcher, ensureIntegrity).claimChannelPoints({
         platform: "twitch",
         username: "creator",
         url: "https://www.twitch.tv/creator",
@@ -3769,7 +3774,7 @@ describe("TwitchAdapter integrity recovery", () => {
         throw new Error(`Unexpected op ${op}`);
       });
 
-      await expect(new TwitchAdapter(fetcher, ensureIntegrity).claimChannelPoints({
+      await expect(twitchAdapter(fetcher, ensureIntegrity).claimChannelPoints({
         platform: "twitch",
         username: "creator",
         url: "https://www.twitch.tv/creator",
@@ -3802,7 +3807,7 @@ describe("TwitchAdapter integrity recovery", () => {
         throw new Error(`Unexpected op ${op}`);
       });
 
-      await expect(new TwitchAdapter(fetcher, ensureIntegrity).claimChannelPoints({
+      await expect(twitchAdapter(fetcher, ensureIntegrity).claimChannelPoints({
         platform: "twitch",
         username: "creator",
         url: "https://www.twitch.tv/creator",

--- a/packages/extension/tests/authHealth.test.ts
+++ b/packages/extension/tests/authHealth.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_STATE, mergeSchedulerState, normalizePlatformAuthHealth } from "@lurkloot/core/defaults";
-import type { PlatformAdapter } from "@lurkloot/core/adapter";
+import { ignoreEvent, unavailableWatchTabPort, type PlatformAdapter } from "@lurkloot/core/adapter";
 import { KickAdapter } from "@lurkloot/core/kick";
 import { applyPlatformAuthHealth } from "@lurkloot/core/authHealth";
+import { testCompatibility } from "./helpers/compatibility";
+
+const KICK_COMPAT = testCompatibility().kick;
 
 describe("authentication health normalization", () => {
   it("requires adapters to expose a browser-neutral auth probe", async () => {
@@ -23,7 +26,7 @@ describe("authentication health normalization", () => {
       },
     };
 
-    const health = await new KickAdapter(fetcher).checkAuthHealth();
+    const health = await new KickAdapter(fetcher, unavailableWatchTabPort, undefined, { compatibility: KICK_COMPAT }, ignoreEvent).checkAuthHealth();
 
     expect(health.status).toBe("healthy");
     expect(Date.parse(health.checkedAt ?? "")).not.toBeNaN();
@@ -40,7 +43,7 @@ describe("authentication health normalization", () => {
     // here is what suspended farming for signed-in users (regression from #213/#214).
     const fetcher = { fetchJson: async <T,>(): Promise<T> => response as T };
 
-    await expect(new KickAdapter(fetcher).checkAuthHealth()).resolves.toMatchObject({
+    await expect(new KickAdapter(fetcher, unavailableWatchTabPort, undefined, { compatibility: KICK_COMPAT }, ignoreEvent).checkAuthHealth()).resolves.toMatchObject({
       status: "unavailable",
       reasonCode: "platform_unavailable",
       message: { key: "authPlatformUnavailable" },

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -14,8 +14,9 @@ import type { RuntimeSnapshot } from "@lurkloot/shared/messages";
 import { applySettingsPatch, DEFAULT_SETTINGS, isFarmingActive } from "@lurkloot/shared/settings";
 import { DEFAULT_STATE } from "../src/core/storage";
 import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
-import { createKickFetcher, KickAdapter, KickClaimState } from "@lurkloot/core/kick";
-import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
+import { createKickFetcher, KickClaimState } from "@lurkloot/core/kick";
+import { TwitchDiscoveryState } from "@lurkloot/core/twitch";
+import { kickAdapter, twitchAdapter } from "./helpers/adapters";
 import type { TablessWatchController } from "@lurkloot/core/tablessWatch";
 import type { StopPageContextTabs } from "@lurkloot/core/scheduler";
 import {
@@ -2115,7 +2116,7 @@ describe("background controller", () => {
       }) as PageFetcher["fetchJson"],
     };
     vi.mocked(env.deps.createAdapter).mockImplementation((_platform, emit, settings) => ({
-      adapter: new TwitchAdapter(fetcher, undefined, undefined, { discoveryState }, emit),
+      adapter: twitchAdapter(fetcher, undefined, undefined, { discoveryState }, emit),
       ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
     }));
 
@@ -2275,7 +2276,7 @@ describe("background controller", () => {
         backgroundStarted = resolve;
       });
       const pageFetch = vi.fn(async () => ({ id: 42 }));
-      const kick = new KickAdapter(createKickFetcher({
+      const kick = kickAdapter(createKickFetcher({
         background: async (_url, init) => {
           backgroundStarted();
           await new Promise<void>((resolve) => {
@@ -3412,7 +3413,7 @@ describe("background controller", () => {
     };
     const claimState = new KickClaimState();
     env.deps.createAdapter.mockImplementation((platform, emit, settings) => {
-      const kick = new KickAdapter(fetcher, undefined, undefined, emit, { claimState });
+      const kick = kickAdapter(fetcher, undefined, undefined, emit, { claimState });
       kick.listCandidateChannels = vi.fn(async () => []);
       return {
         adapter: platform === "kick" ? kick : env.twitch,
@@ -3441,7 +3442,7 @@ describe("background controller", () => {
     expect(claimPosts).toBe(2);
 
     const separateState = new KickClaimState();
-    const separateAdapter = new KickAdapter(fetcher, undefined, undefined, () => {}, { claimState: separateState });
+    const separateAdapter = kickAdapter(fetcher, undefined, undefined, () => {}, { claimState: separateState });
     await separateAdapter.claimReward(campaign("kick", "claimable"), campaign("kick", "claimable").rewards[0]);
     expect(claimPosts).toBe(3);
   });

--- a/packages/extension/tests/helpers/adapters.ts
+++ b/packages/extension/tests/helpers/adapters.ts
@@ -1,0 +1,48 @@
+import { ignoreEvent, unavailableWatchTabPort, type PageFetcher, type WatchTabPort } from "@lurkloot/core/adapter";
+import { KickAdapter, type KickAdapterOptions } from "@lurkloot/core/kick";
+import type { WebSocketFactory } from "@lurkloot/core/kick/watch";
+import type { TwitchIntegrityRequest } from "@lurkloot/core/tabs";
+import { TwitchAdapter, type TwitchAdapterOptions } from "@lurkloot/core/twitch";
+import type { EventEmitter } from "@lurkloot/shared/events";
+import { testCompatibility } from "./compatibility";
+
+export const TWITCH_COMPAT = testCompatibility().twitch;
+export const KICK_COMPAT = testCompatibility().kick;
+
+// TwitchAdapterOptions/KickAdapterOptions require a resolved compatibility (see
+// #360), so every construction site must supply one. These wrappers keep
+// fixtures' existing call shapes (positional args, `undefined` placeholders for
+// skipped middle ones) while resolving compatibility through the real resolver
+// instead of restating a capability id by hand; a test that cares about a
+// specific capability still overrides it via `options`.
+export function twitchAdapter(
+  fetcher: PageFetcher,
+  ensureIntegrity?: (request?: TwitchIntegrityRequest) => Promise<boolean>,
+  watchTabPort?: WatchTabPort,
+  options?: Partial<TwitchAdapterOptions>,
+  emit?: EventEmitter,
+): TwitchAdapter {
+  return new TwitchAdapter(
+    fetcher,
+    ensureIntegrity ?? (async () => false),
+    watchTabPort ?? unavailableWatchTabPort,
+    { compatibility: TWITCH_COMPAT, ...options },
+    emit ?? ignoreEvent,
+  );
+}
+
+export function kickAdapter(
+  fetcher: PageFetcher,
+  watchTabPort?: WatchTabPort,
+  webSocketFactory?: WebSocketFactory,
+  emit?: EventEmitter,
+  options?: Partial<KickAdapterOptions>,
+): KickAdapter {
+  return new KickAdapter(
+    fetcher,
+    watchTabPort ?? unavailableWatchTabPort,
+    webSocketFactory,
+    { compatibility: KICK_COMPAT, ...options },
+    emit ?? ignoreEvent,
+  );
+}

--- a/packages/extension/tests/helpers/compatibility.ts
+++ b/packages/extension/tests/helpers/compatibility.ts
@@ -1,0 +1,12 @@
+import { resolveCompatibility, type CompatibilityHostFacts, type ResolvedCompatibility } from "@lurkloot/core";
+import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
+
+// TwitchAdapterOptions/KickAdapterOptions require a resolved compatibility —
+// no construction site may restate a capability id by hand. Fixtures build
+// theirs through the real resolver, on the extension's own host facts, so
+// they exercise the same path production does rather than drifting from it.
+const EXTENSION_HOST_FACTS: CompatibilityHostFacts = { host: "extension", twitchIdentity: "web" };
+
+export function testCompatibility(hostFacts: CompatibilityHostFacts = EXTENSION_HOST_FACTS): ResolvedCompatibility {
+  return resolveCompatibility(DEFAULT_SETTINGS.compatibility, hostFacts).compatibility;
+}

--- a/packages/extension/tests/tablessWatch.test.ts
+++ b/packages/extension/tests/tablessWatch.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import type { DiagnosticEvent } from "@lurkloot/shared/events";
 import type { ChannelCandidate } from "@lurkloot/shared/models";
 import { buildMinuteWatchedEvent, buildSpadeInput, gzipBase64 } from "@lurkloot/core/twitch/watch";
-import { createTwitchGqlTransport, TwitchAdapter } from "@lurkloot/core/twitch";
-import { createKickFetcher, KickAdapter } from "@lurkloot/core/kick";
+import { createTwitchGqlTransport } from "@lurkloot/core/twitch";
+import { createKickFetcher } from "@lurkloot/core/kick";
 import { KickWatcher, type WebSocketLike } from "@lurkloot/core/kick/watch";
 import { PendingWatcherDiagnostics } from "@lurkloot/core/tablessWatch";
+import { kickAdapter, twitchAdapter } from "./helpers/adapters";
+import { testCompatibility } from "./helpers/compatibility";
+
+const TWITCH_COMPAT = testCompatibility().twitch;
 
 async function gunzipBase64(b64: string): Promise<string> {
   const binary = atob(b64);
@@ -114,7 +118,7 @@ describe("kick viewer watcher", () => {
       if (url.includes("/viewer/v1/token")) return { data: { token: "tok" } };
       throw new Error(`unexpected url ${url}`);
     });
-    const adapter = new KickAdapter(
+    const adapter = kickAdapter(
       createKickFetcher({ background, pageFetch: async () => { throw new Error("page fallback not expected"); } }),
       undefined,
       () => socket,
@@ -236,7 +240,7 @@ describe("kick viewer watcher", () => {
 
   it("does not strand an expected close diagnostic after intentional stop", async () => {
     const socket = new AsyncCloseSocket();
-    const adapter = new KickAdapter(
+    const adapter = kickAdapter(
       {
         fetchJson: vi.fn(async (url: string) => {
           if (url.includes("/api/v2/channels/")) return { id: 123, livestream: { id: 456, is_live: true } } as never;
@@ -271,7 +275,7 @@ describe("kick viewer watcher", () => {
       if (url.includes("/viewer/v1/token")) return { data: { token: "tok" } } as never;
       throw new Error(`unexpected url ${url}`);
     });
-    const adapter = new KickAdapter(
+    const adapter = kickAdapter(
       { fetchJson },
       undefined,
       () => sockets.shift()!,
@@ -456,7 +460,7 @@ describe("adapter-created twitch watcher diagnostics", () => {
     });
     const transport = createTwitchGqlTransport(
       { fetchJson: fetchJson as never },
-      { clientId: "neutral-client", userAgent: "neutral-agent" },
+      { clientId: "neutral-client", userAgent: "neutral-agent", compatibility: TWITCH_COMPAT },
     );
 
     await transport("StreamInfo", "hash", { channel: "creator" }, "query StreamInfo { user { id } }", "omit", (event) => {
@@ -481,11 +485,14 @@ describe("adapter-created twitch watcher diagnostics", () => {
       if (operationName === "SendEvents") return { data: { sendSpadeEvents: { statusCode: 204 } } };
       throw new Error(`unexpected operation ${operationName}`);
     });
-    const adapter = new TwitchAdapter(
+    // GQL-v1 heartbeat: it sends minute-watched via the SendEvents GQL mutation
+    // mocked below, unlike the recommended Spade profile (a separate page-fetch
+    // transport this fixture does not wire up).
+    const adapter = twitchAdapter(
       { fetchJson: fetchJson as never },
       undefined,
       undefined,
-      undefined,
+      { compatibility: { ...TWITCH_COMPAT, heartbeat: "twitch-heartbeat-gql-v1" } },
       (event) => creationEvents.push(event as DiagnosticEvent),
     );
     const watcher = adapter.createTablessWatcher?.();
@@ -523,7 +530,15 @@ describe("adapter-created twitch watcher diagnostics", () => {
       throw new Error(`unexpected operation ${operationName}`);
     });
     const ensureIntegrity = vi.fn(async (request?: { forceRefresh?: boolean }) => request?.forceRefresh === true);
-    const adapter = new TwitchAdapter({ fetchJson: fetchJson as never }, ensureIntegrity);
+    // GQL-v1 heartbeat: it sends minute-watched via the SendEvents GQL mutation
+    // mocked below, unlike the recommended Spade profile (a separate page-fetch
+    // transport this fixture does not wire up).
+    const adapter = twitchAdapter(
+      { fetchJson: fetchJson as never },
+      ensureIntegrity,
+      undefined,
+      { compatibility: { ...TWITCH_COMPAT, heartbeat: "twitch-heartbeat-gql-v1" } },
+    );
     const watcher = adapter.createTablessWatcher?.();
 
     // No userId in the context, so the watcher must resolve it itself.

--- a/packages/extension/tests/twitchHeartbeat.test.ts
+++ b/packages/extension/tests/twitchHeartbeat.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { TwitchAdapter } from "@lurkloot/core/twitch";
 import type { TwitchHeartbeatStrategy } from "@lurkloot/core/twitch/heartbeat";
 import {
   createSpadeHeartbeat,
@@ -9,6 +8,7 @@ import {
 } from "@lurkloot/core/twitch/heartbeat";
 import { resolveCompatibility } from "@lurkloot/core";
 import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
+import { twitchAdapter } from "./helpers/adapters";
 
 describe("Twitch heartbeat strategies", () => {
   describe("compatibility selection", () => {
@@ -94,7 +94,7 @@ describe("Twitch heartbeat strategies", () => {
       }
       throw new Error(`unexpected operation ${operationName}`);
     });
-    const adapter = new TwitchAdapter(
+    const adapter = twitchAdapter(
       { fetchJson: fetchJson as never },
       undefined,
       undefined,


### PR DESCRIPTION
## Summary

Closes #360.

`TwitchAdapterOptions`/`KickAdapterOptions` each had an inline `?? "default"` fallback for one capability id:

```ts
options.compatibility?.heartbeat  ?? "twitch-heartbeat-gql-v1"   // platforms/twitch/index.ts
options.compatibility?.inventory  ?? "twitch-inventory-v1"       // platforms/twitch/index.ts
options.compatibility?.claim      ?? "kick-claim-v2"             // platforms/kick/index.ts
```

Two of these actively contradict `resolveCompatibility()`'s automatic path (legacy heartbeat/inventory versions vs. the recommended Spade/v2 ones), so any construction site that forgot to pass `compatibility` silently got a *different, non-representative* capability than what production actually selects. Every production construction site (`background.ts`, `http.ts`, `impersonate.ts`) already passed `compatibility` explicitly — only test fixtures relied on the defaults.

**This surfaced 3 real latent bugs in the test suite**, not just a lint-style gap: once the fallback was removed, two `tablessWatch.test.ts` tests broke with `twitch-heartbeat-spade-v1 requires a page fetch transport`, and one `adapters.test.ts` test asserted a v1 inventory GQL hash that no longer matched. All three were silently exercising legacy capabilities (`twitch-heartbeat-gql-v1`, `twitch-inventory-v1`) that production never selects — the exact class of drift #360 (and the linked #358 investigation) was trying to make impossible. Fixed by having those specific tests explicitly opt into the legacy capability they're actually testing, rather than getting it by accident.

## Changes

- `compatibility` is now required on `TwitchAdapterOptions` and `KickAdapterOptions`; the three inline fallbacks are gone.
- **Constructor signature note:** making `options.compatibility` required means TypeScript no longer allows `options` itself to have a default (`= {}`) if any earlier parameter is also optional/defaulted (a required parameter can't follow an optional one).
  - `TwitchAdapter`'s parameter order already had `options` before `emit`, so only `ensureIntegrity`/`watchTabPort` lost their defaults (now required, unchanged position).
  - `KickAdapter` had `emit` before `options`. Rather than also stripping `emit`'s default, I **reordered** the last two parameters to `(..., options, emit)` so callers that only care about compatibility don't also need to pass an explicit `emit`. This means `TwitchAdapter` and `KickAdapter` now have asymmetric final-parameter orders for the same conceptual slot — flagging that explicitly since a reviewer skimming both classes side by side will otherwise read it as inconsistent-by-accident rather than deliberate.
- Test fixtures build compatibility through the real resolver via two new shared helpers: `tests/helpers/compatibility.ts` (`testCompatibility()`, wraps `resolveCompatibility()` on the extension's host facts) and `tests/helpers/adapters.ts` (`twitchAdapter()`/`kickAdapter()` wrapper functions that preserve every existing call site's shape — positional args, `undefined` placeholders for skipped middle ones — while resolving `compatibility` instead of a test restating a capability id by hand). Direct construction in the four smaller test files got resolved compatibility inline instead, since each had only a couple of call sites.

## ⚠️ Cross-PR conflict with #364

**#364** (`refactor/cli-transport-shared-adapters`, not yet merged) adds `createCliAdapters()` in `packages/cli/src/transport/common.ts`, which constructs `KickAdapter` with the **old** argument order (`fetcher, watchTabPort, webSocketFactory, emit, options`). It doesn't touch the same lines as this PR, so git will merge the two without a textual conflict — but the result will be broken: `emit` and `options` land in each other's positions. TypeScript will catch it (a plain object isn't assignable to `EventEmitter`), so it won't ship silently, but **whichever of #364 / #360 merges second needs `common.ts`'s `KickAdapter` call updated to the new `(..., options, emit)` order** before it can be merged. I'll fix up whichever branch needs it once the merge order is decided.

## Testing

- `pnpm -r typecheck` — all green
- `pnpm test` (full workspace, including all 1348 extension tests + 149 CLI tests) — all green
- `pnpm verify` (full check + both Chrome/Firefox builds) — all green