### PR TITLE
fix(twitch): recover progressing channel availability

### DIFF
--- a/docs/superpowers/plans/2026-08-15-twitch-progressing-availability.md
+++ b/docs/superpowers/plans/2026-08-15-twitch-progressing-availability.md
@@ -1,0 +1,430 @@
+# Twitch Progressing Availability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent stale or contradictory Twitch channel-availability negatives from blocking a campaign that can be farmed.
+
+**Architecture:** Scope cached `AvailableDrops` snapshots to the Twitch broadcast that produced them and use a shorter TTL for negative snapshots. Separately retain short-lived, authenticated positive evidence when `DropCurrentSessionContext` proves that one exact channel is advancing one exact campaign; both batch and single selection consult the same state APIs.
+
+**Tech Stack:** TypeScript, pnpm workspace, Vitest, WXT-compatible browser-free core.
+
+## Global Constraints
+
+- Twitch core code remains browser-free and must not import WXT or browser globals.
+- Diagnostic messages are English literals and are not added to locale catalogs.
+- Do not log OAuth tokens, cookies, request headers, or raw authenticated responses.
+- Do not accept every live stream in a campaign category.
+- Do not infer campaign aliases from names, categories, artwork, or reward display text.
+- Positive availability snapshots live for 120 seconds; negative snapshots live for 30 seconds.
+- Progress-confirmed facts live for five minutes and share the existing 128-entry FIFO bound.
+- Authenticated-user changes and generation mismatches invalidate both availability snapshots and progress-confirmed facts.
+
+---
+
+## File Structure
+
+- Modify `packages/core/src/platforms/twitch/index.ts`: extend discovery-state records and APIs, propagate broadcast IDs through candidate selection, unify availability resolution, and record progress-confirmed evidence.
+- Modify `packages/extension/tests/adapters.test.ts`: add deterministic regression tests for broadcast invalidation, asymmetric TTLs, exact progress overrides, identity isolation, diagnostics, and batch/single parity.
+
+No new production file is needed: all affected behavior already belongs to the Twitch adapter's discovery state and availability paths.
+
+### Task 1: Make availability snapshots broadcast-scoped
+
+**Files:**
+- Modify: `packages/core/src/platforms/twitch/index.ts:26-38,286-350,390-545,1069-1115,1190-1660`
+- Test: `packages/extension/tests/adapters.test.ts:2580-3075,3380-3665`
+
+**Interfaces:**
+- Produces: `cachedChannelAvailability(channelId: string, broadcastId: string): ChannelAvailabilityLookup`
+- Produces: `rememberChannelAvailability(channelId: string, broadcastId: string, campaignIds: ReadonlySet<string>, requestIdentity: TwitchAvailabilityRequestIdentity): boolean`
+- Produces: `ChannelAvailabilityLookup` status `broadcast_changed` for diagnostic accounting.
+- Consumes: `ChannelCandidate.broadcastId?: string` from `@lurkloot/shared/models`.
+
+- [ ] **Step 1: Write failing discovery-state tests for broadcast identity and TTL polarity**
+
+Add tests beside the existing availability-cache tests. Use fake timers and direct `TwitchDiscoveryState` calls:
+
+```ts
+it("invalidates a cached channel availability snapshot when the broadcast changes", () => {
+  const discoveryState = new TwitchDiscoveryState();
+  const identity = discoveryState.availabilityRequestIdentity();
+
+  discoveryState.rememberChannelAvailability(
+    "channel-id",
+    "broadcast-a",
+    new Set<string>(),
+    identity,
+  );
+
+  expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-a"))
+    .toEqual({ status: "hit", campaignIds: new Set() });
+  expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-b"))
+    .toEqual({ status: "broadcast_changed" });
+  expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-a"))
+    .toEqual({ status: "miss" });
+});
+
+it("expires negative availability before positive availability", () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-15T15:00:00Z"));
+  const discoveryState = new TwitchDiscoveryState();
+  const identity = discoveryState.availabilityRequestIdentity();
+
+  discoveryState.rememberChannelAvailability("negative", "broadcast-n", new Set(), identity);
+  discoveryState.rememberChannelAvailability("positive", "broadcast-p", new Set(["campaign"]), identity);
+  vi.advanceTimersByTime(30_001);
+
+  expect(discoveryState.cachedChannelAvailability("negative", "broadcast-n"))
+    .toEqual({ status: "expired" });
+  expect(discoveryState.cachedChannelAvailability("positive", "broadcast-p"))
+    .toEqual({ status: "hit", campaignIds: new Set(["campaign"]) });
+  vi.useRealTimers();
+});
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts -t "broadcast changes|negative availability before positive"
+```
+
+Expected: FAIL because the discovery-state methods do not accept `broadcastId`, no `broadcast_changed` state exists, and all snapshots currently use the same 120-second TTL.
+
+- [ ] **Step 3: Implement broadcast-aware cache records and asymmetric TTLs**
+
+In `packages/core/src/platforms/twitch/index.ts`, replace the single TTL with:
+
+```ts
+const POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS = 2 * 60_000;
+const NEGATIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS = 30_000;
+```
+
+Extend `CachedAvailableCampaigns` with `broadcastId: string`. Extend `ChannelAvailabilityLookup` with `{ status: "broadcast_changed" }`. Change `cachedChannelAvailability` to delete and return `broadcast_changed` when `cached.broadcastId !== broadcastId`. Change `rememberChannelAvailability` to store the broadcast ID and select the TTL from `campaignIds.size > 0`.
+
+Keep the existing identity-generation guard and FIFO eviction unchanged.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing adapter tests for broadcast revalidation and diagnostic accounting**
+
+Add one single-channel test and one batch-selection test:
+
+```ts
+it("refetches single-channel availability when the channel starts a new broadcast", async () => {
+  let broadcastId = "broadcast-a";
+  let availabilityCalls = 0;
+  const fetcher = jsonFetcher((_url, init) => {
+    const op = operation(init);
+    if (op === "StreamInfo") {
+      return { data: { user: { id: "channel-id", stream: { id: broadcastId, game: { id: "game" } } } } };
+    }
+    if (op === "DropsHighlightService_AvailableDrops") {
+      availabilityCalls += 1;
+      return {
+        data: {
+          channel: {
+            id: "channel-id",
+            viewerDropCampaigns: availabilityCalls === 1 ? [] : [{ id: "campaign" }],
+          },
+        },
+      };
+    }
+    throw new Error(`Unexpected op ${op}`);
+  });
+  const discoveryState = new TwitchDiscoveryState();
+  const candidate = { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" } as const;
+  const campaign = { id: "campaign", categoryId: "game" } as DropCampaign;
+
+  await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState })
+    .checkChannel(candidate, { campaign })).resolves.toMatchObject({ campaignMatches: false });
+  broadcastId = "broadcast-b";
+  await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState })
+    .checkChannel(candidate, { campaign })).resolves.toMatchObject({ campaignMatches: true });
+
+  expect(availabilityCalls).toBe(2);
+});
+```
+
+For the batch case, provide two trusted directory candidates with `broadcastId`, populate a negative for the first broadcast, then select again with a changed first broadcast. Assert that the new batch request includes that channel and the selection diagnostic contains `1 availability broadcast invalidations`.
+
+- [ ] **Step 6: Run the adapter tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts -t "new broadcast|broadcast invalidations"
+```
+
+Expected: FAIL because batch and single paths still perform channel-only lookups and diagnostics do not count broadcast invalidations.
+
+- [ ] **Step 7: Propagate broadcast identity through batch and single availability paths**
+
+Change the internal candidate shape used by `batchCampaignAvailability` and `batchCampaignAvailabilityChunk` to:
+
+```ts
+type TwitchAvailabilityCandidate = {
+  channelId: string;
+  channelLogin: string;
+  broadcastId: string;
+};
+```
+
+Pass `stream.id` from both `batchStreamInfoChunk` and `checkChannel`. For trusted directory candidates, retain `edge.node.id` as `ChannelCandidate.broadcastId`; add `id` to the inline `DirectoryPage_Game` selection and the `TwitchDirectoryData` stream node type. If a caller supplies a trusted directory candidate without a broadcast ID, route it through the existing `StreamInfo` batch instead of caching a channel-only result.
+
+Update every cache read/write to include `broadcastId`. Add `broadcastInvalidations` to the batch result and selection diagnostic. Keep failed or ambiguous responses as `undefined` and uncached.
+
+- [ ] **Step 8: Run all adapter tests and typecheck the core changes**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts
+pnpm --filter @lurkloot/core typecheck
+pnpm --filter @lurkloot/extension typecheck
+```
+
+Expected: PASS. Update existing direct discovery-state tests and trusted-directory fixtures to supply stable broadcast IDs where they intentionally exercise cache hits.
+
+- [ ] **Step 9: Commit the broadcast-scoped cache change**
+
+```bash
+git add packages/core/src/platforms/twitch/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "fix(twitch): scope availability cache to broadcasts"
+```
+
+### Task 2: Let material current-session progress override an exact negative
+
+**Files:**
+- Modify: `packages/core/src/platforms/twitch/index.ts:340-545,930-940,1200-1660,1855-1910`
+- Test: `packages/extension/tests/adapters.test.ts:2580-3075,3700-3910`
+
+**Interfaces:**
+- Produces: `hasProgressConfirmedAvailability(channelId: string, campaignId: string): boolean`
+- Produces: `rememberProgressConfirmedAvailability(channelId: string, campaignId: string, requestIdentity: TwitchAvailabilityRequestIdentity): boolean`
+- Consumes: the broadcast-aware cache APIs produced by Task 1.
+- Consumes: `DropCurrentSessionContext.dropID` and `currentMinutesWatched` already parsed by `TwitchCurrentDropData`.
+
+- [ ] **Step 1: Write failing state tests for exact, bounded, identity-isolated progress evidence**
+
+Add direct `TwitchDiscoveryState` tests proving:
+
+```ts
+it("limits progress-confirmed availability to the exact channel and campaign", () => {
+  const discoveryState = new TwitchDiscoveryState();
+  const identity = discoveryState.availabilityRequestIdentity();
+
+  expect(discoveryState.rememberProgressConfirmedAvailability(
+    "channel-a",
+    "campaign-a",
+    identity,
+  )).toBe(true);
+
+  expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-a")).toBe(true);
+  expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-b")).toBe(false);
+  expect(discoveryState.hasProgressConfirmedAvailability("channel-b", "campaign-a")).toBe(false);
+});
+```
+
+Also test five-minute expiry with fake timers, FIFO eviction after 128 unique pairs, clearing on `setAuthenticatedUser`, and rejection of a write captured before an A → B → A identity round trip.
+
+- [ ] **Step 2: Run the focused state tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts -t "progress-confirmed availability"
+```
+
+Expected: FAIL because progress-confirmed state and methods do not exist.
+
+- [ ] **Step 3: Implement bounded progress-confirmed state**
+
+Add:
+
+```ts
+const PROGRESS_CONFIRMED_AVAILABILITY_TTL_MS = 5 * 60_000;
+
+interface ProgressConfirmedAvailability {
+  channelId: string;
+  campaignId: string;
+  expiresAt: number;
+}
+```
+
+Store facts in a FIFO `Map<string, ProgressConfirmedAvailability>` keyed by `${channelId}:${campaignId}`. `hasProgressConfirmedAvailability` deletes expired entries on read. `rememberProgressConfirmedAvailability` applies the existing request-identity generation guard, enforces the 128-entry bound, refreshes the pair's expiry, and adds `campaignId` to an existing cached snapshot for `channelId` so a contradictory negative cannot survive.
+
+Clear this map whenever `setAuthenticatedUser` increments the availability generation.
+
+- [ ] **Step 4: Run the focused state tests and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing refresh tests for material progress detection**
+
+Extend the existing `merges current watched drop progress` coverage with three tests:
+
+1. Inventory reports 10 minutes and `DropCurrentSessionContext` reports 11 for `drop`; after refresh, the exact channel/campaign fact exists.
+2. Both sources report 10; no fact exists.
+3. The returned `dropID` occurs in zero or two campaigns; no fact exists.
+
+Use an injected `TwitchDiscoveryState`, make `VideoPlayerStreamInfoOverlayChannel` return both `channel-id` and `broadcast-id`, and assert through `hasProgressConfirmedAvailability` rather than private adapter state.
+
+- [ ] **Step 6: Run the progress refresh tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts -t "material current-session progress|unchanged current-session progress|ambiguous current-session drop"
+```
+
+Expected: FAIL because `mergeCurrentSessionProgress` merges minutes but records no availability evidence.
+
+- [ ] **Step 7: Record progress only when the evidence is material and unambiguous**
+
+In `mergeCurrentSessionProgress`:
+
+```ts
+const matchingCampaigns = campaigns.filter((campaign) =>
+  campaign.rewards.some((reward) => reward.id === drop.dropID)
+);
+const matchingCampaign = matchingCampaigns.length === 1 ? matchingCampaigns[0] : undefined;
+const previousReward = matchingCampaign?.rewards.find((reward) => reward.id === drop.dropID);
+if (
+  matchingCampaign
+  && previousReward
+  && currentMinutesWatched > previousReward.watchedMinutes
+) {
+  this.discoveryState.rememberProgressConfirmedAvailability(
+    channelId,
+    matchingCampaign.id,
+    requestIdentity,
+  );
+}
+```
+
+Capture `requestIdentity` immediately before dispatching `DropCurrentSessionContext`, then pass it to the guarded write. Keep the existing campaign-progress merge unchanged after recording the evidence.
+
+Emit one English debug diagnostic naming only the campaign ID and channel login when new material evidence overrides a contradictory negative; do not emit it for routine expiry refreshes.
+
+- [ ] **Step 8: Run the progress refresh tests and verify GREEN**
+
+Run the command from Step 6.
+
+Expected: PASS.
+
+- [ ] **Step 9: Write failing batch/single parity tests for the override**
+
+Create a progress-confirmed fact for `channel-a/campaign-a`, then arrange `AvailableDrops` to omit `campaign-a`.
+
+- For `checkChannel`, assert `campaignMatches: true` and zero `AvailableDrops` calls for the proven pair.
+- For `selectCandidateChannel`, include `channel-a` and a genuine negative `channel-b`; assert `channel-a` wins, no availability request is made for it, and `channel-b` remains rejectable.
+- Repeat the assertions for `campaign-b` on channel A and `campaign-a` on channel B; both must remain false.
+- Assert the batch selection diagnostic reports `1 progress-confirmed availability overrides`.
+
+- [ ] **Step 10: Run parity tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts -t "progress-confirmed override|progress-confirmed availability overrides"
+```
+
+Expected: FAIL because batch and single paths do not consult the positive evidence.
+
+- [ ] **Step 11: Consult progress evidence before cached or fresh snapshots in both paths**
+
+In both `batchCampaignAvailability` and `checkCampaignAvailability`, return true before reading the broadcast-scoped snapshot when `hasProgressConfirmedAvailability(channelId, campaignId)` is true. Add `progressOverrides` to batch metrics and the final selection diagnostic.
+
+Do not write an `AvailableDrops` snapshot for an overridden pair and do not let an unrelated fact skip the network request.
+
+- [ ] **Step 12: Run all adapter tests and workspace typechecks**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts
+pnpm typecheck
+```
+
+Expected: PASS with no TypeScript errors or changed behavior outside Twitch availability.
+
+- [ ] **Step 13: Commit the progress-confirmed override**
+
+```bash
+git add packages/core/src/platforms/twitch/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "fix(twitch): trust confirmed campaign progress"
+```
+
+### Task 3: Verify the complete issue #392 behavior
+
+**Files:**
+- Verify: `packages/core/src/platforms/twitch/index.ts`
+- Verify: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Consumes: broadcast-scoped cache and metrics from Task 1.
+- Consumes: progress-confirmed evidence and metrics from Task 2.
+- Produces: a verified implementation satisfying issue #392 acceptance criteria.
+
+- [ ] **Step 1: Add one end-to-end contradictory-observation regression test**
+
+Use a shared `TwitchDiscoveryState` across adapter reconstructions:
+
+1. `checkChannel` observes `broadcast-a` and caches an explicit negative for `campaign-a`.
+2. `refreshCampaigns` for that same session observes inventory at 10 minutes and current-session progress at 11 minutes.
+3. A reconstructed adapter checks the same channel/campaign while `AvailableDrops` still omits it.
+4. Assert the channel is accepted without another availability request.
+5. Advance five minutes and one millisecond, keep the same broadcast, and assert the negative is queried again rather than preserved by the expired proof.
+
+- [ ] **Step 2: Run the regression test and confirm GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- adapters.test.ts -t "recovers a contradictory Twitch availability negative after material progress"
+```
+
+Expected: PASS. If it fails, fix production behavior without weakening the test's exact channel/campaign assertions.
+
+- [ ] **Step 3: Run formatting and diff checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors and only the intended Twitch adapter/test changes.
+
+- [ ] **Step 4: Run the full repository verification appropriate to the change**
+
+Run:
+
+```bash
+pnpm test
+pnpm typecheck
+pnpm build
+pnpm build:firefox
+```
+
+Expected: all test suites, workspace typechecks, and both browser production builds pass.
+
+- [ ] **Step 5: Commit any final regression-only adjustment**
+
+If Step 1 required a new test commit after Task 2, commit it separately:
+
+```bash
+git add packages/extension/tests/adapters.test.ts packages/core/src/platforms/twitch/index.ts
+git commit -m "test(twitch): cover contradictory availability recovery"
+```
+
+If no files changed after the Task 2 commit, skip this commit rather than creating an empty one.

--- a/docs/superpowers/specs/2026-08-15-twitch-progressing-availability-design.md
+++ b/docs/superpowers/specs/2026-08-15-twitch-progressing-availability-design.md
@@ -1,0 +1,157 @@
+# Twitch Progressing Availability Design
+
+## Problem
+
+Twitch channel selection currently treats a successful
+`DropsHighlightService_AvailableDrops` response as an authoritative snapshot for
+the channel for two minutes. The cache is keyed only by channel ID. In practice,
+the answer can change as channels go offline and begin new broadcasts, and Twitch
+can temporarily omit a campaign even while the exact channel is advancing one of
+that campaign's rewards.
+
+This creates two correctness failures:
+
+- a negative learned during one broadcast can reject the channel during a later
+  broadcast; and
+- a negative response can overrule stronger authenticated evidence that the
+  selected channel is advancing the selected campaign.
+
+The observed EWC and Tarkov cases also show why a broad category fallback is not
+safe. Many live streams can match the game while remaining genuinely ineligible
+for the selected campaign.
+
+## Goals
+
+- Revalidate negative channel availability when the underlying Twitch broadcast
+  changes.
+- Let material reward progress prove availability for the exact channel and
+  campaign that produced it.
+- Preserve rejection of unrelated channels and unrelated campaigns.
+- Make batch selection and single-channel checking use identical availability
+  semantics.
+- Keep shared discovery state bounded and isolated by authenticated Twitch user.
+- Leave complete negative searches eligible for ordinary future retries; do not
+  classify them as authoritative input for long negative-search backoff.
+
+## Non-goals
+
+- Do not accept every live stream in the campaign's category.
+- Do not infer campaign equivalence from names, categories, artwork, or reward
+  display text.
+- Do not replace `AvailableDrops` with a per-candidate
+  `DropCurrentSessionContext` request.
+- Do not solve campaign-ID aliases without a captured response that proves such
+  an alias relationship.
+- Do not add browser permissions or persist credentials.
+
+## Design
+
+### Broadcast-scoped availability snapshots
+
+An authoritative `AvailableDrops` snapshot will be cached against a channel ID
+and the broadcast ID observed when the request was made. A lookup is reusable
+only when both identities match. If the same channel is checked with a different
+broadcast ID, the old snapshot is discarded and Twitch is queried again.
+
+Channel candidates that do not yet carry a broadcast ID must obtain one from the
+existing `StreamInfo` validation before an availability result can be reused as
+an authoritative negative. Twitch directory candidates currently bypass that
+validation, so the selection path must retain or obtain their stream ID rather
+than treating a channel-only negative as valid across broadcasts.
+
+Positive and negative observations have different risk. Positive snapshots keep
+the existing two-minute lifetime. Negative snapshots live for 30 seconds, so the
+next one-minute scheduler tick can recover even when the broadcast is unchanged.
+The constants live beside the existing bounded availability-cache constants.
+
+### Progress-confirmed positive evidence
+
+`refreshCampaigns` already queries `DropCurrentSessionContext` for the current
+watch session. Before merging its result, the adapter can identify the campaign
+containing the returned `dropID` and compare `currentMinutesWatched` with that
+reward's pre-merge watched minutes.
+
+When the current-session value is strictly greater, Twitch has provided material
+evidence that this exact channel is advancing this exact campaign. The discovery
+state records a bounded, expiring positive fact keyed by channel ID and campaign
+ID. Recording it also removes any contradictory cached negative for that pair.
+Progress-confirmed facts live for five minutes and use the existing 128-entry
+FIFO bound. A later material-progress observation refreshes the fact's lifetime.
+
+The proof is not created when:
+
+- the drop ID cannot be mapped to exactly one discovered campaign;
+- watched minutes are absent or unchanged;
+- the session channel cannot be resolved to a Twitch channel ID; or
+- the authenticated identity changes while the request is in flight.
+
+Progress-confirmed evidence is consulted before an `AvailableDrops` snapshot in
+both batch and single paths. It can only turn the proven pair positive. It cannot
+make another campaign available on that channel or make the same campaign
+available on another channel.
+
+### Shared state and identity isolation
+
+Both availability snapshots and progress-confirmed facts live in
+`TwitchDiscoveryState`, because adapters are reconstructed on every scheduler
+tick. They use the existing authenticated-user generation guard so requests
+started under an old identity cannot populate the current user's state.
+
+The state remains bounded with FIFO eviction and TTL expiry. An authenticated
+user change clears both collections. Broadcast changes invalidate only the
+affected channel snapshot; they do not erase unrelated channel evidence.
+
+### Unified availability decision
+
+Batch selection and `checkChannel` will resolve availability in the same order:
+
+1. A live/category mismatch is rejected before campaign availability work.
+2. A valid progress-confirmed fact for the exact channel/campaign returns true.
+3. A broadcast-matching cached `AvailableDrops` snapshot answers normally.
+4. Otherwise Twitch is queried and the result is cached with the current
+   broadcast identity and positive/negative lifetime.
+5. An ambiguous or failed response remains `undefined`, preserving the current
+   fail-open behavior for transport uncertainty.
+
+If a full campaign search has no winner, the scheduler remains idle or keeps its
+existing lower-priority watch according to current behavior. The search is not
+promoted into a long-lived authoritative negative: later ticks re-evaluate new
+broadcasts, newly live candidates, expired negative snapshots, and any newly
+observed progress.
+
+## Diagnostics
+
+Existing English selection diagnostics will continue reporting cache hits,
+misses, and expirations. They will additionally distinguish broadcast
+invalidations and progress-confirmed overrides so future reports show why a
+channel was rechecked or accepted. These are diagnostic literals, not localized
+activity events.
+
+No OAuth tokens, cookies, request headers, or raw authenticated responses are
+logged.
+
+## Testing
+
+Deterministic adapter tests will cover:
+
+- a cached negative being reused during the same broadcast;
+- a new broadcast ID invalidating that negative and triggering a request;
+- a negative expiring sooner than a positive snapshot;
+- increased current-session minutes creating an exact positive override;
+- unchanged minutes creating no override;
+- the override defeating a contradictory cached or fresh negative;
+- the override not affecting another channel or campaign;
+- authenticated-user changes clearing snapshots and progress evidence;
+- stale in-flight requests failing the generation guard; and
+- batch and single-channel paths producing the same result for each case.
+
+Focused tests will be run first, followed by the repository's full `pnpm test`,
+`pnpm typecheck`, and proportionate build verification.
+
+## Expected Outcome
+
+Normal channel churn causes fresh availability checks instead of reusing a
+negative from an obsolete broadcast. Transient negatives recover promptly. If
+Twitch nevertheless contradicts itself for the active channel, observed reward
+progress wins only for the exact proven channel/campaign pair. Genuine
+live/category matches without the selected campaign remain rejectable.

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -28,7 +28,8 @@ const TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 // 60s apart reuse the same entry instead of always missing at the boundary.
 // A cadence configured longer than this still misses every time — same as
 // before — but the default (and every shorter cadence) now actually hits.
-const CHANNEL_CAMPAIGN_CACHE_TTL_MS = 2 * 60_000;
+const POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS = 2 * 60_000;
+const NEGATIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS = 30_000;
 // FIFO bound, not LRU: a cache hit returns immediately without touching this
 // map, so a hot channel's insertion order never refreshes and it can still be
 // evicted before a colder one. Accepted trade-off: FIFO is one Map without a
@@ -171,6 +172,7 @@ const TWITCH_INLINE_QUERIES: Partial<Record<string, string>> = {
       streams(options: $options, first: $limit, sortTypeIsRecency: $sortTypeIsRecency) {
         edges {
           node {
+            id
             title
             viewersCount
             broadcaster { id login displayName profileImageURL }
@@ -288,6 +290,7 @@ interface TwitchDirectoryData {
     streams?: {
       edges?: Array<{
         node?: {
+          id?: string;
           title?: string;
           viewersCount?: number;
           broadcaster?: {
@@ -345,9 +348,16 @@ interface TwitchAvailableDropsData {
 }
 
 interface CachedAvailableCampaigns {
+  broadcastId: string;
   campaignIds: Set<string>;
   expiresAt: number;
 }
+
+type TwitchAvailabilityCandidate = {
+  channelId: string;
+  channelLogin: string;
+  broadcastId: string;
+};
 
 interface TwitchFollowedLiveData {
   currentUser?: {
@@ -384,6 +394,7 @@ function reconcileInventoryCampaignStatuses(
 
 export type ChannelAvailabilityLookup =
   | { status: "hit"; campaignIds: ReadonlySet<string> }
+  | { status: "broadcast_changed" }
   | { status: "expired" }
   | { status: "miss" };
 
@@ -502,9 +513,13 @@ export class TwitchDiscoveryState {
   // Lives here rather than on TwitchAdapter so it survives the per-tick
   // adapter reconstruction (see the class comment on followedChannels above)
   // — without that, the cache is structurally incapable of ever hitting.
-  cachedChannelAvailability(channelId: string): ChannelAvailabilityLookup {
+  cachedChannelAvailability(channelId: string, broadcastId: string): ChannelAvailabilityLookup {
     const cached = this.availableCampaignsByChannel.get(channelId);
     if (!cached) return { status: "miss" };
+    if (cached.broadcastId !== broadcastId) {
+      this.availableCampaignsByChannel.delete(channelId);
+      return { status: "broadcast_changed" };
+    }
     if (cached.expiresAt <= Date.now()) {
       this.availableCampaignsByChannel.delete(channelId);
       return { status: "expired" };
@@ -521,6 +536,7 @@ export class TwitchDiscoveryState {
   // its own caller.
   rememberChannelAvailability(
     channelId: string,
+    broadcastId: string,
     campaignIds: ReadonlySet<string>,
     requestIdentity: TwitchAvailabilityRequestIdentity,
   ): boolean {
@@ -538,8 +554,11 @@ export class TwitchDiscoveryState {
       if (oldest !== undefined) this.availableCampaignsByChannel.delete(oldest);
     }
     this.availableCampaignsByChannel.set(channelId, {
+      broadcastId,
       campaignIds: new Set(campaignIds),
-      expiresAt: Date.now() + CHANNEL_CAMPAIGN_CACHE_TTL_MS,
+      expiresAt: Date.now() + (campaignIds.size > 0
+        ? POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS
+        : NEGATIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS),
     });
     return true;
   }
@@ -1110,6 +1129,7 @@ export class TwitchAdapter implements PlatformAdapter {
           title: edge.node?.title,
           live: true,
           channelId: broadcaster.id,
+          broadcastId: edge.node?.id,
         };
       })
       .filter((candidate): candidate is ChannelCandidate => Boolean(candidate));
@@ -1199,7 +1219,7 @@ export class TwitchAdapter implements PlatformAdapter {
     let trustedDirectoryCandidates = 0;
     for (let index = 0; index < candidates.length; index += 1) {
       const candidate = candidates[index];
-      if (candidate.live === true && candidate.isAclMatch === false) {
+      if (candidate.live === true && candidate.isAclMatch === false && candidate.broadcastId) {
         trustedDirectoryCandidates += 1;
         checks[index] = {
           live: true,
@@ -1222,10 +1242,11 @@ export class TwitchAdapter implements PlatformAdapter {
     const availabilityResult = campaign
       ? await this.batchCampaignAvailability(
           checks.flatMap((check) =>
-            check?.live && check.categoryMatches && check.candidate.channelId
+            check?.live && check.categoryMatches && check.candidate.channelId && check.candidate.broadcastId
               ? [{
                   channelId: check.candidate.channelId,
                   channelLogin: check.candidate.username,
+                  broadcastId: check.candidate.broadcastId,
                 }]
               : []),
           campaign.id,
@@ -1238,6 +1259,7 @@ export class TwitchAdapter implements PlatformAdapter {
           cacheHits: 0,
           cacheMisses: 0,
           cacheExpirations: 0,
+          broadcastInvalidations: 0,
         };
 
     let checked = 0;
@@ -1246,7 +1268,7 @@ export class TwitchAdapter implements PlatformAdapter {
       diagnostic(
         this.emit,
         "debug",
-        `Twitch ${selectionDescription} finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${availabilityResult.cacheMisses} availability cache misses, ${availabilityResult.cacheExpirations} availability cache expirations, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
+        `Twitch ${selectionDescription} finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${availabilityResult.cacheMisses} availability cache misses, ${availabilityResult.cacheExpirations} availability cache expirations, ${availabilityResult.broadcastInvalidations} availability broadcast invalidations, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
         "twitch",
       );
     };
@@ -1280,7 +1302,7 @@ export class TwitchAdapter implements PlatformAdapter {
   }
 
   private async batchCampaignAvailability(
-    candidates: readonly { channelId: string; channelLogin: string }[],
+    candidates: readonly TwitchAvailabilityCandidate[],
     campaignId: string,
     signal?: AbortSignal,
   ): Promise<{
@@ -1290,21 +1312,24 @@ export class TwitchAdapter implements PlatformAdapter {
     cacheHits: number;
     cacheMisses: number;
     cacheExpirations: number;
+    broadcastInvalidations: number;
   }> {
     const matches = new Map<string, boolean | undefined>();
-    const uncached: Array<{ channelId: string; channelLogin: string }> = [];
+    const uncached: TwitchAvailabilityCandidate[] = [];
     let cacheHits = 0;
     let cacheMisses = 0;
     let cacheExpirations = 0;
+    let broadcastInvalidations = 0;
     for (const candidate of candidates) {
       if (matches.has(candidate.channelId)) continue;
-      const lookup = this.discoveryState.cachedChannelAvailability(candidate.channelId);
+      const lookup = this.discoveryState.cachedChannelAvailability(candidate.channelId, candidate.broadcastId);
       if (lookup.status === "hit") {
         cacheHits += 1;
         matches.set(candidate.channelId, lookup.campaignIds.has(campaignId));
         continue;
       }
       if (lookup.status === "expired") cacheExpirations += 1;
+      else if (lookup.status === "broadcast_changed") broadcastInvalidations += 1;
       else cacheMisses += 1;
       uncached.push(candidate);
     }
@@ -1319,6 +1344,7 @@ export class TwitchAdapter implements PlatformAdapter {
         candidate.channelId,
         await this.checkCampaignAvailability(
           candidate.channelId,
+          candidate.broadcastId,
           campaignId,
           candidate.channelLogin,
           signal,
@@ -1332,6 +1358,7 @@ export class TwitchAdapter implements PlatformAdapter {
         cacheHits: cacheHits + metrics.cacheHits,
         cacheMisses,
         cacheExpirations,
+        broadcastInvalidations,
       };
     }
     const chunks = Array.from(
@@ -1373,11 +1400,12 @@ export class TwitchAdapter implements PlatformAdapter {
       cacheHits,
       cacheMisses,
       cacheExpirations,
+      broadcastInvalidations,
     };
   }
 
   private async batchCampaignAvailabilityChunk(
-    candidates: readonly { channelId: string; channelLogin: string }[],
+    candidates: readonly TwitchAvailabilityCandidate[],
     campaignId: string,
     signal?: AbortSignal,
   ): Promise<{
@@ -1386,12 +1414,13 @@ export class TwitchAdapter implements PlatformAdapter {
   }> {
     const matches = new Map<string, boolean | undefined>();
     const fallback = async (
-      candidate: { channelId: string; channelLogin: string },
+      candidate: TwitchAvailabilityCandidate,
     ): Promise<void> => {
       matches.set(
         candidate.channelId,
         await this.checkCampaignAvailability(
           candidate.channelId,
+          candidate.broadcastId,
           campaignId,
           candidate.channelLogin,
           signal,
@@ -1457,7 +1486,12 @@ export class TwitchAdapter implements PlatformAdapter {
         await fallback(candidate);
         continue;
       }
-      this.discoveryState.rememberChannelAvailability(candidate.channelId, campaignIds, requestIdentity);
+      this.discoveryState.rememberChannelAvailability(
+        candidate.channelId,
+        candidate.broadcastId,
+        campaignIds,
+        requestIdentity,
+      );
       matches.set(candidate.channelId, campaignIds.has(campaignId));
     }
     return { matches, singleFallbacks };
@@ -1584,8 +1618,9 @@ export class TwitchAdapter implements PlatformAdapter {
       const actualCategoryId = stream?.game?.id;
       const expectedCategoryId = campaign?.categoryId ?? channel.categoryId;
       const categoryMatches = !expectedCategoryId || actualCategoryId === expectedCategoryId;
-      const campaignMatches = stream && categoryMatches && campaign && channelId
-        ? await this.checkCampaignAvailability(channelId, campaign.id, channel.username, signal)
+      const broadcastId = stream?.id;
+      const campaignMatches = stream && categoryMatches && campaign && channelId && broadcastId
+        ? await this.checkCampaignAvailability(channelId, broadcastId, campaign.id, channel.username, signal)
         : undefined;
       return {
         live: Boolean(stream),
@@ -1603,7 +1638,7 @@ export class TwitchAdapter implements PlatformAdapter {
           categoryName: stream?.game?.name ?? channel.categoryName,
           viewerCount: stream?.viewersCount ?? channel.viewerCount,
           channelId: channelId ?? channel.channelId,
-          broadcastId: stream?.id ?? channel.broadcastId,
+          broadcastId: broadcastId ?? channel.broadcastId,
         },
       };
     } catch (error) {
@@ -1614,12 +1649,13 @@ export class TwitchAdapter implements PlatformAdapter {
 
   private async checkCampaignAvailability(
     channelId: string,
+    broadcastId: string,
     campaignId: string,
     channelLogin: string,
     signal?: AbortSignal,
     metrics?: { checks: number; cacheHits: number },
   ): Promise<boolean | undefined> {
-    const lookup = this.discoveryState.cachedChannelAvailability(channelId);
+    const lookup = this.discoveryState.cachedChannelAvailability(channelId, broadcastId);
     if (lookup.status === "hit") {
       if (metrics) metrics.cacheHits += 1;
       return lookup.campaignIds.has(campaignId);
@@ -1646,7 +1682,12 @@ export class TwitchAdapter implements PlatformAdapter {
         return undefined;
       }
 
-      this.discoveryState.rememberChannelAvailability(channelId, campaignIds, requestIdentity);
+      this.discoveryState.rememberChannelAvailability(
+        channelId,
+        broadcastId,
+        campaignIds,
+        requestIdentity,
+      );
       return campaignIds.has(campaignId);
     } catch (error) {
       signal?.throwIfAborted();

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -30,6 +30,7 @@ const TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 // before — but the default (and every shorter cadence) now actually hits.
 const POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS = 2 * 60_000;
 const NEGATIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS = 30_000;
+const PROGRESS_CONFIRMED_AVAILABILITY_TTL_MS = 5 * 60_000;
 // FIFO bound, not LRU: a cache hit returns immediately without touching this
 // map, so a hot channel's insertion order never refreshes and it can still be
 // evicted before a colder one. Accepted trade-off: FIFO is one Map without a
@@ -353,6 +354,12 @@ interface CachedAvailableCampaigns {
   expiresAt: number;
 }
 
+interface ProgressConfirmedAvailability {
+  channelId: string;
+  campaignId: string;
+  expiresAt: number;
+}
+
 type TwitchAvailabilityCandidate = {
   channelId: string;
   channelLogin: string;
@@ -413,6 +420,7 @@ export interface TwitchAvailabilityRequestIdentity {
 export class TwitchDiscoveryState {
   private readonly campaignDetailsByDropId = new Map<string, CachedCampaignDetails>();
   private readonly availableCampaignsByChannel = new Map<string, CachedAvailableCampaigns>();
+  private readonly progressConfirmedAvailabilityByPair = new Map<string, ProgressConfirmedAvailability>();
   private authenticatedUserId?: string;
   // Starts at 0 so a request captured before any identity is known (userId
   // undefined) still matches the initial state — see availabilityRequestIdentity.
@@ -454,6 +462,7 @@ export class TwitchDiscoveryState {
     if (previousUserId !== userId) {
       this.availabilityGeneration += 1;
       this.availableCampaignsByChannel.clear();
+      this.progressConfirmedAvailabilityByPair.clear();
     }
     this.authenticatedUserId = userId;
     return identityChanged;
@@ -560,6 +569,45 @@ export class TwitchDiscoveryState {
         ? POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS
         : NEGATIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS),
     });
+    return true;
+  }
+
+  hasProgressConfirmedAvailability(channelId: string, campaignId: string): boolean {
+    const key = `${channelId}:${campaignId}`;
+    const confirmed = this.progressConfirmedAvailabilityByPair.get(key);
+    if (!confirmed) return false;
+    if (confirmed.expiresAt <= Date.now()) {
+      this.progressConfirmedAvailabilityByPair.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  rememberProgressConfirmedAvailability(
+    channelId: string,
+    campaignId: string,
+    requestIdentity: TwitchAvailabilityRequestIdentity,
+  ): boolean {
+    if (
+      requestIdentity.userId !== this.authenticatedUserId
+      || requestIdentity.generation !== this.availabilityGeneration
+    ) {
+      return false;
+    }
+    const key = `${channelId}:${campaignId}`;
+    if (
+      !this.progressConfirmedAvailabilityByPair.has(key)
+      && this.progressConfirmedAvailabilityByPair.size >= CHANNEL_CAMPAIGN_CACHE_MAX_ENTRIES
+    ) {
+      const oldest = this.progressConfirmedAvailabilityByPair.keys().next().value;
+      if (oldest !== undefined) this.progressConfirmedAvailabilityByPair.delete(oldest);
+    }
+    this.progressConfirmedAvailabilityByPair.set(key, {
+      channelId,
+      campaignId,
+      expiresAt: Date.now() + PROGRESS_CONFIRMED_AVAILABILITY_TTL_MS,
+    });
+    this.availableCampaignsByChannel.get(channelId)?.campaignIds.add(campaignId);
     return true;
   }
 }
@@ -1260,6 +1308,7 @@ export class TwitchAdapter implements PlatformAdapter {
           cacheMisses: 0,
           cacheExpirations: 0,
           broadcastInvalidations: 0,
+          progressOverrides: 0,
         };
 
     let checked = 0;
@@ -1268,7 +1317,7 @@ export class TwitchAdapter implements PlatformAdapter {
       diagnostic(
         this.emit,
         "debug",
-        `Twitch ${selectionDescription} finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${availabilityResult.cacheMisses} availability cache misses, ${availabilityResult.cacheExpirations} availability cache expirations, ${availabilityResult.broadcastInvalidations} availability broadcast invalidations, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
+        `Twitch ${selectionDescription} finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${availabilityResult.cacheMisses} availability cache misses, ${availabilityResult.cacheExpirations} availability cache expirations, ${availabilityResult.broadcastInvalidations} availability broadcast invalidations, ${availabilityResult.progressOverrides} progress-confirmed availability overrides, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
         "twitch",
       );
     };
@@ -1313,6 +1362,7 @@ export class TwitchAdapter implements PlatformAdapter {
     cacheMisses: number;
     cacheExpirations: number;
     broadcastInvalidations: number;
+    progressOverrides: number;
   }> {
     const matches = new Map<string, boolean | undefined>();
     const uncached: TwitchAvailabilityCandidate[] = [];
@@ -1320,8 +1370,14 @@ export class TwitchAdapter implements PlatformAdapter {
     let cacheMisses = 0;
     let cacheExpirations = 0;
     let broadcastInvalidations = 0;
+    let progressOverrides = 0;
     for (const candidate of candidates) {
       if (matches.has(candidate.channelId)) continue;
+      if (this.discoveryState.hasProgressConfirmedAvailability(candidate.channelId, campaignId)) {
+        progressOverrides += 1;
+        matches.set(candidate.channelId, true);
+        continue;
+      }
       const lookup = this.discoveryState.cachedChannelAvailability(candidate.channelId, candidate.broadcastId);
       if (lookup.status === "hit") {
         cacheHits += 1;
@@ -1359,6 +1415,7 @@ export class TwitchAdapter implements PlatformAdapter {
         cacheMisses,
         cacheExpirations,
         broadcastInvalidations,
+        progressOverrides,
       };
     }
     const chunks = Array.from(
@@ -1401,6 +1458,7 @@ export class TwitchAdapter implements PlatformAdapter {
       cacheMisses,
       cacheExpirations,
       broadcastInvalidations,
+      progressOverrides,
     };
   }
 
@@ -1655,6 +1713,7 @@ export class TwitchAdapter implements PlatformAdapter {
     signal?: AbortSignal,
     metrics?: { checks: number; cacheHits: number },
   ): Promise<boolean | undefined> {
+    if (this.discoveryState.hasProgressConfirmedAvailability(channelId, campaignId)) return true;
     const lookup = this.discoveryState.cachedChannelAvailability(channelId, broadcastId);
     if (lookup.status === "hit") {
       if (metrics) metrics.cacheHits += 1;
@@ -1912,6 +1971,9 @@ export class TwitchAdapter implements PlatformAdapter {
       const channelId = streamInfo.data?.user?.id;
       if (!channelId) return campaigns;
 
+      // Captured immediately before this request so progress from a session
+      // that outlives an account switch cannot become availability evidence.
+      const requestIdentity = this.discoveryState.availabilityRequestIdentity();
       const current = await this.gqlWithIntegrityRetry<TwitchCurrentDropData>(
         "DropCurrentSessionContext",
         TWITCH_QUERIES.currentDropHash,
@@ -1924,6 +1986,44 @@ export class TwitchAdapter implements PlatformAdapter {
       const drop = current.data?.currentUser?.dropCurrentSession;
       if (!drop?.dropID || drop.currentMinutesWatched == null) return campaigns;
       const currentMinutesWatched = drop.currentMinutesWatched;
+      const matchingCampaigns = campaigns.filter((campaign) =>
+        campaign.rewards.some((reward) => reward.id === drop.dropID)
+      );
+      const matchingCampaign = matchingCampaigns.length === 1 ? matchingCampaigns[0] : undefined;
+      const previousReward = matchingCampaign?.rewards.find((reward) => reward.id === drop.dropID);
+      if (
+        matchingCampaign
+        && previousReward
+        && currentMinutesWatched > previousReward.watchedMinutes
+      ) {
+        const wasProgressConfirmed = this.discoveryState.hasProgressConfirmedAvailability(
+          channelId,
+          matchingCampaign.id,
+        );
+        const broadcastId = streamInfo.data?.user?.stream?.id;
+        const availability = broadcastId
+          ? this.discoveryState.cachedChannelAvailability(channelId, broadcastId)
+          : { status: "miss" as const };
+        const overridesNegativeAvailability = availability.status === "hit"
+          && !availability.campaignIds.has(matchingCampaign.id);
+        const wrote = this.discoveryState.rememberProgressConfirmedAvailability(
+          channelId,
+          matchingCampaign.id,
+          requestIdentity,
+        );
+        if (
+          wrote
+          && !wasProgressConfirmed
+          && overridesNegativeAvailability
+        ) {
+          diagnostic(
+            this.emit,
+            "debug",
+            `Twitch current-session progress confirmed campaign ${matchingCampaign.id} for ${channel.username} despite a negative availability snapshot`,
+            "twitch",
+          );
+        }
+      }
 
       return campaigns.map((campaign) => ({
         ...campaign,

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -607,7 +607,11 @@ export class TwitchDiscoveryState {
       campaignId,
       expiresAt: Date.now() + PROGRESS_CONFIRMED_AVAILABILITY_TTL_MS,
     });
-    this.availableCampaignsByChannel.get(channelId)?.campaignIds.add(campaignId);
+    const cachedAvailability = this.availableCampaignsByChannel.get(channelId);
+    if (cachedAvailability && !cachedAvailability.campaignIds.has(campaignId)) {
+      cachedAvailability.campaignIds.add(campaignId);
+      cachedAvailability.expiresAt = Date.now() + POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS;
+    }
     return true;
   }
 }

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2929,6 +2929,34 @@ describe("TwitchAdapter", () => {
     });
   });
 
+  it("promotes a progress-confirmed negative availability snapshot to the positive TTL", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T15:00:00Z"));
+      const discoveryState = new TwitchDiscoveryState();
+      const identity = discoveryState.availabilityRequestIdentity();
+      discoveryState.rememberChannelAvailability("channel-a", "broadcast-a", new Set(), identity);
+      discoveryState.rememberProgressConfirmedAvailability("channel-a", "campaign-a", identity);
+
+      vi.advanceTimersByTime(30_001);
+      expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({
+        status: "hit",
+        campaignIds: new Set(["campaign-a"]),
+      });
+
+      vi.advanceTimersByTime(89_998);
+      expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({
+        status: "hit",
+        campaignIds: new Set(["campaign-a"]),
+      });
+
+      vi.advanceTimersByTime(1);
+      expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({ status: "expired" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("expires progress-confirmed availability after five minutes", () => {
     vi.useFakeTimers();
     try {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2604,7 +2604,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game", name: "Game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game", name: "Game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         expect(requestBody(init).variables).toEqual({ channelID: "channel-id" });
@@ -2629,7 +2629,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         return { data: { channel: { id: "channel-id", viewerDropCampaigns: [{ id: "other" }] } } };
@@ -2653,7 +2653,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") throw new Error("availability unavailable");
       throw new Error(`Unexpected op ${op}`);
@@ -2674,7 +2674,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         return { data: { channel: { id: "channel-id" } } };
@@ -2698,7 +2698,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         availabilityAttempts += 1;
@@ -2726,7 +2726,7 @@ describe("TwitchAdapter", () => {
       const fetcher = jsonFetcher((_url, init) => {
         const op = operation(init);
         if (op === "StreamInfo") {
-          return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+          return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
         }
         if (op === "DropsHighlightService_AvailableDrops") {
           availabilityCalls += 1;
@@ -2774,7 +2774,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         availabilityCalls += 1;
@@ -2795,6 +2795,40 @@ describe("TwitchAdapter", () => {
     expect(availabilityCalls).toBe(1);
   });
 
+  it("refetches single-channel availability when the channel starts a new broadcast", async () => {
+    let broadcastId = "broadcast-a";
+    let availabilityCalls = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-id", stream: { id: broadcastId, game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        availabilityCalls += 1;
+        return {
+          data: {
+            channel: {
+              id: "channel-id",
+              viewerDropCampaigns: availabilityCalls === 1 ? [] : [{ id: "campaign" }],
+            },
+          },
+        };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+    const discoveryState = new TwitchDiscoveryState();
+    const candidate = { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" } as const;
+    const campaign = { id: "campaign", categoryId: "game" } as DropCampaign;
+
+    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .checkChannel(candidate, { campaign })).resolves.toMatchObject({ campaignMatches: false });
+    broadcastId = "broadcast-b";
+    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState })
+      .checkChannel(candidate, { campaign })).resolves.toMatchObject({ campaignMatches: true });
+
+    expect(availabilityCalls).toBe(2);
+  });
+
   it("drops the campaign availability cache when the authenticated user changes", async () => {
     // Availability results are per-account, same as follows — a cache
     // populated under one user must never answer for the next one.
@@ -2802,7 +2836,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         availabilityCalls += 1;
@@ -2857,22 +2891,61 @@ describe("TwitchAdapter", () => {
     // this one must keep working safely under the initial generation.
     const requestIdentity = discoveryState.availabilityRequestIdentity();
     for (let index = 0; index < 128; index += 1) {
-      discoveryState.rememberChannelAvailability(`channel-${index}`, new Set(["campaign"]), requestIdentity);
+      discoveryState.rememberChannelAvailability(`channel-${index}`, `broadcast-${index}`, new Set(["campaign"]), requestIdentity);
     }
-    expect(discoveryState.cachedChannelAvailability("channel-0")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-0", "broadcast-0")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });
 
     // Pushes the cache past its bound; the oldest entry must be evicted, not
     // an arbitrary or most-recent one.
-    discoveryState.rememberChannelAvailability("channel-128", new Set(["campaign"]), requestIdentity);
+    discoveryState.rememberChannelAvailability("channel-128", "broadcast-128", new Set(["campaign"]), requestIdentity);
 
-    expect(discoveryState.cachedChannelAvailability("channel-0")).toEqual({ status: "miss" });
-    expect(discoveryState.cachedChannelAvailability("channel-128")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-0", "broadcast-0")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-128", "broadcast-128")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });
+  });
+
+  it("invalidates a cached channel availability snapshot when the broadcast changes", () => {
+    const discoveryState = new TwitchDiscoveryState();
+    const identity = discoveryState.availabilityRequestIdentity();
+
+    discoveryState.rememberChannelAvailability(
+      "channel-id",
+      "broadcast-a",
+      new Set<string>(),
+      identity,
+    );
+
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-a"))
+      .toEqual({ status: "hit", campaignIds: new Set() });
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-b"))
+      .toEqual({ status: "broadcast_changed" });
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-a"))
+      .toEqual({ status: "miss" });
+  });
+
+  it("expires negative availability before positive availability", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T15:00:00Z"));
+      const discoveryState = new TwitchDiscoveryState();
+      const identity = discoveryState.availabilityRequestIdentity();
+
+      discoveryState.rememberChannelAvailability("negative", "broadcast-n", new Set(), identity);
+      discoveryState.rememberChannelAvailability("positive", "broadcast-p", new Set(["campaign"]), identity);
+      vi.advanceTimersByTime(30_001);
+
+      expect(discoveryState.cachedChannelAvailability("negative", "broadcast-n"))
+        .toEqual({ status: "expired" });
+      expect(discoveryState.cachedChannelAvailability("positive", "broadcast-p"))
+        .toEqual({ status: "hit", campaignIds: new Set(["campaign"]) });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reports availability cache hits, misses, and expirations in the selection diagnostic", async () => {
@@ -2884,6 +2957,7 @@ describe("TwitchAdapter", () => {
         username: "directory-winner",
         url: "https://www.twitch.tv/directory-winner",
         channelId: "winner-id",
+        broadcastId: "winner-broadcast",
         categoryId: "game",
         live: true,
         isAclMatch: false,
@@ -2927,6 +3001,70 @@ describe("TwitchAdapter", () => {
     }
   });
 
+  it("refetches batch availability after a trusted directory candidate starts a new broadcast", async () => {
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.rememberChannelAvailability(
+      "channel-a",
+      "broadcast-a",
+      new Set(),
+      discoveryState.availabilityRequestIdentity(),
+    );
+    const candidates = [
+      {
+        platform: "twitch" as const,
+        username: "directory-a",
+        url: "https://www.twitch.tv/directory-a",
+        channelId: "channel-a",
+        broadcastId: "broadcast-a-next",
+        categoryId: "game",
+        live: true,
+        isAclMatch: false,
+      },
+      {
+        platform: "twitch" as const,
+        username: "directory-b",
+        url: "https://www.twitch.tv/directory-b",
+        channelId: "channel-b",
+        broadcastId: "broadcast-b",
+        categoryId: "game",
+        live: true,
+        isAclMatch: false,
+      },
+    ];
+    const batchRequests: string[][] = [];
+    const events: EngineEvent[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Array<Record<string, unknown>>;
+      expect(Array.isArray(body)).toBe(true);
+      batchRequests.push(body.map((entry) => String((entry.variables as { channelID?: string }).channelID)));
+      return body.map((entry) => {
+        const channelId = String((entry.variables as { channelID?: string }).channelID);
+        return {
+          data: {
+            channel: {
+              id: channelId,
+              viewerDropCampaigns: channelId === "channel-b" ? [{ id: "campaign" }] : [],
+            },
+          },
+        };
+      });
+    });
+
+    const selection = await twitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => {
+      events.push(event);
+    }).selectCandidateChannel?.(
+      candidates,
+      { id: "campaign", name: "Campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    expect(selection?.channel?.username).toBe("directory-b");
+    expect(batchRequests).toEqual([["channel-a", "channel-b"]]);
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      message: expect.stringContaining("1 availability broadcast invalidations"),
+    }));
+  });
+
   it("does not cache a failed or malformed Twitch campaign availability response", async () => {
     // A transport failure or a malformed payload must not poison the cache
     // with an authoritative negative — the next lookup has to hit the network
@@ -2935,7 +3073,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         availabilityCalls += 1;
@@ -2962,7 +3100,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         availabilityCalls += 1;
@@ -2985,7 +3123,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         availabilityCalls += 1;
@@ -3003,7 +3141,7 @@ describe("TwitchAdapter", () => {
     await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).checkChannel(candidate, { campaign });
 
     expect(availabilityCalls).toBe(2);
-    expect(discoveryState.cachedChannelAvailability("channel-id")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id")).toEqual({ status: "miss" });
   });
 
   it("treats a missing availability response channel id as ambiguous and never caches it", async () => {
@@ -3011,7 +3149,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         availabilityCalls += 1;
@@ -3035,7 +3173,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         availabilityCalls += 1;
@@ -3058,7 +3196,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         return { data: { channel: { id: "channel-id", viewerDropCampaigns: [null, { id: "campaign" }] } } };
@@ -3079,6 +3217,7 @@ describe("TwitchAdapter", () => {
         username: "directory-a",
         url: "https://www.twitch.tv/directory-a",
         channelId: "channel-a",
+        broadcastId: "broadcast-a",
         categoryId: "game",
         live: true,
         isAclMatch: false,
@@ -3088,6 +3227,7 @@ describe("TwitchAdapter", () => {
         username: "directory-b",
         url: "https://www.twitch.tv/directory-b",
         channelId: "channel-b",
+        broadcastId: "broadcast-b",
         categoryId: "game",
         live: true,
         isAclMatch: false,
@@ -3121,8 +3261,8 @@ describe("TwitchAdapter", () => {
     // so the selection still lands on the first (unconfirmed) candidate.
     expect(selection?.channel?.username).toBe("directory-a");
     expect(singleFallbackCalls).toBe(1);
-    expect(discoveryState.cachedChannelAvailability("channel-a")).toEqual({ status: "miss" });
-    expect(discoveryState.cachedChannelAvailability("channel-b")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-b", "broadcast-b")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });
@@ -3140,6 +3280,7 @@ describe("TwitchAdapter", () => {
         username: "directory-a",
         url: "https://www.twitch.tv/directory-a",
         channelId: "channel-a",
+        broadcastId: "broadcast-a",
         categoryId: "game",
         live: true,
         isAclMatch: false,
@@ -3149,6 +3290,7 @@ describe("TwitchAdapter", () => {
         username: "directory-b",
         url: "https://www.twitch.tv/directory-b",
         channelId: "channel-b",
+        broadcastId: "broadcast-b",
         categoryId: "game",
         live: true,
         isAclMatch: false,
@@ -3178,6 +3320,7 @@ describe("TwitchAdapter", () => {
         username: "directory-a",
         url: "https://www.twitch.tv/directory-a",
         channelId: "channel-a",
+        broadcastId: "broadcast-a",
         categoryId: "game",
         live: true,
         isAclMatch: false,
@@ -3187,6 +3330,7 @@ describe("TwitchAdapter", () => {
         username: "directory-b",
         url: "https://www.twitch.tv/directory-b",
         channelId: "channel-b",
+        broadcastId: "broadcast-b",
         categoryId: "game",
         live: true,
         isAclMatch: false,
@@ -3225,8 +3369,8 @@ describe("TwitchAdapter", () => {
     // had been ignored, this response would have cached directly and the
     // fallback would never have been called.
     expect(singleFallbackCalls).toBe(1);
-    expect(discoveryState.cachedChannelAvailability("channel-a")).toEqual({ status: "miss" });
-    expect(discoveryState.cachedChannelAvailability("channel-b")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-b", "broadcast-b")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });
@@ -3248,7 +3392,7 @@ describe("TwitchAdapter", () => {
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       if (op === "StreamInfo") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropsHighlightService_AvailableDrops") {
         availabilityCalls += 1;
@@ -3279,7 +3423,7 @@ describe("TwitchAdapter", () => {
     // Request A still answers its own caller correctly...
     await expect(pendingA).resolves.toMatchObject({ campaignMatches: true });
     // ...but must not have repopulated the shared cache under user-b.
-    expect(discoveryState.cachedChannelAvailability("channel-id")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id")).toEqual({ status: "miss" });
 
     // A fresh request under user-b reaches the network and populates the cache.
     await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState })
@@ -3304,17 +3448,19 @@ describe("TwitchAdapter", () => {
 
     expect(discoveryState.rememberChannelAvailability(
       "channel-id",
+      "broadcast-id",
       new Set(["campaign"]),
       staleIdentity,
     )).toBe(false);
-    expect(discoveryState.cachedChannelAvailability("channel-id")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id")).toEqual({ status: "miss" });
 
     expect(discoveryState.rememberChannelAvailability(
       "channel-id",
+      "broadcast-id",
       new Set(["campaign"]),
       discoveryState.availabilityRequestIdentity(),
     )).toBe(true);
-    expect(discoveryState.cachedChannelAvailability("channel-id")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });
@@ -3338,6 +3484,7 @@ describe("TwitchAdapter", () => {
             streams: {
               edges: [{
                 node: {
+                  id: "broadcast-id",
                   title: "FNCS",
                   viewersCount: 34513,
                   broadcaster: {
@@ -3373,6 +3520,7 @@ describe("TwitchAdapter", () => {
       title: "FNCS",
       campaignId: "campaign",
       categoryId: "33214",
+      broadcastId: "broadcast-id",
     });
   });
 
@@ -3388,6 +3536,7 @@ describe("TwitchAdapter", () => {
       username: "directory-winner",
       url: "https://www.twitch.tv/directory-winner",
       channelId: "winner-id",
+      broadcastId: "winner-broadcast",
       categoryId: "game",
       live: true,
       isAclMatch: false,
@@ -3402,12 +3551,50 @@ describe("TwitchAdapter", () => {
     expect(operations).toEqual(["DropsHighlightService_AvailableDrops"]);
   });
 
+  it("revalidates a trusted directory candidate without a broadcast id before checking availability", async () => {
+    const operations: string[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      if (Array.isArray(body)) {
+        operations.push(String(body[0]?.operationName));
+        return [{
+          data: {
+            user: {
+              id: "winner-id",
+              stream: { id: "winner-broadcast", game: { id: "game" } },
+            },
+          },
+        }];
+      }
+      operations.push(String(body.operationName));
+      return { data: { channel: { id: "winner-id", viewerDropCampaigns: [{ id: "campaign" }] } } };
+    });
+    const candidate = {
+      platform: "twitch" as const,
+      username: "directory-winner",
+      url: "https://www.twitch.tv/directory-winner",
+      channelId: "winner-id",
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    };
+
+    const selection = await twitchAdapter(fetcher).selectCandidateChannel?.(
+      [candidate],
+      { id: "campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    expect(selection?.channel?.username).toBe("directory-winner");
+    expect(operations).toEqual(["StreamInfo", "DropsHighlightService_AvailableDrops"]);
+  });
+
   it("batches campaign availability checks for trusted directory candidates", async () => {
     const candidates = Array.from({ length: 24 }, (_, index) => ({
       platform: "twitch" as const,
       username: `directory-${index}`,
       url: `https://www.twitch.tv/directory-${index}`,
       channelId: `channel-${index}`,
+      broadcastId: `broadcast-${index}`,
       categoryId: "game",
       live: true,
       isAclMatch: false,
@@ -3485,6 +3672,7 @@ describe("TwitchAdapter", () => {
       username: `directory-${index}`,
       url: `https://www.twitch.tv/directory-${index}`,
       channelId: `channel-${index}`,
+      broadcastId: `broadcast-${index}`,
       categoryId: "game",
       live: true,
       isAclMatch: false,
@@ -3747,7 +3935,7 @@ describe("TwitchAdapter", () => {
         };
       }
       if (op === "VideoPlayerStreamInfoOverlayChannel") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropCurrentSessionContext") {
         return { data: { currentUser: { dropCurrentSession: { dropID: "drop", currentMinutesWatched: 42 } } } };
@@ -3877,7 +4065,7 @@ describe("TwitchAdapter", () => {
       }
       if (op === "ViewerDropsDashboard") return twitchDashboard([]);
       if (op === "VideoPlayerStreamInfoOverlayChannel") {
-        return { data: { user: { id: "channel-id", stream: { game: { id: "game" } } } } };
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
       }
       if (op === "DropCurrentSessionContext") {
         return { data: { currentUser: { dropCurrentSession: { dropID: "drop", currentMinutesWatched: 60 } } } };

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2909,6 +2909,88 @@ describe("TwitchAdapter", () => {
     });
   });
 
+  it("limits progress-confirmed availability to the exact channel and campaign", () => {
+    const discoveryState = new TwitchDiscoveryState();
+    const identity = discoveryState.availabilityRequestIdentity();
+
+    discoveryState.rememberChannelAvailability("channel-a", "broadcast-a", new Set(), identity);
+    expect(discoveryState.rememberProgressConfirmedAvailability(
+      "channel-a",
+      "campaign-a",
+      identity,
+    )).toBe(true);
+
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-a")).toBe(true);
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-b")).toBe(false);
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-b", "campaign-a")).toBe(false);
+    expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({
+      status: "hit",
+      campaignIds: new Set(["campaign-a"]),
+    });
+  });
+
+  it("expires progress-confirmed availability after five minutes", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T15:00:00Z"));
+      const discoveryState = new TwitchDiscoveryState();
+      const identity = discoveryState.availabilityRequestIdentity();
+
+      discoveryState.rememberProgressConfirmedAvailability("channel-a", "campaign-a", identity);
+      vi.advanceTimersByTime(5 * 60_000 - 1);
+      expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-a")).toBe(true);
+
+      vi.advanceTimersByTime(1);
+      expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-a")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds progress-confirmed availability to 128 pairs in FIFO order", () => {
+    const discoveryState = new TwitchDiscoveryState();
+    const identity = discoveryState.availabilityRequestIdentity();
+    for (let index = 0; index < 128; index += 1) {
+      discoveryState.rememberProgressConfirmedAvailability(`channel-${index}`, "campaign", identity);
+    }
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-0", "campaign")).toBe(true);
+
+    discoveryState.rememberProgressConfirmedAvailability("channel-128", "campaign", identity);
+
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-0", "campaign")).toBe(false);
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-128", "campaign")).toBe(true);
+  });
+
+  it("clears progress-confirmed availability when the authenticated user changes", () => {
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-a");
+    discoveryState.rememberProgressConfirmedAvailability(
+      "channel-a",
+      "campaign-a",
+      discoveryState.availabilityRequestIdentity(),
+    );
+
+    discoveryState.setAuthenticatedUser("user-b");
+
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-a")).toBe(false);
+  });
+
+  it("rejects progress-confirmed availability captured before an A -> B -> A identity round trip", () => {
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.setAuthenticatedUser("user-a");
+    const staleIdentity = discoveryState.availabilityRequestIdentity();
+
+    discoveryState.setAuthenticatedUser("user-b");
+    discoveryState.setAuthenticatedUser("user-a");
+
+    expect(discoveryState.rememberProgressConfirmedAvailability(
+      "channel-a",
+      "campaign-a",
+      staleIdentity,
+    )).toBe(false);
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-a")).toBe(false);
+  });
+
   it("invalidates a cached channel availability snapshot when the broadcast changes", () => {
     const discoveryState = new TwitchDiscoveryState();
     const identity = discoveryState.availabilityRequestIdentity();
@@ -2999,6 +3081,133 @@ describe("TwitchAdapter", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("uses a progress-confirmed override for single-channel availability", async () => {
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.rememberProgressConfirmedAvailability(
+      "channel-a",
+      "campaign-a",
+      discoveryState.availabilityRequestIdentity(),
+    );
+    let availabilityCalls = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        return { data: { user: { id: "channel-a", stream: { id: "broadcast-a", game: { id: "game" } } } } };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        availabilityCalls += 1;
+        return { data: { channel: { id: "channel-a", viewerDropCampaigns: [] } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).checkChannel(
+      { platform: "twitch", username: "channel-a", url: "https://www.twitch.tv/channel-a" },
+      { campaign: { id: "campaign-a", categoryId: "game" } as DropCampaign },
+    )).resolves.toMatchObject({ campaignMatches: true });
+
+    expect(availabilityCalls).toBe(0);
+  });
+
+  it("uses a progress-confirmed override in batch selection", async () => {
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.rememberProgressConfirmedAvailability(
+      "channel-a",
+      "campaign-a",
+      discoveryState.availabilityRequestIdentity(),
+    );
+    const availabilityChannels: string[] = [];
+    const events: EngineEvent[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+      const requests = Array.isArray(body) ? body : [body];
+      availabilityChannels.push(...requests.map((request) => String((request.variables as { channelID?: string }).channelID)));
+      const response = (request: Record<string, unknown>) => ({
+        data: {
+          channel: {
+            id: String((request.variables as { channelID?: string }).channelID),
+            viewerDropCampaigns: [],
+          },
+        },
+      });
+      return Array.isArray(body) ? requests.map(response) : response(body);
+    });
+    const candidates = [
+      {
+        platform: "twitch" as const,
+        username: "channel-a",
+        url: "https://www.twitch.tv/channel-a",
+        channelId: "channel-a",
+        broadcastId: "broadcast-a",
+        categoryId: "game",
+        live: true,
+        isAclMatch: false,
+      },
+      {
+        platform: "twitch" as const,
+        username: "channel-b",
+        url: "https://www.twitch.tv/channel-b",
+        channelId: "channel-b",
+        broadcastId: "broadcast-b",
+        categoryId: "game",
+        live: true,
+        isAclMatch: false,
+      },
+    ];
+
+    const selection = await twitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => {
+      events.push(event);
+    }).selectCandidateChannel?.(candidates, { id: "campaign-a", name: "Campaign", categoryId: "game" } as DropCampaign);
+
+    expect(selection?.channel?.username).toBe("channel-a");
+    expect(availabilityChannels).toEqual(["channel-b"]);
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      message: expect.stringContaining("1 progress-confirmed availability overrides"),
+    }));
+  });
+
+  it("does not use a progress-confirmed override for an unrelated campaign or channel", async () => {
+    const discoveryState = new TwitchDiscoveryState();
+    discoveryState.rememberProgressConfirmedAvailability(
+      "channel-a",
+      "campaign-a",
+      discoveryState.availabilityRequestIdentity(),
+    );
+    const availabilityChannels: string[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "StreamInfo") {
+        const channel = String((requestBody(init).variables as { channel?: string }).channel);
+        return {
+          data: {
+            user: {
+              id: channel,
+              stream: { id: `broadcast-${channel}`, game: { id: "game" } },
+            },
+          },
+        };
+      }
+      if (op === "DropsHighlightService_AvailableDrops") {
+        const channelId = String((requestBody(init).variables as { channelID?: string }).channelID);
+        availabilityChannels.push(channelId);
+        return { data: { channel: { id: channelId, viewerDropCampaigns: [] } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).checkChannel(
+      { platform: "twitch", username: "channel-a", url: "https://www.twitch.tv/channel-a" },
+      { campaign: { id: "campaign-b", categoryId: "game" } as DropCampaign },
+    )).resolves.toMatchObject({ campaignMatches: false });
+    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).checkChannel(
+      { platform: "twitch", username: "channel-b", url: "https://www.twitch.tv/channel-b" },
+      { campaign: { id: "campaign-a", categoryId: "game" } as DropCampaign },
+    )).resolves.toMatchObject({ campaignMatches: false });
+
+    expect(availabilityChannels).toEqual(["channel-a", "channel-b"]);
   });
 
   it("refetches batch availability after a trusted directory candidate starts a new broadcast", async () => {
@@ -3956,6 +4165,148 @@ describe("TwitchAdapter", () => {
       status: "in_progress",
       isCurrentReward: true,
     });
+  });
+
+  it("records material current-session progress as availability evidence", async () => {
+    const discoveryState = new TwitchDiscoveryState();
+    const events: EngineEvent[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") {
+        return {
+          data: {
+            currentUser: {
+              id: "user-id",
+              inventory: {
+                dropCampaignsInProgress: [{
+                  id: "campaign",
+                  timeBasedDrops: [{
+                    id: "drop",
+                    requiredMinutesWatched: 60,
+                    self: { currentMinutesWatched: 10, isClaimed: false },
+                  }],
+                }],
+              },
+            },
+          },
+        };
+      }
+      if (op === "VideoPlayerStreamInfoOverlayChannel") {
+        discoveryState.rememberChannelAvailability(
+          "channel-id",
+          "broadcast-id",
+          new Set(),
+          discoveryState.availabilityRequestIdentity(),
+        );
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
+      }
+      if (op === "DropCurrentSessionContext") {
+        return { data: { currentUser: { dropCurrentSession: { dropID: "drop", currentMinutesWatched: 11 } } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    await twitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => {
+      events.push(event);
+    }).refreshCampaigns({
+      platform: "twitch",
+      status: "watching",
+      offlineChecks: 0,
+      channel: { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+    });
+
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-id", "campaign")).toBe(true);
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      level: "debug",
+      message: "Twitch current-session progress confirmed campaign campaign for creator despite a negative availability snapshot",
+    }));
+  });
+
+  it("does not record unchanged current-session progress as availability evidence", async () => {
+    const discoveryState = new TwitchDiscoveryState();
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") {
+        return {
+          data: {
+            currentUser: {
+              inventory: {
+                dropCampaignsInProgress: [{
+                  id: "campaign",
+                  timeBasedDrops: [{
+                    id: "drop",
+                    requiredMinutesWatched: 60,
+                    self: { currentMinutesWatched: 10, isClaimed: false },
+                  }],
+                }],
+              },
+            },
+          },
+        };
+      }
+      if (op === "VideoPlayerStreamInfoOverlayChannel") {
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
+      }
+      if (op === "DropCurrentSessionContext") {
+        return { data: { currentUser: { dropCurrentSession: { dropID: "drop", currentMinutesWatched: 10 } } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns({
+      platform: "twitch",
+      status: "watching",
+      offlineChecks: 0,
+      channel: { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+    });
+
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-id", "campaign")).toBe(false);
+  });
+
+  it.each([
+    ["zero", []],
+    ["two", ["campaign-a", "campaign-b"]],
+  ])("does not record an ambiguous current-session drop that occurs in %s campaigns", async (_occurrences, campaignIds) => {
+    const discoveryState = new TwitchDiscoveryState();
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      if (op === "Inventory") {
+        return {
+          data: {
+            currentUser: {
+              inventory: {
+                dropCampaignsInProgress: campaignIds.map((id) => ({
+                  id,
+                  timeBasedDrops: [{
+                    id: "drop",
+                    requiredMinutesWatched: 60,
+                    self: { currentMinutesWatched: 10, isClaimed: false },
+                  }],
+                })),
+              },
+            },
+          },
+        };
+      }
+      if (op === "VideoPlayerStreamInfoOverlayChannel") {
+        return { data: { user: { id: "channel-id", stream: { id: "broadcast-id", game: { id: "game" } } } } };
+      }
+      if (op === "DropCurrentSessionContext") {
+        return { data: { currentUser: { dropCurrentSession: { dropID: "drop", currentMinutesWatched: 11 } } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns({
+      platform: "twitch",
+      status: "watching",
+      offlineChecks: 0,
+      channel: { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+    });
+
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-id", "campaign-a")).toBe(false);
+    expect(discoveryState.hasProgressConfirmedAvailability("channel-id", "campaign-b")).toBe(false);
   });
 
   it("claims a Twitch reward with the real drop-instance id", async () => {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2795,6 +2795,89 @@ describe("TwitchAdapter", () => {
     expect(availabilityCalls).toBe(1);
   });
 
+  it("recovers a contradictory Twitch availability negative after material progress", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T15:00:00.000Z"));
+      let availabilityCalls = 0;
+      const discoveryState = new TwitchDiscoveryState();
+      discoveryState.setAuthenticatedUser("user-id");
+      const fetcher = jsonFetcher((_url, init) => {
+        const op = operation(init);
+        if (op === "StreamInfo" || op === "VideoPlayerStreamInfoOverlayChannel") {
+          return {
+            data: {
+              user: {
+                id: "channel-id",
+                stream: { id: "broadcast-a", game: { id: "game" } },
+              },
+            },
+          };
+        }
+        if (op === "DropsHighlightService_AvailableDrops") {
+          availabilityCalls += 1;
+          return { data: { channel: { id: "channel-id", viewerDropCampaigns: [] } } };
+        }
+        if (op === "Inventory") {
+          return {
+            data: {
+              currentUser: {
+                id: "user-id",
+                inventory: {
+                  dropCampaignsInProgress: [{
+                    id: "campaign-a",
+                    timeBasedDrops: [{
+                      id: "drop-a",
+                      requiredMinutesWatched: 60,
+                      self: { currentMinutesWatched: 10, isClaimed: false },
+                    }],
+                  }],
+                },
+              },
+            },
+          };
+        }
+        if (op === "ViewerDropsDashboard") return twitchDashboard([], "user-id");
+        if (op === "DropCurrentSessionContext") {
+          return {
+            data: {
+              currentUser: {
+                dropCurrentSession: { dropID: "drop-a", currentMinutesWatched: 11 },
+              },
+            },
+          };
+        }
+        throw new Error(`Unexpected op ${op}`);
+      });
+      const candidate = { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" } as const;
+      const campaign = { id: "campaign-a", categoryId: "game" } as DropCampaign;
+
+      await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState })
+        .checkChannel(candidate, { campaign })).resolves.toMatchObject({ campaignMatches: false });
+      expect(availabilityCalls).toBe(1);
+
+      const progress = await twitchAdapter(fetcher, undefined, undefined, { discoveryState })
+        .refreshCampaigns({
+          platform: "twitch",
+          status: "watching",
+          offlineChecks: 0,
+          channel: candidate,
+        });
+      expect(progress[0]?.rewards[0]?.watchedMinutes).toBe(11);
+
+      await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState })
+        .checkChannel(candidate, { campaign })).resolves.toMatchObject({ campaignMatches: true });
+      expect(availabilityCalls).toBe(1);
+
+      vi.advanceTimersByTime(5 * 60_000 + 1);
+      await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState })
+        .checkChannel(candidate, { campaign })).resolves.toMatchObject({ campaignMatches: false });
+      expect(availabilityCalls).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("refetches single-channel availability when the channel starts a new broadcast", async () => {
     let broadcastId = "broadcast-a";
     let availabilityCalls = 0;


### PR DESCRIPTION
## Summary

- scope cached Twitch campaign availability to the broadcast that produced it
- expire explicit negative snapshots after 30 seconds while retaining positive snapshots for two minutes
- let material `DropCurrentSessionContext` progress override a contradictory negative for the exact channel/campaign pair
- preserve fail-open handling for ambiguous Twitch responses while keeping explicit negatives rejectable
- add diagnostics and deterministic coverage for broadcast changes, account changes, cache expiry, batch/single parity, and contradictory progress

## Root cause

Channel availability was cached only by channel ID. A negative could therefore survive an offline/online transition into a different broadcast. Twitch can also temporarily omit a campaign from `AvailableDrops` even while authenticated current-session data proves that the exact channel is advancing that campaign.

The fix scopes snapshots to broadcast identity and records bounded, short-lived positive evidence only after watched minutes materially increase for one unambiguous channel/campaign pair.

## Impact

Lurkloot rechecks availability when a channel starts a new broadcast and promptly retries transient negatives. When Twitch contradicts itself, proven progress wins narrowly without admitting unrelated category-matching channels.

## Testing

- `pnpm verify`
  - script/release tests passed
  - workspace typechecks passed
  - CLI: 154 tests passed
  - extension: 1,489 tests passed
  - site tests/build passed
  - Chromium production build passed
  - Firefox production build passed
- task-scoped reviews and final whole-branch review completed with no blocking findings

Closes #392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Twitch channel availability tracking across broadcast changes.
  * Added support for confirming campaign availability through verified viewing progress.
  * Enhanced batch and individual channel selection with more reliable availability checks.
  * Added safeguards to prevent outdated availability information from affecting results.

* **Bug Fixes**
  * Reduced incorrect exclusions caused by temporary or conflicting Twitch availability responses.
  * Improved handling when channels change broadcasts or return incomplete availability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->