### PR TITLE
docs(core): define scheduler lane roadmap

### DIFF
--- a/docs/superpowers/plans/2026-08-15-backlog-roadmap.md
+++ b/docs/superpowers/plans/2026-08-15-backlog-roadmap.md
@@ -1,0 +1,87 @@
+# Backlog Roadmap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the approved dependency-aware assignments for nine scheduler issues to the public Lurkloot GitHub Project.
+
+**Architecture:** Resolve every issue to its existing Project #2 item, update only the approved project fields through GitHub's ProjectV2 API, and then read all nine items back as a compact verification table. Project item IDs are treated as opaque live identifiers; issue numbers are the stable lookup keys.
+
+**Tech Stack:** GitHub CLI `gh`, GitHub ProjectV2 GraphQL/API, `jq`.
+
+## Global Constraints
+
+- Target `jamezrin` Project #2 (`PVT_kwHOAFrIcs4BeaR4`).
+- Change only Status, Priority, Size, Iteration, Start date, Target date, Area, and Platform.
+- Do not change issue bodies, labels, milestones, assignees, repository state, or project configuration.
+- Do not duplicate existing project items.
+- Use exact assignments from `docs/superpowers/specs/2026-08-15-backlog-roadmap-design.md`.
+- Verify every field by reading the live project after mutation.
+
+---
+
+### Task 1: Resolve live project identifiers
+
+**Files:**
+- Read: `docs/superpowers/specs/2026-08-15-backlog-roadmap-design.md`
+- Create transiently: `/tmp/lurkloot-project-fields.json`
+- Create transiently: `/tmp/lurkloot-project-items.json`
+
+**Interfaces:**
+- Consumes: issue numbers 336, 337, 339, 361, 382, 391, 392, 394, and 395.
+- Produces: one unique ProjectV2 item ID per issue plus live field and option IDs.
+
+- [ ] **Step 1: Refresh project metadata**
+
+```bash
+gh project field-list 2 --owner jamezrin --format json > /tmp/lurkloot-project-fields.json
+gh project item-list 2 --owner jamezrin --limit 200 --format json > /tmp/lurkloot-project-items.json
+```
+
+- [ ] **Step 2: Verify all nine issues resolve exactly once**
+
+Use `jq` to count items by `content.number`. Abort without mutation if any requested issue has a count other than one.
+
+### Task 2: Apply approved roadmap fields
+
+**Files:**
+- Read: `/tmp/lurkloot-project-fields.json`
+- Read: `/tmp/lurkloot-project-items.json`
+
+**Interfaces:**
+- Consumes: unique item IDs and exact roadmap assignment table.
+- Produces: live project items carrying the approved project metadata.
+
+- [ ] **Step 1: Apply Status, Priority, Size, Area, and Platform**
+
+For every issue, call `gh project item-edit` with Project #2's corresponding single-select field and option IDs. Apply the values exactly as specified; do not infer alternatives.
+
+- [ ] **Step 2: Apply Start date and Target date**
+
+Use `gh project item-edit --date YYYY-MM-DD` for both date fields on every issue.
+
+- [ ] **Step 3: Apply iterations only to the approved items**
+
+Assign Iteration 2 to #391 and #392 and Iteration 3 to #336. Leave iteration unset for #337, #339, #361, #382, #394, and #395.
+
+### Task 3: Verify the live roadmap
+
+**Files:**
+- Recreate transiently: `/tmp/lurkloot-project-items-after.json`
+
+**Interfaces:**
+- Consumes: mutated Project #2.
+- Produces: a nine-row verification table suitable for the user handoff.
+
+- [ ] **Step 1: Read Project #2 again**
+
+```bash
+gh project item-list 2 --owner jamezrin --limit 200 --format json > /tmp/lurkloot-project-items-after.json
+```
+
+- [ ] **Step 2: Compare all approved values**
+
+Assert exact status, priority, size, area, platform, start date, target date, and iteration for each issue. Report and stop on any mismatch rather than claiming completion.
+
+- [ ] **Step 3: Present the action plan**
+
+Return the project link, the critical chain `#392 → #336 → #339 → #394 → #395 → #337`, parallel #391, and tracking roles for #361/#382.

--- a/docs/superpowers/plans/2026-08-15-scheduler-lane-decomposition.md
+++ b/docs/superpowers/plans/2026-08-15-scheduler-lane-decomposition.md
@@ -1,0 +1,230 @@
+# Scheduler Lane Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Twitch and Kick watch heartbeats on an independent 60-second cadence while discovery refresh and target selection operate from coherent provider snapshots.
+
+**Architecture:** Deliver three independently reviewable changes. First isolate an immutable active-watch context and heartbeat lane from the platform discovery lock. Then add single-flight provider-owned discovery snapshots. Finally make target selection consume committed snapshot revisions and run only from material changes or explicit triggers.
+
+**Tech Stack:** TypeScript, `@lurkloot/core`, `@lurkloot/shared`, WXT browser alarms, Node timers, Vitest, pnpm.
+
+## Global Constraints
+
+- The target heartbeat cadence is exactly 60 seconds for Twitch and Kick.
+- A late timer produces one attempt, never a burst of catch-up attempts.
+- The heartbeat lane performs no campaign refresh, candidate enumeration, target ranking, or routine auth-health probe.
+- Twitch and Kick eligibility evidence remains provider-specific behind `PlatformAdapter`.
+- Ambiguous, incomplete, or failed discovery preserves a healthy current watch; explicit supported negatives remain rejectable.
+- Discovery is single-flight per provider with at most one coalesced pending refresh.
+- Network requests never run under the short scheduler-state commit lock.
+- Diagnostics are aggregate English literals; do not add locale keys or per-candidate events.
+- Add no browser permissions and persist no raw provider payloads.
+
+---
+
+### Task 1: Isolate the provider-neutral watch heartbeat lane (#336)
+
+**Files:**
+- Create: `packages/core/src/background/watchLane.ts`
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/core/src/core/tablessWatch.ts`
+- Modify: `packages/shared/src/models.ts`
+- Modify: `packages/extension/entrypoints/background.ts`
+- Modify: `packages/cli/src/runtime/run.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/extension/tests/backgroundEntrypoint.test.ts`
+- Test: `packages/cli/tests/run.test.ts`
+
+**Interfaces:**
+- Produces: `CommittedWatchContext`, an immutable provider watch identity containing platform, channel, broadcast, campaign, reward, and timing revision.
+- Produces: `WatchLane.attemptDue(platform, now): Promise<WatchLaneResult>` and `WatchLane.commit(context): void`.
+- Consumes: existing `TablessWatchController.tick()` implementations and short state persistence callbacks.
+
+- [ ] **Step 1: Add failing controller tests for lock independence**
+
+Use a deferred `refreshCampaigns()` promise in `backgroundController.test.ts`. Start a Twitch discovery tick, fire `runWatchHeartbeat()`, and assert the Twitch watcher receives `tick()` before resolving discovery. Repeat for Kick.
+
+- [ ] **Step 2: Run the focused tests and verify the current shared lock blocks them**
+
+Run: `pnpm --filter @lurkloot/extension test -- backgroundController.test.ts`
+
+Expected: both new assertions fail because `runPlatformWatchHeartbeat()` waits on `withStateLock()`.
+
+- [ ] **Step 3: Add timing, coalescing, and handoff tests**
+
+Cover a 60-second due boundary, no accumulated drift after slow persistence, one attempt after a late alarm, concurrent alarm coalescing, immediate-switch deduplication, restart recovery, and a simultaneous channel switch that observes either the complete old context or complete new context.
+
+- [ ] **Step 4: Implement the watch-context and lane boundary**
+
+Move heartbeat network transmission out of the platform mutation lock. Restrict synchronization to atomic context replacement, watcher lifecycle ownership, and a short merge-safe result commit. Keep existing failure counts and tab fallback semantics.
+
+- [ ] **Step 5: Give both hosts a fixed heartbeat driver**
+
+Keep the extension `WATCH_ALARM_NAME` at one minute and calculate due time from persisted timing. Add a separate 60-second CLI heartbeat timer instead of relying on `pollIntervalMinutes`; keep discovery on its existing configurable timer.
+
+- [ ] **Step 6: Add aggregate timing diagnostics**
+
+Report scheduled due time, actual attempt time, timer lateness, internal synchronization delay, coalescing, and stale-result rejection without logging credentials or per-candidate data.
+
+- [ ] **Step 7: Run focused and workspace verification**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts backgroundEntrypoint.test.ts
+pnpm --filter @lurkloot/cli test -- run.test.ts
+pnpm typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit the independently reviewable watch lane**
+
+```bash
+git add packages/core/src/background/watchLane.ts packages/core/src/background/controller.ts packages/core/src/core/tablessWatch.ts packages/shared/src/models.ts packages/extension/entrypoints/background.ts packages/cli/src/runtime/run.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/backgroundEntrypoint.test.ts packages/cli/tests/run.test.ts
+git commit -m "fix(core): isolate watch heartbeat cadence"
+```
+
+### Task 2: Publish asynchronous provider discovery snapshots
+
+**Files:**
+- Create: `packages/core/src/core/discoverySnapshot.ts`
+- Modify: `packages/core/src/platforms/adapter.ts`
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Modify: `packages/core/src/platforms/kick/index.ts`
+- Modify: `packages/core/src/background/controller.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Produces: `DiscoverySnapshot` with platform, revision, observed time, campaigns, completeness, and provider-owned candidate observations.
+- Produces: `PlatformAdapter.refreshDiscoverySnapshot(previous, options): Promise<DiscoverySnapshot>`.
+- Consumes: existing Twitch/Kick discovery state, batching, caches, `refreshCampaigns`, `listCandidateChannels`, and `checkChannel` behavior.
+
+- [ ] **Step 1: Add failing single-flight and provider-independence tests**
+
+Block Twitch refresh, request it again, and assert only one pending rerun is retained. While Twitch is blocked, assert Kick refresh completes and publishes its own revision.
+
+- [ ] **Step 2: Add failing snapshot-coherence tests**
+
+Assert an incomplete/failed refresh retains the last completed snapshot, identity/settings generation changes discard stale results, and a cold process starts without persisted raw provider data.
+
+- [ ] **Step 3: Define the normalized snapshot envelope**
+
+Keep only scheduling metadata shared. Store provider-specific candidate evidence through opaque adapter-owned structures or adapter methods so Kick is not required to emulate Twitch `AvailableDrops`.
+
+- [ ] **Step 4: Implement per-provider single-flight refresh**
+
+Add controller ownership for one active refresh and one boolean/latest pending request per provider. Publish a completed revision atomically; never publish partial work as an authoritative empty snapshot.
+
+- [ ] **Step 5: Adapt Twitch discovery**
+
+Build snapshots using existing campaign details, liveness/category batches, availability cache, and #392 progress-confirmed fail-open semantics. Keep #339 caching and #337 backoff compatible with this lane.
+
+- [ ] **Step 6: Adapt Kick discovery**
+
+Build snapshots from Kick campaign/ACL/category data and fresh liveness/category checks. Represent absence of a channel-specific eligibility API as unknown, not false.
+
+- [ ] **Step 7: Add aggregate discovery diagnostics**
+
+Report provider, duration, revision, snapshot age/completeness, cache/batch counters, pending coalescing, and discarded stale generations.
+
+- [ ] **Step 8: Run focused and workspace verification**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- backgroundController.test.ts adapters.test.ts
+pnpm typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Commit the discovery snapshot lane**
+
+```bash
+git add packages/core/src/core/discoverySnapshot.ts packages/core/src/platforms/adapter.ts packages/core/src/platforms/twitch/index.ts packages/core/src/platforms/kick/index.ts packages/core/src/background/controller.ts packages/extension/tests/backgroundController.test.ts packages/extension/tests/adapters.test.ts
+git commit -m "refactor(core): publish provider discovery snapshots"
+```
+
+### Task 3: Select targets from committed snapshot revisions
+
+**Files:**
+- Modify: `packages/core/src/core/scheduler.ts`
+- Modify: `packages/core/src/background/controller.ts`
+- Modify: `packages/core/src/core/discoverySnapshot.ts`
+- Test: `packages/extension/tests/scheduler.test.ts`
+- Test: `packages/extension/tests/backgroundController.test.ts`
+
+**Interfaces:**
+- Consumes: `DiscoverySnapshot` revisions published by Task 2.
+- Produces: a pure snapshot-based selection input and an atomic `CommittedWatchContext` handoff to Task 1.
+
+- [ ] **Step 1: Add failing tests proving selection performs no discovery I/O**
+
+Pass a committed snapshot to selection, make every adapter refresh/list method throw if called, and assert selection chooses or retains a target solely from the snapshot.
+
+- [ ] **Step 2: Add trigger and material-change tests**
+
+Cover new snapshot revisions with no material change, meaningful availability/campaign changes, claim handoff, current-watch failure, relevant settings changes, and explicit refresh/resume.
+
+- [ ] **Step 3: Add fail-open and stale-generation tests**
+
+Assert ambiguous/stale snapshots retain a healthy current watch, fresh provider-supported negatives reject candidates, and an old selection result cannot publish after identity/settings/target generation advances.
+
+- [ ] **Step 4: Split refresh from scheduler evaluation**
+
+Change `runSchedulerTick()` or introduce a focused selection function so campaign refresh and candidate network checks are absent from the selection call path. Preserve claim, notification, page-context, and lifecycle behavior at their existing controller boundaries.
+
+- [ ] **Step 5: Wire snapshot publication to lightweight selection**
+
+Trigger selection after material publication, coalesce concurrent selection requests per provider, and commit the chosen `CommittedWatchContext` atomically without acquiring the watch transport during network work.
+
+- [ ] **Step 6: Add aggregate selection diagnostics**
+
+Report trigger, snapshot revision and age, material-change decision, candidate counts, selected target or retention reason, and discarded stale work.
+
+- [ ] **Step 7: Run focused and full verification**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- scheduler.test.ts backgroundController.test.ts
+pnpm verify
+```
+
+Expected: all tests, typechecks, site build, and both extension builds pass.
+
+- [ ] **Step 8: Commit snapshot-driven selection**
+
+```bash
+git add packages/core/src/core/scheduler.ts packages/core/src/background/controller.ts packages/core/src/core/discoverySnapshot.ts packages/extension/tests/scheduler.test.ts packages/extension/tests/backgroundController.test.ts
+git commit -m "refactor(core): select from discovery snapshots"
+```
+
+### Task 4: Soak and close the architectural initiative
+
+**Files:**
+- Modify only if evidence requires: provider/controller diagnostic tests and the relevant GitHub issue acceptance criteria.
+
+**Interfaces:**
+- Consumes: watch timing diagnostics, discovery revision diagnostics, and selection revision diagnostics from Tasks 1-3.
+- Produces: credential-free evidence that all three lanes operate independently in an authenticated extension session and headless CLI run.
+
+- [ ] **Step 1: Run an authenticated extension soak**
+
+Capture several discovery cycles for both providers, including a channel going online/offline or an explicit refresh. Confirm heartbeat internal delay remains near zero while discovery is active and no credentials appear in exports.
+
+- [ ] **Step 2: Run a CLI timing soak**
+
+Use a discovery interval different from one minute and confirm Twitch/Kick watch attempts retain the independent 60-second target cadence.
+
+- [ ] **Step 3: Run final verification**
+
+Run: `pnpm verify`
+
+Expected: all checks pass.
+
+- [ ] **Step 4: Record evidence and close linked issues**
+
+Attach aggregate credential-free timing excerpts to the three implementation issues, close completed children, and update #361/#382 so their remaining #337/#339 work is accurately separated from heartbeat latency.

--- a/docs/superpowers/specs/2026-08-15-backlog-roadmap-design.md
+++ b/docs/superpowers/specs/2026-08-15-backlog-roadmap-design.md
@@ -1,0 +1,58 @@
+# Backlog Roadmap Design
+
+## Goal
+
+Turn the current scheduler-related backlog into a dependency-aware action plan in the public [Lurkloot GitHub Project](https://github.com/users/jamezrin/projects/2).
+
+## Project fields
+
+Use the existing project fields only:
+
+- `Status`: Backlog, Ready, In progress, In review, Done
+- `Priority`: P0, P1, P2
+- `Size`: XS, S, M, L, XL
+- `Iteration`: Iteration 2 (2026-08-07 through 2026-08-20) and Iteration 3 (2026-08-21 through 2026-09-03)
+- `Start date` and `Target date`
+- `Area`: core or release/ci for this scope
+- `Platform`: Twitch or Both
+
+Later work uses start/target dates because the project currently exposes no iteration after Iteration 3.
+
+## Roadmap assignments
+
+| Issue | Role | Status | Priority | Size | Iteration | Start | Target | Area | Platform |
+|---|---|---|---|---|---|---|---|---|---|
+| #392 | Availability correctness prerequisite | In progress | P0 | M | Iteration 2 | 2026-08-15 | 2026-08-20 | core | Twitch |
+| #391 | Independent reward-blocker correctness | Ready | P1 | S | Iteration 2 | 2026-08-15 | 2026-08-20 | core | Both |
+| #336 | Independent heartbeat lane | Ready | P0 | L | Iteration 3 | 2026-08-21 | 2026-09-03 | core | Both |
+| #339 | Reduce Twitch discovery cost | Ready | P1 | M | none | 2026-09-04 | 2026-09-10 | core | Twitch |
+| #394 | Provider discovery snapshots | Backlog | P0 | XL | none | 2026-09-11 | 2026-09-24 | core | Both |
+| #395 | Snapshot-driven target selection | Backlog | P0 | L | none | 2026-09-25 | 2026-10-08 | core | Both |
+| #337 | Negative-search backoff in final architecture | Backlog | P1 | M | none | 2026-10-09 | 2026-10-15 | core | Twitch |
+| #361 | Scheduler-efficiency epic | In progress | P0 | XL | none | 2026-08-15 | 2026-10-15 | core | Both |
+| #382 | Initiative handoff and coordination tracker | In progress | P1 | XS | none | 2026-08-15 | 2026-10-15 | release/ci | Both |
+
+## Dependency order
+
+1. Complete #392 before any negative availability backoff. Confirmed progress must continue overriding ambiguous Twitch channel-availability evidence.
+2. Complete #336 before the larger discovery refactor so farming cadence is protected independently.
+3. Complete #339 before #394 so campaign-detail request reduction is established inside the discovery boundary.
+4. Complete #394 before #395 because selection requires committed discovery snapshots.
+5. Complete #337 after #395 so negative-search memory is implemented against the final discovery/selection architecture instead of rewritten.
+
+#391 is independent and small enough to run alongside #392. #361 and #382 are tracking items, not implementation stages.
+
+## Mutation rules
+
+- Add an issue to Project #2 if it is not already present; do not duplicate items.
+- Set only the approved roadmap fields. Do not change issue bodies, labels, milestones, assignees, or repository status.
+- Preserve #392 as `In progress`; no issue is marked `Done` by this operation.
+- Use exact ISO dates from the assignment table.
+- Verify every item by reading the project after mutation.
+
+## Success criteria
+
+- All nine issues appear in the Lurkloot project.
+- Each has the approved status, priority, size, area, platform, dates, and iteration where applicable.
+- The roadmap communicates one critical implementation chain: #392 → #336 → #339 → #394 → #395 → #337.
+- #391 is visibly parallel work and #361/#382 are visibly initiative trackers.

--- a/docs/superpowers/specs/2026-08-15-scheduler-lane-decomposition-design.md
+++ b/docs/superpowers/specs/2026-08-15-scheduler-lane-decomposition-design.md
@@ -1,0 +1,173 @@
+# Scheduler Lane Decomposition Design
+
+## Purpose
+
+Keep the active Twitch or Kick watch transport on a fixed, low-latency cadence while campaign discovery, channel availability refresh, and target selection run independently. Slow provider APIs must not postpone the operation that maintains farming progress.
+
+This design decomposes the work into separate GitHub issues. It does not fold the refactor into the Twitch availability correction tracked by #392.
+
+## Current behavior and root cause
+
+The controller already has a dedicated one-minute watch alarm. However, `runPlatformWatchHeartbeat()` and the normal scheduler tick both acquire the same per-platform state lock. A discovery tick holds that lock across campaign refresh, candidate discovery and validation, scheduler evaluation, watcher reconciliation, and persistence. When discovery wins the lock, a due heartbeat waits for all of that work.
+
+Campaign discovery and target selection are also one operation today. This means selection cannot use a stable last-known discovery result independently, and refreshing provider data always participates in the same critical path as state mutation.
+
+The problem affects both providers even though their evidence differs:
+
+- Twitch has campaign details, channel liveness/category checks, and channel-specific `AvailableDrops` evidence.
+- Kick has campaign metadata and ACL/category-derived candidates, plus fresh channel liveness/category checks, but no Twitch-equivalent channel-specific campaign availability query.
+
+The architecture must preserve those provider differences behind `PlatformAdapter` rather than inventing a false shared notion of authoritative availability.
+
+## Chosen architecture
+
+Each enabled provider has three logical lanes.
+
+### 1. Watch lane
+
+The watch lane maintains only the currently committed watch target. It runs on a fixed 60-second target cadence for both Twitch and Kick and does not perform campaign refresh, candidate enumeration, target prioritization, or routine auth-health probing.
+
+The next due time is anchored to the previous heartbeat attempt rather than to completion of ancillary processing. Browser alarms may fire late, so the lane calculates lateness from persisted timing state instead of assuming exact alarm delivery.
+
+The lane reads an immutable, internally consistent watch-context snapshot containing all values needed by the provider transport, such as platform, channel identity, broadcast identity, campaign/reward identity, and transport-specific session data. A concurrent handoff can expose either the old committed snapshot or the new committed snapshot, never a mixture.
+
+Starting or switching a target may request an immediate heartbeat. Due-time accounting deduplicates that send against the next scheduled attempt.
+
+Heartbeat result persistence and diagnostics use a short commit section. Discovery network work cannot hold the synchronization primitive needed to read the watch snapshot or transmit the heartbeat.
+
+### 2. Discovery lane
+
+Each provider periodically refreshes a provider-owned, in-memory discovery snapshot. A snapshot contains normalized campaigns and the candidate/availability observations that the provider can actually support, together with observation timestamps, completeness, and failure/ambiguity metadata.
+
+Only one discovery refresh may run per provider. If another refresh becomes due while one is running, the controller records at most one pending refresh; it never queues every missed interval. Twitch and Kick refresh independently.
+
+Provider-specific batching, caching, TTLs, and fail-open interpretation remain inside the adapters. A refresh failure or incomplete response does not replace the last successful coherent snapshot with an empty or authoritative-negative result. A Manifest V3 service-worker restart may begin with a cold in-memory snapshot and fetch again.
+
+“Periodically check channels” is bounded. The adapter operates on the provider's current campaign candidate set and existing batching/rate-limit constraints. The controller does not continuously probe every possible channel, and it does not require Kick to produce channel-specific eligibility evidence that Kick's APIs do not expose.
+
+### 3. Selection lane
+
+Selection consumes only committed discovery snapshots. It runs when:
+
+- a provider publishes a materially changed snapshot;
+- the current watch becomes invalid or unhealthy;
+- a claim requires a handoff;
+- relevant settings change; or
+- the user explicitly requests refresh/resume.
+
+Selection does not run as part of the 60-second watch heartbeat. It may retain the current target using the latest known-good snapshot while discovery is incomplete or failing. This preserves the existing fail-open principle: ambiguity must not stop a healthy current watch, while a fresh explicit negative may still reject a candidate according to provider rules.
+
+Publishing a newly selected target is an atomic handoff to the watch lane. Selection can be slow without delaying an already-due heartbeat for the old committed target.
+
+## State and synchronization boundaries
+
+The refactor introduces narrow ownership rather than one platform-wide critical section:
+
+- **Watch-context synchronization:** protects only reading/replacing the immutable active watch snapshot and transport lifecycle.
+- **Discovery ownership:** protects one in-flight refresh and publication of a completed provider snapshot.
+- **Scheduler-state commit:** serializes short persisted state merges so heartbeat health, selection results, settings changes, and platform state cannot overwrite one another.
+
+Network calls must not execute while holding the scheduler-state commit lock. Operations carry a generation or snapshot revision and validate it before committing, so stale discovery or selection work cannot overwrite a newer target, identity, settings generation, or disabled platform.
+
+## Timing semantics
+
+- The watch target cadence is 60 seconds for Twitch and Kick.
+- Cadence measures target attempt times and does not accumulate processing duration as drift.
+- A late browser alarm produces one due attempt, not a burst of catch-up sends.
+- Concurrent watch-alarm invocations coalesce per provider.
+- Discovery cadence is independent and may remain configurable by existing polling settings.
+- Discovery overruns coalesce; they never create an unbounded backlog.
+- Snapshot publication may trigger selection immediately, but selection never preempts or blocks a due heartbeat.
+
+## Failure behavior
+
+- A heartbeat failure updates watch health and can invoke the existing bounded fallback behavior without waiting for discovery.
+- A discovery failure retains the last coherent snapshot and emits aggregate diagnostics.
+- An incomplete or ambiguous discovery result cannot invalidate a healthy current target.
+- An explicit provider-supported negative can affect future selection according to its TTL and cache rules.
+- Disabling a provider or automation invalidates outstanding generations, stops its transport, and prevents late work from republishing state.
+- Auth or identity changes invalidate provider caches and outstanding discovery/selection results before they can commit.
+
+## Diagnostics
+
+Diagnostics remain aggregate and English-only. They should distinguish:
+
+- scheduled heartbeat due time, actual attempt time, and internal delay;
+- browser-alarm lateness from time spent waiting on internal synchronization;
+- discovery start/finish, duration, revision, completeness, and coalescing;
+- selection trigger, consumed snapshot revision/age, and outcome;
+- stale work discarded because its generation no longer matches.
+
+No per-candidate diagnostic stream is introduced.
+
+## Issue decomposition
+
+### Issue A: expand #336 into a provider-neutral watch lane
+
+Scope:
+
+- Twitch and Kick fixed 60-second watch cadence;
+- immutable atomic watch-context snapshots;
+- heartbeat transmission independent of discovery and selection locks;
+- immediate start/switch heartbeat deduplication;
+- restart recovery from persisted timing state;
+- existing heartbeat failure and tab fallback behavior;
+- timing and contention diagnostics.
+
+Out of scope: campaign/channel refresh, target ranking, stalled-progress detection, and transport canaries.
+
+### Issue B: asynchronous provider discovery snapshots
+
+Scope:
+
+- provider-owned Twitch and Kick snapshot models;
+- independent periodic refresh per provider;
+- single-flight refresh with one coalesced pending request;
+- bounded candidate checking using provider capabilities;
+- coherent publication and last-good retention;
+- cache/identity/settings invalidation;
+- aggregate refresh diagnostics.
+
+Out of scope: changing prioritization rules or watch transport cadence.
+
+Existing #339 remains a Twitch discovery optimization inside this lane. Existing #337 remains a policy for backing off costly negative higher-priority searches and must preserve the #392 fail-open correction.
+
+### Issue C: snapshot-driven selection and invalidation
+
+Scope:
+
+- selection reads committed snapshots instead of performing refresh inline;
+- material snapshot changes trigger selection;
+- explicit user/settings/claim/current-watch-invalid triggers;
+- stale-snapshot fail-open retention of a healthy target;
+- atomic publication of a selected watch context;
+- selection revision and reason diagnostics.
+
+Out of scope: stalled-progress detection (#53/#107) and independent transport canaries (#51).
+
+## Delivery order
+
+1. Issue A isolates the latency-critical watch lane without requiring the discovery data model to change.
+2. Issue B creates independently refreshed, provider-owned discovery snapshots.
+3. Issue C moves selection onto those snapshots and removes discovery from selection's synchronous path.
+
+#339 and #337 can improve Twitch discovery before or during Issue B, but they do not substitute for Issue A. The #392 correction lands independently and its fail-open behavior becomes an invariant for Issues B and C.
+
+## Testing strategy
+
+Issue A tests use blocked discovery promises and a fake clock to prove both providers transmit a due heartbeat without waiting, avoid drift and duplicate sends, survive restart, and keep channel/broadcast/campaign context atomic during a handoff.
+
+Issue B tests use fake adapters and clocks to prove per-provider single-flight execution, coalescing, independent Twitch/Kick progress, last-good retention, bounded candidate work, identity invalidation, and stale-result rejection.
+
+Issue C tests prove selection consumes a named snapshot revision, reacts only to material changes or explicit triggers, retains healthy watches on ambiguous/stale data, rejects supported explicit negatives, and cannot publish a stale target after settings, identity, or target generations change.
+
+Cross-cutting controller tests block each lane independently to demonstrate that no network-bound lane prevents the 60-second watch attempt.
+
+## Success criteria
+
+- A due Twitch or Kick heartbeat is not delayed by campaign refresh, channel checks, auth probing, notification work, or target selection.
+- Heartbeat attempts remain anchored to a 60-second target without cumulative processing drift.
+- Discovery remains fresh on its own cadence without overlapping or accumulating missed runs.
+- Selection reacts to coherent completed observations without placing discovery back on the watch path.
+- Healthy current farming survives ambiguous or failed refreshes.
+- Twitch and Kick retain their real provider-specific eligibility semantics.


### PR DESCRIPTION
## Summary

- document the provider-neutral watch, discovery, and selection lane architecture
- provide a task-by-task implementation plan for #336, #394, and #395
- capture the dependency-aware scheduler backlog roadmap and exact GitHub Project field assignments
- document the auditable procedure used to apply and verify the roadmap

## Why

The active Twitch/Kick watch path currently shares execution and state boundaries with slower campaign discovery and target selection work. The backlog needed a coherent architecture and delivery order so correctness fixes, latency isolation, discovery optimization, and the larger refactor can land without being conflated or rewritten.

The resulting critical path is:

`#392 → #336 → #339 → #394 → #395 → #337`

#391 remains parallel work, while #361 and #382 track the overall initiative.

## Impact

This PR changes documentation only. The corresponding fields have already been applied and verified in the public Lurkloot GitHub Project. Runtime behavior is unchanged.

## Testing

- `git diff --check origin/develop...HEAD`
- `pnpm test`
  - extension: 66 test files, 1,470 tests
  - CLI: 12 test files, 154 tests
  - site: 3 tests

## Related issues

- #336
- #337
- #339
- #361
- #382
- #391
- #392
- #394
- #395
