### PR TITLE
fix(core): treat future timestamps as stale in staleness checks

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "./criticalHealth": "./src/core/criticalHealth.ts",
     "./fetchError": "./src/core/fetchError.ts",
     "./staleCache": "./src/core/staleCache.ts",
+    "./timestamps": "./src/core/timestamps.ts",
     "./adapter": "./src/platforms/adapter.ts",
     "./twitch": "./src/platforms/twitch/index.ts",
     "./twitch/parser": "./src/platforms/twitch/parser.ts",

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -6,6 +6,7 @@ import { isFarmingActive } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
 import { isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
 import { isPlaybackTelemetryHealthy, MANUAL_WATCH_TTL_MS, runSchedulerTick, type StopPageContextTabs } from "../core/scheduler";
+import { isTimestampStale } from "../core/timestamps";
 import {
   currentManagedPageContextTabs,
   INTEGRITY_REFRESH_TIMEOUT_MS,
@@ -2241,7 +2242,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
     const active = message.telemetry.playingVideoCount > 0 && !message.telemetry.documentHidden;
     const previous = manualWatch[message.platform];
-    const recentPrevious = previous?.active && Date.now() - Date.parse(previous.checkedAt) <= MANUAL_WATCH_TTL_MS;
+    const recentPrevious = previous?.active && !isTimestampStale(previous.checkedAt, MANUAL_WATCH_TTL_MS, Date.now());
     if (!active && previous?.tabId !== senderTabId && recentPrevious) return state;
 
     manualWatch[message.platform] = {

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -29,6 +29,7 @@ import { authHealthFromError, isSafeFetchError } from "./fetchError";
 import { applyPlatformAuthHealth } from "./authHealth";
 import type { CriticalHealthObservation } from "./criticalHealth";
 import { isManagedTabBreakerOpen, observeCriticalHealth, recordManagedTabOpen } from "./criticalHealth";
+import { isTimestampStale, PLAYBACK_TELEMETRY_MAX_AGE_MS } from "./timestamps";
 
 const PLATFORMS: Platform[] = ["twitch", "kick"];
 const MAX_PLATFORM_BACKOFF_MINUTES = 30;
@@ -1177,8 +1178,7 @@ export async function runSchedulerTick(
 function hasRecentManualWatch(state: SchedulerState, platform: Platform): boolean {
   const manualWatch = state.manualWatch?.[platform];
   if (!manualWatch?.active) return false;
-  const checkedAt = Date.parse(manualWatch.checkedAt);
-  return !Number.isNaN(checkedAt) && Date.now() - checkedAt <= MANUAL_WATCH_TTL_MS;
+  return !isTimestampStale(manualWatch.checkedAt, MANUAL_WATCH_TTL_MS, Date.now());
 }
 
 function hasIdleWatchlistChannels(settings: EngineSettings, platform: Platform): boolean {
@@ -1480,8 +1480,7 @@ export function isPlaybackTelemetryHealthy(telemetry: Pick<PlaybackTelemetry, "v
 function isPlaybackHealthy(session: WatchSession): boolean {
   const playback = session.playback;
   if (!playback) return false;
-  const checkedAt = Date.parse(playback.checkedAt);
-  if (!Number.isNaN(checkedAt) && Date.now() - checkedAt > 2 * 60 * 1000) return false;
+  if (isTimestampStale(playback.checkedAt, PLAYBACK_TELEMETRY_MAX_AGE_MS, Date.now())) return false;
   return isPlaybackTelemetryHealthy(playback);
 }
 

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -4,6 +4,7 @@ import type { LogLevel } from "@lurkloot/shared/logging";
 import type { TwitchIntegrity } from "./twitchIntegrity";
 import type { PreparedWatchTab, WatchTabOptions } from "../platforms/adapter";
 import { SafeFetchError, safeFetchFailure, type SafeFetchFailure } from "./fetchError";
+import { isTimestampStale, PLAYBACK_TELEMETRY_MAX_AGE_MS } from "./timestamps";
 
 const ignoreEvent: EventEmitter = () => {};
 
@@ -222,8 +223,7 @@ function shouldPrimePlayback(tab: BrowserTab, url: string, session?: WatchSessio
   if (tab.url !== url) return true;
   const playback = session?.playback;
   if (!playback) return true;
-  const checkedAt = Date.parse(playback.checkedAt);
-  if (!Number.isNaN(checkedAt) && Date.now() - checkedAt > 2 * 60 * 1000) return true;
+  if (isTimestampStale(playback.checkedAt, PLAYBACK_TELEMETRY_MAX_AGE_MS, Date.now())) return true;
   // Priming foreground-activates the tab to coax a deferred player into loading
   // and playing — not to unmute. A muted-but-playing video is fine, so do not
   // re-prime just because the browser kept it muted.

--- a/packages/core/src/core/timestamps.ts
+++ b/packages/core/src/core/timestamps.ts
@@ -1,0 +1,17 @@
+// A self-written ISO timestamp can land in the future if the clock moves
+// backwards after it was written (an NTP correction, a VM resuming from
+// suspend, a user changing the system clock). Comparing it against `now`
+// then yields a negative elapsed time, which passes almost any "is this
+// recent enough" bound — so a value written before the jump reads as
+// maximally fresh instead of maximally stale. Folding the unparseable and
+// future cases into the same "stale" branch as the elapsed-time check keeps
+// every caller from having to special-case them separately.
+export function isTimestampStale(iso: string, maxAgeMs: number, now: number): boolean {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed) || parsed > now) return true;
+  return now - parsed > maxAgeMs;
+}
+
+// Shared by the scheduler's playback-health check and the tab manager's
+// re-priming check, which both judge the same `playback.checkedAt` stamp.
+export const PLAYBACK_TELEMETRY_MAX_AGE_MS = 2 * 60 * 1000;

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -4728,6 +4728,40 @@ describe("background controller", () => {
     });
   });
 
+  // A clock rollback can leave the stored manual-watch `checkedAt` in the
+  // future. Reading that as "recently active" would keep a stale record
+  // winning over fresher telemetry from a different tab, so a future stamp
+  // counts as stale and the new telemetry is applied instead.
+  it("overrides manual watch activity stamped in the future with fresh telemetry", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+    env.state.manualWatch = {
+      twitch: {
+        platform: "twitch",
+        tabId: 999,
+        active: true,
+        checkedAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+      },
+    };
+
+    await env.controller.handleMessage({
+      type: "playbackTelemetry",
+      platform: "twitch",
+      telemetry: {
+        videoCount: 1,
+        mutedVideoCount: 0,
+        unmutedVideoCount: 1,
+        playingVideoCount: 0,
+        blockedPlaybackCount: 0,
+        documentHidden: false,
+      },
+    }, { tab: { id: 1000 } });
+
+    expect(env.state.manualWatch?.twitch).toMatchObject({
+      tabId: 1000,
+      active: false,
+    });
+  });
+
   it("logs playback transitions such as ad starts and blocked playback", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1470,6 +1470,32 @@ describe("scheduler tick", () => {
     expect(twitch.prepareWatchTab).toHaveBeenCalled();
   });
 
+  // A clock rollback can leave `checkedAt` in the future. Treating that as
+  // "recently watched" would pause farming until the clock caught up, so a
+  // future stamp counts as stale instead (mirrors the Kick challenge-poll fix).
+  it("ignores manual watch activity stamped in the future", async () => {
+    const twitch = adapter("twitch", [campaign("drops")], [channel("creator")]);
+
+    const result = await runSchedulerTick(
+      {
+        authHealth: HEALTHY_AUTH,
+        sessions: {
+          twitch: { platform: "twitch", status: "idle", offlineChecks: 0 },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        manualWatch: {
+          twitch: { platform: "twitch", tabId: 99, active: true, checkedAt: new Date(Date.now() + 60 * 60_000).toISOString() },
+        },
+        campaigns: { twitch: [], kick: [] },
+      },
+      settings({ platform: { twitch: { enabled: true, idleWatchlistChannels: [] }, kick: { enabled: false, idleWatchlistChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(result.state.sessions.twitch.status).toBe("watching");
+    expect(twitch.prepareWatchTab).toHaveBeenCalled();
+  });
+
   it("returns diagnostics without host log filtering", async () => {
     const twitch = adapter("twitch", [campaign("drops")], [channel("creator")]);
     const adapters = () => ({ twitch, kick: adapter("kick", [], []) });
@@ -1879,6 +1905,103 @@ describe("scheduler tick", () => {
 
     expect(result.state.sessions.twitch.playbackChecks).toBe(0);
     expect(result.state.sessions.twitch.playback?.playingVideoCount).toBe(1);
+  });
+
+  // A clock rollback can leave `playback.checkedAt` in the future. Reading
+  // that as "just checked" would let telemetry from before the rollback keep
+  // counting as healthy indefinitely, so a future stamp counts as stale and
+  // still accumulates toward the offline-retry limit.
+  it("treats playback telemetry stamped in the future as stale", async () => {
+    const old = channel("old");
+    const twitch = adapter("twitch", [campaign("drops")], [old]);
+    vi.mocked(twitch.checkChannel).mockResolvedValue({ live: true, categoryMatches: true, candidate: old });
+    vi.mocked(twitch.prepareWatchTab).mockResolvedValue({ tabId: 7, managedByExtension: true });
+
+    const result = await runSchedulerTick(
+      {
+        authHealth: HEALTHY_AUTH,
+        sessions: {
+          twitch: {
+            platform: "twitch",
+            status: "watching",
+            channel: old,
+            campaignId: "drops",
+            rewardId: "reward-in_progress",
+            offlineChecks: 0,
+            playbackChecks: 0,
+            tabId: 7,
+            watchMode: "tab",
+            watchTabOpenedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+            playback: {
+              platform: "twitch",
+              checkedAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+              videoCount: 1,
+              mutedVideoCount: 0,
+              unmutedVideoCount: 1,
+              playingVideoCount: 1,
+              blockedPlaybackCount: 0,
+              documentHidden: true,
+            },
+          },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [], kick: [] },
+      },
+      settings({ platform: { twitch: { enabled: true, idleWatchlistChannels: [] }, kick: { enabled: false, idleWatchlistChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(result.state.sessions.twitch.status).toBe("watching");
+    expect(result.state.sessions.twitch.tabId).toBe(7);
+    expect(result.state.sessions.twitch.playbackChecks).toBe(1);
+  });
+
+  // An unparseable `checkedAt` must land on the same "stale" branch as a
+  // future one — previously it fell through to the telemetry check instead
+  // (NaN comparisons are always false), which happened to read as healthy.
+  it("treats unparseable playback telemetry timestamps as stale", async () => {
+    const old = channel("old");
+    const twitch = adapter("twitch", [campaign("drops")], [old]);
+    vi.mocked(twitch.checkChannel).mockResolvedValue({ live: true, categoryMatches: true, candidate: old });
+    vi.mocked(twitch.prepareWatchTab).mockResolvedValue({ tabId: 7, managedByExtension: true });
+
+    const result = await runSchedulerTick(
+      {
+        authHealth: HEALTHY_AUTH,
+        sessions: {
+          twitch: {
+            platform: "twitch",
+            status: "watching",
+            channel: old,
+            campaignId: "drops",
+            rewardId: "reward-in_progress",
+            offlineChecks: 0,
+            playbackChecks: 0,
+            tabId: 7,
+            watchMode: "tab",
+            watchTabOpenedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+            playback: {
+              platform: "twitch",
+              checkedAt: "not-a-date",
+              videoCount: 1,
+              mutedVideoCount: 0,
+              unmutedVideoCount: 1,
+              playingVideoCount: 1,
+              blockedPlaybackCount: 0,
+              documentHidden: true,
+            },
+          },
+          kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+        },
+        campaigns: { twitch: [], kick: [] },
+      },
+      settings({ platform: { twitch: { enabled: true, idleWatchlistChannels: [] }, kick: { enabled: false, idleWatchlistChannels: [] } } }),
+      { twitch, kick: adapter("kick", [], []) },
+    );
+
+    expect(result.state.sessions.twitch.status).toBe("watching");
+    expect(result.state.sessions.twitch.tabId).toBe(7);
+    expect(result.state.sessions.twitch.playbackChecks).toBe(1);
   });
 
   it("treats a muted but playing watch tab as healthy", async () => {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -331,6 +331,75 @@ describe("tab manager", () => {
     expect(browser.tabs.update).not.toHaveBeenCalled();
   });
 
+  // A clock rollback can leave `playback.checkedAt` in the future. Reading
+  // that as "just checked" would let stale-but-healthy-looking telemetry from
+  // before the rollback suppress re-priming indefinitely, so a future stamp
+  // counts as stale and re-priming still happens.
+  it("re-primes a matching managed tab whose playback telemetry is stamped in the future", async () => {
+    const browser = browserMock();
+    browser.tabs.get.mockResolvedValue({
+      id: 4,
+      url: channel.url,
+      pinned: true,
+      mutedInfo: { muted: true },
+      active: false,
+    });
+
+    await openPinnedMutedTabWithBrowser(browser, channel, {
+      platform: "twitch",
+      status: "watching",
+      offlineChecks: 0,
+      tabId: 4,
+      tabManagedByExtension: true,
+      playback: {
+        platform: "twitch",
+        checkedAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+        videoCount: 1,
+        mutedVideoCount: 0,
+        unmutedVideoCount: 1,
+        playingVideoCount: 1,
+        blockedPlaybackCount: 0,
+        documentHidden: false,
+      },
+    });
+
+    expect(browser.tabs.update).toHaveBeenCalledWith(4, { active: true });
+  });
+
+  // An unparseable `checkedAt` must land on the same "stale" branch as a
+  // future one — previously NaN comparisons were always false, so it fell
+  // through to the telemetry check and read as healthy instead.
+  it("re-primes a matching managed tab whose playback telemetry has an unparseable timestamp", async () => {
+    const browser = browserMock();
+    browser.tabs.get.mockResolvedValue({
+      id: 4,
+      url: channel.url,
+      pinned: true,
+      mutedInfo: { muted: true },
+      active: false,
+    });
+
+    await openPinnedMutedTabWithBrowser(browser, channel, {
+      platform: "twitch",
+      status: "watching",
+      offlineChecks: 0,
+      tabId: 4,
+      tabManagedByExtension: true,
+      playback: {
+        platform: "twitch",
+        checkedAt: "not-a-date",
+        videoCount: 1,
+        mutedVideoCount: 0,
+        unmutedVideoCount: 1,
+        playingVideoCount: 1,
+        blockedPlaybackCount: 0,
+        documentHidden: false,
+      },
+    });
+
+    expect(browser.tabs.update).toHaveBeenCalledWith(4, { active: true });
+  });
+
   it("does not re-prime a matching managed tab that is playing but muted", async () => {
     const browser = browserMock();
     browser.tabs.get.mockResolvedValue({

--- a/packages/extension/tests/timestamps.test.ts
+++ b/packages/extension/tests/timestamps.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isTimestampStale } from "@lurkloot/core/timestamps";
+
+describe("isTimestampStale", () => {
+  it("is stale when the timestamp cannot be parsed", () => {
+    expect(isTimestampStale("not-a-date", 1000, Date.now())).toBe(true);
+  });
+
+  // A clock rollback (NTP correction, a suspended VM) can leave a self-written
+  // stamp in the future. `Date.now() - parsed` would then be negative, passing
+  // almost any elapsed-time bound, so a future stamp must be treated the same
+  // as an unparseable one rather than as freshly written.
+  it("is stale when the timestamp is in the future", () => {
+    const now = Date.now();
+    expect(isTimestampStale(new Date(now + 1).toISOString(), 1000, now)).toBe(true);
+  });
+
+  it("is not stale exactly at the parsed time", () => {
+    const now = Date.now();
+    expect(isTimestampStale(new Date(now).toISOString(), 1000, now)).toBe(false);
+  });
+
+  it("is not stale exactly at the max age boundary", () => {
+    const now = Date.now();
+    expect(isTimestampStale(new Date(now - 1000).toISOString(), 1000, now)).toBe(false);
+  });
+
+  it("is stale once elapsed time exceeds the max age", () => {
+    const now = Date.now();
+    expect(isTimestampStale(new Date(now - 1001).toISOString(), 1000, now)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #168. Four staleness checks parsed a self-written ISO timestamp and compared it against `Date.now()`, guarding only against `NaN`. A clock rollback (NTP correction, a suspended VM, a user changing the system clock) can leave that stamp in the future, producing a negative elapsed time that passes almost any "is this recent?" bound — so a stale value read as maximally fresh instead of maximally stale.

Same class of bug already fixed for `challengePollDue` in `e66e880` (#166); this applies the same shape to the four sites the issue's triage identified:

- `hasRecentManualWatch` (`packages/core/src/core/scheduler.ts`) — worst of the four: a future manual-watch stamp kept farming paused until the clock caught up.
- `recentPrevious` (`packages/core/src/background/controller.ts`) — a stale manual-watch record could keep winning over fresher telemetry from a different tab. This site had no `NaN` guard at all before (it relied on `NaN` comparisons evaluating false, the safe direction by accident).
- `isPlaybackHealthy` (`packages/core/src/core/scheduler.ts`) — stale playback telemetry could read as healthy.
- `shouldPrimePlayback` (`packages/core/src/core/tabs.ts`) — same, on the tab-priming path.

## Approach

Added a shared `isTimestampStale(iso, maxAgeMs, now)` helper in a new `packages/core/src/core/timestamps.ts` (exported as `@lurkloot/core/timestamps`), used at all four sites. It folds the unparseable and future cases into the same "stale" branch, using `Number.isFinite` per the issue's note (rejects `Infinity` too, unlike the sites' previous `!Number.isNaN`). The two comparison directions the issue flagged (fresh-if-`<=`-TTL vs. stale-if-`>`-threshold) both fall out of negating the same helper call.

`challengePollDue` is left as-is — it already has the correct shape and is the reference this issue points at — but it uses an inclusive `>=` on its interval where the new helper uses `>`, so folding it in would shift that boundary; not worth it for an already-correct site.

**Not in scope, flagging for a follow-up:** `isHeartbeatHealthy` (`scheduler.ts`, tabless heartbeat check) has the same shape (`Date.now() - at < 3 * 60 * 1000`) and the same bug — a future `lastHeartbeatAt` would read as healthy. The original issue enumerated exactly four sites during triage, so I left it out of this PR rather than silently widening the fix; happy to take it in a follow-up if wanted.

## Testing

- `pnpm --filter @lurkloot/extension test` — all 1359 tests pass (added 8 new: 4 future-timestamp regressions across the four sites, 2 NaN-behavior pins for the two playback sites whose NaN handling changed direction, 1 direct unit test file for the helper's boundary semantics, plus the controller override case).
- Verified all four regression tests fail against the pre-fix source (temporarily stashed the fix, confirmed the exact failure each site's issue description predicts, then restored the fix).
- `pnpm -r typecheck` — clean across all packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or future timestamps so stale telemetry is detected reliably.
  * Prevented clock-skewed timestamps from blocking manual-watch activity or playback recovery.
  * Ensured affected playback tabs are re-primed when telemetry timestamps are invalid or stale.

* **Tests**
  * Added coverage for timestamp boundaries, invalid values, future timestamps, and clock-skew scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->