### PR TITLE
refactor(core): share the Kick session-bearer predicate

### DIFF
--- a/packages/cli/src/transport/cycle.ts
+++ b/packages/cli/src/transport/cycle.ts
@@ -1,5 +1,5 @@
 import initCycleTLS, { type CycleTLSClient, type CycleTLSWebSocketResponse } from "cycletls";
-import { KickWafBlockedError, safeKickFailure } from "@lurkloot/core/tabs";
+import { KickWafBlockedError, needsKickSessionBearer, safeKickFailure } from "@lurkloot/core/tabs";
 import { SafeFetchError } from "@lurkloot/core/fetchError";
 import type { PageFetcher } from "@lurkloot/core/adapter";
 import type { WebSocketFactory, WebSocketLike } from "@lurkloot/core/kick/watch";
@@ -8,29 +8,14 @@ import { CHROME_HTTP2, CHROME_JA3, CHROME_UA, hasHeader, headersToObject } from 
 
 export type { CycleTLSClient } from "cycletls";
 
-// Hosts whose endpoints replay the session_token cookie as a Bearer (mirrors the
-// engine's needsKickSessionBearer in @lurkloot/core/tabs). kick.com/api/v2/* is
-// public and needs no auth; bare kick.com only needs it on the two paths below
-// (the identity probe and the followed-live lookup), both of which Kick would
-// otherwise answer as an unauthenticated stranger rather than reject outright.
-const KICK_AUTH_HOSTS = ["web.kick.com", "websockets.kick.com"];
-const KICK_BEARER_PATHS = ["/api/v1/user", "/api/v1/user/livestreams"];
+// wss:, not just https:, because the viewer WebSocket (websockets.kick.com)
+// goes through this same header builder — see createCycleKickWebSocketFactory.
+// This is the only Kick transport that needs the widened protocol set: the
+// engine's own callers of needsKickSessionBearer never reach wss.
+const KICK_BEARER_PROTOCOLS = ["https:", "wss:"];
 
 export function initCycle(): Promise<CycleTLSClient> {
   return initCycleTLS();
-}
-
-function needsKickBearer(url: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return false;
-  }
-  // wss:, not just https:, because the viewer WebSocket (websockets.kick.com)
-  // goes through this same header builder — see createCycleKickWebSocketFactory.
-  if (parsed.protocol !== "https:" && parsed.protocol !== "wss:") return false;
-  return KICK_AUTH_HOSTS.includes(parsed.host) || (parsed.host === "kick.com" && KICK_BEARER_PATHS.includes(parsed.pathname));
 }
 
 export function kickHeaders(url: string, init: RequestInit | undefined, creds: PlatformCredentials): Record<string, string> {
@@ -38,7 +23,7 @@ export function kickHeaders(url: string, init: RequestInit | undefined, creds: P
   headers.Origin ??= "https://kick.com";
   headers.Referer ??= "https://kick.com/";
   const sessionToken = creds.kick?.sessionToken;
-  if (sessionToken && needsKickBearer(url) && !hasHeader(headers, "authorization")) {
+  if (sessionToken && needsKickSessionBearer(url, { protocols: KICK_BEARER_PROTOCOLS }) && !hasHeader(headers, "authorization")) {
     headers.authorization = `Bearer ${decodeURIComponent(sessionToken)}`;
   }
   return headers;

--- a/packages/cli/tests/cycleKickHeaders.test.ts
+++ b/packages/cli/tests/cycleKickHeaders.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { KICK_BEARER_NEAR_MISS_CASES, KICK_BEARER_POSITIVE_CASES } from "@lurkloot/core/kickBearerCases";
 import { kickHeaders } from "../src/transport/cycle";
 import type { PlatformCredentials } from "../src/authStore";
 
@@ -8,34 +9,22 @@ const creds: PlatformCredentials = {
 };
 
 describe("kickHeaders", () => {
-  it("attaches the session token to web.kick.com and websockets.kick.com", () => {
-    expect(kickHeaders("https://web.kick.com/api/v1/drops/campaigns", undefined, creds).authorization)
-      .toBe("Bearer sess 789");
+  it.each(KICK_BEARER_POSITIVE_CASES)("attaches the session token to %s", (_case, url) => {
+    expect(kickHeaders(url, undefined, creds).authorization).toBe("Bearer sess 789");
+  });
+
+  // This transport is the one copy that reaches Kick over wss, not just https —
+  // the viewer WebSocket goes through this same header builder (see
+  // createCycleKickWebSocketFactory in ../src/transport/cycle.ts).
+  it("attaches the session token to websockets.kick.com over wss", () => {
     expect(kickHeaders("wss://websockets.kick.com/viewer", undefined, creds).authorization)
       .toBe("Bearer sess 789");
   });
 
-  it("attaches the session token to the bare kick.com identity and followed-live endpoints", () => {
-    expect(kickHeaders("https://kick.com/api/v1/user", undefined, creds).authorization)
-      .toBe("Bearer sess 789");
-    expect(kickHeaders("https://kick.com/api/v1/user/livestreams", undefined, creds).authorization)
-      .toBe("Bearer sess 789");
-  });
-
-  it("does not attach the session token to the public kick.com channel API", () => {
-    expect(kickHeaders("https://kick.com/api/v2/channels/someone", undefined, creds).authorization)
-      .toBeUndefined();
-  });
-
-  // Every URL here is a near-miss for a genuinely authenticated endpoint: a
-  // look-alike host, an unintended subpath, or a plaintext downgrade of an
-  // endpoint that *does* receive the token over https/wss. None may receive it.
-  it.each([
-    ["look-alike host mentioning a Kick host", "https://evil.example/?r=web.kick.com"],
-    ["look-alike host suffixing a Kick host", "https://web.kick.com.evil.example/api/v1/user"],
-    ["subpath of the identity endpoint", "https://kick.com/api/v1/user/profile"],
-    ["plaintext downgrade of an authenticated endpoint", "http://web.kick.com/api/v1/drops/progress"],
-  ])("never attaches the session token to a %s", (_case, url) => {
+  // Every case here is shared with tabs.test.ts (needsKickSessionBearer) and
+  // pageFetchJson's own test, so all three copies of the predicate are pinned to
+  // the same expectations. See packages/core/src/core/kickBearerCases.ts.
+  it.each(KICK_BEARER_NEAR_MISS_CASES)("never attaches the session token to a %s", (_case, url) => {
     expect(kickHeaders(url, undefined, creds).authorization).toBeUndefined();
   });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "./tablessWatch": "./src/core/tablessWatch.ts",
     "./twitchIntegrity": "./src/core/twitchIntegrity.ts",
     "./tabs": "./src/core/tabs.ts",
+    "./kickBearerCases": "./src/core/kickBearerCases.ts",
     "./defaults": "./src/core/defaults.ts",
     "./authHealth": "./src/core/authHealth.ts",
     "./activityDiagnostics": "./src/core/activityDiagnostics.ts",

--- a/packages/core/src/core/kickBearerCases.ts
+++ b/packages/core/src/core/kickBearerCases.ts
@@ -1,0 +1,31 @@
+// Shared test fixture: URLs asserted against every copy of the Kick
+// session_token Bearer predicate (packages/core/src/core/tabs.ts's
+// needsKickSessionBearer, packages/cli/src/transport/cycle.ts's kickHeaders,
+// and tabs.ts's inlined pageFetchJson). Kept here rather than duplicated in
+// each package's test suite so the three copies stay pinned to the same
+// expectations. Not imported by any runtime code path.
+
+// Genuinely authenticated endpoints that must receive the Bearer over https,
+// true for every copy regardless of which extra protocols it accepts (only
+// the CLI's WebSocket transport widens beyond https; see needsKickSessionBearer's
+// `protocols` option and kickHeaders in packages/cli/src/transport/cycle.ts).
+export const KICK_BEARER_POSITIVE_CASES: ReadonlyArray<readonly [string, string]> = [
+  ["web.kick.com", "https://web.kick.com/api/v1/drops/campaigns"],
+  ["bare kick.com identity endpoint", "https://kick.com/api/v1/user"],
+  ["bare kick.com followed-live endpoint", "https://kick.com/api/v1/user/livestreams"],
+];
+
+// Near-misses for a genuinely authenticated endpoint: a look-alike host, an
+// unintended subpath, or a plaintext/unencrypted downgrade of an endpoint that
+// *does* receive the token over https (or, for the CLI transport, wss). None
+// may receive it from any copy — including "ws://websockets.kick.com/viewer",
+// the plaintext downgrade of the one endpoint whose bearer-eligible protocol
+// set is wider than https alone.
+export const KICK_BEARER_NEAR_MISS_CASES: ReadonlyArray<readonly [string, string]> = [
+  ["look-alike host mentioning a Kick host", "https://evil.example/?r=web.kick.com"],
+  ["look-alike host suffixing a Kick host", "https://web.kick.com.evil.example/api/v1/user"],
+  ["subpath of the identity endpoint", "https://kick.com/api/v1/user/profile"],
+  ["plaintext downgrade of an authenticated endpoint", "http://web.kick.com/api/v1/drops/progress"],
+  ["plaintext downgrade of the WebSocket endpoint", "ws://websockets.kick.com/viewer"],
+  ["public kick.com channel API", "https://kick.com/api/v2/channels/someone"],
+];

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -989,14 +989,20 @@ const KICK_BEARER_PATHS = ["/api/v1/user", "/api/v1/user/livestreams"];
 // Matched on the parsed host and pathname rather than by substring: `includes` would
 // also attach the session token to hosts that merely mention a Kick host (e.g.
 // https://evil.example/?r=web.kick.com) and to unintended subpaths of /api/v1/user.
-function needsKickSessionBearer(url: string): boolean {
+//
+// Exported so packages/cli/src/transport/cycle.ts shares this decision instead of
+// reimplementing it (see #370): the CLI's WebSocket transport reaches
+// websockets.kick.com over wss, not https, which this module's own callers never
+// do, so the accepted protocols are parameterized rather than hardcoded here.
+export function needsKickSessionBearer(url: string, options?: { protocols?: readonly string[] }): boolean {
+  const protocols = options?.protocols ?? ["https:"];
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
     return false;
   }
-  if (parsed.protocol !== "https:") return false;
+  if (!protocols.includes(parsed.protocol)) return false;
   if (parsed.host === "web.kick.com" || parsed.host === "websockets.kick.com") return true;
   return parsed.host === "kick.com" && KICK_BEARER_PATHS.includes(parsed.pathname);
 }
@@ -1665,7 +1671,12 @@ export type SchedulerManagedPageContexts = Partial<Record<Platform, ManagedPageC
 // cannot be reached from the twitch.tv page (CORS / anti-tampering). Must be
 // self-contained: executeScript only serializes this function's own source, so
 // module-scope helpers are unavailable in the page.
-async function pageFetchJson(targetUrl: string, initJson?: string): Promise<unknown> {
+//
+// Test seam: exported so tests can call it directly with a stubbed fetch/document
+// instead of only through the mocked executeScript path (see fetchJsonInPageWithBrowser's
+// tests). Exporting does not affect executeScript injection, which serializes only
+// this function's own toString() output, not how it was imported.
+export async function pageFetchJson(targetUrl: string, initJson?: string): Promise<unknown> {
   const parsedInit = initJson ? JSON.parse(initJson) : undefined;
   const headers = new Headers(parsedInit?.headers ?? {});
   // Mirrors needsKickSessionBearer (KICK_BEARER_PATHS); inlined because

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -17,6 +17,7 @@ import {
   KickWafBlockedError,
   noteTwitchGqlRequest,
   openPinnedMutedTabWithBrowser,
+  pageFetchJson,
   PLAYBACK_PRIME_BACKOFF_MS,
   PLAYBACK_PRIME_MAX_ATTEMPTS,
   recordManagedPageContextBackgroundSuccessWithBrowser,
@@ -30,6 +31,7 @@ import {
   type TwitchIntegrityRequest,
 } from "@lurkloot/core/tabs";
 import { isSafeFetchError } from "@lurkloot/core/fetchError";
+import { KICK_BEARER_NEAR_MISS_CASES, KICK_BEARER_POSITIVE_CASES } from "@lurkloot/core/kickBearerCases";
 
 const channel: ChannelCandidate = {
   platform: "twitch",
@@ -2220,20 +2222,6 @@ describe("fetchKickInBackgroundWith", () => {
     vi.unstubAllGlobals();
   });
 
-  it("does not attach a Bearer for the public kick.com channel API", async () => {
-    let captured: RequestInit | undefined;
-    vi.stubGlobal("fetch", vi.fn(async (_url: string, init: RequestInit) => {
-      captured = init;
-      return new Response(JSON.stringify({ id: 1 }), { status: 200, headers: { "content-type": "application/json" } });
-    }));
-
-    await fetchKickInBackgroundWith(cookieApi, "https://kick.com/api/v2/channels/someone");
-
-    expect(cookieApi.cookies.get).not.toHaveBeenCalled();
-    expect(new Headers(captured?.headers).has("authorization")).toBe(false);
-    vi.unstubAllGlobals();
-  });
-
   it("replays the session_token cookie as a Bearer for the kick.com identity endpoint", async () => {
     // Kick serves this endpoint anonymously as `200 {}` rather than a 401, so without the
     // Bearer the auth probe cannot tell a signed-in account from a signed-out one.
@@ -2268,15 +2256,10 @@ describe("fetchKickInBackgroundWith", () => {
     }
   });
 
-  // Every URL here is a near-miss for a genuinely authenticated endpoint: a look-alike
-  // host, an unintended subpath, or a plaintext downgrade of an endpoint that *does*
-  // receive the token over https (see the web.kick.com case above). None may receive it.
-  it.each([
-    ["look-alike host mentioning a Kick host", "https://evil.example/?r=web.kick.com"],
-    ["look-alike host suffixing a Kick host", "https://web.kick.com.evil.example/api/v1/user"],
-    ["subpath of the identity endpoint", "https://kick.com/api/v1/user/profile"],
-    ["plaintext downgrade of an authenticated endpoint", "http://web.kick.com/api/v1/drops/progress"],
-  ])("never attaches the session token to a %s", async (_case, url) => {
+  // Shared with cycleKickHeaders.test.ts (kickHeaders) and pageFetchJson's own
+  // test, so all three copies of the predicate are pinned to the same
+  // expectations. See packages/core/src/core/kickBearerCases.ts.
+  it.each(KICK_BEARER_NEAR_MISS_CASES)("never attaches the session token to a %s", async (_case, url) => {
     let captured: RequestInit | undefined;
     vi.stubGlobal("fetch", vi.fn(async (_url: string, init: RequestInit) => {
       captured = init;
@@ -2366,6 +2349,54 @@ describe("fetchKickInBackgroundWith", () => {
 
     expect(result.html).toBe("<html>is_live</html>");
     vi.unstubAllGlobals();
+  });
+});
+
+// pageFetchJson is injected into a Kick page's MAIN world via executeScript
+// (see fetchJsonInPageWithBrowser), whose tests mock executeScript wholesale and
+// so never exercise this function's own logic. These tests call it directly with
+// a stubbed fetch/document instead, including its inlined Bearer predicate — the
+// one copy that cannot import needsKickSessionBearer (see fetchKickInBackgroundWith
+// above and kickHeaders in packages/cli/src/transport/cycle.ts for the other two).
+describe("pageFetchJson", () => {
+  beforeEach(() => {
+    vi.stubGlobal("document", { cookie: "session_token=sess%20789" });
+  });
+
+  it.each(KICK_BEARER_POSITIVE_CASES)("replays the session_token cookie as a Bearer for %s", async (_case, url) => {
+    let captured: RequestInit | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (_target: string, init: RequestInit) => {
+      captured = init;
+      return new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } });
+    }));
+
+    try {
+      await pageFetchJson(url);
+
+      expect(new Headers(captured?.headers).get("authorization")).toBe("Bearer sess 789");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  // Shared with tabs.test.ts's fetchKickInBackgroundWith suite and
+  // cycleKickHeaders.test.ts (kickHeaders), so all three copies of the
+  // predicate are pinned to the same expectations. See
+  // packages/core/src/core/kickBearerCases.ts.
+  it.each(KICK_BEARER_NEAR_MISS_CASES)("never attaches the session token to a %s", async (_case, url) => {
+    let captured: RequestInit | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (_target: string, init: RequestInit) => {
+      captured = init;
+      return new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } });
+    }));
+
+    try {
+      await pageFetchJson(url);
+
+      expect(new Headers(captured?.headers).has("authorization")).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Exports `needsKickSessionBearer` from `packages/core/src/core/tabs.ts`, parameterized on the protocols it accepts (`{ protocols?: readonly string[] }`, defaulting to `["https:"]`).
- `packages/cli/src/transport/cycle.ts` now calls the shared predicate with `["https:", "wss:"]` instead of reimplementing `needsKickBearer`/`KICK_AUTH_HOSTS`/`KICK_BEARER_PATHS`. The "wss: because the viewer WebSocket shares this header builder" rationale moved to the call site with it.
- `pageFetchJson` stays inlined (an `executeScript`-injected function can't import module-scope helpers) but is now `export`ed with a test seam, and is exercised directly for the first time — its previous test coverage only mocked `executeScript` wholesale and never ran its actual logic.
- Added `packages/core/src/core/kickBearerCases.ts`: a shared table of positive/near-miss URLs (look-alike host, suffixed look-alike, unintended subpath, plaintext downgrade, and a new plaintext downgrade of the WebSocket endpoint), imported by both `packages/extension/tests/tabs.test.ts` and `packages/cli/tests/cycleKickHeaders.test.ts` so all three copies are pinned to the same expectations.

**Note for reviewers:** the issue states "Copies B and C have no equivalent coverage," but `packages/cli/tests/cycleKickHeaders.test.ts` (landed with #351) already had the four near-miss cases and the `wss://websockets.kick.com` assertion — that part of the issue was stale. Only copy C (`pageFetchJson`) was actually uncovered before this PR; it now has direct coverage for the first time.

Closes #370

## Testing

- `pnpm -r typecheck` — pass
- `pnpm -r --if-present test` — pass (cli 152, extension 1369, site 3)
- `pnpm verify` — pass (script tests, typecheck, extension tests, site build, chrome build, firefox build)
- Confirmed no fourth copy of the predicate exists via a broad grep for `session_token`/`web.kick.com`/`websockets.kick.com` across `packages/**/*.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session authentication handling for secure HTTPS and WebSocket connections.
  * Prevented authorization headers from being added to look-alike hosts, invalid paths, insecure protocols, and public API endpoints.
  * Preserved existing authorization headers and behavior when no session token is available.

* **Tests**
  * Expanded coverage for authenticated, excluded, and near-miss URLs across supported transports and tab requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->