### PR TITLE
fix(popup): clarify next reward remaining time

### DIFF
--- a/docs/superpowers/plans/2026-08-10-clarify-next-reward-time.md
+++ b/docs/superpowers/plans/2026-08-10-clarify-next-reward-time.md
@@ -1,0 +1,96 @@
+# Clarify Next Reward Remaining Time Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show reward-specific remaining watch time beside the next reward while retaining and clearly labeling the campaign-wide remaining total.
+
+**Architecture:** Extend the existing `CampaignStats` view-model contract with a derived `nextRewardRemaining` field. Keep UI formatting in `drops.tsx`, and add one localized `campaignLeft` key to every catalog.
+
+**Tech Stack:** TypeScript, React, Vitest, pnpm workspaces, JSON locale catalogs
+
+## Global Constraints
+
+- `remaining` remains the campaign-wide total across all watch rewards.
+- `nextRewardRemaining` is the next incomplete watch reward's own remaining minutes, clamped to zero.
+- The next-reward row uses `nextRewardRemaining`; the summary statistic uses `remaining`.
+- The summary label uses a localized `campaignLeft` key in every locale catalog.
+- Diagnostic messages remain English literals and are unaffected.
+- Follow strict TypeScript, ES modules, two-space indentation, double quotes, and semicolons.
+
+---
+
+### Task 1: Separate next-reward and campaign remaining time
+
+**Files:**
+- Modify: `packages/popup-ui/src/types.ts`
+- Modify: `packages/popup-ui/src/viewModels.ts`
+- Modify: `packages/popup-ui/src/drops.tsx`
+- Modify: `packages/locales/messages/{ar,de,en,es,fr,hi,it,pt_BR,ru,tr,zh_CN}.json`
+- Test: `packages/extension/tests/subscriptionDropsView.test.ts`
+
+**Interfaces:**
+- Consumes: `CampaignView.rewards`, `RewardView.requiredMinutes`, `RewardView.progress`, and the existing `rewardComplete()` predicate.
+- Produces: `CampaignStats.nextRewardRemaining?: number` and the `campaignLeft` locale message.
+
+- [ ] **Step 1: Write failing view-model and rendering tests**
+
+Add a test using four untouched sequential watch rewards of 30, 60, 120, and 240 minutes. Assert that `campaignStats(view)` contains `remaining: 450` and `nextRewardRemaining: 30`. Render the expanded view and assert that the next-reward row contains `30m left`, the summary contains `7h 30m`, and the localized summary label resolves to `Campaign left` rather than the raw key.
+
+Add a second test whose next incomplete watch reward has `requiredMinutes: 60`, `watchedMinutes: 15`, and `status: "in_progress"`. Assert `nextRewardRemaining: 45`.
+
+Add `campaignLeft: "Campaign left"`, `left: "Left"`, and `nextReward: "Next: $1"` to `testMessages` so the rendering assertions exercise translated copy.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- subscriptionDropsView.test.ts`
+
+Expected: FAIL because `nextRewardRemaining` is absent and the rendered next-reward time still uses the 450-minute campaign total.
+
+- [ ] **Step 3: Extend the view model and update the UI**
+
+Add `nextRewardRemaining?: number` to `CampaignStats`. In `campaignStats()`, after selecting `nextReward`, calculate the value only when `nextReward.requirement === "watch"`:
+
+```ts
+const nextRewardRemaining = nextReward?.requirement === "watch"
+  ? Math.max(nextReward.requiredMinutes * (1 - (nextReward.progress ?? 0) / 100), 0)
+  : undefined;
+```
+
+Include `nextRewardRemaining` in the returned stats object. In `drops.tsx`, format `stats.nextRewardRemaining` beside `Next: <reward>`, while leaving `stats.remaining` as the summary value. Change the summary `MetaStat` label from `t("left")` to `t("campaignLeft")`.
+
+- [ ] **Step 4: Add the localized summary label**
+
+Insert `campaignLeft` next to `left` in every locale catalog with these messages:
+
+```text
+ar: المتبقي للحملة
+de: Kampagne übrig
+en: Campaign left
+es: Restante de campaña
+fr: Restant pour la campagne
+hi: अभियान शेष
+it: Campagna rimanente
+pt_BR: Restante da campanha
+ru: Осталось в кампании
+tr: Kampanyada kalan
+zh_CN: 活动剩余
+```
+
+- [ ] **Step 5: Verify GREEN and the repository checks**
+
+Run the focused test until it passes:
+
+`pnpm --filter @lurkloot/extension test -- subscriptionDropsView.test.ts`
+
+Then run once before committing:
+
+`pnpm check`
+
+Expected: all tests, workspace typechecks, script checks, and the site build pass with no failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/popup-ui/src/types.ts packages/popup-ui/src/viewModels.ts packages/popup-ui/src/drops.tsx packages/locales/messages packages/extension/tests/subscriptionDropsView.test.ts
+git commit -m "fix(popup): clarify next reward remaining time"
+```

--- a/docs/superpowers/plans/2026-08-10-clarify-next-reward-time.md
+++ b/docs/superpowers/plans/2026-08-10-clarify-next-reward-time.md
@@ -48,11 +48,11 @@ Expected: FAIL because `nextRewardRemaining` is absent and the rendered next-rew
 
 - [ ] **Step 3: Extend the view model and update the UI**
 
-Add `nextRewardRemaining?: number` to `CampaignStats`. In `campaignStats()`, after selecting `nextReward`, calculate the value only when `nextReward.requirement === "watch"`:
+Add `nextRewardRemaining?: number` to `CampaignStats`. In `campaignStats()`, preserve the actual incomplete reward separately from the display fallback and calculate the value only when `nextIncompleteReward.requirement === "watch"`:
 
 ```ts
-const nextRewardRemaining = nextReward?.requirement === "watch"
-  ? Math.max(nextReward.requiredMinutes * (1 - (nextReward.progress ?? 0) / 100), 0)
+const nextRewardRemaining = nextIncompleteReward?.requirement === "watch"
+  ? Math.max(nextIncompleteReward.requiredMinutes * (1 - (nextIncompleteReward.progress ?? 0) / 100), 0)
   : undefined;
 ```
 
@@ -94,3 +94,7 @@ Expected: all tests, workspace typechecks, script checks, and the site build pas
 git add packages/popup-ui/src/types.ts packages/popup-ui/src/viewModels.ts packages/popup-ui/src/drops.tsx packages/locales/messages packages/extension/tests/subscriptionDropsView.test.ts
 git commit -m "fix(popup): clarify next reward remaining time"
 ```
+
+## As built
+
+The shipped `campaignStats()` implementation uses `nextIncompleteReward` to calculate `nextRewardRemaining`, while `nextReward` retains the final-reward display fallback. This preserves `undefined` when no incomplete watch reward exists, including a completed but unclaimed reward, as covered by `subscriptionDropsView.test.ts`.

--- a/docs/superpowers/specs/2026-08-10-clarify-next-reward-time-design.md
+++ b/docs/superpowers/specs/2026-08-10-clarify-next-reward-time-design.md
@@ -1,0 +1,24 @@
+# Clarify Next Reward Remaining Time
+
+## Context
+
+The expanded campaign card currently renders the campaign-wide remaining watch time beside the next reward. For sequential rewards, that makes the next reward appear to require the sum of every remaining reward's watch time.
+
+## Design
+
+`campaignStats()` will continue to calculate `remaining` as the total watch time left across the campaign. It will also expose `nextRewardRemaining`, calculated from the next incomplete watch reward's own requirement and progress and clamped to zero.
+
+The expanded campaign card will use `nextRewardRemaining` beside `Next: <reward>`. The three-column summary will continue to use the campaign-wide `remaining`, but its label will use a new localized `campaignLeft` message so the scope is explicit.
+
+All locale catalogs will define `campaignLeft`. Diagnostic messages are unaffected.
+
+## Edge Cases
+
+- A partially progressed next reward reports only its own remaining minutes.
+- A completed campaign does not show next-reward time, matching current rendering behavior.
+- A non-watch next reward does not show watch-time remaining.
+- Campaign totals and progress calculations retain their existing semantics.
+
+## Testing
+
+Focused view-model tests will cover untouched sequential rewards and a partially progressed next reward. Existing popup, typecheck, and build verification will protect the UI and locale integration.

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -189,6 +189,17 @@ describe("subscription drop popup views", () => {
     expect(campaignStats(view)).toMatchObject({ nextRewardRemaining: 45 });
   });
 
+  it("does not show remaining time for a completed but unclaimed watch reward", () => {
+    const source = campaign("claimable-watch", [
+      reward({ id: "reward-60", name: "60 minute reward", requirement: "watch", requiredMinutes: 60, watchedMinutes: 60, status: "claimable" }),
+    ]);
+    const view = campaignViewFromCampaign(source, 0, idleSession, false);
+    const stats = campaignStats(view);
+
+    expect(stats.nextRewardRemaining).toBeUndefined();
+    expect(renderDrops([expandedView(view)])).not.toContain("&lt;1m left");
+  });
+
   it("models action-only campaigns without watch progress", () => {
     const source = campaign("action-only", [
       reward({ id: "purchase", name: "Purchase", requirement: "action", isWatchBased: false }),

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -251,6 +251,17 @@ describe("subscription drop popup views", () => {
     expect(markup).not.toContain("&lt;1m");
   });
 
+  it("shows campaign watch time when a non-watch reward is next", () => {
+    const source = campaign("mixed", [
+      reward({ id: "subscribe", name: "Subscriber Cape", requirement: "subscription", requiredSubs: 2 }),
+      reward({ id: "watch", name: "Watch Crown", requirement: "watch", requiredMinutes: 60 }),
+    ]);
+    const markup = renderDrops([expandedView(campaignViewFromCampaign(source, 0, idleSession, false))]);
+
+    expect(markup).toContain("1h");
+    expect(markup.match(/Progress unavailable/g)).toHaveLength(1);
+  });
+
   it("shows unknown remaining work after mixed campaign watch minutes are complete", () => {
     const source = campaign("mixed", [
       reward({

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -42,12 +42,15 @@ function campaign(id: string, rewards: DropReward[]): DropCampaign {
 
 const testMessages: Record<string, string> = {
   actionRequired: "Action required",
+  campaignLeft: "Campaign left",
   earned: "Earned",
   excluded: "Excluded",
   excludeFromFarming: "Exclude from farming",
   farmingLabel: "Farming",
   insufficientTimeRemaining: "Insufficient time remaining",
+  left: "Left",
   notEarnableByWatching: "Not earnable by watching",
+  nextReward: "Next: $1",
   qualifyingSubscriptionsRequired: "Requires $1 qualifying subscriptions",
   subscribedRefresh: "I've subscribed — refresh status",
   subscriptionProgressUnknown: "Progress unavailable",
@@ -157,6 +160,33 @@ describe("subscription drop popup views", () => {
       totalRewards: 2,
       complete: false,
     });
+  });
+
+  it("separates next-reward time from total campaign time", () => {
+    const source = campaign("sequential", [
+      reward({ id: "reward-30", name: "30 minute reward", requirement: "watch", requiredMinutes: 30 }),
+      reward({ id: "reward-60", name: "60 minute reward", requirement: "watch", requiredMinutes: 60 }),
+      reward({ id: "reward-120", name: "120 minute reward", requirement: "watch", requiredMinutes: 120 }),
+      reward({ id: "reward-240", name: "240 minute reward", requirement: "watch", requiredMinutes: 240 }),
+    ]);
+    const view = campaignViewFromCampaign(source, 0, idleSession, false);
+
+    expect(campaignStats(view)).toMatchObject({ remaining: 450, nextRewardRemaining: 30 });
+
+    const markup = renderDrops([expandedView(view)]);
+    expect(markup).toContain("30m left");
+    expect(markup).toContain("7h 30m");
+    expect(markup).toContain("Campaign left");
+    expect(markup).not.toContain(">left<");
+  });
+
+  it("calculates remaining time for an in-progress next watch reward", () => {
+    const source = campaign("in-progress", [
+      reward({ id: "reward-60", name: "60 minute reward", requirement: "watch", requiredMinutes: 60, watchedMinutes: 15, status: "in_progress" }),
+    ]);
+    const view = campaignViewFromCampaign(source, 0, idleSession, false);
+
+    expect(campaignStats(view)).toMatchObject({ nextRewardRemaining: 45 });
   });
 
   it("models action-only campaigns without watch progress", () => {

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "المتبقي"
   },
+  "campaignLeft": {
+    "message": "المتبقي للحملة"
+  },
   "done": {
     "message": "تم"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "Übrig"
   },
+  "campaignLeft": {
+    "message": "Kampagne übrig"
+  },
   "done": {
     "message": "Fertig"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "Left"
   },
+  "campaignLeft": {
+    "message": "Campaign left"
+  },
   "done": {
     "message": "Done"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "Restante"
   },
+  "campaignLeft": {
+    "message": "Restante de campaña"
+  },
   "done": {
     "message": "Listo"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "Restant"
   },
+  "campaignLeft": {
+    "message": "Restant pour la campagne"
+  },
   "done": {
     "message": "Terminé"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "बाकी"
   },
+  "campaignLeft": {
+    "message": "अभियान शेष"
+  },
   "done": {
     "message": "हो गया"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "Rimasto"
   },
+  "campaignLeft": {
+    "message": "Campagna rimanente"
+  },
   "done": {
     "message": "Fatto"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "Restante"
   },
+  "campaignLeft": {
+    "message": "Restante da campanha"
+  },
   "done": {
     "message": "Concluído"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "Осталось"
   },
+  "campaignLeft": {
+    "message": "Осталось в кампании"
+  },
   "done": {
     "message": "Готово"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "kaldı"
   },
+  "campaignLeft": {
+    "message": "Kampanyada kalan"
+  },
   "done": {
     "message": "Bitti"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -323,6 +323,9 @@
   "left": {
     "message": "剩余"
   },
+  "campaignLeft": {
+    "message": "活动剩余"
+  },
   "done": {
     "message": "完成"
   },

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -360,7 +360,7 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
                       label={t("campaignLeft")}
                       value={stats.complete
                         ? t("done")
-                        : stats.nextReward?.requirement === "watch"
+                        : campaign.hasWatchRewards && stats.remaining > 0
                           ? formatMinutes(stats.remaining)
                           : t("subscriptionProgressUnknown")}
                     />

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -350,14 +350,14 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
                           ? <div className="mt-0.5 truncate text-[11px] font-medium" style={{ color: "var(--accent-text)" }}>{t("complete")}</div>
                           : <div className="mt-0.5 truncate text-[11px] text-zinc-600 dark:text-zinc-300">{t("nextReward", stats.nextReward?.name ?? "")}</div>}
                       </div>
-                      {!stats.complete && stats.nextReward?.requirement === "watch" ? <div className="shrink-0 text-right text-[10px] tabular text-zinc-500 dark:text-zinc-400">{formatMinutes(stats.remaining)} {t("left").toLowerCase()}</div> : null}
+                      {!stats.complete && stats.nextReward?.requirement === "watch" ? <div className="shrink-0 text-right text-[10px] tabular text-zinc-500 dark:text-zinc-400">{formatMinutes(stats.nextRewardRemaining ?? 0)} {t("left").toLowerCase()}</div> : null}
                     </div>
                   </div>
                   <div className="grid grid-cols-3 gap-1.5">
                     <MetaStat icon={Clock3} label={t("farmed")} value={formatHours(stats.totalFarmed)} />
                     <MetaStat
                       icon={RotateCcw}
-                      label={t("left")}
+                      label={t("campaignLeft")}
                       value={stats.complete
                         ? t("done")
                         : stats.nextReward?.requirement === "watch"

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -350,7 +350,7 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
                           ? <div className="mt-0.5 truncate text-[11px] font-medium" style={{ color: "var(--accent-text)" }}>{t("complete")}</div>
                           : <div className="mt-0.5 truncate text-[11px] text-zinc-600 dark:text-zinc-300">{t("nextReward", stats.nextReward?.name ?? "")}</div>}
                       </div>
-                      {!stats.complete && stats.nextReward?.requirement === "watch" ? <div className="shrink-0 text-right text-[10px] tabular text-zinc-500 dark:text-zinc-400">{formatMinutes(stats.nextRewardRemaining ?? 0)} {t("left").toLowerCase()}</div> : null}
+                      {!stats.complete && stats.nextRewardRemaining != null ? <div className="shrink-0 text-right text-[10px] tabular text-zinc-500 dark:text-zinc-400">{formatMinutes(stats.nextRewardRemaining)} {t("left").toLowerCase()}</div> : null}
                     </div>
                   </div>
                   <div className="grid grid-cols-3 gap-1.5">

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -68,6 +68,7 @@ export type CampaignStats = {
   completed: number;
   totalRewards: number;
   nextReward?: RewardView;
+  nextRewardRemaining?: number;
   complete: boolean;
 };
 

--- a/packages/popup-ui/src/viewModels.ts
+++ b/packages/popup-ui/src/viewModels.ts
@@ -100,8 +100,11 @@ export function campaignStats(campaign: CampaignView): CampaignStats {
   const progress = totalRequired ? Math.min(100, (totalFarmed / totalRequired) * 100) : undefined;
   const completed = campaign.rewards.filter(rewardComplete).length;
   const nextReward = campaign.rewards.find((reward) => !rewardComplete(reward)) ?? campaign.rewards.at(-1);
+  const nextRewardRemaining = nextReward?.requirement === "watch"
+    ? Math.max(nextReward.requiredMinutes * (1 - (nextReward.progress ?? 0) / 100), 0)
+    : undefined;
   const complete = campaign.rewards.length > 0 && campaign.rewards.every((reward) => reward.obtained);
-  return { kind, totalRequired, totalFarmed, remaining, progress, completed, totalRewards: campaign.rewards.length, nextReward, complete };
+  return { kind, totalRequired, totalFarmed, remaining, progress, completed, totalRewards: campaign.rewards.length, nextReward, nextRewardRemaining, complete };
 }
 
 function rewardComplete(reward: RewardView): boolean {

--- a/packages/popup-ui/src/viewModels.ts
+++ b/packages/popup-ui/src/viewModels.ts
@@ -99,9 +99,10 @@ export function campaignStats(campaign: CampaignView): CampaignStats {
   const remaining = Math.max(totalRequired - totalFarmed, 0);
   const progress = totalRequired ? Math.min(100, (totalFarmed / totalRequired) * 100) : undefined;
   const completed = campaign.rewards.filter(rewardComplete).length;
-  const nextReward = campaign.rewards.find((reward) => !rewardComplete(reward)) ?? campaign.rewards.at(-1);
-  const nextRewardRemaining = nextReward?.requirement === "watch"
-    ? Math.max(nextReward.requiredMinutes * (1 - (nextReward.progress ?? 0) / 100), 0)
+  const nextIncompleteReward = campaign.rewards.find((reward) => !rewardComplete(reward));
+  const nextReward = nextIncompleteReward ?? campaign.rewards.at(-1);
+  const nextRewardRemaining = nextIncompleteReward?.requirement === "watch"
+    ? Math.max(nextIncompleteReward.requiredMinutes * (1 - (nextIncompleteReward.progress ?? 0) / 100), 0)
     : undefined;
   const complete = campaign.rewards.length > 0 && campaign.rewards.every((reward) => reward.obtained);
   return { kind, totalRequired, totalFarmed, remaining, progress, completed, totalRewards: campaign.rewards.length, nextReward, nextRewardRemaining, complete };


### PR DESCRIPTION
## Summary

- show the next incomplete watch reward's own remaining time beside its name
- keep the campaign-wide remaining total and label it explicitly as “Campaign left”
- localize the new summary label across every supported locale
- avoid showing remaining watch time for rewards that are already complete but awaiting claim

## Why

The popup reused the campaign-wide remaining total beside the next reward, making a 30-minute reward appear to require the sum of all sequential reward requirements.

## Impact

Users now see the correct reward-specific duration beside “Next,” while the campaign summary continues to show the total remaining farming time with clearer wording.

## Testing

- `pnpm check`
- 17 Chrome Web Store script tests passed
- 70 release script tests passed
- all workspace typechecks passed
- 152 CLI tests passed
- 1,372 extension tests passed
- 3 site tests passed
- Astro site builds passed (existing Vite chunk-size warning only)

Closes #379


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign progress now shows the remaining watch time for the next reward.
  * Campaign-wide remaining time is clearly labeled separately.
* **Localization**
  * Added translated campaign-time labels across 11 supported languages.
* **Bug Fixes**
  * Improved timing behavior for in-progress, completed, and claimable rewards.
  * Remaining time is now calculated and displayed consistently across reward types.
* **Tests**
  * Added coverage for total campaign time, next-reward time, and completed reward display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->