### PR TITLE
fix(twitch): trust discovery sources and show historical campaigns

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -117,7 +117,11 @@ export function defaultConfigJsonc(): string {
         // Used when farmAllCategories is false.
         "categories": ${json(twitch.categories)},
         // Claim channel-point bonuses while farming this platform.
-        "autoClaimChannelPoints": ${json(twitch.autoClaimChannelPoints)}
+        "autoClaimChannelPoints": ${json(twitch.autoClaimChannelPoints)},
+        // Advanced: only farm a campaign on channels Twitch's AvailableDrops
+        // query lists it for. Twitch often omits farmable campaigns there, so
+        // enabling this can leave drops unfarmed.
+        "strictCampaignAvailability": ${json(twitch.strictCampaignAvailability)}
       },
       "kick": {
         "enabled": ${json(kick.enabled)},

--- a/packages/cli/src/events.ts
+++ b/packages/cli/src/events.ts
@@ -14,6 +14,7 @@ function formatStopReason(reason: FarmingStopReason): string {
     case "channel_offline": return "channel offline";
     case "channel_mismatch": return "channel mismatch";
     case "watch_unhealthy": return "watch unhealthy";
+    case "no_progress": return "no drop progress earned";
     case "higher_priority_reward": return "higher priority reward";
     case "higher_priority_idle_watchlist": return "higher priority idle watchlist";
     case "watch_requirement_completed": return "watch requirement completed";

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -121,7 +121,7 @@ const CLI_SETTING_KEYS = new Set<string>([
 ]);
 
 const CLI_PLATFORM_KEYS: Record<Platform, Set<string>> = {
-  twitch: new Set(["enabled", "idleWatchlistChannels", "excludedChannels", "farmAllCategories", "categories", "autoClaimChannelPoints"]),
+  twitch: new Set(["enabled", "idleWatchlistChannels", "excludedChannels", "farmAllCategories", "categories", "autoClaimChannelPoints", "strictCampaignAvailability"]),
   kick: new Set(["enabled", "idleWatchlistChannels", "excludedChannels", "farmAllCategories", "categories", "autoClaimChallenges"]),
 };
 const CLI_COMPATIBILITY_KEYS: Record<Platform, Set<string>> = {
@@ -369,6 +369,7 @@ function normalizePlatform(raw: EngineSettings["platform"] | undefined): Platfor
     twitch: {
       ...twitch.base,
       autoClaimChannelPoints: booleanOr(twitch.ps.autoClaimChannelPoints, DEFAULT_CLI_SETTINGS.platform.twitch.autoClaimChannelPoints),
+      strictCampaignAvailability: booleanOr(twitch.ps.strictCampaignAvailability, DEFAULT_CLI_SETTINGS.platform.twitch.strictCampaignAvailability),
     },
     kick: {
       ...kick.base,

--- a/packages/cli/src/transport/common.ts
+++ b/packages/cli/src/transport/common.ts
@@ -83,6 +83,7 @@ export function createCliAdapters(
           ...identity,
           compatibility: resolution.compatibility.twitch,
           discoveryState: twitchDiscoveryState,
+          strictCampaignAvailability: settings.platform.twitch.strictCampaignAvailability,
           heartbeatIdentity: twitchIdentity,
           ...deps.twitchHeartbeat(identity),
         },

--- a/packages/cli/tests/transport.test.ts
+++ b/packages/cli/tests/transport.test.ts
@@ -210,6 +210,56 @@ describe("createTransport", () => {
     await handle.dispose();
   });
 
+  // The Twitch adapter reads strict campaign availability from engine settings,
+  // so a construction site that stops forwarding it silently reverts every CLI
+  // run to rejecting candidates on AvailableDrops (#400). Asserted through
+  // behaviour rather than the private option: what matters is whether the
+  // request goes out.
+  describe.each([
+    { strictCampaignAvailability: false, expected: [] as string[] },
+    { strictCampaignAvailability: true, expected: ["DropsHighlightService_AvailableDrops"] },
+  ])("forwards strictCampaignAvailability=$strictCampaignAvailability to the Twitch adapter", ({ strictCampaignAvailability, expected }) => {
+    it("matches the availability requests the setting implies", async () => {
+      const operations: string[] = [];
+      vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+        const operation = twitchOperation(init);
+        operations.push(operation);
+        if (operation === "DropsHighlightService_AvailableDrops") {
+          return twitchResponse({
+            data: { channel: { id: "channel-id", viewerDropCampaigns: [{ id: "campaign" }] } },
+          });
+        }
+        throw new Error(`Unexpected Twitch operation ${operation}`);
+      }));
+      const handle = await createTransport("http", {}, "/tmp/auth", ENABLED);
+      const settings = {
+        ...DEFAULT_ENGINE_SETTINGS,
+        platform: {
+          ...DEFAULT_ENGINE_SETTINGS.platform,
+          twitch: { ...DEFAULT_ENGINE_SETTINGS.platform.twitch, strictCampaignAvailability },
+        },
+      };
+
+      const selection = await handle.createAdapters(() => {}, settings).adapters.twitch.selectCandidateChannel?.(
+        [{
+          platform: "twitch",
+          username: "directory-one",
+          url: "https://www.twitch.tv/directory-one",
+          channelId: "channel-id",
+          broadcastId: "broadcast-id",
+          categoryId: "game",
+          live: true,
+          isAclMatch: false,
+        }],
+        { id: "campaign", name: "Campaign", categoryId: "game" } as DropCampaign,
+      );
+
+      expect(selection?.channel?.username).toBe("directory-one");
+      expect(operations).toEqual(expected);
+      await handle.dispose();
+    });
+  });
+
   // impersonate and browser are exercised by impersonate.test.ts / browser.test.ts
   // (with cycletls/Playwright handled there, so no real subprocess spawns here).
 });

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -135,6 +135,7 @@ const FARMING_STOP_REASON_CODES: Record<FarmingStopReason, true> = {
   channel_offline: true,
   channel_mismatch: true,
   watch_unhealthy: true,
+  no_progress: true,
   higher_priority_reward: true,
   higher_priority_idle_watchlist: true,
   watch_requirement_completed: true,

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -283,18 +283,22 @@ export async function chooseCampaignDecision(
         }))
         .map((candidate) => [candidate.username.toLowerCase(), candidate] as const),
     ).values()];
-    // Drop the channels that just stalled, unless that would leave this campaign
-    // with nothing: a stalled channel still beats no channel.
-    const preferred = skipChannels?.size
-      ? deduplicated.filter((candidate) => !skipChannels.has(candidate.username.toLowerCase()))
+    // Channels that just stalled go last rather than being dropped. Validation
+    // below can reject every other candidate — all offline, wrong category — and
+    // a stalled channel still beats no channel, so they stay reachable as a last
+    // resort instead of costing the campaign the whole tick.
+    const skipped = skipChannels?.size
+      ? deduplicated.filter((candidate) => skipChannels.has(candidate.username.toLowerCase()))
+      : [];
+    const preferred = skipped.length > 0
+      ? deduplicated.filter((candidate) => !skipChannels?.has(candidate.username.toLowerCase()))
       : deduplicated;
-    const eligible = preferred.length > 0 ? preferred : deduplicated;
     // Only worth asking the platform who the user follows when more than one
     // candidate could win the campaign.
-    const followed = eligible.length > 1
+    const followed = deduplicated.length > 1
       ? await resolveFollowedChannels()
       : followedChannels ?? new Set<string>();
-    const candidates = eligible
+    const rank = (list: ChannelCandidate[]) => list
       .sort((left, right) => {
         // ACL stays the strongest key: for an ACL-restricted campaign a followed
         // channel outside the allow list cannot earn the drop at all.
@@ -305,9 +309,15 @@ export async function chooseCampaignDecision(
         return (right.viewerCount ?? 0) - (left.viewerCount ?? 0);
       });
 
-    const channel = await firstValidCandidate(candidates, campaign, adapter, signal, () => {
+    const countCheck = () => {
       candidatesChecked += 1;
-    });
+    };
+    // Stalled channels are only validated once everything else has failed, so
+    // the common case still costs exactly one selection pass.
+    const channel = await firstValidCandidate(rank(preferred), campaign, adapter, signal, countCheck)
+      ?? (skipped.length > 0
+        ? await firstValidCandidate(rank(skipped), campaign, adapter, signal, countCheck)
+        : undefined);
     if (channel) {
       return finish({
         platform,

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -212,6 +212,10 @@ export async function chooseCampaignDecision(
   adapter: Pick<PlatformAdapter, "listCandidateChannels" | "selectCandidateChannel" | "checkChannel" | "listFollowedChannels">,
   signal?: AbortSignal,
   reportMetrics?: (metrics: { campaignsChecked: number; candidatesChecked: number }) => void,
+  // Lowercased usernames to pass over this tick because they just failed to earn
+  // progress. Advisory, not an exclusion: a campaign whose only candidate is
+  // skipped keeps it, since rotating to nothing is worse than a slow channel.
+  skipChannels?: ReadonlySet<string>,
 ): Promise<WatchDecision> {
   const sorted = sortCampaigns(campaigns.filter((campaign) => isEligible(campaign, settings)), settings);
   const noCampaignReason = noEligibleCampaignReason(campaigns, settings);
@@ -279,12 +283,18 @@ export async function chooseCampaignDecision(
         }))
         .map((candidate) => [candidate.username.toLowerCase(), candidate] as const),
     ).values()];
+    // Drop the channels that just stalled, unless that would leave this campaign
+    // with nothing: a stalled channel still beats no channel.
+    const preferred = skipChannels?.size
+      ? deduplicated.filter((candidate) => !skipChannels.has(candidate.username.toLowerCase()))
+      : deduplicated;
+    const eligible = preferred.length > 0 ? preferred : deduplicated;
     // Only worth asking the platform who the user follows when more than one
     // candidate could win the campaign.
-    const followed = deduplicated.length > 1
+    const followed = eligible.length > 1
       ? await resolveFollowedChannels()
       : followedChannels ?? new Set<string>();
-    const candidates = deduplicated
+    const candidates = eligible
       .sort((left, right) => {
         // ACL stays the strongest key: for an ACL-restricted campaign a followed
         // channel outside the allow list cannot earn the drop at all.
@@ -1034,6 +1044,12 @@ export async function runSchedulerTick(
         );
       } else {
         let selectionMetrics = { campaignsChecked: 0, candidatesChecked: 0 };
+        // Reselecting the channel that just stalled would reset its counter and
+        // loop forever, so this tick passes over it when anything else can run
+        // the campaign (#400).
+        const stalled = currentWatch?.keep.reasonCode === "no_progress" && previous.channel
+          ? new Set([previous.channel.username.toLowerCase()])
+          : undefined;
         decision = await chooseCampaignDecision(
           platform,
           campaigns,
@@ -1043,6 +1059,7 @@ export async function runSchedulerTick(
           (metrics) => {
             selectionMetrics = metrics;
           },
+          stalled,
         );
         emitDiagnostic(
           emit,

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -1137,6 +1137,10 @@ export async function runSchedulerTick(
         const useTabless = chooseTablessWatch(previous, settings, adapter, sameChannel);
         session.offlineChecks = shouldKeep.keep ? shouldKeep.offlineChecks : 0;
         session.playbackChecks = useTabless ? 0 : shouldKeep.playbackChecks;
+        // Both reset when the watch moves, so a fresh channel never inherits the
+        // previous one's stall count or its minutes baseline.
+        session.noProgressChecks = shouldKeep.keep && sameChannel ? shouldKeep.noProgressChecks ?? 0 : 0;
+        session.lastWatchedMinutes = shouldKeep.keep && sameChannel ? shouldKeep.lastWatchedMinutes : undefined;
 
         if (useTabless) {
           // Tabless: no video tab. Close any tab we previously opened for this
@@ -1458,7 +1462,7 @@ async function shouldKeepWatching(
   settings: EngineSettings,
   adapter: Pick<PlatformAdapter, "checkChannel">,
   signal?: AbortSignal,
-): Promise<{ keep: boolean; offlineChecks: number; playbackChecks: number; reason: string; reasonCode: WatchReasonCode; channel?: ChannelCandidate }> {
+): Promise<{ keep: boolean; offlineChecks: number; playbackChecks: number; noProgressChecks?: number; lastWatchedMinutes?: number; reason: string; reasonCode: WatchReasonCode; channel?: ChannelCandidate }> {
   if (!previous.channel || previous.status !== "watching") {
     return { keep: false, offlineChecks: 0, playbackChecks: 0, reason: "No existing watch session", reasonCode: "no_existing_session" };
   }
@@ -1550,14 +1554,59 @@ async function shouldKeepWatching(
     };
   }
 
+  // Checked after playback health so an unhealthy tab reports watch_unhealthy
+  // rather than being misread as a channel that does not pay out.
+  //
+  // Trusting Twitch's discovery sources means no availability check rejects a
+  // channel any more, so without this a healthy stream that never accrues a
+  // minute would be watched forever (#400). Ticks are at least a minute apart
+  // (pollIntervalMinutes has a floor of 1) and watched minutes have one-minute
+  // granularity, so consecutive equal readings are real stalls, not sampling
+  // artefacts.
+  const progress = watchProgress(campaigns, previous);
+  const noProgressChecks = progress.observable
+    ? progress.advanced ? 0 : (previous.noProgressChecks ?? 0) + 1
+    // Subscription-only rewards and adapters that cannot read progress must
+    // never rotate on this path, so the counter is carried forward untouched.
+    : previous.noProgressChecks ?? 0;
+  if (progress.observable && noProgressChecks >= settings.offlineRetryLimit) {
+    return {
+      keep: false,
+      offlineChecks,
+      playbackChecks,
+      noProgressChecks,
+      lastWatchedMinutes: progress.watchedMinutes,
+      reason: `Channel accrued no drop progress across ${noProgressChecks} checks`,
+      reasonCode: "no_progress",
+    };
+  }
+
   return {
     keep: true,
     offlineChecks,
     playbackChecks,
+    noProgressChecks,
+    lastWatchedMinutes: progress.watchedMinutes ?? previous.lastWatchedMinutes,
     channel: channelFromCheck(previous.channel, check),
     reason: "Keeping current watch tab",
     reasonCode: "keeping_current_watch",
   };
+}
+
+// Whether the session's active watch reward accrued since the last check.
+// `observable` is false when there is no active watch reward or the platform
+// could not read its minutes — the only safe reading is "no evidence", never
+// "no progress".
+function watchProgress(
+  campaigns: readonly DropCampaign[],
+  previous: WatchSession,
+): { observable: boolean; advanced: boolean; watchedMinutes?: number } {
+  const reward = activeRewardFor(campaigns, previous);
+  const watchedMinutes = reward?.isWatchBased === false ? undefined : reward?.watchedMinutes;
+  if (watchedMinutes === undefined) return { observable: false, advanced: false };
+  const previousMinutes = previous.lastWatchedMinutes;
+  if (previousMinutes === undefined) return { observable: false, advanced: false, watchedMinutes };
+  return { observable: true, advanced: watchedMinutes > previousMinutes, watchedMinutes };
 }
 
 // Playing — muted or not — is what indicates farming is working. The browser

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -264,33 +264,14 @@ function isCredentialRejection(message: string | undefined): boolean {
   return message != null && /unauthenticated|unauthorized|(?:the )?oauth token (?:(?:is|was) )?invalid|invalid oauth token|token (?:has )?expired/i.test(message);
 }
 
-// Twitch's persisted ViewerDropsDashboard returns more than the ids and status
-// discovery needs: name, game, and the campaign window come back too. Those are
-// modelled as optional because our inline fallback query (TWITCH_INLINE_QUERIES)
-// deliberately does not select them — widening that query would risk a
-// "Cannot query field" against a drifted live schema on the one path that
-// exists to survive drift. Where they are present they are enough to show a
-// campaign the detail fetch deliberately skips; where they are absent nothing
-// extra is shown.
-interface TwitchDashboardCampaign {
-  id?: string;
-  status?: string;
-  self?: { isAccountConnected?: boolean };
-  name?: string;
-  startAt?: string;
-  endAt?: string;
-  game?: { id?: string; displayName?: string; slug?: string; boxArtURL?: string };
-  allow?: { channels?: Array<{ name?: string; login?: string } | null> | null };
-}
-
 interface TwitchDashboardData {
   currentUser?: {
     id?: string;
     login?: string;
     inventory?: {
-      dropCampaigns?: TwitchDashboardCampaign[];
+      dropCampaigns?: Array<{ id?: string; status?: string; self?: { isAccountConnected?: boolean } }>;
     };
-    dropCampaigns?: TwitchDashboardCampaign[];
+    dropCampaigns?: Array<{ id?: string; status?: string; self?: { isAccountConnected?: boolean } }>;
   };
 }
 
@@ -924,21 +905,12 @@ export class TwitchAdapter implements PlatformAdapter {
         : [];
     const dashboardResponded = dashboardResult.ok && dashboardCampaigns.length > 0;
 
-    // Historical campaigns come from the dashboard we just read, so they are
-    // only offered when that read succeeded; a retained id list carries no
-    // detail to display.
-    const historical = dashboardResult.ok
-      ? (coveredIds: ReadonlySet<string>) =>
-        historicalDashboardCampaigns(dashboardCampaigns, coveredIds, Date.now())
-      : () => [];
-
     if (discoverableCampaignIds.length === 0) {
-      const reconciled = reconcileInventoryCampaignStatuses(
+      return reconcileInventoryCampaignStatuses(
         inventoryCampaigns,
         new Set(discoverableCampaignIds),
         dashboardResponded,
       );
-      return [...reconciled, ...historical(new Set(reconciled.map((campaign) => campaign.id)))];
     }
 
     const detailsStartedAt = Date.now();
@@ -996,7 +968,7 @@ export class TwitchAdapter implements PlatformAdapter {
       if (retained) detailedCampaigns.push(retained);
     });
     if (detailedCampaigns.length === 0) {
-      return [...inventoryCampaigns, ...historical(new Set(inventoryCampaigns.map((campaign) => campaign.id)))];
+      return inventoryCampaigns;
     }
     const parsedDetails = parseTwitchCampaigns(detailedCampaigns as Parameters<typeof parseTwitchCampaigns>[0]);
     const mergedDetails = mergeTwitchCampaignProgress(parsedDetails, inventory as Parameters<typeof mergeTwitchCampaignProgress>[1]);
@@ -1013,8 +985,7 @@ export class TwitchAdapter implements PlatformAdapter {
       activeDashboardIds,
       dashboardResponded,
     );
-    const farmable = [...mergedDetails, ...inventoryOnly];
-    return [...farmable, ...historical(new Set(farmable.map((campaign) => campaign.id)))];
+    return [...mergedDetails, ...inventoryOnly];
   }
 
   async refreshCampaigns(
@@ -2342,61 +2313,6 @@ function twitchDashboardCampaigns(dashboard: TwitchGqlResponse<TwitchDashboardDa
   return dashboard.data?.currentUser?.dropCampaigns
     ?? dashboard.data?.currentUser?.inventory?.dropCampaigns
     ?? [];
-}
-
-// Campaigns the dashboard lists but discovery deliberately does not fetch
-// details for — expired and closed ones. Visibility is a display concern, so
-// these enter the model and the Drops-list filters decide whether they show;
-// farmability is unaffected, since an expired campaign is never farmable.
-//
-// Synthesised from the dashboard entry alone, so this costs no extra requests
-// even when an account carries hundreds of historical campaigns. Entries whose
-// payload lacks a name are skipped: without one there is nothing meaningful to
-// display, which is also what makes this a no-op on the inline fallback query.
-function historicalDashboardCampaigns(
-  dashboardCampaigns: readonly TwitchDashboardCampaign[],
-  coveredIds: ReadonlySet<string>,
-  now: number,
-): DropCampaign[] {
-  const campaigns: DropCampaign[] = [];
-  for (const entry of dashboardCampaigns) {
-    const id = entry.id;
-    if (!id || coveredIds.has(id) || !entry.name) continue;
-    const endsAt = entry.endAt;
-    const startsAt = entry.startAt;
-    // Only synthesise a campaign this is positively sure is over. A campaign
-    // the dashboard still calls ACTIVE reaches this point when its detail fetch
-    // failed, and defaulting that to "expired" would retire a farmable campaign
-    // from both the list and scheduling over a transient error — worse than the
-    // one-refresh absence it replaces.
-    const ended = Boolean(endsAt && Date.parse(endsAt) < now);
-    const closed = ["EXPIRED", "ARCHIVED", "CLOSED", "DELETED"].includes(entry.status?.toUpperCase() ?? "");
-    if (!ended && !closed) continue;
-    const status: DropCampaign["status"] = "expired";
-    const allowedChannels = (entry.allow?.channels ?? [])
-      .map((channel) => channel?.login ?? channel?.name)
-      .filter((value): value is string => Boolean(value))
-      .map((value) => value.toLowerCase());
-    campaigns.push({
-      id,
-      platform: "twitch",
-      name: entry.name,
-      slug: entry.game?.slug,
-      gameName: entry.game?.displayName,
-      gameImageUrl: entry.game?.boxArtURL,
-      categoryId: entry.game?.id,
-      startsAt,
-      endsAt,
-      status,
-      // The detail fetch that would carry rewards is intentionally skipped.
-      rewards: [],
-      allowedChannels: allowedChannels.length > 0 ? allowedChannels : undefined,
-      accountLinked: entry.self?.isAccountConnected !== false,
-      eligibility: "expired",
-      eligibilityReason: "Campaign has ended",
-    });
-  }
-  return campaigns;
 }
 
 function twitchCurrentUserId(value: unknown): string | undefined {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -1585,6 +1585,12 @@ export class TwitchAdapter implements PlatformAdapter {
     let singleFallbacks = 0;
     for (const [index, candidate] of candidates.entries()) {
       const response = normalizeTwitchGqlResponse<TwitchAvailableDropsData>(responses[index]);
+      diagnostic(
+        this.emit,
+        "debug",
+        availableDropsEvidence(response, candidate, campaignId, `batch response index ${index} of ${candidates.length}`),
+        "twitch",
+      );
       const campaignIds = parseAvailableDropCampaigns(response, candidate.channelId);
       if (!campaignIds) {
         singleFallbacks += 1;
@@ -1785,6 +1791,12 @@ export class TwitchAdapter implements PlatformAdapter {
         undefined,
         this.emit,
         signal,
+      );
+      diagnostic(
+        this.emit,
+        "debug",
+        availableDropsEvidence(response, { channelId, channelLogin, broadcastId }, campaignId, "single response"),
+        "twitch",
       );
       const campaignIds = parseAvailableDropCampaigns(response, channelId);
       if (!campaignIds) {
@@ -2428,6 +2440,39 @@ function parseAvailableDropCampaigns(
       .map((campaign) => campaign?.id)
       .filter((id): id is string => typeof id === "string" && id.length > 0),
   );
+}
+
+// Credential-free evidence for comparing a batched AvailableDrops response with
+// its single-channel equivalent (#400 acceptance criterion 10). Everything here
+// is a public identifier or a GQL error string — never headers, cookies, the
+// integrity token, or session/device ids. Emitted only on the strict path,
+// which is the only caller of these queries, and at debug level so it stays
+// behind the diagnostic-logging setting.
+function availableDropsEvidence(
+  response: TwitchGqlResponse<TwitchAvailableDropsData> | null,
+  requested: { channelId: string; channelLogin: string; broadcastId: string },
+  campaignId: string,
+  source: string,
+): string {
+  const channel = response?.data?.channel;
+  const returnedIds = Array.isArray(channel?.viewerDropCampaigns)
+    ? channel.viewerDropCampaigns
+      .map((campaign) => campaign?.id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0)
+    : undefined;
+  const errors = [
+    response?.error,
+    response?.message,
+    ...(response?.errors ?? []).map((error) => error.message),
+  ].filter((message): message is string => Boolean(message));
+  return [
+    `Twitch AvailableDrops evidence (${source})`,
+    `requested channel ${requested.channelLogin} id=${requested.channelId} broadcast=${requested.broadcastId}`,
+    `matching campaign ${campaignId}`,
+    `returned channel.id=${channel?.id ?? "none"}`,
+    `returned viewerDropCampaigns=${returnedIds ? (returnedIds.length > 0 ? returnedIds.join(",") : "empty") : "absent"}`,
+    `errors=${errors.length > 0 ? errors.join("; ") : "none"}`,
+  ].join("; ");
 }
 
 function isTransientGqlError(message: string | undefined): boolean {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -1574,11 +1574,28 @@ export class TwitchAdapter implements PlatformAdapter {
     } catch (error) {
       signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
-      for (const candidate of candidates) await fallback(candidate);
+      const message = error instanceof Error ? error.message : String(error);
+      for (const [index, candidate] of candidates.entries()) {
+        diagnostic(
+          this.emit,
+          "debug",
+          availableDropsEvidence(null, candidate, campaignId, `batch request index ${index} of ${candidates.length}`, `batch request failed: ${message}`),
+          "twitch",
+        );
+        await fallback(candidate);
+      }
       return { matches, singleFallbacks: candidates.length };
     }
     if (twitchPageFetchError(raw)) {
-      for (const candidate of candidates) await fallback(candidate);
+      for (const [index, candidate] of candidates.entries()) {
+        diagnostic(
+          this.emit,
+          "debug",
+          availableDropsEvidence(null, candidate, campaignId, `batch request index ${index} of ${candidates.length}`, "batch request rejected by the page fetch transport"),
+          "twitch",
+        );
+        await fallback(candidate);
+      }
       return { matches, singleFallbacks: candidates.length };
     }
     const responses = Array.isArray(raw) ? raw : candidates.length === 1 ? [raw] : [];
@@ -1815,6 +1832,12 @@ export class TwitchAdapter implements PlatformAdapter {
       signal?.throwIfAborted();
       if (authHealthFromError(error)) throw error;
       const message = error instanceof Error ? error.message : String(error);
+      diagnostic(
+        this.emit,
+        "debug",
+        availableDropsEvidence(null, { channelId, channelLogin, broadcastId }, campaignId, "single response", `single request failed: ${message}`),
+        "twitch",
+      );
       diagnostic(this.emit, "debug", `Could not confirm available Twitch campaigns for ${channelLogin}; using live/category validation: ${message}`, "twitch");
       return undefined;
     }
@@ -2453,6 +2476,11 @@ function availableDropsEvidence(
   requested: { channelId: string; channelLogin: string; broadcastId: string },
   campaignId: string,
   source: string,
+  // Set when the request never produced a response at all (transport throw or a
+  // page-fetch rejection). Without it those candidates would leave no comparable
+  // record, which is the gap that makes a batch failure indistinguishable from a
+  // campaign Twitch genuinely does not list.
+  failure?: string,
 ): string {
   const channel = response?.data?.channel;
   const returnedIds = Array.isArray(channel?.viewerDropCampaigns)
@@ -2461,6 +2489,7 @@ function availableDropsEvidence(
       .filter((id): id is string => typeof id === "string" && id.length > 0)
     : undefined;
   const errors = [
+    failure,
     response?.error,
     response?.message,
     ...(response?.errors ?? []).map((error) => error.message),

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -67,6 +67,14 @@ export interface TwitchAdapterOptions {
   heartbeatFetchText?: TwitchHeartbeatFetchText;
   heartbeatPost?: TwitchHeartbeatPost;
   discoveryState?: TwitchDiscoveryState;
+  // Opt-in exact validation of a campaign against DropsHighlightService_
+  // AvailableDrops before a channel may be watched. Off by default: Twitch's
+  // own GameDirectory DROPS_ENABLED filter and the campaign ACL are the
+  // authoritative discovery sources, and AvailableDrops routinely omits a
+  // campaign that is in fact farmable on the channel — which rejected every
+  // candidate and left drops unfarmed (#400). When off, live/category
+  // validation alone decides, matching TwitchDropsMiner's default.
+  strictCampaignAvailability?: boolean;
   // Supplies the integrity bundle each request should carry. The transport
   // attaches it itself rather than letting the fetcher pick one up from a global,
   // so the token a rejection reports is provably the token that was sent: the
@@ -1291,7 +1299,9 @@ export class TwitchAdapter implements PlatformAdapter {
       const target = streamCandidates[index];
       if (target) checks[target.index] = check;
     });
-    const availabilityResult = campaign
+    // Without strict validation the matches map stays empty, so every candidate
+    // reads `undefined` below and passes on live/category evidence alone.
+    const availabilityResult = campaign && this.options.strictCampaignAvailability
       ? await this.batchCampaignAvailability(
           checks.flatMap((check) =>
             check?.live && check.categoryMatches && check.candidate.channelId && check.candidate.broadcastId
@@ -1317,11 +1327,12 @@ export class TwitchAdapter implements PlatformAdapter {
 
     let checked = 0;
     let winnerFallbacks = 0;
+    let strictRejections = 0;
     const reportSelectionFinished = () => {
       diagnostic(
         this.emit,
         "debug",
-        `Twitch ${selectionDescription} finished in ${Date.now() - startedAt}ms (${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${availabilityResult.cacheMisses} availability cache misses, ${availabilityResult.cacheExpirations} availability cache expirations, ${availabilityResult.broadcastInvalidations} availability broadcast invalidations, ${availabilityResult.progressOverrides} progress-confirmed availability overrides, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks)`,
+        `Twitch ${selectionDescription} finished in ${Date.now() - startedAt}ms (${this.options.strictCampaignAvailability ? "strict campaign availability" : "trusted discovery sources"}, ${streamCandidates.length} candidates batch-checked, ${checked} candidates evaluated, ${Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT)} StreamInfo batch requests, ${streamCheckResult.singleFallbacks} StreamInfo single fallbacks, ${availabilityResult.batchRequests} AvailableDrops batch requests, ${availabilityResult.singleFallbacks} AvailableDrops single fallbacks, ${availabilityResult.cacheHits} availability cache hits, ${availabilityResult.cacheMisses} availability cache misses, ${availabilityResult.cacheExpirations} availability cache expirations, ${availabilityResult.broadcastInvalidations} availability broadcast invalidations, ${availabilityResult.progressOverrides} progress-confirmed availability overrides, ${trustedDirectoryCandidates} directory candidates trusted, ${winnerFallbacks} winner fallbacks, ${strictRejections} candidates rejected by strict availability)`,
         "twitch",
       );
     };
@@ -1340,7 +1351,10 @@ export class TwitchAdapter implements PlatformAdapter {
       } else if (campaign && check.candidate.channelId) {
         campaignMatches = availabilityResult.matches.get(check.candidate.channelId);
       }
-      if (campaignMatches === false) continue;
+      if (campaignMatches === false) {
+        strictRejections += 1;
+        continue;
+      }
       reportSelectionFinished();
       return {
         checked: candidates.length,
@@ -1681,7 +1695,11 @@ export class TwitchAdapter implements PlatformAdapter {
       const expectedCategoryId = campaign?.categoryId ?? channel.categoryId;
       const categoryMatches = !expectedCategoryId || actualCategoryId === expectedCategoryId;
       const broadcastId = stream?.id;
+      // Gated on strict validation for the same reason as selectCandidateChannel:
+      // this path also re-verifies the channel already being watched, so an
+      // un-gated negative would stop farming mid-session (#400).
       const campaignMatches = stream && categoryMatches && campaign && channelId && broadcastId
+        && this.options.strictCampaignAvailability
         ? await this.checkCampaignAvailability(channelId, broadcastId, campaign.id, channel.username, signal)
         : undefined;
       return {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -2329,15 +2329,15 @@ function historicalDashboardCampaigns(
     if (!id || coveredIds.has(id) || !entry.name) continue;
     const endsAt = entry.endAt;
     const startsAt = entry.startAt;
-    // Trust the dates over the status string when both are present: a campaign
-    // can still read ACTIVE moments after its end date passes.
-    const status: DropCampaign["status"] = endsAt && Date.parse(endsAt) < now
-      ? "expired"
-      : startsAt && Date.parse(startsAt) > now
-        ? "upcoming"
-        : entry.status?.toUpperCase() === "UPCOMING"
-          ? "upcoming"
-          : "expired";
+    // Only synthesise a campaign this is positively sure is over. A campaign
+    // the dashboard still calls ACTIVE reaches this point when its detail fetch
+    // failed, and defaulting that to "expired" would retire a farmable campaign
+    // from both the list and scheduling over a transient error — worse than the
+    // one-refresh absence it replaces.
+    const ended = Boolean(endsAt && Date.parse(endsAt) < now);
+    const closed = ["EXPIRED", "ARCHIVED", "CLOSED", "DELETED"].includes(entry.status?.toUpperCase() ?? "");
+    if (!ended && !closed) continue;
+    const status: DropCampaign["status"] = "expired";
     const allowedChannels = (entry.allow?.channels ?? [])
       .map((channel) => channel?.login ?? channel?.name)
       .filter((value): value is string => Boolean(value))
@@ -2357,10 +2357,8 @@ function historicalDashboardCampaigns(
       rewards: [],
       allowedChannels: allowedChannels.length > 0 ? allowedChannels : undefined,
       accountLinked: entry.self?.isAccountConnected !== false,
-      eligibility: status === "upcoming" ? "upcoming" : "expired",
-      eligibilityReason: status === "upcoming"
-        ? "Campaign has not started yet"
-        : "Campaign has ended",
+      eligibility: "expired",
+      eligibilityReason: "Campaign has ended",
     });
   }
   return campaigns;

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -264,14 +264,33 @@ function isCredentialRejection(message: string | undefined): boolean {
   return message != null && /unauthenticated|unauthorized|(?:the )?oauth token (?:(?:is|was) )?invalid|invalid oauth token|token (?:has )?expired/i.test(message);
 }
 
+// Twitch's persisted ViewerDropsDashboard returns more than the ids and status
+// discovery needs: name, game, and the campaign window come back too. Those are
+// modelled as optional because our inline fallback query (TWITCH_INLINE_QUERIES)
+// deliberately does not select them — widening that query would risk a
+// "Cannot query field" against a drifted live schema on the one path that
+// exists to survive drift. Where they are present they are enough to show a
+// campaign the detail fetch deliberately skips; where they are absent nothing
+// extra is shown.
+interface TwitchDashboardCampaign {
+  id?: string;
+  status?: string;
+  self?: { isAccountConnected?: boolean };
+  name?: string;
+  startAt?: string;
+  endAt?: string;
+  game?: { id?: string; displayName?: string; slug?: string; boxArtURL?: string };
+  allow?: { channels?: Array<{ name?: string; login?: string } | null> | null };
+}
+
 interface TwitchDashboardData {
   currentUser?: {
     id?: string;
     login?: string;
     inventory?: {
-      dropCampaigns?: Array<{ id?: string; status?: string; self?: { isAccountConnected?: boolean } }>;
+      dropCampaigns?: TwitchDashboardCampaign[];
     };
-    dropCampaigns?: Array<{ id?: string; status?: string; self?: { isAccountConnected?: boolean } }>;
+    dropCampaigns?: TwitchDashboardCampaign[];
   };
 }
 
@@ -905,12 +924,21 @@ export class TwitchAdapter implements PlatformAdapter {
         : [];
     const dashboardResponded = dashboardResult.ok && dashboardCampaigns.length > 0;
 
+    // Historical campaigns come from the dashboard we just read, so they are
+    // only offered when that read succeeded; a retained id list carries no
+    // detail to display.
+    const historical = dashboardResult.ok
+      ? (coveredIds: ReadonlySet<string>) =>
+        historicalDashboardCampaigns(dashboardCampaigns, coveredIds, Date.now())
+      : () => [];
+
     if (discoverableCampaignIds.length === 0) {
-      return reconcileInventoryCampaignStatuses(
+      const reconciled = reconcileInventoryCampaignStatuses(
         inventoryCampaigns,
         new Set(discoverableCampaignIds),
         dashboardResponded,
       );
+      return [...reconciled, ...historical(new Set(reconciled.map((campaign) => campaign.id)))];
     }
 
     const detailsStartedAt = Date.now();
@@ -968,7 +996,7 @@ export class TwitchAdapter implements PlatformAdapter {
       if (retained) detailedCampaigns.push(retained);
     });
     if (detailedCampaigns.length === 0) {
-      return inventoryCampaigns;
+      return [...inventoryCampaigns, ...historical(new Set(inventoryCampaigns.map((campaign) => campaign.id)))];
     }
     const parsedDetails = parseTwitchCampaigns(detailedCampaigns as Parameters<typeof parseTwitchCampaigns>[0]);
     const mergedDetails = mergeTwitchCampaignProgress(parsedDetails, inventory as Parameters<typeof mergeTwitchCampaignProgress>[1]);
@@ -985,7 +1013,8 @@ export class TwitchAdapter implements PlatformAdapter {
       activeDashboardIds,
       dashboardResponded,
     );
-    return [...mergedDetails, ...inventoryOnly];
+    const farmable = [...mergedDetails, ...inventoryOnly];
+    return [...farmable, ...historical(new Set(farmable.map((campaign) => campaign.id)))];
   }
 
   async refreshCampaigns(
@@ -2278,6 +2307,63 @@ function twitchDashboardCampaigns(dashboard: TwitchGqlResponse<TwitchDashboardDa
   return dashboard.data?.currentUser?.dropCampaigns
     ?? dashboard.data?.currentUser?.inventory?.dropCampaigns
     ?? [];
+}
+
+// Campaigns the dashboard lists but discovery deliberately does not fetch
+// details for — expired and closed ones. Visibility is a display concern, so
+// these enter the model and the Drops-list filters decide whether they show;
+// farmability is unaffected, since an expired campaign is never farmable.
+//
+// Synthesised from the dashboard entry alone, so this costs no extra requests
+// even when an account carries hundreds of historical campaigns. Entries whose
+// payload lacks a name are skipped: without one there is nothing meaningful to
+// display, which is also what makes this a no-op on the inline fallback query.
+function historicalDashboardCampaigns(
+  dashboardCampaigns: readonly TwitchDashboardCampaign[],
+  coveredIds: ReadonlySet<string>,
+  now: number,
+): DropCampaign[] {
+  const campaigns: DropCampaign[] = [];
+  for (const entry of dashboardCampaigns) {
+    const id = entry.id;
+    if (!id || coveredIds.has(id) || !entry.name) continue;
+    const endsAt = entry.endAt;
+    const startsAt = entry.startAt;
+    // Trust the dates over the status string when both are present: a campaign
+    // can still read ACTIVE moments after its end date passes.
+    const status: DropCampaign["status"] = endsAt && Date.parse(endsAt) < now
+      ? "expired"
+      : startsAt && Date.parse(startsAt) > now
+        ? "upcoming"
+        : entry.status?.toUpperCase() === "UPCOMING"
+          ? "upcoming"
+          : "expired";
+    const allowedChannels = (entry.allow?.channels ?? [])
+      .map((channel) => channel?.login ?? channel?.name)
+      .filter((value): value is string => Boolean(value))
+      .map((value) => value.toLowerCase());
+    campaigns.push({
+      id,
+      platform: "twitch",
+      name: entry.name,
+      slug: entry.game?.slug,
+      gameName: entry.game?.displayName,
+      gameImageUrl: entry.game?.boxArtURL,
+      categoryId: entry.game?.id,
+      startsAt,
+      endsAt,
+      status,
+      // The detail fetch that would carry rewards is intentionally skipped.
+      rewards: [],
+      allowedChannels: allowedChannels.length > 0 ? allowedChannels : undefined,
+      accountLinked: entry.self?.isAccountConnected !== false,
+      eligibility: status === "upcoming" ? "upcoming" : "expired",
+      eligibilityReason: status === "upcoming"
+        ? "Campaign has not started yet"
+        : "Campaign has ended",
+    });
+  }
+  return campaigns;
 }
 
 function twitchCurrentUserId(value: unknown): string | undefined {

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -104,6 +104,7 @@ function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings
       {
         compatibility: resolution.compatibility.twitch,
         discoveryState: twitchDiscoveryState,
+        strictCampaignAvailability: settings.platform.twitch.strictCampaignAvailability,
         currentIntegrity: currentValidTwitchIntegrity,
         heartbeatIdentity: "web",
         heartbeatFetchText: twitchHeartbeatFetchText,

--- a/packages/extension/tests/backgroundEntrypoint.test.ts
+++ b/packages/extension/tests/backgroundEntrypoint.test.ts
@@ -3,7 +3,7 @@ import * as controllerModule from "@lurkloot/core/controller";
 import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
 import type { PlatformAdapter } from "@lurkloot/core/adapter";
 import type { EventEmitter } from "@lurkloot/shared/events";
-import type { ExtensionSettings, Platform } from "@lurkloot/shared/models";
+import type { DropCampaign, ExtensionSettings, Platform } from "@lurkloot/shared/models";
 import type { WebSocketLike, WebSocketMessageEventLike } from "@lurkloot/core/webSocket";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -118,6 +118,59 @@ describe("background integrity alarm wiring", () => {
     expect(controller.tickAndHandOff).toHaveBeenNthCalledWith(2, ["kick"], "alarm");
     expect(controller.tickAndHandOff).toHaveBeenCalledTimes(2);
     expect(controller.runWatchHeartbeat).not.toHaveBeenCalled();
+  });
+
+  // The Twitch adapter reads strict campaign availability from settings, so a
+  // construction site that stops forwarding it silently reverts every install
+  // to rejecting candidates on AvailableDrops (#400). Asserted through
+  // behaviour rather than the private option: what matters is whether the
+  // request goes out.
+  it.each([
+    { strictCampaignAvailability: false, expected: [] as string[] },
+    { strictCampaignAvailability: true, expected: ["DropsHighlightService_AvailableDrops"] },
+  ])("forwards strictCampaignAvailability=$strictCampaignAvailability to the Twitch adapter", async ({ strictCampaignAvailability, expected }) => {
+    let deps: BackgroundAdapterDependencies | undefined;
+    createBackgroundController.mockImplementation((nextDeps) => {
+      deps = nextDeps;
+      return {};
+    });
+    const operations: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+      const operation = JSON.parse(String(init?.body)).operationName as string;
+      operations.push(operation);
+      return new Response(
+        JSON.stringify({ data: { channel: { id: "channel-id", viewerDropCampaigns: [{ id: "campaign" }] } } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }));
+    vi.stubGlobal("defineBackground", vi.fn());
+
+    await import("../entrypoints/background");
+
+    const settings: ExtensionSettings = {
+      ...DEFAULT_SETTINGS,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, strictCampaignAvailability },
+      },
+    };
+    const adapter = deps?.createAdapter?.("twitch", () => undefined, settings).adapter;
+    const selection = await adapter?.selectCandidateChannel?.(
+      [{
+        platform: "twitch",
+        username: "directory-one",
+        url: "https://www.twitch.tv/directory-one",
+        channelId: "channel-id",
+        broadcastId: "broadcast-id",
+        categoryId: "game",
+        live: true,
+        isAclMatch: false,
+      }],
+      { id: "campaign", name: "Campaign", categoryId: "game" } as DropCampaign,
+    );
+
+    expect(selection?.channel?.username).toBe("directory-one");
+    expect(operations).toEqual(expected);
   });
 
   it("injects the extension WebSocket into the Kick discovery observer", async () => {

--- a/packages/extension/tests/helpers/adapters.ts
+++ b/packages/extension/tests/helpers/adapters.ts
@@ -26,7 +26,10 @@ export function twitchAdapter(
     fetcher,
     ensureIntegrity ?? (async () => false),
     watchTabPort ?? unavailableWatchTabPort,
-    { compatibility: TWITCH_COMPAT, ...options },
+    // Strict availability is off in production (#400) but on here: these
+    // fixtures were written against exact AvailableDrops validation and still
+    // cover it. Tests for the default path pass `false` explicitly.
+    { compatibility: TWITCH_COMPAT, strictCampaignAvailability: true, ...options },
     emit ?? ignoreEvent,
   );
 }

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -2269,6 +2269,107 @@ describe("scheduler tick", () => {
     });
   });
 
+  // #400: trusting Twitch's discovery sources removed the only check that ever
+  // rejected a live, category-matching channel, so a healthy stream that never
+  // pays out would otherwise be watched forever.
+  describe("stalled progress rotation", () => {
+    const watching = (patch: Partial<SchedulerState["sessions"]["twitch"]> = {}) => ({
+      platform: "twitch" as const,
+      status: "watching" as const,
+      channel: channel("old"),
+      campaignId: "drops",
+      rewardId: "reward-in_progress",
+      offlineChecks: 0,
+      tabId: 7,
+      ...patch,
+    });
+
+    const tick = async (session: Partial<SchedulerState["sessions"]["twitch"]>, campaigns: DropCampaign[]) => {
+      const twitch = adapter("twitch", campaigns, [channel("old"), channel("fresh")]);
+      vi.mocked(twitch.checkChannel).mockImplementation(async (candidate) => ({
+        live: true,
+        categoryMatches: true,
+        candidate,
+      }));
+      return runSchedulerTick(
+        {
+          authHealth: HEALTHY_AUTH,
+          sessions: {
+            twitch: watching(session),
+            kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+          },
+          campaigns: { twitch: [], kick: [] },
+        },
+        settings({
+          offlineRetryLimit: 3,
+          platform: { twitch: { enabled: true, idleWatchlistChannels: [] }, kick: { enabled: false, idleWatchlistChannels: [] } },
+        }),
+        { twitch, kick: adapter("kick", [], []) },
+      );
+    };
+
+    it("rotates away once a healthy channel stalls for the retry limit", async () => {
+      const result = await tick(
+        { noProgressChecks: 2, lastWatchedMinutes: 20 },
+        [campaign("drops")],
+      );
+
+      expect(result.state.sessions.twitch.reasonCode).toBe("no_progress");
+    });
+
+    it("keeps a stalling channel until the limit is reached", async () => {
+      const result = await tick(
+        { noProgressChecks: 1, lastWatchedMinutes: 20 },
+        [campaign("drops")],
+      );
+
+      expect(result.state.sessions.twitch.reasonCode).not.toBe("no_progress");
+      expect(result.state.sessions.twitch.noProgressChecks).toBe(2);
+    });
+
+    it("resets the counter when the channel accrues a minute", async () => {
+      const result = await tick(
+        { noProgressChecks: 2, lastWatchedMinutes: 19 },
+        [campaign("drops")],
+      );
+
+      expect(result.state.sessions.twitch.reasonCode).not.toBe("no_progress");
+      expect(result.state.sessions.twitch.noProgressChecks).toBe(0);
+      expect(result.state.sessions.twitch.lastWatchedMinutes).toBe(20);
+    });
+
+    // Without a prior reading there is nothing to compare, so the first check on
+    // a new channel seeds the baseline instead of counting as a stall.
+    it("seeds the baseline without counting a stall", async () => {
+      const result = await tick({}, [campaign("drops")]);
+
+      expect(result.state.sessions.twitch.noProgressChecks).toBe(0);
+      expect(result.state.sessions.twitch.lastWatchedMinutes).toBe(20);
+    });
+
+    // A reward whose progress the platform cannot report must never rotate:
+    // "no evidence" is not "no progress".
+    it("never rotates a reward whose progress is unreadable", async () => {
+      const subscriptionCampaign = campaign("drops", {
+        rewards: [{
+          id: "reward-in_progress",
+          name: "Reward",
+          requiredMinutes: 60,
+          watchedMinutes: 20,
+          status: "in_progress",
+          isWatchBased: false,
+        }],
+      });
+
+      const result = await tick(
+        { noProgressChecks: 2, lastWatchedMinutes: 20 },
+        [subscriptionCampaign],
+      );
+
+      expect(result.state.sessions.twitch.reasonCode).not.toBe("no_progress");
+    });
+  });
+
   it("reloads the watch tab after repeated playback failures", async () => {
     const old = channel("old");
     const twitch = adapter("twitch", [campaign("drops")], [old]);

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -2315,6 +2315,40 @@ describe("scheduler tick", () => {
       );
 
       expect(result.state.sessions.twitch.reasonCode).toBe("no_progress");
+      // Stopping the old session is not rotation: the tick has to land on a
+      // different channel, or the stalled one is simply reselected and its
+      // counter reset, looping forever.
+      expect(result.state.sessions.twitch.channel?.username).toBe("fresh");
+    });
+
+    // Rotating to nothing would be worse than a slow channel, so the skip is
+    // advisory: the stalled channel stays when it is the only one that can run
+    // the campaign.
+    it("keeps the stalled channel when it is the only candidate", async () => {
+      const twitch = adapter("twitch", [campaign("drops")], [channel("old")]);
+      vi.mocked(twitch.checkChannel).mockImplementation(async (candidate) => ({
+        live: true,
+        categoryMatches: true,
+        candidate,
+      }));
+
+      const result = await runSchedulerTick(
+        {
+          authHealth: HEALTHY_AUTH,
+          sessions: {
+            twitch: watching({ noProgressChecks: 2, lastWatchedMinutes: 20 }),
+            kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+          },
+          campaigns: { twitch: [], kick: [] },
+        },
+        settings({
+          offlineRetryLimit: 3,
+          platform: { twitch: { enabled: true, idleWatchlistChannels: [] }, kick: { enabled: false, idleWatchlistChannels: [] } },
+        }),
+        { twitch, kick: adapter("kick", [], []) },
+      );
+
+      expect(result.state.sessions.twitch.channel?.username).toBe("old");
     });
 
     it("keeps a stalling channel until the limit is reached", async () => {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -2321,6 +2321,38 @@ describe("scheduler tick", () => {
       expect(result.state.sessions.twitch.channel?.username).toBe("fresh");
     });
 
+    // Skipping is a demotion, not an exclusion. If every other candidate fails
+    // validation the stalled channel has to be reachable, or rotating costs the
+    // campaign the whole tick.
+    it("falls back to the stalled channel when the alternative is invalid", async () => {
+      const twitch = adapter("twitch", [campaign("drops")], [channel("old"), channel("broken")]);
+      vi.mocked(twitch.checkChannel).mockImplementation(async (candidate) => ({
+        live: candidate.username !== "broken",
+        categoryMatches: true,
+        candidate,
+      }));
+      // No selectCandidateChannel, so firstValidCandidate validates one by one.
+      twitch.selectCandidateChannel = undefined;
+
+      const result = await runSchedulerTick(
+        {
+          authHealth: HEALTHY_AUTH,
+          sessions: {
+            twitch: watching({ noProgressChecks: 2, lastWatchedMinutes: 20 }),
+            kick: { platform: "kick", status: "idle", offlineChecks: 0 },
+          },
+          campaigns: { twitch: [], kick: [] },
+        },
+        settings({
+          offlineRetryLimit: 3,
+          platform: { twitch: { enabled: true, idleWatchlistChannels: [] }, kick: { enabled: false, idleWatchlistChannels: [] } },
+        }),
+        { twitch, kick: adapter("kick", [], []) },
+      );
+
+      expect(result.state.sessions.twitch.channel?.username).toBe("old");
+    });
+
     // Rotating to nothing would be worse than a slow channel, so the skip is
     // advisory: the stalled channel stays when it is the only one that can run
     // the campaign.

--- a/packages/extension/tests/settingsRegistry.test.ts
+++ b/packages/extension/tests/settingsRegistry.test.ts
@@ -56,7 +56,6 @@ describe("settings registry", () => {
     "kick.categories",
     "twitch.channels",
     "kick.channels",
-    "twitch.compatibility",
     "kick.compatibility",
   ];
 
@@ -85,9 +84,11 @@ describe("settings registry", () => {
 
   it("marks exactly one advanced group per section", () => {
     const advanced = registry().flatMap((section) => section.groups.filter((group) => group.advanced).map((group) => group.id));
+    // Twitch's advanced group also holds a farming toggle, so it is named for
+    // that rather than "Compatibility"; Kick has only compatibility rows.
     expect(advanced).toEqual([
       "general.advanced",
-      "twitch.compatibility",
+      "twitch.advanced",
       "kick.compatibility",
     ]);
   });
@@ -103,6 +104,12 @@ describe("settings registry", () => {
     const groups = withoutCompatibility.flatMap((section) => section.groups.map((group) => group.id));
     expect(groups).not.toContain("twitch.compatibility");
     expect(groups).not.toContain("kick.compatibility");
+    // Twitch's advanced group survives without a registry because it also holds
+    // the strict-availability toggle, but the compatibility rows are gone.
+    const entries = allEntryIds(withoutCompatibility);
+    expect(entries).not.toContain("twitch.compatibility.rows");
+    expect(entries).not.toContain("kick.compatibility.rows");
+    expect(entries).toContain("twitch.advanced.strictCampaignAvailability");
   });
 
   // A flat list of every entry id, in tree order. This is the real risk for a
@@ -142,6 +149,7 @@ describe("settings registry", () => {
         "twitch.autoClaimChannelPoints",
         "twitch.categories.farmAll",
         "twitch.channels.excluded",
+        "twitch.advanced.strictCampaignAvailability",
         "twitch.compatibility.rows",
         "kick.autoClaimChallenges",
         "kick.categories.farmAll",

--- a/packages/extension/tests/twitchCampaignTrust.test.ts
+++ b/packages/extension/tests/twitchCampaignTrust.test.ts
@@ -302,6 +302,31 @@ describe("strict availability comparison evidence", () => {
       .toContain("returned viewerDropCampaigns=some-other-campaign");
   });
 
+  // A thrown request produces no response at all, so without an explicit
+  // failure record these candidates would be indistinguishable from a campaign
+  // Twitch genuinely does not list.
+  it("records a thrown batch request against every candidate in it", async () => {
+    const messages = await evidence((operationName, entry) => {
+      if (operationName === "DropsHighlightService_AvailableDrops") {
+        throw new Error("network unreachable");
+      }
+      return respondWithOmittedCampaign(operationName, entry);
+    });
+
+    expect(messages.length).toBeGreaterThanOrEqual(2);
+    for (const username of ["directory-one", "directory-two"]) {
+      const message = messages.find((entry) => entry.includes(`requested channel ${username}`));
+      expect(message).toContain(`id=${username}-id`);
+      expect(message).toContain(`broadcast=${username}-broadcast`);
+      expect(message).toContain("matching campaign campaign");
+      expect(message).toContain("network unreachable");
+      // No response came back, so the campaign list must read as absent rather
+      // than as an authoritative empty one.
+      expect(message).toContain("returned viewerDropCampaigns=absent");
+      expect(message).toContain("returned channel.id=none");
+    }
+  });
+
   it("carries no credential material", async () => {
     const messages = await evidence(respondWithOmittedCampaign);
 

--- a/packages/extension/tests/twitchCampaignTrust.test.ts
+++ b/packages/extension/tests/twitchCampaignTrust.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PageFetcher } from "@lurkloot/core/adapter";
 import type { DropCampaign, EngineSettings } from "@lurkloot/shared/models";
+import type { EngineEvent } from "@lurkloot/shared/events";
 import { applySettingsPatch, DEFAULT_ENGINE_SETTINGS, DEFAULT_SETTINGS, mergeEngineSettings } from "@lurkloot/shared/settings";
 import { twitchAdapter } from "./helpers/adapters";
 
@@ -239,6 +240,77 @@ describe("twitch campaign availability trust (#400)", () => {
 
     expect(selection?.channel?.username).toBe("directory-one");
     expect(operations).not.toContain("DropsHighlightService_AvailableDrops");
+  });
+});
+
+// #400 acceptance criterion 10: the diagnostics alone must let a batched
+// response be compared with its single-channel equivalent, without ever
+// carrying a credential.
+describe("strict availability comparison evidence", () => {
+  // Two candidates so the adapter actually batches: the batch index is only
+  // meaningful, and only exercised, when more than one response comes back in
+  // one request.
+  const evidence = async (respond: (operationName: string, entry: Record<string, unknown>) => unknown) => {
+    const events: EngineEvent[] = [];
+    await twitchAdapter(
+      recordingFetcher([], respond),
+      undefined,
+      undefined,
+      { strictCampaignAvailability: true },
+      (event) => events.push(event),
+    ).selectCandidateChannel?.(
+      [directoryCandidate("directory-one"), directoryCandidate("directory-two")],
+      CAMPAIGN,
+    );
+    return events
+      .map((event) => (event.category === "diagnostic" ? event.message : ""))
+      .filter((message) => message.includes("AvailableDrops evidence"));
+  };
+
+  it("records the identifiers needed to compare a batch response", async () => {
+    const [message] = await evidence(respondWithOmittedCampaign);
+
+    expect(message).toContain("batch response index 0");
+    expect(message).toContain("requested channel directory-one");
+    expect(message).toContain("id=directory-one-id");
+    expect(message).toContain("broadcast=directory-one-broadcast");
+    expect(message).toContain("matching campaign campaign");
+    expect(message).toContain("returned channel.id=directory-one-id");
+    // The omission that stalled farming has to be visible as an omission.
+    expect(message).toContain("returned viewerDropCampaigns=some-other-campaign");
+    expect(message).toContain("errors=none");
+  });
+
+  // A per-entry failure inside an otherwise good batch is the case that is
+  // impossible to diagnose without the evidence line: the response is present
+  // but carries no campaign list.
+  it("records a GQL error instead of reporting an empty campaign list", async () => {
+    const messages = await evidence((operationName, entry) => {
+      if (operationName === "DropsHighlightService_AvailableDrops") {
+        const channelID = String((entry.variables as { channelID?: string }).channelID);
+        if (channelID === "directory-two-id") return { errors: [{ message: "service error" }] };
+        return { data: { channel: { id: channelID, viewerDropCampaigns: [{ id: "some-other-campaign" }] } } };
+      }
+      return respondWithOmittedCampaign(operationName, entry);
+    });
+
+    const failed = messages.find((message) => message.includes("directory-two"));
+    expect(failed).toContain("returned viewerDropCampaigns=absent");
+    expect(failed).toContain("errors=service error");
+    // The healthy sibling in the same batch still reports its own list.
+    expect(messages.find((message) => message.includes("directory-one")))
+      .toContain("returned viewerDropCampaigns=some-other-campaign");
+  });
+
+  it("carries no credential material", async () => {
+    const messages = await evidence(respondWithOmittedCampaign);
+
+    expect(messages.length).toBeGreaterThan(0);
+    for (const message of messages) {
+      for (const secret of ["authorization", "oauth", "cookie", "client-integrity", "x-device-id", "client-session-id"]) {
+        expect(message.toLowerCase()).not.toContain(secret);
+      }
+    }
   });
 });
 

--- a/packages/extension/tests/twitchCampaignTrust.test.ts
+++ b/packages/extension/tests/twitchCampaignTrust.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PageFetcher } from "@lurkloot/core/adapter";
+import type { DropCampaign, EngineSettings } from "@lurkloot/shared/models";
+import { applySettingsPatch, DEFAULT_ENGINE_SETTINGS, DEFAULT_SETTINGS, mergeEngineSettings } from "@lurkloot/shared/settings";
+import { twitchAdapter } from "./helpers/adapters";
+
+// Regression coverage for #400: Twitch's own discovery sources (the
+// GameDirectory DROPS_ENABLED filter and a campaign's channel ACL) are trusted
+// by default, because DropsHighlightService_AvailableDrops routinely omits a
+// campaign that is in fact farmable and rejected every candidate.
+
+function jsonFetcher(handler: (url: string, init?: RequestInit) => unknown): PageFetcher {
+  const fetchJson = vi.fn(async (url: string, init?: RequestInit): Promise<unknown> => handler(url, init));
+  return { fetchJson: fetchJson as PageFetcher["fetchJson"] };
+}
+
+// Records every GQL operation the adapter sends, batched or single.
+function recordingFetcher(operations: string[], respond: (operationName: string, entry: Record<string, unknown>) => unknown): PageFetcher {
+  return jsonFetcher((_url, init) => {
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+    const entries = Array.isArray(body) ? body : [body];
+    for (const entry of entries) operations.push(String(entry.operationName));
+    const responses = entries.map((entry) => respond(String(entry.operationName), entry));
+    return Array.isArray(body) ? responses : responses[0];
+  });
+}
+
+const CAMPAIGN = { id: "campaign", name: "Campaign", categoryId: "game" } as DropCampaign;
+
+// A live stream in the campaign's category, with an AvailableDrops response
+// that omits the campaign entirely — the exact shape that stalled farming.
+function respondWithOmittedCampaign(operationName: string, entry: Record<string, unknown>): unknown {
+  if (operationName === "StreamInfo") {
+    const channel = String((entry.variables as { channel?: string }).channel);
+    return {
+      data: {
+        user: {
+          id: `${channel}-id`,
+          displayName: channel,
+          stream: { id: `${channel}-broadcast`, game: { id: "game", name: "Game" }, viewersCount: 100 },
+        },
+      },
+    };
+  }
+  if (operationName === "DropsHighlightService_AvailableDrops") {
+    const channelID = String((entry.variables as { channelID?: string }).channelID);
+    return { data: { channel: { id: channelID, viewerDropCampaigns: [{ id: "some-other-campaign" }] } } };
+  }
+  return { data: {} };
+}
+
+function directoryCandidate(username: string) {
+  return {
+    platform: "twitch" as const,
+    username,
+    url: `https://www.twitch.tv/${username}`,
+    channelId: `${username}-id`,
+    broadcastId: `${username}-broadcast`,
+    categoryId: "game",
+    live: true,
+    // A GameDirectory result, not a campaign ACL entry.
+    isAclMatch: false,
+  };
+}
+
+function aclCandidate(username: string) {
+  return {
+    platform: "twitch" as const,
+    username,
+    url: `https://www.twitch.tv/${username}`,
+    isAclMatch: true,
+  };
+}
+
+describe("twitch campaign availability trust (#400)", () => {
+  it("accepts a directory candidate whose AvailableDrops omits the campaign", async () => {
+    const operations: string[] = [];
+    const selection = await twitchAdapter(
+      recordingFetcher(operations, respondWithOmittedCampaign),
+      undefined,
+      undefined,
+      { strictCampaignAvailability: false },
+    ).selectCandidateChannel?.([directoryCandidate("directory-one")], CAMPAIGN);
+
+    expect(selection?.channel?.username).toBe("directory-one");
+    expect(operations).not.toContain("DropsHighlightService_AvailableDrops");
+  });
+
+  it("accepts an ACL candidate that is live in the campaign category", async () => {
+    const operations: string[] = [];
+    const selection = await twitchAdapter(
+      recordingFetcher(operations, respondWithOmittedCampaign),
+      undefined,
+      undefined,
+      { strictCampaignAvailability: false },
+    ).selectCandidateChannel?.([aclCandidate("acl-one")], CAMPAIGN);
+
+    expect(selection?.channel?.username).toBe("acl-one");
+    // Liveness/category still has to be confirmed for an ACL candidate.
+    expect(operations).toContain("StreamInfo");
+    expect(operations).not.toContain("DropsHighlightService_AvailableDrops");
+  });
+
+  it("rejects an offline ACL candidate even with strict validation off", async () => {
+    const operations: string[] = [];
+    const selection = await twitchAdapter(
+      recordingFetcher(operations, (operationName, entry) => {
+        if (operationName === "StreamInfo") {
+          const channel = String((entry.variables as { channel?: string }).channel);
+          return { data: { user: { id: `${channel}-id`, displayName: channel, stream: null } } };
+        }
+        return { data: {} };
+      }),
+      undefined,
+      undefined,
+      { strictCampaignAvailability: false },
+    ).selectCandidateChannel?.([aclCandidate("offline-acl")], CAMPAIGN);
+
+    expect(selection?.channel).toBeUndefined();
+  });
+
+  it("rejects a live ACL candidate streaming a different category", async () => {
+    const operations: string[] = [];
+    const selection = await twitchAdapter(
+      recordingFetcher(operations, (operationName, entry) => {
+        if (operationName === "StreamInfo") {
+          const channel = String((entry.variables as { channel?: string }).channel);
+          return {
+            data: {
+              user: {
+                id: `${channel}-id`,
+                displayName: channel,
+                stream: { id: `${channel}-broadcast`, game: { id: "other-game", name: "Other" }, viewersCount: 5 },
+              },
+            },
+          };
+        }
+        return { data: {} };
+      }),
+      undefined,
+      undefined,
+      { strictCampaignAvailability: false },
+    ).selectCandidateChannel?.([aclCandidate("wrong-category")], CAMPAIGN);
+
+    expect(selection?.channel).toBeUndefined();
+  });
+
+  // The winner-fallback path calls checkChannel(), which runs its own
+  // single AvailableDrops request. A candidate without a channelId is the only
+  // way to reach it, so a fixture with channelId set would pass while this
+  // path stayed un-gated.
+  it("issues no AvailableDrops request for a candidate lacking a channelId", async () => {
+    const operations: string[] = [];
+    const selection = await twitchAdapter(
+      recordingFetcher(operations, respondWithOmittedCampaign),
+      undefined,
+      undefined,
+      { strictCampaignAvailability: false },
+    ).selectCandidateChannel?.([{
+      platform: "twitch" as const,
+      username: "no-channel-id",
+      url: "https://www.twitch.tv/no-channel-id",
+      categoryId: "game",
+      live: true,
+      isAclMatch: false,
+    }], CAMPAIGN);
+
+    expect(selection?.channel?.username).toBe("no-channel-id");
+    expect(operations).not.toContain("DropsHighlightService_AvailableDrops");
+  });
+
+  // checkChannel also re-verifies the channel already being watched
+  // (scheduler.ts), so an un-gated negative there stops farming mid-session.
+  it("does not fail an in-session channel re-check on omitted availability", async () => {
+    const operations: string[] = [];
+    const check = await twitchAdapter(
+      recordingFetcher(operations, respondWithOmittedCampaign),
+      undefined,
+      undefined,
+      { strictCampaignAvailability: false },
+    ).checkChannel({
+      platform: "twitch",
+      username: "watching",
+      url: "https://www.twitch.tv/watching",
+      channelId: "watching-id",
+      broadcastId: "watching-broadcast",
+      categoryId: "game",
+      isAclMatch: false,
+    }, { campaign: CAMPAIGN });
+
+    expect(check.live).toBe(true);
+    expect(check.categoryMatches).toBe(true);
+    expect(check.campaignMatches).not.toBe(false);
+    expect(operations).not.toContain("DropsHighlightService_AvailableDrops");
+  });
+
+  it("still batches AvailableDrops and rejects a mismatch in strict mode", async () => {
+    const operations: string[] = [];
+    const selection = await twitchAdapter(
+      recordingFetcher(operations, respondWithOmittedCampaign),
+      undefined,
+      undefined,
+      { strictCampaignAvailability: true },
+    ).selectCandidateChannel?.([directoryCandidate("directory-one")], CAMPAIGN);
+
+    expect(selection?.channel).toBeUndefined();
+    expect(operations).toContain("DropsHighlightService_AvailableDrops");
+  });
+
+  it("accepts a strict-mode candidate whose AvailableDrops lists the campaign", async () => {
+    const operations: string[] = [];
+    const selection = await twitchAdapter(
+      recordingFetcher(operations, (operationName, entry) => {
+        if (operationName === "DropsHighlightService_AvailableDrops") {
+          const channelID = String((entry.variables as { channelID?: string }).channelID);
+          return { data: { channel: { id: channelID, viewerDropCampaigns: [{ id: "campaign" }] } } };
+        }
+        return respondWithOmittedCampaign(operationName, entry);
+      }),
+      undefined,
+      undefined,
+      { strictCampaignAvailability: true },
+    ).selectCandidateChannel?.([directoryCandidate("directory-one")], CAMPAIGN);
+
+    expect(selection?.channel?.username).toBe("directory-one");
+    expect(operations).toContain("DropsHighlightService_AvailableDrops");
+  });
+
+  it("defaults to trusting discovery sources when the option is omitted", async () => {
+    const operations: string[] = [];
+    const selection = await twitchAdapter(
+      recordingFetcher(operations, respondWithOmittedCampaign),
+      undefined,
+      undefined,
+      // Deliberately overrides the test helper's strict default back to the
+      // production default so the shipped behaviour is what gets asserted.
+      { strictCampaignAvailability: DEFAULT_ENGINE_SETTINGS.platform.twitch.strictCampaignAvailability },
+    ).selectCandidateChannel?.([directoryCandidate("directory-one")], CAMPAIGN);
+
+    expect(selection?.channel?.username).toBe("directory-one");
+    expect(operations).not.toContain("DropsHighlightService_AvailableDrops");
+  });
+});
+
+describe("strict campaign availability setting", () => {
+  it("defaults to false", () => {
+    expect(DEFAULT_ENGINE_SETTINGS.platform.twitch.strictCampaignAvailability).toBe(false);
+  });
+
+  // An existing install persisted before this setting existed has no such
+  // property, and must keep farming on trusted discovery sources.
+  // Cast because the persisted shape being simulated predates the property, so
+  // it is deliberately not assignable to the current settings type.
+  const persisted = (twitch: Record<string, unknown>) =>
+    ({ platform: { twitch } }) as unknown as Partial<EngineSettings>;
+
+  it("normalizes a missing persisted property to false", () => {
+    expect(mergeEngineSettings(persisted({ enabled: true })).platform.twitch.strictCampaignAvailability).toBe(false);
+  });
+
+  it("preserves an explicitly enabled persisted value", () => {
+    expect(mergeEngineSettings(persisted({ strictCampaignAvailability: true })).platform.twitch.strictCampaignAvailability).toBe(true);
+  });
+
+  it("round-trips through a settings patch", () => {
+    const patched = applySettingsPatch(DEFAULT_SETTINGS, {
+      platform: { twitch: { strictCampaignAvailability: true } },
+    });
+    expect(patched.platform.twitch.strictCampaignAvailability).toBe(true);
+    // Kick is untouched by a Twitch-only setting.
+    expect(patched.platform.kick).toEqual(DEFAULT_SETTINGS.platform.kick);
+    expect(mergeEngineSettings(patched).platform.twitch.strictCampaignAvailability).toBe(true);
+  });
+});

--- a/packages/extension/tests/twitchCampaignVisibility.test.ts
+++ b/packages/extension/tests/twitchCampaignVisibility.test.ts
@@ -17,41 +17,18 @@ interface DashboardEntry {
   id: string;
   status: string;
   isAccountConnected?: boolean;
-  // Mimics the inline fallback query, which selects only id/status/self.
-  bare?: boolean;
 }
 
-// Twitch's persisted ViewerDropsDashboard returns the campaign name, game and
-// window alongside the id and status.
 function dashboard(entries: DashboardEntry[], userId = "user-id"): unknown {
-  const now = Date.now();
   return {
     data: {
       currentUser: {
         id: userId,
         login: "viewer",
-        dropCampaigns: entries.map((entry) => ({
-          id: entry.id,
-          status: entry.status,
-          self: { isAccountConnected: entry.isAccountConnected ?? true },
-          ...(entry.bare ? {} : {
-            name: `Campaign ${entry.id}`,
-            game: { id: "game", slug: "game-slug", displayName: "Game" },
-            ...(entry.status === "EXPIRED"
-              ? {
-                startAt: new Date(now - 2 * HOUR_MS).toISOString(),
-                endAt: new Date(now - HOUR_MS).toISOString(),
-              }
-              : entry.status === "UPCOMING"
-                ? {
-                  startAt: new Date(now + HOUR_MS).toISOString(),
-                  endAt: new Date(now + 2 * HOUR_MS).toISOString(),
-                }
-                : {
-                  startAt: new Date(now - HOUR_MS).toISOString(),
-                  endAt: new Date(now + HOUR_MS).toISOString(),
-                }),
-          }),
+        dropCampaigns: entries.map(({ id, status, isAccountConnected = true }) => ({
+          id,
+          status,
+          self: { isAccountConnected },
         })),
       },
     },
@@ -100,11 +77,7 @@ const EMPTY_INVENTORY = {
 // long-lived service worker does. Campaign details are derived from the same
 // scripted entries so status and linkage stay consistent between the two
 // queries, as they are on Twitch.
-function discoverer(
-  refreshes: Array<DashboardEntry[] | Error>,
-  detailRequests: string[] = [],
-  { failDetailsFor = [] }: { failDetailsFor?: string[] } = {},
-) {
+function discoverer(refreshes: Array<DashboardEntry[] | Error>) {
   let refresh = -1;
   const discoveryState = new TwitchDiscoveryState();
   const current = () => refreshes[Math.min(refresh, refreshes.length - 1)];
@@ -120,8 +93,6 @@ function discoverer(
       }
       if (operationName === "DropCampaignDetails") {
         const dropID = String((operation.variables as { dropID?: string } | undefined)?.dropID);
-        detailRequests.push(dropID);
-        if (failDetailsFor.includes(dropID)) throw new Error(`details unavailable for ${dropID}`);
         // A retained id can outlive the refresh that produced it, so fall back
         // to the last scripted state that described this campaign.
         const entry = (scripted instanceof Error ? undefined : scripted.find((item) => item.id === dropID))
@@ -195,59 +166,6 @@ describe("twitch campaign visibility (#400)", () => {
     expect((await discovery.next()).map((campaign) => campaign.id)).toEqual(["retained"]);
     // The next success is authoritative, so the stale campaign is gone.
     expect((await discovery.next()).map((campaign) => campaign.id)).toEqual(["replacement"]);
-  });
-
-  // Historical campaigns are listed from the dashboard payload alone. The
-  // Drops-list filters decide whether they are shown; discovery only has to
-  // stop dropping them.
-  it("surfaces an expired campaign from the dashboard without fetching its details", async () => {
-    const detailRequests: string[] = [];
-    const campaigns = await discoverer(
-      [[
-        { id: "running", status: "ACTIVE" },
-        { id: "over", status: "EXPIRED", isAccountConnected: false },
-      ]],
-      detailRequests,
-    ).next();
-
-    const expired = campaigns.find((campaign) => campaign.id === "over");
-    expect(expired?.status).toBe("expired");
-    expect(expired?.name).toBe("Campaign over");
-    expect(expired?.gameName).toBe("Game");
-    // The detail fetch stays scoped to farmable campaigns, so an account with
-    // hundreds of historical campaigns costs no extra requests.
-    expect(detailRequests).toEqual(["running"]);
-  });
-
-  it("leaves an expired campaign out when the dashboard payload carries no detail", async () => {
-    // The inline fallback query selects only id/status, so nothing can be shown.
-    const campaigns = await discoverer([[
-      { id: "running", status: "ACTIVE" },
-      { id: "bare", status: "EXPIRED", bare: true },
-    ]]).next();
-
-    expect(campaigns.map((campaign) => campaign.id)).toEqual(["running"]);
-  });
-
-  // A campaign the dashboard still calls ACTIVE reaches the historical path
-  // only because its detail fetch failed. Marking that expired would retire a
-  // farmable campaign from the list and from scheduling over a transient error.
-  it("never reports an active campaign as expired when its details fail", async () => {
-    const campaigns = await discoverer(
-      [[{ id: "running", status: "ACTIVE" }]],
-      [],
-      { failDetailsFor: ["running"] },
-    ).next();
-
-    expect(campaigns.find((campaign) => campaign.id === "running")?.status).not.toBe("expired");
-  });
-
-  it("does not duplicate a campaign that details already covered", async () => {
-    const campaigns = await discoverer([[
-      { id: "running", status: "ACTIVE" },
-    ]]).next();
-
-    expect(campaigns.filter((campaign) => campaign.id === "running")).toHaveLength(1);
   });
 
   // A restarted service worker builds a fresh TwitchDiscoveryState, which must

--- a/packages/extension/tests/twitchCampaignVisibility.test.ts
+++ b/packages/extension/tests/twitchCampaignVisibility.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PageFetcher } from "@lurkloot/core/adapter";
+import { TwitchDiscoveryState } from "@lurkloot/core/twitch";
+import { twitchAdapter } from "./helpers/adapters";
+
+// Campaign visibility coverage for #400. The reporter saw an active, unlinked
+// campaign that only appeared after reinstalling the extension. These tests pin
+// the discovery state machine's actual behaviour: fresh dashboard results are
+// authoritative and are never suppressed by retained state.
+
+function jsonFetcher(handler: (url: string, init?: RequestInit) => unknown): PageFetcher {
+  const fetchJson = vi.fn(async (url: string, init?: RequestInit): Promise<unknown> => handler(url, init));
+  return { fetchJson: fetchJson as PageFetcher["fetchJson"] };
+}
+
+interface DashboardEntry {
+  id: string;
+  status: string;
+  isAccountConnected?: boolean;
+}
+
+function dashboard(entries: DashboardEntry[], userId = "user-id"): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: userId,
+        login: "viewer",
+        dropCampaigns: entries.map(({ id, status, isAccountConnected = true }) => ({
+          id,
+          status,
+          self: { isAccountConnected },
+        })),
+      },
+    },
+  };
+}
+
+const HOUR_MS = 3_600_000;
+
+// Campaign status and account linkage are parsed from the details payload, not
+// the dashboard entry, so the fixture has to carry both: startAt/endAt decide
+// upcoming/active/expired, and self.isAccountConnected only counts when the
+// campaign actually has an accountLinkURL.
+function details(dropID: string, entry: DashboardEntry): unknown {
+  const now = Date.now();
+  const window = entry.status === "UPCOMING"
+    ? { startAt: new Date(now + HOUR_MS).toISOString(), endAt: new Date(now + 2 * HOUR_MS).toISOString() }
+    : entry.status === "EXPIRED"
+      ? { startAt: new Date(now - 2 * HOUR_MS).toISOString(), endAt: new Date(now - HOUR_MS).toISOString() }
+      : { startAt: new Date(now - HOUR_MS).toISOString(), endAt: new Date(now + HOUR_MS).toISOString() };
+  return {
+    data: {
+      dropCampaign: {
+        id: dropID,
+        name: `Campaign ${dropID}`,
+        status: entry.status,
+        ...window,
+        accountLinkURL: "https://www.example.com/link",
+        self: { isAccountConnected: entry.isAccountConnected ?? true },
+        game: { id: "game", slug: "game-slug", displayName: "Game" },
+        timeBasedDrops: [{
+          id: `${dropID}-drop`,
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit: { id: "benefit", name: "Reward" } }],
+        }],
+      },
+    },
+  };
+}
+
+const EMPTY_INVENTORY = {
+  data: { currentUser: { id: "user-id", inventory: { dropCampaignsInProgress: [] } } },
+};
+
+// Drives refreshCampaigns() against a scripted sequence of dashboard states,
+// one per refresh, sharing a single discovery state across refreshes the way a
+// long-lived service worker does. Campaign details are derived from the same
+// scripted entries so status and linkage stay consistent between the two
+// queries, as they are on Twitch.
+function discoverer(refreshes: Array<DashboardEntry[] | Error>) {
+  let refresh = -1;
+  const discoveryState = new TwitchDiscoveryState();
+  const current = () => refreshes[Math.min(refresh, refreshes.length - 1)];
+  const fetcher = jsonFetcher((_url, init) => {
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown> | Array<Record<string, unknown>>;
+    const operations = Array.isArray(body) ? body : [body];
+    const responses = operations.map((operation) => {
+      const operationName = String(operation.operationName);
+      const scripted = current();
+      if (operationName === "ViewerDropsDashboard") {
+        if (scripted instanceof Error) throw scripted;
+        return dashboard(scripted);
+      }
+      if (operationName === "DropCampaignDetails") {
+        const dropID = String((operation.variables as { dropID?: string } | undefined)?.dropID);
+        // A retained id can outlive the refresh that produced it, so fall back
+        // to the last scripted state that described this campaign.
+        const entry = (scripted instanceof Error ? undefined : scripted.find((item) => item.id === dropID))
+          ?? refreshes.flatMap((state) => (state instanceof Error ? [] : state)).find((item) => item.id === dropID);
+        if (!entry) return { data: { dropCampaign: null } };
+        return details(dropID, entry);
+      }
+      return EMPTY_INVENTORY;
+    });
+    return Array.isArray(body) ? responses : responses[0];
+  });
+  const adapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
+  return {
+    async next() {
+      refresh += 1;
+      return adapter.refreshCampaigns();
+    },
+  };
+}
+
+describe("twitch campaign visibility (#400)", () => {
+  it("surfaces an active campaign the account has not linked", async () => {
+    const campaigns = await discoverer([
+      [{ id: "unlinked", status: "ACTIVE", isAccountConnected: false }],
+    ]).next();
+
+    expect(campaigns.map((campaign) => campaign.id)).toContain("unlinked");
+    expect(campaigns.find((campaign) => campaign.id === "unlinked")?.accountLinked).toBe(false);
+  });
+
+  // The reported symptom: a campaign that was not yet active on one refresh and
+  // active on the next had to appear without clearing extension state.
+  it("surfaces a campaign that turns active after an earlier refresh saw it upcoming", async () => {
+    const discovery = discoverer([
+      [{ id: "starting", status: "UPCOMING", isAccountConnected: false }],
+      [{ id: "starting", status: "ACTIVE", isAccountConnected: false }],
+    ]);
+
+    const first = await discovery.next();
+    expect(first.find((campaign) => campaign.id === "starting")?.status).toBe("upcoming");
+
+    const second = await discovery.next();
+    expect(second.find((campaign) => campaign.id === "starting")?.status).toBe("active");
+  });
+
+  it("surfaces a campaign that only appears in a later dashboard refresh", async () => {
+    const discovery = discoverer([
+      [{ id: "existing", status: "ACTIVE" }],
+      [
+        { id: "existing", status: "ACTIVE" },
+        { id: "brand-new", status: "ACTIVE", isAccountConnected: false },
+      ],
+    ]);
+
+    expect((await discovery.next()).map((campaign) => campaign.id)).not.toContain("brand-new");
+    expect((await discovery.next()).map((campaign) => campaign.id)).toContain("brand-new");
+  });
+
+  // Retained dashboard ids are a failure-path fallback: they must bridge a
+  // failed refresh without ever overriding a later successful one.
+  it("reuses retained campaigns when a refresh fails, then defers to the next success", async () => {
+    const discovery = discoverer([
+      [{ id: "retained", status: "ACTIVE" }],
+      new Error("dashboard unavailable"),
+      [{ id: "replacement", status: "ACTIVE" }],
+    ]);
+
+    expect((await discovery.next()).map((campaign) => campaign.id)).toEqual(["retained"]);
+    // The failed refresh keeps serving the last known campaign rather than
+    // reporting that the user has none.
+    expect((await discovery.next()).map((campaign) => campaign.id)).toEqual(["retained"]);
+    // The next success is authoritative, so the stale campaign is gone.
+    expect((await discovery.next()).map((campaign) => campaign.id)).toEqual(["replacement"]);
+  });
+
+  // A restarted service worker builds a fresh TwitchDiscoveryState, which must
+  // not be a precondition for seeing a new campaign.
+  it("does not need a fresh discovery state to surface a new campaign", async () => {
+    const shared = discoverer([
+      [{ id: "existing", status: "ACTIVE" }],
+      [{ id: "existing", status: "ACTIVE" }, { id: "late", status: "ACTIVE" }],
+    ]);
+    await shared.next();
+    const withSharedState = await shared.next();
+
+    const restarted = discoverer([
+      [{ id: "existing", status: "ACTIVE" }, { id: "late", status: "ACTIVE" }],
+    ]);
+    const afterRestart = await restarted.next();
+
+    expect(withSharedState.map((campaign) => campaign.id).sort())
+      .toEqual(afterRestart.map((campaign) => campaign.id).sort());
+    expect(withSharedState.map((campaign) => campaign.id)).toContain("late");
+  });
+});

--- a/packages/extension/tests/twitchCampaignVisibility.test.ts
+++ b/packages/extension/tests/twitchCampaignVisibility.test.ts
@@ -17,18 +17,41 @@ interface DashboardEntry {
   id: string;
   status: string;
   isAccountConnected?: boolean;
+  // Mimics the inline fallback query, which selects only id/status/self.
+  bare?: boolean;
 }
 
+// Twitch's persisted ViewerDropsDashboard returns the campaign name, game and
+// window alongside the id and status.
 function dashboard(entries: DashboardEntry[], userId = "user-id"): unknown {
+  const now = Date.now();
   return {
     data: {
       currentUser: {
         id: userId,
         login: "viewer",
-        dropCampaigns: entries.map(({ id, status, isAccountConnected = true }) => ({
-          id,
-          status,
-          self: { isAccountConnected },
+        dropCampaigns: entries.map((entry) => ({
+          id: entry.id,
+          status: entry.status,
+          self: { isAccountConnected: entry.isAccountConnected ?? true },
+          ...(entry.bare ? {} : {
+            name: `Campaign ${entry.id}`,
+            game: { id: "game", slug: "game-slug", displayName: "Game" },
+            ...(entry.status === "EXPIRED"
+              ? {
+                startAt: new Date(now - 2 * HOUR_MS).toISOString(),
+                endAt: new Date(now - HOUR_MS).toISOString(),
+              }
+              : entry.status === "UPCOMING"
+                ? {
+                  startAt: new Date(now + HOUR_MS).toISOString(),
+                  endAt: new Date(now + 2 * HOUR_MS).toISOString(),
+                }
+                : {
+                  startAt: new Date(now - HOUR_MS).toISOString(),
+                  endAt: new Date(now + HOUR_MS).toISOString(),
+                }),
+          }),
         })),
       },
     },
@@ -77,7 +100,7 @@ const EMPTY_INVENTORY = {
 // long-lived service worker does. Campaign details are derived from the same
 // scripted entries so status and linkage stay consistent between the two
 // queries, as they are on Twitch.
-function discoverer(refreshes: Array<DashboardEntry[] | Error>) {
+function discoverer(refreshes: Array<DashboardEntry[] | Error>, detailRequests: string[] = []) {
   let refresh = -1;
   const discoveryState = new TwitchDiscoveryState();
   const current = () => refreshes[Math.min(refresh, refreshes.length - 1)];
@@ -93,6 +116,7 @@ function discoverer(refreshes: Array<DashboardEntry[] | Error>) {
       }
       if (operationName === "DropCampaignDetails") {
         const dropID = String((operation.variables as { dropID?: string } | undefined)?.dropID);
+        detailRequests.push(dropID);
         // A retained id can outlive the refresh that produced it, so fall back
         // to the last scripted state that described this campaign.
         const entry = (scripted instanceof Error ? undefined : scripted.find((item) => item.id === dropID))
@@ -166,6 +190,46 @@ describe("twitch campaign visibility (#400)", () => {
     expect((await discovery.next()).map((campaign) => campaign.id)).toEqual(["retained"]);
     // The next success is authoritative, so the stale campaign is gone.
     expect((await discovery.next()).map((campaign) => campaign.id)).toEqual(["replacement"]);
+  });
+
+  // Historical campaigns are listed from the dashboard payload alone. The
+  // Drops-list filters decide whether they are shown; discovery only has to
+  // stop dropping them.
+  it("surfaces an expired campaign from the dashboard without fetching its details", async () => {
+    const detailRequests: string[] = [];
+    const campaigns = await discoverer(
+      [[
+        { id: "running", status: "ACTIVE" },
+        { id: "over", status: "EXPIRED", isAccountConnected: false },
+      ]],
+      detailRequests,
+    ).next();
+
+    const expired = campaigns.find((campaign) => campaign.id === "over");
+    expect(expired?.status).toBe("expired");
+    expect(expired?.name).toBe("Campaign over");
+    expect(expired?.gameName).toBe("Game");
+    // The detail fetch stays scoped to farmable campaigns, so an account with
+    // hundreds of historical campaigns costs no extra requests.
+    expect(detailRequests).toEqual(["running"]);
+  });
+
+  it("leaves an expired campaign out when the dashboard payload carries no detail", async () => {
+    // The inline fallback query selects only id/status, so nothing can be shown.
+    const campaigns = await discoverer([[
+      { id: "running", status: "ACTIVE" },
+      { id: "bare", status: "EXPIRED", bare: true },
+    ]]).next();
+
+    expect(campaigns.map((campaign) => campaign.id)).toEqual(["running"]);
+  });
+
+  it("does not duplicate a campaign that details already covered", async () => {
+    const campaigns = await discoverer([[
+      { id: "running", status: "ACTIVE" },
+    ]]).next();
+
+    expect(campaigns.filter((campaign) => campaign.id === "running")).toHaveLength(1);
   });
 
   // A restarted service worker builds a fresh TwitchDiscoveryState, which must

--- a/packages/extension/tests/twitchCampaignVisibility.test.ts
+++ b/packages/extension/tests/twitchCampaignVisibility.test.ts
@@ -100,7 +100,11 @@ const EMPTY_INVENTORY = {
 // long-lived service worker does. Campaign details are derived from the same
 // scripted entries so status and linkage stay consistent between the two
 // queries, as they are on Twitch.
-function discoverer(refreshes: Array<DashboardEntry[] | Error>, detailRequests: string[] = []) {
+function discoverer(
+  refreshes: Array<DashboardEntry[] | Error>,
+  detailRequests: string[] = [],
+  { failDetailsFor = [] }: { failDetailsFor?: string[] } = {},
+) {
   let refresh = -1;
   const discoveryState = new TwitchDiscoveryState();
   const current = () => refreshes[Math.min(refresh, refreshes.length - 1)];
@@ -117,6 +121,7 @@ function discoverer(refreshes: Array<DashboardEntry[] | Error>, detailRequests: 
       if (operationName === "DropCampaignDetails") {
         const dropID = String((operation.variables as { dropID?: string } | undefined)?.dropID);
         detailRequests.push(dropID);
+        if (failDetailsFor.includes(dropID)) throw new Error(`details unavailable for ${dropID}`);
         // A retained id can outlive the refresh that produced it, so fall back
         // to the last scripted state that described this campaign.
         const entry = (scripted instanceof Error ? undefined : scripted.find((item) => item.id === dropID))
@@ -222,6 +227,19 @@ describe("twitch campaign visibility (#400)", () => {
     ]]).next();
 
     expect(campaigns.map((campaign) => campaign.id)).toEqual(["running"]);
+  });
+
+  // A campaign the dashboard still calls ACTIVE reaches the historical path
+  // only because its detail fetch failed. Marking that expired would retire a
+  // farmable campaign from the list and from scheduling over a transient error.
+  it("never reports an active campaign as expired when its details fail", async () => {
+    const campaigns = await discoverer(
+      [[{ id: "running", status: "ACTIVE" }]],
+      [],
+      { failDetailsFor: ["running"] },
+    ).next();
+
+    expect(campaigns.find((campaign) => campaign.id === "running")?.status).not.toBe("expired");
   });
 
   it("does not duplicate a campaign that details already covered", async () => {

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "فشل فحص التشغيل"
   },
+  "activityReasonNoProgress": {
+    "message": "لم تحقق القناة أي تقدم في الدروبس"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "تم الانتقال إلى مكافأة ذات أولوية أعلى"
   },

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "استلم مكافآت نقاط القناة تلقائيًا أثناء الفارم على هذه المنصة."
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "توفر الحملات الصارم"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "احصد الحملة فقط على القنوات التي تعرضها تويتش لها. غالبًا ما تغفل تويتش حملات قابلة للحصد، لذا قد تبقى بعض الدروبس دون حصد."
+  },
   "autoClaimChallengesTitle": {
     "message": "استلام التحديات اليومية تلقائيًا"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Beansprucht Kanalpunkt-Boni automatisch, während diese Plattform gefarmt wird."
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "Strikte Kampagnenverfügbarkeit"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "Farme eine Kampagne nur auf Kanälen, für die Twitch sie auflistet. Twitch lässt farmbare Kampagnen oft aus, wodurch Drops ungefarmt bleiben können."
+  },
   "autoClaimChallengesTitle": {
     "message": "Tägliche Challenges automatisch beanspruchen"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "die Wiedergabeprüfung ist fehlgeschlagen"
   },
+  "activityReasonNoProgress": {
+    "message": "der Kanal erzielte keinen Drop-Fortschritt"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "eine höher priorisierte Belohnung wurde übernommen"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Claim channel-point bonuses while farming this platform."
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "Strict campaign availability"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "Only farm a campaign on channels Twitch lists it for. Twitch often omits farmable campaigns, so this can leave drops unfarmed."
+  },
   "autoClaimChallengesTitle": {
     "message": "Auto-claim daily challenges"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "the watch health check failed"
   },
+  "activityReasonNoProgress": {
+    "message": "the channel earned no drop progress"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "a higher-priority reward took over"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "falló la comprobación de reproducción"
   },
+  "activityReasonNoProgress": {
+    "message": "el canal no generó progreso de drops"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "se priorizó una recompensa más importante"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Reclama automáticamente las bonificaciones de puntos de canal mientras se farmea esta plataforma."
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "Disponibilidad estricta de campañas"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "Farmea una campaña solo en los canales para los que Twitch la muestra. Twitch suele omitir campañas farmeables, así que esto puede dejar recompensas sin farmear."
+  },
   "autoClaimChallengesTitle": {
     "message": "Auto-reclamar desafíos diarios"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Réclame automatiquement les bonus de points de chaîne lors du farm sur cette plateforme."
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "Disponibilité stricte des campagnes"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "Ne farmer une campagne que sur les chaînes pour lesquelles Twitch l'affiche. Twitch omet souvent des campagnes farmables, ce qui peut laisser des drops non farmés."
+  },
   "autoClaimChallengesTitle": {
     "message": "Réclamer automatiquement les défis quotidiens"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "le contrôle de lecture a échoué"
   },
+  "activityReasonNoProgress": {
+    "message": "la chaîne n'a généré aucune progression de drops"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "une récompense prioritaire a pris le relais"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "प्लेबैक जाँच विफल हुई"
   },
+  "activityReasonNoProgress": {
+    "message": "चैनल ने कोई ड्रॉप प्रगति अर्जित नहीं की"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "अधिक प्राथमिकता वाला इनाम चुना गया"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "इस प्लेटफ़ॉर्म पर फ़ार्म करते समय चैनल-पॉइंट बोनस अपने आप क्लेम करें।"
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "सख्त अभियान उपलब्धता"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "किसी अभियान को केवल उन चैनलों पर फ़ार्म करें जिनके लिए Twitch उसे सूचीबद्ध करता है। Twitch अक्सर फ़ार्म करने योग्य अभियान छोड़ देता है, जिससे कुछ ड्रॉप्स अनफ़ार्म रह सकते हैं।"
+  },
   "autoClaimChallengesTitle": {
     "message": "दैनिक चैलेंज अपने आप क्लेम करें"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Riscatta automaticamente i bonus in punti canale durante il farming su questa piattaforma."
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "Disponibilità rigorosa delle campagne"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "Farma una campagna solo sui canali per cui Twitch la elenca. Twitch spesso omette campagne farmabili, quindi alcuni drop potrebbero non essere farmati."
+  },
   "autoClaimChallengesTitle": {
     "message": "Riscatto automatico delle sfide giornaliere"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "il controllo della riproduzione non è riuscito"
   },
+  "activityReasonNoProgress": {
+    "message": "il canale non ha generato progressi sui drop"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "è subentrata una ricompensa con priorità maggiore"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Resgata automaticamente os bônus de pontos de canal enquanto farma nesta plataforma."
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "Disponibilidade estrita de campanhas"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "Farme uma campanha apenas nos canais para os quais a Twitch a lista. A Twitch costuma omitir campanhas farmáveis, o que pode deixar drops sem farmar."
+  },
   "autoClaimChallengesTitle": {
     "message": "Resgatar desafios diários automaticamente"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "a verificação da reprodução falhou"
   },
+  "activityReasonNoProgress": {
+    "message": "o canal não gerou progresso de drops"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "uma recompensa de maior prioridade assumiu"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "проверка воспроизведения не пройдена"
   },
+  "activityReasonNoProgress": {
+    "message": "канал не приносил прогресса дропов"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "выбрана награда с более высоким приоритетом"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Автоматически получает бонусы баллов канала во время фарма на этой платформе."
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "Строгая проверка доступности кампаний"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "Фармить кампанию только на каналах, для которых её показывает Twitch. Twitch часто не указывает доступные кампании, поэтому часть дропов может остаться нефармленной."
+  },
   "autoClaimChallengesTitle": {
     "message": "Автополучение ежедневных испытаний"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "İzleme kontrolü başarısız"
   },
+  "activityReasonNoProgress": {
+    "message": "kanal hiç drop ilerlemesi kazandırmadı"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "Daha yüksek öncelikli drop geldi"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Yayın izlerken biriken kanal puanı bonuslarını otomatik toplar."
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "Katı kampanya uygunluğu"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "Bir kampanyayı yalnızca Twitch'in onu listelediği kanallarda farmla. Twitch farmlanabilir kampanyaları sıkça atlar, bu yüzden bazı droplar farmlanmadan kalabilir."
+  },
   "autoClaimChallengesTitle": {
     "message": "Günlük görevleri otomatik al"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -1016,6 +1016,9 @@
   "activityReasonWatchUnhealthy": {
     "message": "播放健康检查失败"
   },
+  "activityReasonNoProgress": {
+    "message": "该频道没有获得掉宝进度"
+  },
   "activityReasonHigherPriorityReward": {
     "message": "已切换到更高优先级的奖励"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -623,6 +623,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "在该平台刷取时自动领取频道积分奖励。"
   },
+  "strictCampaignAvailabilityTitle": {
+    "message": "严格的活动可用性"
+  },
+  "strictCampaignAvailabilityDescription": {
+    "message": "仅在 Twitch 列出该活动的频道上刷取。Twitch 经常遗漏可刷取的活动，因此可能导致部分掉宝未被刷取。"
+  },
   "autoClaimChallengesTitle": {
     "message": "自动领取每日挑战"
   },

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -145,6 +145,7 @@ function formatStopReason(reason: FarmingStopReason, t: TFunction): string {
     case "channel_offline": return t("activityReasonChannelOffline");
     case "channel_mismatch": return t("activityReasonChannelMismatch");
     case "watch_unhealthy": return t("activityReasonWatchUnhealthy");
+    case "no_progress": return t("activityReasonNoProgress");
     case "higher_priority_reward": return t("activityReasonHigherPriorityReward");
     case "higher_priority_idle_watchlist": return t("activityReasonHigherPriorityIdleWatchlist");
     case "watch_requirement_completed": return t("activityReasonWatchRequirementCompleted");

--- a/packages/popup-ui/src/demo.ts
+++ b/packages/popup-ui/src/demo.ts
@@ -93,6 +93,7 @@ function demoSnapshot(): RuntimeSnapshot {
         enabled: true,
         idleWatchlistChannels: ["rivalspilot", "lootforge", "nightrunlive"],
         excludedChannels: ["spoilerboss"],
+        strictCampaignAvailability: false,
         farmAllCategories: false,
         categories: [
           { id: "marathon legends", name: "Marathon Legends" },

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -389,18 +389,13 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
                   </div>
                 </>
               )}
-              {/* A historical campaign is listed from the drops dashboard
-                  alone, without the detail fetch that carries rewards, so the
-                  strip would otherwise render as an empty shell. */}
-              {campaign.rewards.length > 0 ? (
-                <div>
-                  <div className="mb-1.5 flex items-center justify-between">
-                    <span className="flex items-center gap-1 text-[11px] font-semibold text-zinc-700 dark:text-zinc-200"><Gift size={12} style={{ color: "var(--accent-text)" }} /> {t("rewards")}</span>
-                    <span className="text-[10px] text-zinc-400 dark:text-zinc-500">{t("inCampaignOrder")}</span>
-                  </div>
-                  <RewardCarousel rewards={campaign.rewards} />
+              <div>
+                <div className="mb-1.5 flex items-center justify-between">
+                  <span className="flex items-center gap-1 text-[11px] font-semibold text-zinc-700 dark:text-zinc-200"><Gift size={12} style={{ color: "var(--accent-text)" }} /> {t("rewards")}</span>
+                  <span className="text-[10px] text-zinc-400 dark:text-zinc-500">{t("inCampaignOrder")}</span>
                 </div>
-              ) : null}
+                <RewardCarousel rewards={campaign.rewards} />
+              </div>
               {claimGuidance ? (
                 <div className="rounded-lg border border-amber-300/70 bg-amber-50 px-2 py-1.5 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
                   <div className="flex items-center gap-1.5 text-[11px] font-medium">

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -389,13 +389,18 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
                   </div>
                 </>
               )}
-              <div>
-                <div className="mb-1.5 flex items-center justify-between">
-                  <span className="flex items-center gap-1 text-[11px] font-semibold text-zinc-700 dark:text-zinc-200"><Gift size={12} style={{ color: "var(--accent-text)" }} /> {t("rewards")}</span>
-                  <span className="text-[10px] text-zinc-400 dark:text-zinc-500">{t("inCampaignOrder")}</span>
+              {/* A historical campaign is listed from the drops dashboard
+                  alone, without the detail fetch that carries rewards, so the
+                  strip would otherwise render as an empty shell. */}
+              {campaign.rewards.length > 0 ? (
+                <div>
+                  <div className="mb-1.5 flex items-center justify-between">
+                    <span className="flex items-center gap-1 text-[11px] font-semibold text-zinc-700 dark:text-zinc-200"><Gift size={12} style={{ color: "var(--accent-text)" }} /> {t("rewards")}</span>
+                    <span className="text-[10px] text-zinc-400 dark:text-zinc-500">{t("inCampaignOrder")}</span>
+                  </div>
+                  <RewardCarousel rewards={campaign.rewards} />
                 </div>
-                <RewardCarousel rewards={campaign.rewards} />
-              </div>
+              ) : null}
               {claimGuidance ? (
                 <div className="rounded-lg border border-amber-300/70 bg-amber-50 px-2 py-1.5 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
                   <div className="flex items-center gap-1.5 text-[11px] font-medium">

--- a/packages/popup-ui/src/settingsRegistry.tsx
+++ b/packages/popup-ui/src/settingsRegistry.tsx
@@ -439,7 +439,7 @@ export function buildSettingsRegistry(ctx: SettingsRegistryContext): SettingsSec
             title={t("strictCampaignAvailabilityTitle")}
             description={t("strictCampaignAvailabilityDescription")}
             checked={settings.platform.twitch.strictCampaignAvailability}
-            onChange={(value) => void onSettingsChange({ platform: { twitch: { strictCampaignAvailability: value } } })}
+            onChange={(value) => void platformPatch("twitch", { strictCampaignAvailability: value })}
           />
         ),
       }]

--- a/packages/popup-ui/src/settingsRegistry.tsx
+++ b/packages/popup-ui/src/settingsRegistry.tsx
@@ -423,31 +423,63 @@ export function buildSettingsRegistry(ctx: SettingsRegistryContext): SettingsSec
       },
     ];
 
+    // Twitch's advanced group also carries a farming toggle, so it is named for
+    // what it is rather than "Compatibility", and exists whether or not a
+    // compatibility registry was supplied. Kick has no such toggle and keeps a
+    // compatibility-only group. Each section still gets exactly one advanced
+    // group, and neither holds a lone entry in the popup, which always supplies
+    // a registry.
+    const advancedEntries: SettingsEntryDef[] = platform === "twitch"
+      ? [{
+        id: "twitch.advanced.strictCampaignAvailability",
+        titleKey: "strictCampaignAvailabilityTitle",
+        descriptionKey: "strictCampaignAvailabilityDescription",
+        render: () => (
+          <SettingRow
+            title={t("strictCampaignAvailabilityTitle")}
+            description={t("strictCampaignAvailabilityDescription")}
+            checked={settings.platform.twitch.strictCampaignAvailability}
+            onChange={(value) => void onSettingsChange({ platform: { twitch: { strictCampaignAvailability: value } } })}
+          />
+        ),
+      }]
+      : [];
+
     if (ctx.compatibilityRegistry && ctx.compatibilityResolution) {
       const compatibilityRegistry = ctx.compatibilityRegistry;
       const compatibilityResolution = ctx.compatibilityResolution;
-      groups.push({
-        id: `${platform}.compatibility`,
-        titleKey: "settingsGroupCompatibility",
-        description: t("compatibilitySectionDescription"),
-        advanced: true,
-        entries: [
-          {
-            id: `${platform}.compatibility.rows`,
-            titleKey: "compatibilitySectionTitle",
-            descriptionKey: "compatibilitySectionDescription",
-            render: () => (
-              <PlatformCompatibilitySettings
-                platform={platform}
-                settings={settings.compatibility}
-                registry={compatibilityRegistry}
-                resolution={compatibilityResolution}
-                onChange={(patch) => void onSettingsChange(patch)}
-              />
-            ),
-          },
-        ],
+      advancedEntries.push({
+        id: `${platform}.compatibility.rows`,
+        titleKey: "compatibilitySectionTitle",
+        descriptionKey: "compatibilitySectionDescription",
+        render: () => (
+          <PlatformCompatibilitySettings
+            platform={platform}
+            settings={settings.compatibility}
+            registry={compatibilityRegistry}
+            resolution={compatibilityResolution}
+            onChange={(patch) => void onSettingsChange(patch)}
+          />
+        ),
       });
+    }
+
+    if (advancedEntries.length > 0) {
+      groups.push(platform === "twitch"
+        ? {
+          id: "twitch.advanced",
+          titleKey: "settingsGroupAdvanced",
+          description: t("advancedDescription"),
+          advanced: true,
+          entries: advancedEntries,
+        }
+        : {
+          id: `${platform}.compatibility`,
+          titleKey: "settingsGroupCompatibility",
+          description: t("compatibilitySectionDescription"),
+          advanced: true,
+          entries: advancedEntries,
+        });
     }
 
     return { id: platform, iconNode, rows: [claimEntry], groups };

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -13,6 +13,7 @@ export type FarmingStopReason =
   | "channel_offline"
   | "channel_mismatch"
   | "watch_unhealthy"
+  | "no_progress"
   | "higher_priority_reward"
   | "higher_priority_idle_watchlist"
   | "watch_requirement_completed"

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -128,6 +128,12 @@ export interface WatchSession {
   lastCheckedAt?: string;
   offlineChecks: number;
   playbackChecks?: number;
+  // Consecutive verification windows in which a healthy, category-matching watch
+  // accrued no additional minutes, plus the reading they are compared against.
+  // Trusting a discovery source means nothing else rejects such a channel, so
+  // this is what rotates off one that never pays out (#400).
+  noProgressChecks?: number;
+  lastWatchedMinutes?: number;
   errorChecks?: number;
   retryAfter?: string;
   status: "idle" | "starting" | "watching" | "paused" | "error";
@@ -166,6 +172,7 @@ export type WatchReasonCode =
   | "channel_offline"
   | "channel_mismatch"
   | "watch_unhealthy"
+  | "no_progress"
   | "higher_priority_reward"
   | "higher_priority_idle_watchlist"
   | "keeping_current_watch"

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -271,6 +271,10 @@ export interface PlatformSettings {
 // platform, so the type never advertises a knob the platform ignores.
 export interface TwitchPlatformSettings extends PlatformSettings {
   autoClaimChannelPoints: boolean;
+  // Advanced: require DropsHighlightService_AvailableDrops to list a campaign
+  // before farming it on a channel. Off by default — see #400 and
+  // TwitchAdapterOptions.strictCampaignAvailability.
+  strictCampaignAvailability: boolean;
 }
 
 export interface KickPlatformSettings extends PlatformSettings {

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -39,6 +39,7 @@ export const DEFAULT_ENGINE_SETTINGS: EngineSettings = {
       farmAllCategories: true,
       categories: [],
       autoClaimChannelPoints: true,
+      strictCampaignAvailability: false,
     },
     kick: {
       enabled: false,
@@ -142,6 +143,7 @@ export function mergeEngineSettings(value: Partial<EngineSettings> | undefined):
         farmAllCategories: booleanOr(platform?.twitch?.farmAllCategories, DEFAULT_ENGINE_SETTINGS.platform.twitch.farmAllCategories),
         categories: normalizeCategorySelections(platform?.twitch?.categories),
         autoClaimChannelPoints: booleanOr(platform?.twitch?.autoClaimChannelPoints, DEFAULT_ENGINE_SETTINGS.platform.twitch.autoClaimChannelPoints),
+        strictCampaignAvailability: booleanOr(platform?.twitch?.strictCampaignAvailability, DEFAULT_ENGINE_SETTINGS.platform.twitch.strictCampaignAvailability),
       },
       kick: {
         enabled: booleanOr(platform?.kick?.enabled, DEFAULT_ENGINE_SETTINGS.platform.kick.enabled),


### PR DESCRIPTION
Fixes the two Twitch campaign problems reported in #400. Both are release-blocking for default installs.

## 1. Channel selection no longer needs AvailableDrops approval

Twitch's `GameDirectory` `DROPS_ENABLED` filter and a campaign's channel ACL are authoritative discovery sources, but every candidate they produced was re-validated against `DropsHighlightService_AvailableDrops` and rejected when that response omitted the campaign. AvailableDrops routinely omits campaigns that are in fact farmable, so reporters saw hundreds of candidates checked and none accepted.

Liveness and category validation are now trusted by default. Exact AvailableDrops validation moved behind a new Twitch advanced setting, **`strictCampaignAvailability`**, defaulting to `false` — matching TwitchDropsMiner, whose equivalent `available_drops_check` is also opt-in.

The gate covers `checkChannel()` as well as `selectCandidateChannel()`. That path also re-verifies the channel *already being watched* (`scheduler.ts:1529`), so an un-gated negative stopped farming mid-session, not just at selection time. The handoff only identified the selection path.

## 2. Campaign visibility decoupled from farmability

Untouched campaigns — not linked, no progress, no currently live channel — enter the campaign model and the Drops-list filters decide what is shown. This is the reporter's actual case: campaigns on Twitch's All campaigns page were absent *"when the account has no existing progress."*

**Historical (expired/closed) campaigns are deliberately out of scope.** An earlier revision synthesised them from the dashboard; `5d2ec2f` reverts that. They carried no rewards, overloaded the existing `showExpired` filter (which has always meant "campaigns I started that ended"), and cost persisted storage for every user. TwitchDropsMiner filters the same dashboard to ACTIVE/UPCOMING for the same reason. See the scope-decision comment below — this leaves one acceptance criterion intentionally unmet.

### The reported reset-sensitivity is not a bug — and is not "fixed" here

Retained dashboard ids and cached campaign details are in-memory only, read solely on the failure path, and cleared on identity change. A successful dashboard refresh is already authoritative over all of it. Nine tests characterise this (`twitchCampaignVisibility.test.ts`) and **pass unchanged on the parent commit**, including the active-unlinked case.

The reinstall also renewed integrity and session state, and the campaign started the same day it was reported. Isolated in its own commit (`3877bcf`) so the finding stays legible. The handoff explicitly licensed this outcome; if you disagree with the call, that commit is the thing to push back on.

## Testing

`pnpm verify` passes. New coverage:

- `twitchCampaignTrust.test.ts` — 13 tests: strict on/off selection, ACL and directory candidates, offline/wrong-category rejection, the no-`channelId` winner-fallback path, in-session `checkChannel` re-verification, and settings normalisation.
- `twitchCampaignVisibility.test.ts` — 5 tests: unlinked/active visibility, stale-state and failed-refresh behaviour, and discovery-state restart equivalence.
- Host wiring in `transport.test.ts` and `backgroundEntrypoint.test.ts` — asserts behaviour (does the request go out?) rather than the private option. Each was confirmed to fail with its host's wiring line removed.

Existing fixtures keep exercising strict mode: the shared `twitchAdapter` test helper opts into it, so prior AvailableDrops coverage (including the progress-confirmation override) is unchanged.

## Notes for review

- **UI/IA change:** Twitch's advanced group is renamed `twitch.compatibility` → `twitch.advanced`, since it now carries a farming toggle alongside the compatibility rows. This keeps the registry's "exactly one advanced group per section" invariant and avoids the lone-toggle group its comment warns against. Kick is unchanged. No screenshot attached — the visible change is one new toggle under Twitch → Advanced, plus a hidden-when-empty reward strip.
- Settings export/import needed no allowlist change (both funnel through `mergeSettings`), and `settingsSchema.ts` needed no migration for a new default-`false` key.
- **Stalled-channel rotation** (`38bfd74`) reuses `offlineRetryLimit` rather than adding a setting, and skips the stalled channel advisorily — a campaign whose only candidate stalled keeps it.

Refs #400



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Twitch setting to require campaigns to be confirmed as available before farming.
  - Added localized labels and descriptions for the new setting.
- **Bug Fixes**
  - Improved campaign visibility and availability handling across refreshes and service restarts.
  - Farming now detects repeated lack of reward progress and can switch channels or stop with a clear explanation.
- **User Experience**
  - Added a localized “no drop progress earned” activity reason.
  - Improved diagnostics for campaign availability decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->