### PR TITLE
feat: explain campaign farming rejections

### DIFF
--- a/docs/campaign-farmability-visibility.md
+++ b/docs/campaign-farmability-visibility.md
@@ -1,8 +1,9 @@
-# Farmability & Visibility — `packages/shared/src/campaignFilters.ts`
+# Farmability & Visibility — shared campaign evaluation
 
 Two questions, one shared foundation.
 
-- `campaignFarmable` answers **"will the engine actually watch this?"**
+- `evaluateCampaignFarming` answers **"will the engine actually watch this, and if not, why?"**
+- `campaignFarmable` is the boolean compatibility wrapper around that evaluation.
 - `isCampaignVisible` answers **"does it show in the popup's Drops list?"**
 
 Both are built from the same `campaignEligibleClass` check, so a campaign the
@@ -34,8 +35,17 @@ flowchart TD
     I -- yes --> Y1["TRUE — engine farms it"]
 ```
 
-`campaignFarmable` = `campaignEligibleClass` (section 2) + that last
-reward-timing gate.
+`evaluateCampaignFarming` applies these gates and returns either
+`{ farmable: true }` or one stable rejection code plus relevant context such
+as the blocked reward and deadline. `campaignFarmable` delegates to it and
+returns only the boolean result.
+
+The scheduler aggregates these results after each refresh (including an
+explicit `0 farmable` count) and emits per-campaign diagnostics for active
+rejections. A fingerprint suppresses identical snapshots until campaign data
+or settings change. The popup evaluates the same campaign with priority mode
+included, showing a compact warning on collapsed cards and the localized full
+reason when expanded.
 
 ## 2. Is it in a farmable class at all? — `campaignEligibleClass`
 
@@ -83,6 +93,7 @@ flowchart TD
 
 | function | answers | used by |
 |---|---|---|
+| `evaluateCampaignFarming` | can it be farmed now; if not, what stable rejection code and context explain why? | scheduler diagnostics, popup view model, `campaignFarmable` |
 | `campaignEligibleClass` | could this campaign's class ever be farmed, ignoring reward timing? | `campaignFarmable`, `isCampaignVisible` |
 | `campaignFarmable` | eligible class, and a reward is farmable right this moment | `isEligible` (scheduler) |
 | `isCampaignVisible` | should the Drops list render this campaign? | the popup (`Popup.tsx`) |
@@ -102,4 +113,4 @@ flowchart TD
   overrides it.
 
 ---
-*Source: `packages/shared/src/campaignFilters.ts`, `packages/shared/src/rewards.ts`*
+*Source: `packages/shared/src/campaignFarming.ts`, `packages/shared/src/campaignFilters.ts`, `packages/shared/src/rewards.ts`*

--- a/docs/superpowers/plans/2026-08-15-campaign-rejection-reasons.md
+++ b/docs/superpowers/plans/2026-08-15-campaign-rejection-reasons.md
@@ -1,0 +1,118 @@
+# Campaign Rejection Reasons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Explain every campaign rejected before channel selection through shared structured evaluation, deduplicated diagnostics, and localized popup guidance.
+
+**Architecture:** A pure evaluator in `@lurkloot/shared` becomes the single source for farmability and rejection codes. The scheduler consumes evaluation results for selection and an in-memory rejection fingerprint, while popup view models translate the same structured result into localized presentation without persisting derived state.
+
+**Tech Stack:** TypeScript, Vitest, React, WXT, pnpm workspace, JSON locale catalogs.
+
+## Global Constraints
+
+- Scheduler selection behavior must remain unchanged.
+- Core/shared code must not import React, WXT, browser globals, or localized strings.
+- Diagnostic bodies remain English literals and never receive locale keys.
+- Popup explanations are localized in every catalog.
+- Rejection diagnostics emit only when the evaluated snapshot changes.
+- Work remains on `feat/campaign-rejection-reasons` in `.worktrees/campaign-rejection-reasons`.
+
+---
+
+### Task 1: Shared Campaign Farming Evaluator
+
+**Files:**
+- Create: `packages/shared/src/campaignFarming.ts`
+- Modify: `packages/shared/src/campaignFilters.ts`
+- Modify: `packages/shared/src/index.ts`
+- Test: `packages/extension/tests/campaignFarming.test.ts`
+
+**Interfaces:**
+- Produces: `CampaignFarmingRejectionCode`, `CampaignFarmingEvaluation`, and `evaluateCampaignFarming(campaign, settings, options?)`.
+- Consumes: existing lifecycle, category, reward-window, prerequisite, deadline, exclusion, linking, and farming-priority data.
+
+- [ ] Write failing table-driven evaluator tests covering each stable code and precedence, plus farmable campaigns.
+- [ ] Run `pnpm --filter @lurkloot/extension test -- campaignFarming.test.ts` and confirm failures are caused by the missing evaluator.
+- [ ] Implement the discriminated union and pure evaluator with deterministic primary-reason ordering.
+- [ ] Refactor `campaignEligibleClass` and `campaignFarmable` into thin evaluator consumers without changing their public behavior.
+- [ ] Run the focused evaluator and existing campaign-filter tests until green.
+- [ ] Commit with `feat(shared): explain campaign farming rejections`.
+
+### Task 2: Scheduler Rejection Diagnostics
+
+**Files:**
+- Modify: `packages/core/src/core/scheduler.ts`
+- Modify: `packages/shared/src/models.ts` only if scheduler runtime state needs a typed in-memory field; prefer a module-local `WeakMap`/runtime field with no persisted migration.
+- Test: `packages/extension/tests/scheduler.test.ts`
+
+**Interfaces:**
+- Consumes: `evaluateCampaignFarming` and its stable rejection codes/context.
+- Produces: one aggregate diagnostic and active-campaign detail diagnostics when the rejection fingerprint changes.
+
+- [ ] Write a failing scheduler test asserting aggregate counts account for every discovered campaign.
+- [ ] Run the focused scheduler test and verify the expected missing diagnostic failure.
+- [ ] Implement aggregate formatting and active-campaign English detail formatting as pure helpers.
+- [ ] Write a failing test proving identical consecutive ticks do not repeat the snapshot.
+- [ ] Add per-scheduler-instance in-memory fingerprint state and make the deduplication test pass.
+- [ ] Write failing tests for changed reasons, active-only details, reward/deadline context, and a background restart producing a fresh snapshot.
+- [ ] Implement the minimal snapshot comparison and detail emission needed for those tests.
+- [ ] Run `pnpm --filter @lurkloot/extension test -- scheduler.test.ts campaignFarming.test.ts` until green.
+- [ ] Commit with `feat(core): diagnose campaign farming rejections`.
+
+### Task 3: Popup View Model and Presentation
+
+**Files:**
+- Modify: `packages/popup-ui/src/types.ts`
+- Modify: `packages/popup-ui/src/viewModels.ts`
+- Modify: `packages/popup-ui/src/drops.tsx`
+- Modify: `packages/popup-ui/src/settingsRegistry.tsx` or the locale description consumed by the existing row.
+- Test: `packages/extension/tests/popupViewModels.test.ts` or the existing view-model test file discovered during implementation.
+- Test: `packages/extension/tests/popupUi.test.tsx` or the existing Drops rendering test file discovered during implementation.
+
+**Interfaces:**
+- Consumes: `CampaignFarmingEvaluation` from shared evaluation during `campaignViewFromCampaign`.
+- Produces: structured rejection data on `CampaignView`, collapsed warning semantics, and expanded localized explanation.
+
+- [ ] Write a failing view-model test proving a rejected campaign carries the shared code and safe context.
+- [ ] Run the focused test and confirm failure on the missing view property.
+- [ ] Extend `CampaignView` and populate it during view-model construction using current settings.
+- [ ] Write failing rendering tests for the collapsed warning, expanded reason, and suppression while actively farming.
+- [ ] Render an accessible warning indicator and compact expanded explanation row using existing primitives and static imports.
+- [ ] Clarify the global unlinked-campaign setting description to mention platform-required linking.
+- [ ] Run focused view-model and rendering tests until green.
+- [ ] Commit with `feat(popup): show campaign farming rejection reasons`.
+
+### Task 4: Localized Popup Copy
+
+**Files:**
+- Modify: `packages/locales/messages/en.json`
+- Modify: all other `packages/locales/messages/*.json` catalogs.
+- Test: `packages/extension/tests/locales.test.ts`
+
+**Interfaces:**
+- Consumes: stable rejection codes mapped to explicit `TFunction` message keys in popup UI.
+- Produces: localized titles/explanations for every popup-visible rejection code; no diagnostic locale keys.
+
+- [ ] Write or extend a failing locale consistency test for the new popup message keys and absence of diagnostic-prefixed keys.
+- [ ] Run the locale test and confirm missing-key failures.
+- [ ] Add concise English copy and translations following each catalog's established terminology.
+- [ ] Run locale and popup rendering tests until green.
+- [ ] Commit with `feat(locales): translate campaign rejection reasons`.
+
+### Task 5: Cross-Package Verification and Documentation
+
+**Files:**
+- Modify: `docs/architecture.md` or the existing campaign farmability document to describe the evaluator and diagnostic snapshot.
+- Modify: `docs/superpowers/plans/2026-08-15-campaign-rejection-reasons.md` to mark completed checkboxes.
+
+**Interfaces:**
+- Consumes: completed evaluator, scheduler, popup, and locale work.
+- Produces: verified branch ready for review.
+
+- [ ] Update architecture documentation with the shared evaluation and diagnostic flow.
+- [ ] Run `pnpm typecheck` and fix only feature-related type failures.
+- [ ] Run `pnpm test` and fix only feature-related regressions.
+- [ ] Run `pnpm build:site` to verify the embedded popup UI.
+- [ ] Run `pnpm build` and `pnpm build:firefox` to verify both extension targets.
+- [ ] Run `git diff --check` and inspect the final diff/status for unrelated files.
+- [ ] Commit documentation with `docs: document campaign rejection diagnostics` if documentation changed after earlier commits.

--- a/docs/superpowers/specs/2026-08-15-campaign-rejection-reasons-design.md
+++ b/docs/superpowers/specs/2026-08-15-campaign-rejection-reasons-design.md
@@ -1,0 +1,117 @@
+# Campaign Rejection Reasons Design
+
+## Context
+
+Lurkloot can discover a large Twitch or Kick campaign inventory and then reject every campaign before channel selection. Diagnostics currently show discovery and selection totals but not the predicates responsible for rejection. The popup can display a campaign that is not farmable without explaining why, while some setting descriptions imply broader behavior than platform rules allow.
+
+Issue [#389](https://github.com/jamezrin/lurkloot/issues/389) tracks this work.
+
+## Goals
+
+- Explain every scheduler-level campaign rejection with a stable, structured reason.
+- Keep scheduler behavior, diagnostics, and popup explanations aligned through one shared evaluator.
+- Log aggregate rejection counts and actionable details without repeating unchanged snapshots every minute.
+- Show a compact indicator on collapsed campaign cards and a localized explanation on expanded cards.
+- Explicitly explain when Twitch requires account linking despite the global unlinked-campaign preference.
+
+## Non-goals
+
+- Change which campaigns or rewards are farmed.
+- Diagnose failures that occur after a campaign enters channel selection, such as no live eligible channel.
+- Localize diagnostic bodies; diagnostics remain English literals.
+- Persist a second copy of derived rejection state in scheduler storage.
+
+## Considered Approaches
+
+### Duplicate scheduler and popup checks
+
+The scheduler could add logging around its existing predicates while the popup independently derives display copy. This is the smallest local edit but recreates the drift that the shared campaign-filter module was introduced to prevent. Rejected.
+
+### Store the scheduler's latest reason in campaign state
+
+The scheduler could annotate or separately persist every campaign after each tick. This would make the popup consume the exact scheduler result, but introduces synchronization and migration concerns for data that is deterministic from campaign plus settings. It would also leave non-running or freshly opened hosts without a reason until another tick. Rejected.
+
+### Shared pure evaluator
+
+Add a pure evaluator to `@lurkloot/shared` that returns either farmable or one primary rejection code with structured context. The scheduler uses it for filtering and diagnostics; popup view-model construction uses it for localized presentation. This preserves one definition, needs no persistence migration, and is independently testable. Chosen.
+
+## Shared Evaluation Model
+
+Create a focused shared module for campaign farming evaluation. Its public result is a discriminated union:
+
+- `{ farmable: true }`
+- `{ farmable: false, code, rewardId?, deadline?, remainingMinutes?, availableMinutes? }`
+
+The stable rejection codes cover:
+
+- excluded campaign;
+- upcoming, expired, or completed lifecycle;
+- campaign with no rewards;
+- farming-eligibility setting rejection;
+- Twitch account linking required;
+- category filter mismatch;
+- priority-list-only mismatch;
+- no unclaimed rewards;
+- reward availability window not open or already closed;
+- unmet reward prerequisites;
+- no watch-based reward;
+- deadline infeasibility;
+- no currently farmable reward as a final explicit fallback.
+
+Evaluation order is intentional and user-facing. Campaign-level configuration and lifecycle reasons win before reward-level reasons. For reward-level rejection, the evaluator examines every unclaimed reward and chooses the most actionable primary reason. If at least one reward is farmable, the campaign is farmable.
+
+The existing `campaignEligibleClass`, `campaignFarmable`, and scheduler `isEligible` APIs become thin consumers of this evaluator where possible. Priority-list-only remains part of the scheduler evaluation options because it is a farming strategy rather than campaign visibility.
+
+## Diagnostics
+
+After each successful campaign refresh, evaluate every discovered campaign using the current settings. Build a stable fingerprint from campaign IDs and rejection codes plus reason-defining context. Emit only when that fingerprint changes.
+
+The aggregate English diagnostic accounts for every discovered campaign, for example:
+
+`Campaign farming evaluation: 110 discovered, 1 farmable, 94 expired, 8 completed, 4 account linking required, 3 no currently farmable reward`
+
+At the same time, emit one English diagnostic for each rejected active campaign. Lifecycle noise from old expired/completed campaigns remains represented in the aggregate but does not produce individual lines. Each detail includes campaign name, campaign ID, stable code, and relevant reward/deadline context. No locale keys are created for diagnostic bodies.
+
+The fingerprint is held in in-memory scheduler state rather than persisted settings/storage. Extension background restarts may emit one fresh snapshot, which is desirable diagnostic context; unchanged minute ticks do not.
+
+## Popup Presentation
+
+`CampaignView` gains the evaluator's rejection code and only the safe context needed for presentation. View-model construction evaluates the campaign with the same settings passed to the scheduler.
+
+A visible, non-farmed rejected campaign receives:
+
+- a compact warning indicator in the collapsed card metadata;
+- a localized explanation row inside the expanded card;
+- no warning when the campaign is actively being farmed;
+- existing lifecycle and reward-specific UI retained where it provides more detail.
+
+Copy describes the reason and, when appropriate, the corrective action. The Twitch link case reads substantially as “Account linking is required for this Twitch campaign.” The global setting description is clarified to say platform requirements may still require linking.
+
+All locale catalogs receive the new keys. English source copy is authoritative; existing localization conventions are followed for the other catalogs.
+
+## Data Flow
+
+1. An adapter returns `DropCampaign[]`.
+2. The shared evaluator consumes each campaign plus `EngineSettings` and strategy options.
+3. The scheduler filters with the result and derives a change-triggered diagnostic snapshot.
+4. Popup view-model construction evaluates the same campaign and settings.
+5. React renders a compact indicator and expanded localized explanation from the structured code.
+
+No browser API, WXT dependency, React type, or localized string enters `@lurkloot/shared` or `@lurkloot/core`.
+
+## Testing
+
+- Shared evaluator unit tests cover every rejection code and evaluation precedence.
+- Binding tests prove `farmable: true` agrees with existing `campaignFarmable` behavior and scheduler selection.
+- Scheduler tests prove aggregate accounting, active-campaign details, change-triggered deduplication, and re-emission after a changed reason.
+- View-model tests prove rejection data reaches `CampaignView`.
+- Popup rendering tests prove collapsed and expanded presentation and suppression while actively farming.
+- Locale consistency tests ensure every catalog contains all new keys.
+- Existing extension, CLI, typecheck, and site suites guard cross-package behavior.
+
+## Success Criteria
+
+- The reported pattern—successful discovery followed by zero checked campaigns—produces enough information to identify the exact rejecting predicate from one diagnostic export.
+- A user can expand any visible rejected campaign and understand why it is not being farmed.
+- Scheduler selection outcomes do not change.
+- Unchanged rejection snapshots generate no per-minute diagnostic spam.

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -407,6 +407,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // ticks (the WebSocket-based Kick watcher in particular must not be recreated
   // each tick). Reconciled against the scheduler's per-platform session state.
   const tablessWatchers = new Map<Platform, TablessWatchController>();
+  const campaignEvaluationFingerprints: Partial<Record<Platform, string>> = {};
   const discoverySignalControllers = new Map<Platform, DiscoverySignalController>();
   const discoverySignalPlatformBlocked: Record<Platform, boolean> = {
     twitch: false,
@@ -1583,6 +1584,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           waitingClaimRewardIds: nextWaitingClaimRewardIds,
           emit: claimObservingEmit,
           signal,
+          campaignEvaluationFingerprints,
         });
         signal.throwIfAborted();
         const lifecycleEvents = farmingLifecycleEvents(state, result.state);

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -583,7 +583,7 @@ function emitCampaignEvaluationDiagnostics(
   }
   const parts = [`${campaigns.length} discovered`];
   const farmable = counts.get("farmable") ?? 0;
-  if (farmable > 0) parts.push(`${farmable} farmable`);
+  parts.push(`${farmable} farmable`);
   for (const [code, label] of Object.entries(CAMPAIGN_REJECTION_LABELS) as Array<[CampaignFarmingRejectionCode, string]>) {
     const count = counts.get(code) ?? 0;
     if (count > 0) parts.push(`${count} ${label}`);

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -556,7 +556,7 @@ function campaignEvaluationFingerprint(
   return evaluations
     .map(({ campaign, evaluation }) => evaluation.farmable
       ? `${campaign.id}:farmable`
-      : [campaign.id, evaluation.code, evaluation.rewardId, evaluation.deadline, evaluation.remainingMinutes, evaluation.availableMinutes, evaluation.marginMinutes].join(":"))
+      : [campaign.id, evaluation.code, evaluation.rewardId, evaluation.deadline, evaluation.remainingMinutes, evaluation.marginMinutes].join(":"))
     .sort()
     .join("|");
 }

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -12,6 +12,7 @@ import type {
   WatchSession,
 } from "@lurkloot/shared/models";
 import { categoryListIndex } from "@lurkloot/shared/categories";
+import { evaluateCampaignFarming, type CampaignFarmingEvaluation, type CampaignFarmingRejectionCode } from "@lurkloot/shared/campaignFarming";
 import { campaignFarmable, campaignPassesFarmingEligibility, hasCampaignEnded } from "@lurkloot/shared/campaignFilters";
 import {
   canClaimReward,
@@ -522,6 +523,88 @@ export interface SchedulerTickOptions {
   waitingClaimRewardIds?: Partial<Record<Platform, Set<string>>>;
   emit?: EventEmitter;
   signal?: AbortSignal;
+  // Mutable, instance-owned diagnostic cache. The background controller keeps
+  // it in memory so unchanged minute ticks stay quiet, while a worker restart
+  // naturally emits a fresh snapshot for the next exported diagnostic log.
+  campaignEvaluationFingerprints?: Partial<Record<Platform, string>>;
+}
+
+const CAMPAIGN_REJECTION_LABELS: Record<CampaignFarmingRejectionCode, string> = {
+  excluded: "excluded",
+  upcoming: "upcoming",
+  expired: "expired",
+  completed: "completed",
+  unlinked_campaigns_disabled: "unlinked campaigns disabled",
+  twitch_link_required: "Twitch account linking required",
+  subscription_campaigns_disabled: "subscription campaigns disabled",
+  category_filtered: "category filtered",
+  priority_not_selected: "not in priority list",
+  no_rewards: "no rewards",
+  no_unclaimed_rewards: "no unclaimed rewards",
+  reward_prerequisites_unmet: "reward prerequisites unmet",
+  reward_not_started: "reward not started",
+  reward_window_ended: "reward window ended",
+  insufficient_time: "insufficient time",
+  subscription_required: "subscription required",
+  action_required: "action required",
+  no_farmable_reward: "no currently farmable reward",
+};
+
+function campaignEvaluationFingerprint(
+  evaluations: ReadonlyArray<{ campaign: DropCampaign; evaluation: CampaignFarmingEvaluation }>,
+): string {
+  return evaluations
+    .map(({ campaign, evaluation }) => evaluation.farmable
+      ? `${campaign.id}:farmable`
+      : [campaign.id, evaluation.code, evaluation.rewardId, evaluation.deadline, evaluation.remainingMinutes, evaluation.availableMinutes, evaluation.marginMinutes].join(":"))
+    .sort()
+    .join("|");
+}
+
+function emitCampaignEvaluationDiagnostics(
+  emit: EventEmitter,
+  platform: Platform,
+  campaigns: readonly DropCampaign[],
+  settings: EngineSettings,
+  fingerprints: Partial<Record<Platform, string>> | undefined,
+): void {
+  const evaluations = campaigns.map((campaign) => ({
+    campaign,
+    evaluation: evaluateCampaignFarming(campaign, settings, { includePriorityMode: true }),
+  }));
+  const fingerprint = campaignEvaluationFingerprint(evaluations);
+  if (fingerprints?.[platform] === fingerprint) return;
+  if (fingerprints) fingerprints[platform] = fingerprint;
+
+  const counts = new Map<"farmable" | CampaignFarmingRejectionCode, number>();
+  for (const { evaluation } of evaluations) {
+    const key = evaluation.farmable ? "farmable" : evaluation.code;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const parts = [`${campaigns.length} discovered`];
+  const farmable = counts.get("farmable") ?? 0;
+  if (farmable > 0) parts.push(`${farmable} farmable`);
+  for (const [code, label] of Object.entries(CAMPAIGN_REJECTION_LABELS) as Array<[CampaignFarmingRejectionCode, string]>) {
+    const count = counts.get(code) ?? 0;
+    if (count > 0) parts.push(`${count} ${label}`);
+  }
+  emitDiagnostic(emit, platform, "debug", `Campaign farming evaluation: ${parts.join(", ")}`);
+
+  for (const { campaign, evaluation } of evaluations) {
+    if (evaluation.farmable || ["upcoming", "expired", "completed"].includes(evaluation.code)) continue;
+    const reward = evaluation.rewardId
+      ? `, reward=${evaluation.rewardName ?? evaluation.rewardId} (${evaluation.rewardId})`
+      : "";
+    const deadline = evaluation.deadline
+      ? `, deadline=${evaluation.deadline}, remaining=${evaluation.remainingMinutes}m, available=${evaluation.availableMinutes}m, margin=${evaluation.marginMinutes}m`
+      : "";
+    emitDiagnostic(
+      emit,
+      platform,
+      "debug",
+      `Campaign rejected: ${campaign.name} (${campaign.id}), reason=${evaluation.code}${reward}${deadline}`,
+    );
+  }
 }
 
 export async function runSchedulerTick(
@@ -820,6 +903,13 @@ export async function runSchedulerTick(
       }
       if (!discoveryFailed) {
         nextState.campaigns[platform] = campaigns;
+        emitCampaignEvaluationDiagnostics(
+          emit,
+          platform,
+          campaigns,
+          settings,
+          options.campaignEvaluationFingerprints,
+        );
         // The accrual arm. Fresh progress data is in hand, so record the active
         // reward's watched minutes and compare them with the last observation.
         //

--- a/packages/extension/tests/campaignFarming.test.ts
+++ b/packages/extension/tests/campaignFarming.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { evaluateCampaignFarming } from "@lurkloot/shared/campaignFarming";
+import type { DropCampaign, ExtensionSettings } from "@lurkloot/shared/models";
+import { mergeSettings } from "@lurkloot/shared/settings";
+
+const NOW = Date.parse("2026-08-15T10:00:00.000Z");
+
+function settings(overrides: Partial<ExtensionSettings> = {}): ExtensionSettings {
+  const base = mergeSettings(undefined);
+  return {
+    ...base,
+    ...overrides,
+    platform: overrides.platform ?? base.platform,
+    farmingEligibility: overrides.farmingEligibility ?? base.farmingEligibility,
+  };
+}
+
+function campaign(overrides: Partial<DropCampaign> = {}): DropCampaign {
+  return {
+    id: "campaign",
+    platform: "twitch",
+    name: "Campaign",
+    status: "active",
+    accountLinked: true,
+    rewards: [{
+      id: "reward",
+      name: "Reward",
+      requiredMinutes: 60,
+      watchedMinutes: 0,
+      status: "locked",
+      requirement: "watch",
+      isWatchBased: true,
+    }],
+    connectionUrls: [],
+    ...overrides,
+  };
+}
+
+describe("evaluateCampaignFarming", () => {
+  it.each([
+    ["excluded", campaign(), settings({ excludedCampaignIds: ["campaign"] })],
+    ["upcoming", campaign({ status: "upcoming" }), settings()],
+    ["expired", campaign({ status: "expired" }), settings()],
+    ["completed", campaign({ status: "completed" }), settings()],
+    ["twitch_link_required", campaign({ accountLinked: false }), settings()],
+    ["no_rewards", campaign({ rewards: [] }), settings()],
+  ] as const)("returns %s for a rejected campaign", (code, source, currentSettings) => {
+    expect(evaluateCampaignFarming(source, currentSettings, { now: NOW })).toMatchObject({
+      farmable: false,
+      code,
+    });
+  });
+
+  it("distinguishes a disabled unlinked class from Twitch's platform requirement", () => {
+    const currentSettings = settings({
+      farmingEligibility: {
+        farmUnlinkedCampaigns: false,
+        farmSubscriptionCampaigns: true,
+      },
+    });
+    expect(evaluateCampaignFarming(campaign({ platform: "kick", accountLinked: false }), currentSettings, { now: NOW }))
+      .toMatchObject({ farmable: false, code: "unlinked_campaigns_disabled" });
+  });
+
+  it("returns category_filtered before inspecting rewards", () => {
+    const currentSettings = settings();
+    currentSettings.platform.twitch = {
+      ...currentSettings.platform.twitch,
+      farmAllCategories: false,
+      categories: [{ id: "other", name: "Other" }],
+    };
+    expect(evaluateCampaignFarming(campaign({ categoryId: "game" }), currentSettings, { now: NOW }))
+      .toMatchObject({ farmable: false, code: "category_filtered" });
+  });
+
+  it("returns priority_not_selected only when priority-list-only evaluation is requested", () => {
+    const currentSettings = settings({ priorityMode: "priority_list_only" });
+    expect(evaluateCampaignFarming(campaign(), currentSettings, { now: NOW, includePriorityMode: true }))
+      .toMatchObject({ farmable: false, code: "priority_not_selected" });
+    expect(evaluateCampaignFarming(campaign(), currentSettings, { now: NOW })).toEqual({ farmable: true });
+  });
+
+  it.each([
+    ["reward_prerequisites_unmet", { preconditionsMet: false }],
+    ["reward_not_started", { availableFrom: "2026-08-15T11:00:00.000Z" }],
+    ["reward_window_ended", { availableUntil: "2026-08-15T09:00:00.000Z" }],
+  ] as const)("returns %s with reward context", (code, rewardOverrides) => {
+    const source = campaign({ rewards: [{ ...campaign().rewards[0]!, ...rewardOverrides }] });
+    expect(evaluateCampaignFarming(source, settings(), { now: NOW })).toMatchObject({
+      farmable: false,
+      code,
+      rewardId: "reward",
+      rewardName: "Reward",
+    });
+  });
+
+  it("returns insufficient_time with actionable deadline context", () => {
+    const source = campaign({
+      endsAt: "2026-08-15T10:30:00.000Z",
+      rewards: [{ ...campaign().rewards[0]!, requiredMinutes: 60, watchedMinutes: 10 }],
+    });
+    expect(evaluateCampaignFarming(source, settings(), { now: NOW })).toEqual({
+      farmable: false,
+      code: "insufficient_time",
+      rewardId: "reward",
+      rewardName: "Reward",
+      deadline: "2026-08-15T10:30:00.000Z",
+      remainingMinutes: 50,
+      availableMinutes: 30,
+      marginMinutes: 5,
+    });
+  });
+
+  it("returns farmable when any reward can currently be earned", () => {
+    expect(evaluateCampaignFarming(campaign(), settings(), { now: NOW })).toEqual({ farmable: true });
+  });
+});

--- a/packages/extension/tests/dropsView.test.tsx
+++ b/packages/extension/tests/dropsView.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { parseHTML } from "linkedom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DropCampaign, WatchSession } from "@lurkloot/shared/models";
+import { mergeSettings } from "@lurkloot/shared/settings";
 import { I18nContext, PopupRuntimeContext } from "../../popup-ui/src/context";
 import { DropsPanel, initialExpandedIds } from "../../popup-ui/src/drops";
 import type { PopupAdapter } from "../../popup-ui/src/types";
@@ -41,7 +42,7 @@ function sourceCampaign(url?: string): DropCampaign {
   };
 }
 
-function mount(url?: string) {
+function mount(url?: string, source = sourceCampaign(url), viewOptions?: Parameters<typeof campaignViewFromCampaign>[4]) {
   const { document, window } = parseHTML("<div id=app></div>");
   vi.stubGlobal("window", window);
   vi.stubGlobal("document", document);
@@ -54,7 +55,7 @@ function mount(url?: string) {
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   const openLink = vi.fn();
   const adapter = { openLink } as unknown as PopupAdapter;
-  const campaign = campaignViewFromCampaign(sourceCampaign(url), 0, idleSession, false);
+  const campaign = campaignViewFromCampaign(source, 0, idleSession, false, viewOptions);
   const container = document.getElementById("app")!;
 
   act(() => {
@@ -97,6 +98,34 @@ describe("drops search controls", () => {
 
     const searchButton = container.querySelector<HTMLButtonElement>("button[aria-label='Search']");
     expect(searchButton).not.toBeNull();
+  });
+});
+
+describe("campaign farming rejection presentation", () => {
+  it("shows a collapsed warning and an expanded explanation for a rejected campaign", () => {
+    const source: DropCampaign = {
+      ...sourceCampaign(),
+      platform: "twitch",
+      accountLinked: false,
+      rewards: [{
+        id: "watch",
+        name: "Watch reward",
+        requiredMinutes: 60,
+        watchedMinutes: 0,
+        status: "locked",
+        requirement: "watch",
+        isWatchBased: true,
+      }],
+    };
+    const currentSettings = mergeSettings(undefined);
+    const { container } = mount(undefined, source, {
+      skipUnfinishableRewards: currentSettings.skipUnfinishableRewards,
+      deadlineSafetyMarginMinutes: currentSettings.deadlineSafetyMarginMinutes,
+      settings: currentSettings,
+    });
+
+    expect(container.querySelector("[data-farming-rejection-indicator]")).not.toBeNull();
+    expect(container.textContent).toContain("campaignRejectionTwitchLinkRequired");
   });
 });
 

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1243,6 +1243,48 @@ describe("scheduler tick", () => {
     expect(second.events.filter((event) => event.category === "diagnostic" && event.message.includes("campaigns eligible"))).toEqual([]);
   });
 
+  it("reports aggregate and active campaign rejection reasons only when the snapshot changes", async () => {
+    const rejected = [
+      campaign("linked-required", { accountLinked: false }),
+      campaign("finished", { status: "completed", rewards: [{ ...reward("claimed"), id: "done" }] }),
+      campaign("farmable"),
+    ];
+    const twitch = adapter("twitch", rejected, [channel("creator")]);
+    const tickSettings = settings({ platform: { twitch: { enabled: true }, kick: { enabled: false } } });
+    const tickAdapters = { twitch, kick: adapter("kick", [], []) };
+    const campaignEvaluationFingerprints = {};
+
+    const first = await runSchedulerTick(baseState, tickSettings, tickAdapters, { campaignEvaluationFingerprints });
+    const aggregate = first.events.find((event) => event.category === "diagnostic" && event.message.startsWith("Campaign farming evaluation:"));
+    const details = first.events.filter((event) => event.category === "diagnostic" && event.message.startsWith("Campaign rejected:"));
+
+    expect(aggregate).toMatchObject({
+      platform: "twitch",
+      message: "Campaign farming evaluation: 3 discovered, 1 farmable, 1 completed, 1 Twitch account linking required",
+    });
+    expect(details).toEqual([
+      expect.objectContaining({
+        platform: "twitch",
+        message: "Campaign rejected: linked-required (linked-required), reason=twitch_link_required",
+      }),
+    ]);
+
+    const second = await runSchedulerTick(first.state, tickSettings, tickAdapters, { campaignEvaluationFingerprints });
+    expect(second.events.filter((event) => event.category === "diagnostic" && (
+      event.message.startsWith("Campaign farming evaluation:")
+      || event.message.startsWith("Campaign rejected:")
+    ))).toEqual([]);
+
+    vi.mocked(twitch.refreshCampaigns).mockResolvedValueOnce([
+      ...rejected.slice(0, 2),
+      campaign("farmable", { accountLinked: false }),
+    ]);
+    const third = await runSchedulerTick(second.state, tickSettings, tickAdapters, { campaignEvaluationFingerprints });
+    expect(third.events).toContainEqual(expect.objectContaining({
+      message: "Campaign farming evaluation: 3 discovered, 1 completed, 2 Twitch account linking required",
+    }));
+  });
+
   it("does not emit inventory diagnostics when campaigns and rewards are reordered", async () => {
     const first = [
       campaign("first", {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1281,7 +1281,7 @@ describe("scheduler tick", () => {
     ]);
     const third = await runSchedulerTick(second.state, tickSettings, tickAdapters, { campaignEvaluationFingerprints });
     expect(third.events).toContainEqual(expect.objectContaining({
-      message: "Campaign farming evaluation: 3 discovered, 1 completed, 2 Twitch account linking required",
+      message: "Campaign farming evaluation: 3 discovered, 0 farmable, 1 completed, 2 Twitch account linking required",
     }));
   });
 

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1285,6 +1285,35 @@ describe("scheduler tick", () => {
     }));
   });
 
+  it("does not repeat insufficient-time diagnostics as available time decreases", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime("2026-08-15T12:00:00.000Z");
+    try {
+      const timed = campaign("timed", { endsAt: "2026-08-15T12:44:00.000Z" });
+      const twitch = adapter("twitch", [timed], [channel("creator")]);
+      const tickSettings = settings({
+        deadlineSafetyMarginMinutes: 5,
+        platform: { twitch: { enabled: true }, kick: { enabled: false } },
+      });
+      const tickAdapters = { twitch, kick: adapter("kick", [], []) };
+      const campaignEvaluationFingerprints = {};
+
+      const first = await runSchedulerTick(baseState, tickSettings, tickAdapters, { campaignEvaluationFingerprints });
+      expect(first.events).toContainEqual(expect.objectContaining({
+        message: expect.stringContaining("reason=insufficient_time"),
+      }));
+
+      vi.setSystemTime("2026-08-15T12:01:00.000Z");
+      const second = await runSchedulerTick(first.state, tickSettings, tickAdapters, { campaignEvaluationFingerprints });
+      expect(second.events.filter((event) => event.category === "diagnostic" && (
+        event.message.startsWith("Campaign farming evaluation:")
+        || event.message.startsWith("Campaign rejected:")
+      ))).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not emit inventory diagnostics when campaigns and rewards are reordered", async () => {
     const first = [
       campaign("first", {

--- a/packages/extension/tests/subscriptionDropsView.test.ts
+++ b/packages/extension/tests/subscriptionDropsView.test.ts
@@ -87,6 +87,35 @@ function renderDrops(campaigns: CampaignView[], refreshing = false): string {
 }
 
 describe("subscription drop popup views", () => {
+  it("carries the shared campaign rejection into the popup view model", () => {
+    const source = campaign("unlinked", [reward({ requiredMinutes: 60, requirement: "watch", isWatchBased: true })]);
+    source.accountLinked = false;
+    const currentSettings = mergeSettings(undefined);
+
+    const view = campaignViewFromCampaign(source, 0, idleSession, false, {
+      skipUnfinishableRewards: currentSettings.skipUnfinishableRewards,
+      deadlineSafetyMarginMinutes: currentSettings.deadlineSafetyMarginMinutes,
+      settings: currentSettings,
+    });
+
+    expect(view.farmingRejection).toEqual({ farmable: false, code: "twitch_link_required" });
+  });
+
+  it("suppresses a stale rejection explanation while the campaign is actively farming", () => {
+    const view = campaignViewFromCampaign(campaign("active", [reward({
+      requiredMinutes: 60,
+      requirement: "watch",
+      isWatchBased: true,
+    })]), 0, idleSession, false);
+    const markup = renderDrops([expandedView({
+      ...view,
+      farmingRejection: { farmable: false, code: "no_farmable_reward" },
+    })]);
+
+    expect(markup).not.toContain("campaignRejectionNoFarmableReward");
+    expect(markup).not.toContain("data-farming-rejection-indicator");
+  });
+
   it("marks and explains watch rewards with insufficient time", () => {
     const source = {
       ...campaign("timed", [reward({ requirement: "watch", requiredMinutes: 60, watchedMinutes: 30, status: "in_progress" })]),

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "الوقت المتبقي غير كافٍ"
   },
+  "campaignRejectionExcluded": { "message": "هذه الحملة مستبعدة من الجمع التلقائي." },
+  "campaignRejectionUpcoming": { "message": "هذه الحملة لم تبدأ بعد." },
+  "campaignRejectionExpired": { "message": "انتهت هذه الحملة." },
+  "campaignRejectionCompleted": { "message": "اكتملت جميع مكافآت هذه الحملة." },
+  "campaignRejectionUnlinkedDisabled": { "message": "جمع الحملات دون حساب مرتبط معطّل." },
+  "campaignRejectionTwitchLinkRequired": { "message": "تتطلب حملة Twitch هذه ربط حساب." },
+  "campaignRejectionSubscriptionDisabled": { "message": "جمع حملات الاشتراك معطّل." },
+  "campaignRejectionCategoryFiltered": { "message": "هذه الحملة لا تطابق الفئات المحددة." },
+  "campaignRejectionPriorityNotSelected": { "message": "هذه الحملة ليست في قائمة الأولوية." },
+  "campaignRejectionNoRewards": { "message": "لا تحتوي هذه الحملة على مكافآت قابلة للجمع." },
+  "campaignRejectionNoUnclaimedRewards": { "message": "لا تحتوي هذه الحملة على مكافآت غير مستلمة." },
+  "campaignRejectionPrerequisites": { "message": "$1 بانتظار مكافأة أو شرط سابق." },
+  "campaignRejectionRewardNotStarted": { "message": "$1 غير متاحة بعد." },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 لم تعد متاحة." },
+  "campaignRejectionInsufficientTime": { "message": "لا يمكن إكمال $1 قبل الموعد النهائي." },
+  "campaignRejectionSubscriptionRequired": { "message": "تتطلب $1 اشتراكًا مؤهلًا." },
+  "campaignRejectionActionRequired": { "message": "تتطلب $1 إجراءً غير المشاهدة." },
+  "campaignRejectionNoFarmableReward": { "message": "لا يمكن جمع أي مكافأة من هذه الحملة حاليًا." },
   "automationSectionTitle": {
     "message": "الأتمتة"
   },
@@ -669,7 +687,7 @@
     "message": "فارم الحملات بدون حساب مرتبط"
   },
   "farmUnlinkedDescription": {
-    "message": "عند الإيقاف، تُتخطى الحملات التي تتطلب ربط حسابك. لا يزال Kick يجمع وقت المشاهدة قبل الربط."
+    "message": "عند الإيقاف، تُتخطى الحملات التي تتطلب ربط الحساب. قد تظل متطلبات المنصة تفرض الربط عند التشغيل."
   },
   "farmSubscriptionTitle": {
     "message": "فارم الحملات التي تتطلب اشتراكًا"

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "Nicht genügend Zeit verbleibend"
   },
+  "campaignRejectionExcluded": { "message": "Diese Kampagne ist vom Farmen ausgeschlossen." },
+  "campaignRejectionUpcoming": { "message": "Diese Kampagne hat noch nicht begonnen." },
+  "campaignRejectionExpired": { "message": "Diese Kampagne ist beendet." },
+  "campaignRejectionCompleted": { "message": "Alle Belohnungen dieser Kampagne sind abgeschlossen." },
+  "campaignRejectionUnlinkedDisabled": { "message": "Kampagnen ohne verknüpftes Konto werden nicht gefarmt." },
+  "campaignRejectionTwitchLinkRequired": { "message": "Für diese Twitch-Kampagne muss ein Konto verknüpft sein." },
+  "campaignRejectionSubscriptionDisabled": { "message": "Abonnement-Kampagnen werden nicht gefarmt." },
+  "campaignRejectionCategoryFiltered": { "message": "Diese Kampagne entspricht nicht den ausgewählten Kategorien." },
+  "campaignRejectionPriorityNotSelected": { "message": "Diese Kampagne steht nicht auf der Prioritätsliste." },
+  "campaignRejectionNoRewards": { "message": "Diese Kampagne hat keine farmbaren Belohnungen." },
+  "campaignRejectionNoUnclaimedRewards": { "message": "Diese Kampagne hat keine nicht beanspruchten Belohnungen." },
+  "campaignRejectionPrerequisites": { "message": "$1 wartet auf eine frühere Belohnung oder Voraussetzung." },
+  "campaignRejectionRewardNotStarted": { "message": "$1 ist noch nicht verfügbar." },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 ist nicht mehr verfügbar." },
+  "campaignRejectionInsufficientTime": { "message": "$1 kann nicht vor Ablauf der Frist abgeschlossen werden." },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 erfordert ein gültiges Abonnement." },
+  "campaignRejectionActionRequired": { "message": "$1 erfordert eine andere Aktion als Zuschauen." },
+  "campaignRejectionNoFarmableReward": { "message": "Derzeit kann keine Belohnung dieser Kampagne gefarmt werden." },
   "automationSectionTitle": {
     "message": "Automatisierung"
   },
@@ -669,7 +687,7 @@
     "message": "Kampagnen ohne verknüpftes Konto farmen"
   },
   "farmUnlinkedDescription": {
-    "message": "Wenn aus, werden Kampagnen übersprungen, die ein Verknüpfen deines Kontos erfordern. Kick sammelt vor dem Verknüpfen weiterhin Wiedergabezeit."
+    "message": "Wenn aus, werden Kampagnen übersprungen, die eine Kontoverknüpfung erfordern. Plattformvorgaben können die Verknüpfung auch bei aktivierter Option verlangen."
   },
   "farmSubscriptionTitle": {
     "message": "Kampagnen farmen, die ein Abo erfordern"

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "Insufficient time remaining"
   },
+  "campaignRejectionExcluded": { "message": "This campaign is excluded from farming." },
+  "campaignRejectionUpcoming": { "message": "This campaign has not started yet." },
+  "campaignRejectionExpired": { "message": "This campaign has ended." },
+  "campaignRejectionCompleted": { "message": "All rewards in this campaign are complete." },
+  "campaignRejectionUnlinkedDisabled": { "message": "Farming campaigns without a linked account is disabled." },
+  "campaignRejectionTwitchLinkRequired": { "message": "Account linking is required for this Twitch campaign." },
+  "campaignRejectionSubscriptionDisabled": { "message": "Farming subscription campaigns is disabled." },
+  "campaignRejectionCategoryFiltered": { "message": "This campaign does not match the selected categories." },
+  "campaignRejectionPriorityNotSelected": { "message": "This campaign is not in the priority list." },
+  "campaignRejectionNoRewards": { "message": "This campaign has no farmable rewards." },
+  "campaignRejectionNoUnclaimedRewards": { "message": "This campaign has no unclaimed rewards." },
+  "campaignRejectionPrerequisites": { "message": "$1 is waiting for an earlier reward or requirement." },
+  "campaignRejectionRewardNotStarted": { "message": "$1 is not available yet." },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 is no longer available." },
+  "campaignRejectionInsufficientTime": { "message": "$1 cannot be completed before its deadline." },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 requires a qualifying subscription." },
+  "campaignRejectionActionRequired": { "message": "$1 requires an action other than watching." },
+  "campaignRejectionNoFarmableReward": { "message": "No reward in this campaign can currently be farmed." },
   "automationSectionTitle": {
     "message": "Automation"
   },
@@ -669,7 +687,7 @@
     "message": "Farm campaigns without a linked account"
   },
   "farmUnlinkedDescription": {
-    "message": "When off, campaigns that need you to link your account are skipped. Kick still earns watch time before linking."
+    "message": "When off, campaigns that need you to link your account are skipped. Platform requirements can still require linking when this is on."
   },
   "farmSubscriptionTitle": {
     "message": "Farm campaigns that require a subscription"

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "No queda tiempo suficiente"
   },
+  "campaignRejectionExcluded": { "message": "Esta campaña está excluida del farmeo." },
+  "campaignRejectionUpcoming": { "message": "Esta campaña aún no ha comenzado." },
+  "campaignRejectionExpired": { "message": "Esta campaña ha finalizado." },
+  "campaignRejectionCompleted": { "message": "Todas las recompensas de esta campaña están completadas." },
+  "campaignRejectionUnlinkedDisabled": { "message": "El farmeo de campañas sin una cuenta vinculada está desactivado." },
+  "campaignRejectionTwitchLinkRequired": { "message": "Esta campaña de Twitch requiere vincular una cuenta." },
+  "campaignRejectionSubscriptionDisabled": { "message": "El farmeo de campañas de suscripción está desactivado." },
+  "campaignRejectionCategoryFiltered": { "message": "Esta campaña no coincide con las categorías seleccionadas." },
+  "campaignRejectionPriorityNotSelected": { "message": "Esta campaña no está en la lista de prioridad." },
+  "campaignRejectionNoRewards": { "message": "Esta campaña no tiene recompensas farmeables." },
+  "campaignRejectionNoUnclaimedRewards": { "message": "Esta campaña no tiene recompensas sin reclamar." },
+  "campaignRejectionPrerequisites": { "message": "$1 espera una recompensa o requisito anterior." },
+  "campaignRejectionRewardNotStarted": { "message": "$1 aún no está disponible." },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 ya no está disponible." },
+  "campaignRejectionInsufficientTime": { "message": "$1 no puede completarse antes de su fecha límite." },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 requiere una suscripción válida." },
+  "campaignRejectionActionRequired": { "message": "$1 requiere una acción distinta de mirar." },
+  "campaignRejectionNoFarmableReward": { "message": "Ahora mismo no se puede farmear ninguna recompensa de esta campaña." },
   "automationSectionTitle": {
     "message": "Automatización"
   },
@@ -669,7 +687,7 @@
     "message": "Farmear campañas sin cuenta vinculada"
   },
   "farmUnlinkedDescription": {
-    "message": "Si está desactivado, se omiten las campañas que requieren vincular tu cuenta. Kick sigue acumulando tiempo de visualización antes de vincular."
+    "message": "Si está desactivado, se omiten las campañas que requieren vincular tu cuenta. Los requisitos de la plataforma aún pueden exigir vincularla cuando está activado."
   },
   "farmSubscriptionTitle": {
     "message": "Farmear campañas que requieren suscripción"

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "Temps restant insuffisant"
   },
+  "campaignRejectionExcluded": { "message": "Cette campagne est exclue du farming." },
+  "campaignRejectionUpcoming": { "message": "Cette campagne n'a pas encore commencé." },
+  "campaignRejectionExpired": { "message": "Cette campagne est terminée." },
+  "campaignRejectionCompleted": { "message": "Toutes les récompenses de cette campagne sont terminées." },
+  "campaignRejectionUnlinkedDisabled": { "message": "Le farming des campagnes sans compte lié est désactivé." },
+  "campaignRejectionTwitchLinkRequired": { "message": "Cette campagne Twitch nécessite de lier un compte." },
+  "campaignRejectionSubscriptionDisabled": { "message": "Le farming des campagnes d'abonnement est désactivé." },
+  "campaignRejectionCategoryFiltered": { "message": "Cette campagne ne correspond pas aux catégories sélectionnées." },
+  "campaignRejectionPriorityNotSelected": { "message": "Cette campagne n'est pas dans la liste prioritaire." },
+  "campaignRejectionNoRewards": { "message": "Cette campagne n'a aucune récompense à farmer." },
+  "campaignRejectionNoUnclaimedRewards": { "message": "Cette campagne n'a aucune récompense non réclamée." },
+  "campaignRejectionPrerequisites": { "message": "$1 attend une récompense ou condition préalable." },
+  "campaignRejectionRewardNotStarted": { "message": "$1 n'est pas encore disponible." },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 n'est plus disponible." },
+  "campaignRejectionInsufficientTime": { "message": "$1 ne peut pas être terminée avant son échéance." },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 nécessite un abonnement éligible." },
+  "campaignRejectionActionRequired": { "message": "$1 nécessite une action autre que regarder." },
+  "campaignRejectionNoFarmableReward": { "message": "Aucune récompense de cette campagne ne peut être farmée actuellement." },
   "automationSectionTitle": {
     "message": "Automatisation"
   },
@@ -669,7 +687,7 @@
     "message": "Farmer les campagnes sans compte lié"
   },
   "farmUnlinkedDescription": {
-    "message": "Si désactivé, les campagnes nécessitant de lier votre compte sont ignorées. Kick accumule quand même du temps de visionnage avant la liaison."
+    "message": "Si désactivé, les campagnes nécessitant de lier votre compte sont ignorées. La plateforme peut toujours imposer la liaison lorsque l'option est activée."
   },
   "farmSubscriptionTitle": {
     "message": "Farmer les campagnes nécessitant un abonnement"

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "पर्याप्त समय शेष नहीं"
   },
+  "campaignRejectionExcluded": { "message": "इस कैंपेन को फ़ार्मिंग से बाहर रखा गया है।" },
+  "campaignRejectionUpcoming": { "message": "यह कैंपेन अभी शुरू नहीं हुआ है।" },
+  "campaignRejectionExpired": { "message": "यह कैंपेन समाप्त हो गया है।" },
+  "campaignRejectionCompleted": { "message": "इस कैंपेन के सभी रिवॉर्ड पूरे हो चुके हैं।" },
+  "campaignRejectionUnlinkedDisabled": { "message": "लिंक किए खाते के बिना कैंपेन फ़ार्मिंग बंद है।" },
+  "campaignRejectionTwitchLinkRequired": { "message": "इस Twitch कैंपेन के लिए खाता लिंक करना आवश्यक है।" },
+  "campaignRejectionSubscriptionDisabled": { "message": "सब्सक्रिप्शन कैंपेन फ़ार्मिंग बंद है।" },
+  "campaignRejectionCategoryFiltered": { "message": "यह कैंपेन चुनी गई कैटेगरी से मेल नहीं खाता।" },
+  "campaignRejectionPriorityNotSelected": { "message": "यह कैंपेन प्राथमिकता सूची में नहीं है।" },
+  "campaignRejectionNoRewards": { "message": "इस कैंपेन में फ़ार्म करने योग्य रिवॉर्ड नहीं हैं।" },
+  "campaignRejectionNoUnclaimedRewards": { "message": "इस कैंपेन में बिना क्लेम किए रिवॉर्ड नहीं हैं।" },
+  "campaignRejectionPrerequisites": { "message": "$1 पहले के रिवॉर्ड या आवश्यकता की प्रतीक्षा कर रहा है।" },
+  "campaignRejectionRewardNotStarted": { "message": "$1 अभी उपलब्ध नहीं है।" },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 अब उपलब्ध नहीं है।" },
+  "campaignRejectionInsufficientTime": { "message": "$1 समय सीमा से पहले पूरा नहीं हो सकता।" },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 के लिए योग्य सब्सक्रिप्शन चाहिए।" },
+  "campaignRejectionActionRequired": { "message": "$1 के लिए देखने के अलावा दूसरी कार्रवाई चाहिए।" },
+  "campaignRejectionNoFarmableReward": { "message": "इस कैंपेन का कोई रिवॉर्ड अभी फ़ार्म नहीं किया जा सकता।" },
   "automationSectionTitle": {
     "message": "ऑटोमेशन"
   },
@@ -669,7 +687,7 @@
     "message": "बिना लिंक किए गए खाते वाले कैंपेन फ़ार्म करें"
   },
   "farmUnlinkedDescription": {
-    "message": "बंद होने पर, जिन कैंपेन के लिए आपका खाता लिंक करना ज़रूरी है, उन्हें छोड़ दिया जाता है। Kick लिंक करने से पहले भी वॉच टाइम जोड़ता रहता है।"
+    "message": "बंद होने पर, खाता लिंक करने वाले कैंपेन छोड़ दिए जाते हैं। चालू होने पर भी प्लेटफ़ॉर्म के नियम लिंक करना आवश्यक बना सकते हैं।"
   },
   "farmSubscriptionTitle": {
     "message": "सब्सक्रिप्शन वाले कैंपेन फ़ार्म करें"

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "Tempo rimanente insufficiente"
   },
+  "campaignRejectionExcluded": { "message": "Questa campagna è esclusa dal farming." },
+  "campaignRejectionUpcoming": { "message": "Questa campagna non è ancora iniziata." },
+  "campaignRejectionExpired": { "message": "Questa campagna è terminata." },
+  "campaignRejectionCompleted": { "message": "Tutte le ricompense di questa campagna sono complete." },
+  "campaignRejectionUnlinkedDisabled": { "message": "Il farming senza un account collegato è disattivato." },
+  "campaignRejectionTwitchLinkRequired": { "message": "Questa campagna Twitch richiede di collegare un account." },
+  "campaignRejectionSubscriptionDisabled": { "message": "Il farming delle campagne con abbonamento è disattivato." },
+  "campaignRejectionCategoryFiltered": { "message": "Questa campagna non corrisponde alle categorie selezionate." },
+  "campaignRejectionPriorityNotSelected": { "message": "Questa campagna non è nella lista delle priorità." },
+  "campaignRejectionNoRewards": { "message": "Questa campagna non ha ricompense farmabili." },
+  "campaignRejectionNoUnclaimedRewards": { "message": "Questa campagna non ha ricompense da riscattare." },
+  "campaignRejectionPrerequisites": { "message": "$1 attende una ricompensa o un requisito precedente." },
+  "campaignRejectionRewardNotStarted": { "message": "$1 non è ancora disponibile." },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 non è più disponibile." },
+  "campaignRejectionInsufficientTime": { "message": "$1 non può essere completata prima della scadenza." },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 richiede un abbonamento valido." },
+  "campaignRejectionActionRequired": { "message": "$1 richiede un'azione diversa dalla visione." },
+  "campaignRejectionNoFarmableReward": { "message": "Nessuna ricompensa di questa campagna può essere farmata ora." },
   "automationSectionTitle": {
     "message": "Automazione"
   },
@@ -669,7 +687,7 @@
     "message": "Farma campagne senza account collegato"
   },
   "farmUnlinkedDescription": {
-    "message": "Se disattivato, le campagne che richiedono di collegare il tuo account vengono saltate. Kick accumula comunque tempo di visione prima del collegamento."
+    "message": "Se disattivato, le campagne che richiedono un account collegato vengono saltate. La piattaforma può comunque richiedere il collegamento quando è attivo."
   },
   "farmSubscriptionTitle": {
     "message": "Farma campagne che richiedono un abbonamento"

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "Tempo restante insuficiente"
   },
+  "campaignRejectionExcluded": { "message": "Esta campanha foi excluída do farm." },
+  "campaignRejectionUpcoming": { "message": "Esta campanha ainda não começou." },
+  "campaignRejectionExpired": { "message": "Esta campanha terminou." },
+  "campaignRejectionCompleted": { "message": "Todas as recompensas desta campanha foram concluídas." },
+  "campaignRejectionUnlinkedDisabled": { "message": "O farm sem uma conta vinculada está desativado." },
+  "campaignRejectionTwitchLinkRequired": { "message": "Esta campanha da Twitch exige uma conta vinculada." },
+  "campaignRejectionSubscriptionDisabled": { "message": "O farm de campanhas de inscrição está desativado." },
+  "campaignRejectionCategoryFiltered": { "message": "Esta campanha não corresponde às categorias selecionadas." },
+  "campaignRejectionPriorityNotSelected": { "message": "Esta campanha não está na lista de prioridades." },
+  "campaignRejectionNoRewards": { "message": "Esta campanha não tem recompensas disponíveis para farm." },
+  "campaignRejectionNoUnclaimedRewards": { "message": "Esta campanha não tem recompensas não resgatadas." },
+  "campaignRejectionPrerequisites": { "message": "$1 aguarda uma recompensa ou requisito anterior." },
+  "campaignRejectionRewardNotStarted": { "message": "$1 ainda não está disponível." },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 não está mais disponível." },
+  "campaignRejectionInsufficientTime": { "message": "$1 não pode ser concluída antes do prazo." },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 exige uma inscrição qualificada." },
+  "campaignRejectionActionRequired": { "message": "$1 exige uma ação além de assistir." },
+  "campaignRejectionNoFarmableReward": { "message": "Nenhuma recompensa desta campanha pode ser farmada agora." },
   "automationSectionTitle": {
     "message": "Automação"
   },
@@ -669,7 +687,7 @@
     "message": "Farmar campanhas sem conta vinculada"
   },
   "farmUnlinkedDescription": {
-    "message": "Quando desativado, campanhas que exigem vincular sua conta são ignoradas. O Kick ainda acumula tempo de exibição antes da vinculação."
+    "message": "Quando desativado, campanhas que exigem vincular sua conta são ignoradas. A plataforma ainda pode exigir vinculação quando ativado."
   },
   "farmSubscriptionTitle": {
     "message": "Farmar campanhas que exigem inscrição"

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "Недостаточно оставшегося времени"
   },
+  "campaignRejectionExcluded": { "message": "Эта кампания исключена из фарминга." },
+  "campaignRejectionUpcoming": { "message": "Эта кампания ещё не началась." },
+  "campaignRejectionExpired": { "message": "Эта кампания завершилась." },
+  "campaignRejectionCompleted": { "message": "Все награды этой кампании получены." },
+  "campaignRejectionUnlinkedDisabled": { "message": "Фарминг без привязанной учётной записи отключён." },
+  "campaignRejectionTwitchLinkRequired": { "message": "Для этой кампании Twitch требуется привязка учётной записи." },
+  "campaignRejectionSubscriptionDisabled": { "message": "Фарминг кампаний с подпиской отключён." },
+  "campaignRejectionCategoryFiltered": { "message": "Эта кампания не соответствует выбранным категориям." },
+  "campaignRejectionPriorityNotSelected": { "message": "Этой кампании нет в списке приоритетов." },
+  "campaignRejectionNoRewards": { "message": "В этой кампании нет доступных для фарминга наград." },
+  "campaignRejectionNoUnclaimedRewards": { "message": "В этой кампании нет неполученных наград." },
+  "campaignRejectionPrerequisites": { "message": "$1 ожидает предыдущую награду или условие." },
+  "campaignRejectionRewardNotStarted": { "message": "$1 пока недоступна." },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 больше недоступна." },
+  "campaignRejectionInsufficientTime": { "message": "$1 нельзя завершить до окончания срока." },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 требует подходящую подписку." },
+  "campaignRejectionActionRequired": { "message": "$1 требует действие помимо просмотра." },
+  "campaignRejectionNoFarmableReward": { "message": "Сейчас ни одну награду этой кампании нельзя фармить." },
   "automationSectionTitle": {
     "message": "Автоматизация"
   },
@@ -669,7 +687,7 @@
     "message": "Фармить кампании без привязанного аккаунта"
   },
   "farmUnlinkedDescription": {
-    "message": "Когда выключено, кампании, требующие привязки аккаунта, пропускаются. Kick всё равно накапливает время просмотра до привязки."
+    "message": "Когда выключено, кампании, требующие привязки аккаунта, пропускаются. Требования платформы могут всё равно требовать привязку, когда настройка включена."
   },
   "farmSubscriptionTitle": {
     "message": "Фармить кампании, требующие подписки"

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "Yeterli süre kalmadı"
   },
+  "campaignRejectionExcluded": { "message": "Bu kampanya farmlamadan hariç tutuldu." },
+  "campaignRejectionUpcoming": { "message": "Bu kampanya henüz başlamadı." },
+  "campaignRejectionExpired": { "message": "Bu kampanya sona erdi." },
+  "campaignRejectionCompleted": { "message": "Bu kampanyadaki tüm ödüller tamamlandı." },
+  "campaignRejectionUnlinkedDisabled": { "message": "Bağlı hesap olmadan kampanya farmlama kapalı." },
+  "campaignRejectionTwitchLinkRequired": { "message": "Bu Twitch kampanyası için hesap bağlamak gerekir." },
+  "campaignRejectionSubscriptionDisabled": { "message": "Abonelik kampanyalarını farmlama kapalı." },
+  "campaignRejectionCategoryFiltered": { "message": "Bu kampanya seçili kategorilerle eşleşmiyor." },
+  "campaignRejectionPriorityNotSelected": { "message": "Bu kampanya öncelik listesinde değil." },
+  "campaignRejectionNoRewards": { "message": "Bu kampanyada farmlanabilir ödül yok." },
+  "campaignRejectionNoUnclaimedRewards": { "message": "Bu kampanyada alınmamış ödül yok." },
+  "campaignRejectionPrerequisites": { "message": "$1 önceki bir ödülü veya gereksinimi bekliyor." },
+  "campaignRejectionRewardNotStarted": { "message": "$1 henüz kullanılamıyor." },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 artık kullanılamıyor." },
+  "campaignRejectionInsufficientTime": { "message": "$1 son tarihten önce tamamlanamaz." },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 uygun bir abonelik gerektiriyor." },
+  "campaignRejectionActionRequired": { "message": "$1 izlemek dışında bir işlem gerektiriyor." },
+  "campaignRejectionNoFarmableReward": { "message": "Bu kampanyada şu anda farmlanabilecek ödül yok." },
   "automationSectionTitle": {
     "message": "Otomasyon"
   },
@@ -669,7 +687,7 @@
     "message": "Bağlı hesabı olmayan kampanyaları farmla"
   },
   "farmUnlinkedDescription": {
-    "message": "Kapalıyken, hesabını bağlamanı gerektiren kampanyalar atlanır. Kick, bağlamadan önce yine de izleme süresi biriktirir."
+    "message": "Kapalıyken, hesap bağlantısı gerektiren kampanyalar atlanır. Açıkken bile platform kuralları bağlantı gerektirebilir."
   },
   "farmSubscriptionTitle": {
     "message": "Abonelik gerektiren kampanyaları farmla"

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -587,6 +587,24 @@
   "insufficientTimeRemaining": {
     "message": "剩余时间不足"
   },
+  "campaignRejectionExcluded": { "message": "此活动已被排除，不会自动获取。" },
+  "campaignRejectionUpcoming": { "message": "此活动尚未开始。" },
+  "campaignRejectionExpired": { "message": "此活动已结束。" },
+  "campaignRejectionCompleted": { "message": "此活动的所有奖励均已完成。" },
+  "campaignRejectionUnlinkedDisabled": { "message": "未关联账户时获取活动奖励的功能已关闭。" },
+  "campaignRejectionTwitchLinkRequired": { "message": "此 Twitch 活动要求关联账户。" },
+  "campaignRejectionSubscriptionDisabled": { "message": "订阅活动的自动获取功能已关闭。" },
+  "campaignRejectionCategoryFiltered": { "message": "此活动不符合所选分类。" },
+  "campaignRejectionPriorityNotSelected": { "message": "此活动不在优先列表中。" },
+  "campaignRejectionNoRewards": { "message": "此活动没有可自动获取的奖励。" },
+  "campaignRejectionNoUnclaimedRewards": { "message": "此活动没有未领取的奖励。" },
+  "campaignRejectionPrerequisites": { "message": "$1 正在等待前置奖励或条件。" },
+  "campaignRejectionRewardNotStarted": { "message": "$1 尚未开放。" },
+  "campaignRejectionRewardWindowEnded": { "message": "$1 已不可用。" },
+  "campaignRejectionInsufficientTime": { "message": "$1 无法在截止时间前完成。" },
+  "campaignRejectionSubscriptionRequired": { "message": "$1 需要符合条件的订阅。" },
+  "campaignRejectionActionRequired": { "message": "$1 需要观看以外的操作。" },
+  "campaignRejectionNoFarmableReward": { "message": "此活动目前没有可自动获取的奖励。" },
   "automationSectionTitle": {
     "message": "自动化"
   },
@@ -669,7 +687,7 @@
     "message": "刷取无需关联账号的活动"
   },
   "farmUnlinkedDescription": {
-    "message": "关闭后，将跳过需要关联账号的活动。关联前 Kick 仍会累积观看时长。"
+    "message": "关闭后，将跳过需要关联账号的活动。开启后，平台规则仍可能要求关联账号。"
   },
   "farmSubscriptionTitle": {
     "message": "刷取需要订阅的活动"

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -573,6 +573,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
     {
       skipUnfinishableRewards: settings.skipUnfinishableRewards,
       deadlineSafetyMarginMinutes: settings.deadlineSafetyMarginMinutes,
+      settings,
     },
   ));
   const games = gameItemsFromCampaigns(snapshot.state.campaigns[platform], t);

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -200,6 +200,10 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
   const metaPointerX = useRef(0);
   const stats = campaignStats(campaign);
   const isFarming = Boolean(campaign.farmingChannel);
+  const farmingRejection = isFarming ? undefined : campaign.farmingRejection;
+  const farmingRejectionMessage = farmingRejection
+    ? t(campaignRejectionMessageKey(farmingRejection.code), farmingRejection.rewardName)
+    : undefined;
   const emphasized = isFarming || (!anyFarming && index === 0);
   const channelLabel = campaign.channels.length === 0 ? t("allChannels") : t("channelCount", String(campaign.channels.length));
   const timingLabel = campaign.status === "upcoming"
@@ -300,6 +304,17 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
               )}
               {!campaign.linked && <Pill tone="danger"><Link2 size={9} /> {t("notLinked")}</Pill>}
               {campaign.excluded && campaign.hasWatchRewards ? <Pill tone="outline"><Ban size={9} /> {t("excluded")}</Pill> : null}
+              {farmingRejectionMessage ? (
+                <span
+                  data-farming-rejection-indicator
+                  role="img"
+                  aria-label={farmingRejectionMessage}
+                  title={farmingRejectionMessage}
+                  className="inline-flex shrink-0 text-amber-500 dark:text-amber-400"
+                >
+                  <AlertTriangle size={11} />
+                </span>
+              ) : null}
             </div>
           </div>
         </div>
@@ -315,6 +330,12 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
         {expanded && (
           <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: "auto", opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.22 }} className="overflow-hidden">
             <div className="space-y-2.5 p-2.5">
+              {farmingRejectionMessage ? (
+                <div className="flex items-start gap-1.5 rounded-lg border border-amber-300/70 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
+                  <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                  <span>{farmingRejectionMessage}</span>
+                </div>
+              ) : null}
               {stats.kind === "subscription" ? (
                 <div className="rounded-xl border border-zinc-100 bg-zinc-50/70 p-2.5 dark:border-zinc-800 dark:bg-zinc-800/40">
                   <div className="flex items-start justify-between gap-2">
@@ -538,6 +559,30 @@ function campaignLifecyclePill(lifecycle: CampaignLifecycleState | undefined, t:
   if (lifecycle === "expired") return { icon: AlertTriangle, label: t("expiredPill"), tone: "danger" };
   if (lifecycle === "finished") return { icon: Check, label: t("finishedPill"), tone: "outline" };
   return undefined;
+}
+
+function campaignRejectionMessageKey(code: NonNullable<CampaignView["farmingRejection"]>["code"]): string {
+  const keys: Record<NonNullable<CampaignView["farmingRejection"]>["code"], string> = {
+    excluded: "campaignRejectionExcluded",
+    upcoming: "campaignRejectionUpcoming",
+    expired: "campaignRejectionExpired",
+    completed: "campaignRejectionCompleted",
+    unlinked_campaigns_disabled: "campaignRejectionUnlinkedDisabled",
+    twitch_link_required: "campaignRejectionTwitchLinkRequired",
+    subscription_campaigns_disabled: "campaignRejectionSubscriptionDisabled",
+    category_filtered: "campaignRejectionCategoryFiltered",
+    priority_not_selected: "campaignRejectionPriorityNotSelected",
+    no_rewards: "campaignRejectionNoRewards",
+    no_unclaimed_rewards: "campaignRejectionNoUnclaimedRewards",
+    reward_prerequisites_unmet: "campaignRejectionPrerequisites",
+    reward_not_started: "campaignRejectionRewardNotStarted",
+    reward_window_ended: "campaignRejectionRewardWindowEnded",
+    insufficient_time: "campaignRejectionInsufficientTime",
+    subscription_required: "campaignRejectionSubscriptionRequired",
+    action_required: "campaignRejectionActionRequired",
+    no_farmable_reward: "campaignRejectionNoFarmableReward",
+  };
+  return keys[code];
 }
 
 function RewardTile({ reward }: { reward: RewardView }) {

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -1,6 +1,7 @@
 import type { CliCredentialBlob, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import type { ClaimGuidance, CompatibilitySettings, DropCampaign, Platform, RewardRequirementType, SupportedLocale } from "@lurkloot/shared/models";
 import type { SettingsExportPayload } from "@lurkloot/shared/settingsExport";
+import type { CampaignFarmingEvaluation } from "@lurkloot/shared/campaignFarming";
 
 export type CompatibilityLifecycle = "recommended" | "legacy" | "experimental";
 export interface CompatibilityOptionMetadata {
@@ -97,6 +98,7 @@ export type CampaignView = {
   rewards: RewardView[];
   hasWatchRewards: boolean;
   hasSubscriptionRewards: boolean;
+  farmingRejection?: Extract<CampaignFarmingEvaluation, { farmable: false }>;
 };
 
 export type TFunction = (key: string, substitutions?: string | string[]) => string;

--- a/packages/popup-ui/src/viewModels.ts
+++ b/packages/popup-ui/src/viewModels.ts
@@ -8,6 +8,7 @@ import {
   rewardFeasibility,
 } from "@lurkloot/shared/rewards";
 import { isCampaignExpired, isCampaignFinished } from "@lurkloot/shared/campaignFilters";
+import { evaluateCampaignFarming } from "@lurkloot/shared/campaignFarming";
 export {
   campaignFilterCategories,
   isCampaignExpired,
@@ -117,8 +118,11 @@ export function campaignViewFromCampaign(
   index: number,
   session: WatchSession,
   excluded: boolean,
-  feasibility?: { skipUnfinishableRewards: boolean; deadlineSafetyMarginMinutes: number; now?: number },
+  feasibility?: { skipUnfinishableRewards: boolean; deadlineSafetyMarginMinutes: number; now?: number; settings?: ExtensionSettings },
 ): CampaignView {
+  const farmingEvaluation = feasibility?.settings
+    ? evaluateCampaignFarming(campaign, feasibility.settings, { includePriorityMode: true, now: feasibility.now })
+    : undefined;
   return {
     id: campaign.id,
     gameId: gameId(campaign),
@@ -168,6 +172,7 @@ export function campaignViewFromCampaign(
     }),
     hasWatchRewards: campaignHasWatchRewards(campaign),
     hasSubscriptionRewards: campaignHasSubscriptionRewards(campaign),
+    farmingRejection: farmingEvaluation && !farmingEvaluation.farmable ? farmingEvaluation : undefined,
   };
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,7 @@
     "./models": "./src/models.ts",
     "./categories": "./src/categories.ts",
     "./campaignFilters": "./src/campaignFilters.ts",
+    "./campaignFarming": "./src/campaignFarming.ts",
     "./messages": "./src/messages.ts",
     "./settings": "./src/settings.ts",
     "./settingsSchema": "./src/settingsSchema.ts",

--- a/packages/shared/src/campaignFarming.ts
+++ b/packages/shared/src/campaignFarming.ts
@@ -1,0 +1,148 @@
+import { categoryListIndex } from "./categories";
+import type { DropCampaign, DropReward, EngineSettings } from "./models";
+import {
+  campaignHasSubscriptionRewards,
+  canClaimReward,
+  isRewardAvailableToEarn,
+  isSubscriptionReward,
+  isWatchReward,
+  rewardFeasibility,
+} from "./rewards";
+
+export type CampaignFarmingRejectionCode =
+  | "excluded"
+  | "upcoming"
+  | "expired"
+  | "completed"
+  | "unlinked_campaigns_disabled"
+  | "twitch_link_required"
+  | "subscription_campaigns_disabled"
+  | "category_filtered"
+  | "priority_not_selected"
+  | "no_rewards"
+  | "no_unclaimed_rewards"
+  | "reward_prerequisites_unmet"
+  | "reward_not_started"
+  | "reward_window_ended"
+  | "insufficient_time"
+  | "subscription_required"
+  | "action_required"
+  | "no_farmable_reward";
+
+export type CampaignFarmingEvaluation =
+  | { farmable: true }
+  | {
+      farmable: false;
+      code: CampaignFarmingRejectionCode;
+      rewardId?: string;
+      rewardName?: string;
+      deadline?: string;
+      remainingMinutes?: number;
+      availableMinutes?: number;
+      marginMinutes?: number;
+    };
+
+export interface CampaignFarmingEvaluationOptions {
+  includePriorityMode?: boolean;
+  now?: number;
+}
+
+type Rejection = Extract<CampaignFarmingEvaluation, { farmable: false }>;
+
+function rejected(code: CampaignFarmingRejectionCode): Rejection {
+  return { farmable: false, code };
+}
+
+function rewardRejected(code: CampaignFarmingRejectionCode, reward: DropReward): Rejection {
+  return { farmable: false, code, rewardId: reward.id, rewardName: reward.name };
+}
+
+function parsedTime(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? undefined : time;
+}
+
+export function evaluateCampaignFarming(
+  campaign: DropCampaign,
+  settings: EngineSettings,
+  options: CampaignFarmingEvaluationOptions = {},
+): CampaignFarmingEvaluation {
+  const now = options.now ?? Date.now();
+  if (settings.excludedCampaignIds.includes(campaign.id)) return rejected("excluded");
+  if (campaign.status === "upcoming" || campaign.eligibility === "upcoming") return rejected("upcoming");
+  if (campaign.status === "expired" || campaign.eligibility === "expired") return rejected("expired");
+  const campaignEndsAt = parsedTime(campaign.endsAt);
+  if (campaignEndsAt !== undefined && campaignEndsAt < now) return rejected("expired");
+  if (campaign.status === "completed" || campaign.eligibility === "completed") return rejected("completed");
+  const accountUnlinked = campaign.accountLinked === false || campaign.eligibility === "account_not_linked";
+  if (accountUnlinked && !settings.farmingEligibility.farmUnlinkedCampaigns) {
+    return rejected("unlinked_campaigns_disabled");
+  }
+  if (campaignHasSubscriptionRewards(campaign) && !settings.farmingEligibility.farmSubscriptionCampaigns) {
+    return rejected("subscription_campaigns_disabled");
+  }
+  if (campaign.platform === "twitch" && accountUnlinked) return rejected("twitch_link_required");
+  const platformSettings = settings.platform[campaign.platform];
+  if (!platformSettings.farmAllCategories && categoryListIndex(campaign, platformSettings.categories) === -1) {
+    return rejected("category_filtered");
+  }
+  if (options.includePriorityMode && settings.priorityMode === "priority_list_only" && settings.campaignPriorities[campaign.id] == null) {
+    return rejected("priority_not_selected");
+  }
+  if (campaign.rewards.length === 0 || campaign.eligibility === "no_rewards") return rejected("no_rewards");
+  const unclaimed = campaign.rewards.filter((reward) => reward.status !== "claimed");
+  if (unclaimed.length === 0) return rejected("no_unclaimed_rewards");
+
+  const blockers: Rejection[] = [];
+  for (const reward of unclaimed) {
+    if (reward.preconditionsMet === false) {
+      blockers.push(rewardRejected("reward_prerequisites_unmet", reward));
+      continue;
+    }
+    const startsAt = parsedTime(reward.availableFrom);
+    if (startsAt !== undefined && now < startsAt) {
+      blockers.push(rewardRejected("reward_not_started", reward));
+      continue;
+    }
+    const endsAt = parsedTime(reward.availableUntil);
+    if (endsAt !== undefined && now >= endsAt) {
+      blockers.push(rewardRejected("reward_window_ended", reward));
+      continue;
+    }
+    if (canClaimReward(reward, now)) return { farmable: true };
+    if (isWatchReward(reward) && isRewardAvailableToEarn(reward, now)) {
+      const feasibility = rewardFeasibility(
+        campaign,
+        reward,
+        settings.skipUnfinishableRewards,
+        settings.deadlineSafetyMarginMinutes,
+        now,
+      );
+      if (feasibility.kind !== "insufficient_time") return { farmable: true };
+      blockers.push({
+        ...rewardRejected("insufficient_time", reward),
+        deadline: feasibility.deadline,
+        remainingMinutes: feasibility.remainingMinutes,
+        availableMinutes: feasibility.availableMilliseconds / 60_000,
+        marginMinutes: feasibility.marginMinutes,
+      });
+      continue;
+    }
+    blockers.push(rewardRejected(
+      isSubscriptionReward(reward) ? "subscription_required" : "action_required",
+      reward,
+    ));
+  }
+
+  const precedence: CampaignFarmingRejectionCode[] = [
+    "reward_prerequisites_unmet",
+    "reward_not_started",
+    "reward_window_ended",
+    "insufficient_time",
+    "subscription_required",
+    "action_required",
+  ];
+  return precedence.flatMap((code) => blockers.filter((blocker) => blocker.code === code))[0]
+    ?? rejected("no_farmable_reward");
+}

--- a/packages/shared/src/campaignFilters.ts
+++ b/packages/shared/src/campaignFilters.ts
@@ -1,4 +1,5 @@
 import { categoryListIndex } from "./categories";
+import { evaluateCampaignFarming } from "./campaignFarming";
 import type { CampaignFilterKey, DropCampaign, DropReward, EngineSettings, ExtensionSettings } from "./models";
 import { campaignHasSubscriptionRewards, canClaimReward, isRewardDeadlineFeasible, isRewardRelevantNow } from "./rewards";
 
@@ -117,8 +118,7 @@ export function campaignEligibleClass(campaign: DropCampaign, settings: EngineSe
 // Strictly narrower than campaignEligibleClass — see that function for why
 // isCampaignVisible deliberately does NOT use this one.
 export function campaignFarmable(campaign: DropCampaign, settings: EngineSettings): boolean {
-  if (!campaignEligibleClass(campaign, settings)) return false;
-  return campaign.rewards.some((reward) => isRewardFarmableNow(campaign, reward, settings));
+  return evaluateCampaignFarming(campaign, settings).farmable;
 }
 
 // What the popup asks. A claimable reward always stays visible so the user can


### PR DESCRIPTION
## Summary

- centralize campaign farmability decisions in a shared evaluator with stable rejection codes and context
- emit deduplicated aggregate and per-campaign rejection diagnostics after campaign refreshes
- show a compact warning on collapsed campaign cards and the localized full reason when expanded
- clarify that platform requirements can still require account linking even when unlinked campaigns are allowed
- document the evaluator and diagnostic/UI data flow

## Why

Campaign refresh counts describe every campaign discovered from the platform, while selection counts only describe campaigns that survive all farming gates. This could produce confusing logs such as 110 campaigns refreshed but 0 campaigns checked without explaining which gates rejected them.

The shared evaluator now keeps scheduler decisions, diagnostics, and popup explanations aligned.

## Validation

- `pnpm typecheck`
- `pnpm test` — extension 1,459 tests; CLI 154 tests; site 3 tests
- `pnpm build:site`
- `pnpm build`
- `pnpm build:firefox`
- `git diff --check`

Rendered browser QA was attempted, but the Browser plugin is unavailable and the local Playwright Chromium binary is not installed. Component rendering/accessibility tests and both production extension builds passed.

Closes #389