### PR TITLE
docs: add chrome pre-release zip install guide

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -130,7 +130,14 @@ jobs:
         working-directory: candidate
         env:
           VERSION: ${{ inputs.version }}
-        run: node ../trusted/scripts/release/cli.mjs notes --version "$VERSION" --out ../notes.md --pending true
+        run: |
+          node ../trusted/scripts/release/cli.mjs notes --version "$VERSION" --out ../notes.md --pending true
+          {
+            echo
+            echo "## Install the Chrome zip"
+            echo
+            echo "To load this pre-release in Chrome from the zip, see [Installing a pre-release build]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/v$VERSION/docs/install-prerelease.md)."
+          } >> ../notes.md
       - name: Create or refresh the owned GitHub prerelease
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,12 @@ jobs:
       - name: Promote the candidate prerelease to the stable release
         run: |
           node scripts/release/cli.mjs notes --version "$VERSION" --out notes.md
+          {
+            echo
+            echo "## Install the Chrome zip"
+            echo
+            echo "To load this pre-release in Chrome from the zip, see [Installing a pre-release build]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/v$VERSION/docs/install-prerelease.md)."
+          } >> notes.md
           node scripts/release/cli.mjs promote-release --pr "$RELEASE_PR" --version "$VERSION" --notes notes.md
       - uses: docker/login-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Lurkloot is free and open source under the [Apache License 2.0](LICENSE).
 
 ## Get started
 
-1. [Install Lurkloot from the Chrome Web Store](https://chromewebstore.google.com/detail/lurkloot/aobaackpofkghaejdnnmpmeaiaoibhdn). Firefox builds are also available from [GitHub Releases](https://github.com/jamezrin/lurkloot/releases).
+1. [Install Lurkloot from the Chrome Web Store](https://chromewebstore.google.com/detail/lurkloot/aobaackpofkghaejdnnmpmeaiaoibhdn). Firefox builds are also available from [GitHub Releases](https://github.com/jamezrin/lurkloot/releases). To try a GitHub pre-release Chrome zip, see [Installing a pre-release build](docs/install-prerelease.md).
 2. Sign in to Twitch or Kick normally in your browser.
 3. Open the Lurkloot popup and enable the platforms you want to use.
 4. Pick your preferred campaigns, games, or channels—or keep the defaults and let Lurkloot choose.

--- a/docs/install-prerelease.md
+++ b/docs/install-prerelease.md
@@ -1,0 +1,32 @@
+# Installing a pre-release Chrome build
+
+Stable Lurkloot installs come from the [Chrome Web Store](https://chromewebstore.google.com/detail/lurkloot/aobaackpofkghaejdnnmpmeaiaoibhdn). Candidate builds are published as GitHub **Pre-release** assets while a version is still under review. Those zips are the same Chrome package the store will receive, and you can load them directly in Chrome.
+
+Do not install the `.crx` asset. Chrome blocks CRX files that did not come from the Chrome Web Store.
+
+## Download the zip
+
+1. Open [GitHub Releases](https://github.com/jamezrin/lurkloot/releases) and select the version marked **Pre-release**.
+2. Download `lurkloot-X.Y.Z-chrome.zip`. Ignore the Firefox zips and `lurkloot-X.Y.Z-chrome.crx`.
+3. Unzip it to a folder you will keep. Chrome reads the extension from that folder, so moving or deleting it later disables the load.
+
+The unzipped folder must contain `manifest.json`. If the archive extracted into a nested directory, select that inner folder in the next section.
+
+A candidate for the same version can be rebuilt before it is published. Re-download the zip when you want the latest candidate.
+
+## Load it in Chrome
+
+1. Go to `chrome://extensions`.
+2. Turn on **Developer mode** (top right).
+3. Click **Load unpacked** and choose the unzipped folder that contains `manifest.json`.
+4. If Lurkloot from the Chrome Web Store is already installed, disable or remove it so you can tell which copy is running.
+
+Chrome may warn on each startup that extensions in developer mode are enabled. That warning is expected for an unpacked load.
+
+The same steps work in other Chromium browsers, using that browser's extensions page (`edge://extensions`, `brave://extensions`).
+
+## Updating or removing a sideloaded build
+
+To update, unzip the newer `lurkloot-X.Y.Z-chrome.zip` over the same folder and click **Reload** on `chrome://extensions`.
+
+To go back to the store build, remove the unpacked extension on `chrome://extensions`, then install Lurkloot from the [Chrome Web Store](https://chromewebstore.google.com/detail/lurkloot/aobaackpofkghaejdnnmpmeaiaoibhdn). Store updates do not apply to a sideloaded copy.


### PR DESCRIPTION
## Summary
- Document how to load a GitHub pre-release Chrome zip with Developer mode and Load unpacked.
- Append a link to that guide after the changelog in candidate and stable GitHub release notes.
- Point the README Get started step at the same guide.

## Test plan
- [ ] Open `docs/install-prerelease.md` and confirm the Chrome-only steps match a real `lurkloot-*-chrome.zip` (manifest.json at the unzipped root, ignore `.crx` and Firefox zips).
- [ ] Confirm the README Get started link resolves to that file.
- [ ] On the next candidate build, check the GitHub pre-release body: changelog first, then **Install the Chrome zip** linking to `blob/vX.Y.Z/docs/install-prerelease.md`.
- [ ] After promotion, confirm the stable release body still includes that section.


Made with [Cursor](https://cursor.com)