### PR TITLE
feat(popup): export full diagnostic history

### DIFF
--- a/docs/superpowers/plans/2026-08-16-diagnostics-full-export.md
+++ b/docs/superpowers/plans/2026-08-16-diagnostics-full-export.md
@@ -1,0 +1,868 @@
+# Diagnostics Full Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Diagnostics users download the complete retained diagnostic history for the selected platform as a `.log` file, while **Copy loaded** still copies only the on-screen page.
+
+**Architecture:** A new `exportDiagnostics` runtime message reads every retained matching diagnostic from IndexedDB in one shot (no 100-row page cap, no search query). The popup formats that list with the existing `buildActivityExport` helper, adds `coverage: full`, and the extension adapter downloads a `.log` via Blob URL. Activity keeps today's **Copy log**.
+
+**Tech Stack:** TypeScript, React, IndexedDB, Vitest, `@lurkloot/shared` messages, `@lurkloot/popup-ui`, JSON locale catalogs.
+
+## Global Constraints
+
+- Export is Diagnostics-only; Activity keeps **Copy log** and gains no export control.
+- Platform scope matches the list: selected platform plus platform-less unscoped events; never the other platform.
+- **Export all** ignores the search box; **Copy loaded** still copies the on-screen (possibly searched) list.
+- File body is the same `timestamp [level] message` text as copy; export header adds `coverage: full`; clipboard text does not change.
+- Filename is `lurkloot-diagnostics-{platform}-{YYYYMMDDTHHMMSSZ}.log`.
+- Retention stays 2,000 diagnostic records / seven days; do not migrate IndexedDB or raise `getActivity`'s `MAX_LIMIT`.
+- No new extension permissions. Core and the CLI stay untouched.
+- Diagnostic line bodies stay English literals. Do not add catalog keys that start with `diagnostic` (see `diagnosticsLocale.test.ts`).
+- Two-space indentation, double quotes, semicolons.
+
+## File structure
+
+- `packages/shared/src/messages.ts`: `exportDiagnostics` message and `DiagnosticsExport` return type.
+- `packages/extension/src/core/activityStorage.ts`: one-shot `exportDiagnostics(platform)` walk.
+- `packages/extension/src/core/activityMessages.ts`: route the new message.
+- `packages/extension/entrypoints/background.ts`: wire the repository method.
+- `packages/extension/tests/coreBoundary.test.ts`: history-API guard includes the new names.
+- `packages/popup-ui/src/activity.logic.ts`: `coverage: "full"` and `.log` filename helper; export request generation.
+- `packages/popup-ui/src/activity.tsx`: **Copy loaded** / **Export all** on Diagnostics.
+- `packages/popup-ui/src/Popup.tsx`: send, format, download, discard stale exports.
+- `packages/popup-ui/src/types.ts` / `entrypoints/popup/app.tsx`: optional `downloadFile` hook.
+- `packages/popup-ui/src/demo.ts`: exhaustive `exportDiagnostics` case; omit `downloadFile`.
+- `packages/locales/messages/*.json`: toolbar chrome only.
+- Tests: `activityStorage.test.ts`, `activityMessages.test.ts`, `activityView.test.ts`, `activityLogView.test.tsx`, `popupDiagnosticsExport.test.tsx`.
+
+This worktree needs `pnpm install --frozen-lockfile` once before Task 1 if `node_modules` is missing.
+
+---
+
+### Task 1: One-shot diagnostic export in IndexedDB
+
+**Files:**
+
+- Modify: `packages/extension/src/core/activityStorage.ts`
+- Test: `packages/extension/tests/activityStorage.test.ts`
+
+**Interfaces:**
+
+- Consumes: existing `CATEGORY_INDEX`, diagnostic retention cutoff, and list platform rule (`!event.platform || event.platform === platform`).
+- Produces: `ActivityRepository.exportDiagnostics(platform: Platform): Promise<ActivityHistoryRecord[]>` (newest-first, no cursor, no text query, no 100-row cap) and `exportDiagnosticsEvents(platform)` wrapper.
+
+- [ ] **Step 1: Write the failing repository tests**
+
+Add these cases next to the existing diagnostic search tests. Reuse `NOW` and `DAY_MS`.
+
+```ts
+it("exports every retained diagnostic for a platform without the page cap or search filter", async () => {
+  await repository.append([
+    ...Array.from({ length: 101 }, (_, index) => ({
+      category: "diagnostic" as const,
+      level: "debug" as const,
+      platform: "kick" as const,
+      message: `kick-${String(index).padStart(3, "0")}`,
+      emittedAt: new Date(NOW.getTime() - index * 1_000).toISOString(),
+    })),
+    {
+      category: "diagnostic",
+      level: "info",
+      platform: "twitch",
+      message: "twitch-only",
+      emittedAt: NOW.toISOString(),
+    },
+    {
+      category: "diagnostic",
+      level: "error",
+      message: "global",
+      emittedAt: new Date(NOW.getTime() + 1_000).toISOString(),
+    },
+  ]);
+
+  const page = await repository.load({ category: "diagnostic", platform: "kick", limit: 100 });
+  const searched = await repository.load({ category: "diagnostic", platform: "kick", query: "global" });
+  const exported = await repository.exportDiagnostics("kick");
+
+  expect(page.events).toHaveLength(100);
+  expect(page.nextCursor).toBeDefined();
+  expect(searched.events.map((event) => event.message)).toEqual(["global"]);
+  expect(exported.map((event) => event.message)).toEqual([
+    "global",
+    ...Array.from({ length: 101 }, (_, index) => `kick-${String(index).padStart(3, "0")}`),
+  ]);
+  expect(exported.some((event) => event.message === "twitch-only")).toBe(false);
+});
+
+it("omits diagnostics past the seven-day cutoff from a full export", async () => {
+  const eightDaysAgo = new Date(NOW.getTime() - 8 * DAY_MS).toISOString();
+  await repository.importLegacy([
+    { id: "old", at: eightDaysAgo, category: "diagnostic", level: "info", message: "expired", legacy: true },
+    { id: "current", at: NOW.toISOString(), category: "diagnostic", level: "info", platform: "kick", message: "current", legacy: true },
+  ]);
+
+  expect((await repository.exportDiagnostics("kick")).map((event) => event.message)).toEqual(["current"]);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityStorage.test.ts`
+
+Expected: FAIL because `exportDiagnostics` is not a function.
+
+- [ ] **Step 3: Implement the repository walk**
+
+Add `exportDiagnostics(platform: Platform): Promise<ActivityHistoryRecord[]>` to `ActivityRepository` and the IndexedDB class. Walk `CATEGORY_INDEX` newest-first (`"prev"`) with the diagnostic retention cutoff, the same way `load` does, but collect every platform-eligible row and stop only when the cursor ends. Do not apply `query`, `limit`, or `MAX_LIMIT`.
+
+```ts
+async exportDiagnostics(platform: Platform): Promise<ActivityHistoryRecord[]> {
+  const database = await this.open();
+  const transaction = database.transaction(EVENT_STORE, "readonly");
+  const index = transaction.objectStore(EVENT_STORE).index(CATEGORY_INDEX);
+  const cutoff = new Date(Date.now() - retentionMs("diagnostic")).toISOString();
+  const range = IDBKeyRange.bound(["diagnostic", cutoff, ""], ["diagnostic", []]);
+  const request = index.openCursor(range, "prev");
+  const events: ActivityHistoryRecord[] = [];
+
+  await new Promise<void>((resolve, reject) => {
+    request.onerror = () => reject(request.error ?? new Error("Could not export diagnostics"));
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (!cursor) {
+        resolve();
+        return;
+      }
+      const event = cursor.value as ActivityHistoryRecord;
+      if (!event.platform || event.platform === platform) events.push(event);
+      cursor.continue();
+    };
+  });
+  await transactionDone(transaction);
+  return events;
+}
+```
+
+Import `Platform` from `@lurkloot/shared/models`. Export a module wrapper:
+
+```ts
+export function exportDiagnosticsEvents(platform: Platform): Promise<ActivityHistoryRecord[]> {
+  return repository.exportDiagnostics(platform);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityStorage.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/extension/src/core/activityStorage.ts packages/extension/tests/activityStorage.test.ts
+git commit -m "feat(activity): export full diagnostic history from indexeddb"
+```
+
+---
+
+### Task 2: Route `exportDiagnostics` through the extension host
+
+**Files:**
+
+- Modify: `packages/shared/src/messages.ts`
+- Modify: `packages/extension/src/core/activityMessages.ts`
+- Modify: `packages/extension/entrypoints/background.ts`
+- Modify: `packages/extension/tests/coreBoundary.test.ts`
+- Test: `packages/extension/tests/activityMessages.test.ts`
+
+**Interfaces:**
+
+- Consumes: `exportDiagnostics(platform)` from Task 1.
+- Produces:
+
+```ts
+export interface DiagnosticsExport {
+  events: ActivityHistoryRecord[];
+}
+
+export type RuntimeMessage =
+  | CoreRuntimeMessage
+  | ({ type: "getActivity" } & ActivityQuery)
+  | { type: "exportDiagnostics"; platform: Platform }
+  | { type: "clearActivity" }
+  | { type: "resetExtension" }
+  | { type: "exportCliCredentials" };
+```
+
+Handler returns `DiagnosticsExport` for that message. Dispatcher sends `exportDiagnostics` to the activity handler, never core.
+
+- [ ] **Step 1: Write the failing message tests**
+
+Update `createActivityMessageHandler` fixtures to include `exportDiagnostics`. Add:
+
+```ts
+it("exports diagnostics through the extension repository", async () => {
+  const events = [{ id: "d1", at: "2026-08-16T00:00:00.000Z", category: "diagnostic", level: "info", message: "hello" }];
+  const exportDiagnostics = vi.fn(async () => events);
+  const handler = createActivityMessageHandler({
+    load: vi.fn(),
+    clear: vi.fn(),
+    exportDiagnostics,
+  });
+
+  await expect(handler({ type: "exportDiagnostics", platform: "kick" }))
+    .resolves.toEqual({ events });
+  expect(exportDiagnostics).toHaveBeenCalledWith("kick");
+});
+```
+
+Extend the dispatcher `it.each` list with `{ type: "exportDiagnostics", platform: "twitch" } as const`.
+
+In `coreBoundary.test.ts`, change:
+
+```ts
+const HISTORY_API = /\b(?:ActivityPage|DiagnosticsExport|getActivity|exportDiagnostics|clearActivity|activityStorage)\b/;
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityMessages.test.ts tests/coreBoundary.test.ts`
+
+Expected: FAIL on missing `exportDiagnostics` in the handler/dispatcher types.
+
+- [ ] **Step 3: Implement the contract and routing**
+
+Add `DiagnosticsExport` and the message variant in `packages/shared/src/messages.ts`.
+
+Widen `ActivityMessageRepository`:
+
+```ts
+interface ActivityMessageRepository {
+  load(query: ActivityQuery): Promise<ActivityPage>;
+  exportDiagnostics(platform: Platform): Promise<ActivityHistoryRecord[]>;
+  clear(): Promise<void>;
+}
+```
+
+Handle it before the `undefined` return:
+
+```ts
+if (message.type === "exportDiagnostics") {
+  return { events: await repository.exportDiagnostics(message.platform) };
+}
+```
+
+Return type becomes `Promise<ActivityPage | DiagnosticsExport | void | undefined>`.
+
+Dispatcher:
+
+```ts
+if (message.type === "getActivity" || message.type === "exportDiagnostics" || message.type === "clearActivity") {
+  return deps.handleActivityMessage(message);
+}
+```
+
+Wire background.ts:
+
+```ts
+import { appendActivityEvents, clearActivityEvents, exportDiagnosticsEvents, loadActivityEvents } from "../src/core/activityStorage";
+
+const handleActivityMessage = createActivityMessageHandler({
+  load: loadActivityEvents,
+  exportDiagnostics: exportDiagnosticsEvents,
+  clear: clearActivityEvents,
+});
+```
+
+Update existing handler tests that construct `{ load, clear }` so they also pass `exportDiagnostics: vi.fn()`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityMessages.test.ts tests/coreBoundary.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/messages.ts packages/extension/src/core/activityMessages.ts packages/extension/entrypoints/background.ts packages/extension/tests/activityMessages.test.ts packages/extension/tests/coreBoundary.test.ts
+git commit -m "feat(extension): route diagnostics export message"
+```
+
+---
+
+### Task 3: Full-coverage export text and `.log` filename
+
+**Files:**
+
+- Modify: `packages/popup-ui/src/activity.logic.ts`
+- Modify: `packages/popup-ui/src/index.ts`
+- Test: `packages/extension/tests/activityView.test.ts`
+
+**Interfaces:**
+
+- Consumes: existing `buildActivityExport`.
+- Produces:
+
+```ts
+coverage?: "full"; // on ActivityExportInput; omit for copy
+
+export function buildDiagnosticsExportFilename(platform: Platform, at: Date): string;
+```
+
+When `coverage === "full"`, the header includes `coverage: full` after `events:`. Copy omits the field, so clipboard text is unchanged.
+
+- [ ] **Step 1: Write the failing formatter tests**
+
+In the existing `describe("activity export")` block:
+
+```ts
+it("adds coverage: full only when requested", () => {
+  const events = [{
+    id: "a",
+    at: "2026-07-14T11:00:00.000Z",
+    category: "diagnostic" as const,
+    level: "info" as const,
+    message: "first",
+  }];
+  const copied = buildActivityExport({ ...exportInput, diagnostics: true, events }, t);
+  const full = buildActivityExport({ ...exportInput, diagnostics: true, coverage: "full", events }, t);
+  const empty = buildActivityExport({ ...exportInput, diagnostics: true, coverage: "full", events: [] }, t);
+
+  expect(copied).not.toContain("coverage:");
+  expect(full.split("\n\n")[0].split("\n")).toContain("coverage: full");
+  expect(full).toContain("2026-07-14T11:00:00.000Z [info] first");
+  expect(empty).toContain("coverage: full");
+  expect(empty).toContain("events: 0");
+  expect(empty.trimEnd().endsWith("(no events)")).toBe(true);
+});
+
+it("builds a windows-safe diagnostics log filename", () => {
+  expect(buildDiagnosticsExportFilename("twitch", new Date("2026-08-16T14:33:27.000Z")))
+    .toBe("lurkloot-diagnostics-twitch-20260816T143327Z.log");
+});
+```
+
+Import `buildDiagnosticsExportFilename` from `@lurkloot/popup-ui`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityView.test.ts`
+
+Expected: FAIL because `coverage` is ignored and the filename helper is missing.
+
+- [ ] **Step 3: Implement formatter and filename**
+
+```ts
+export interface ActivityExportInput {
+  events: readonly ActivityHistoryRecord[];
+  platform: Platform;
+  diagnostics: boolean;
+  version: string;
+  userAgent: string;
+  locale: string;
+  at: string;
+  coverage?: "full";
+}
+
+export function buildActivityExport(input: ActivityExportInput, t: TFunction): string {
+  const header = [
+    `Lurkloot ${input.diagnostics ? "diagnostics" : "activity"} log`,
+    `version: ${input.version}`,
+    `platform: ${input.platform}`,
+    `locale: ${input.locale}`,
+    `exported: ${input.at}`,
+    `browser: ${input.userAgent}`,
+    `events: ${input.events.length}`,
+    ...(input.coverage === "full" ? ["coverage: full"] : []),
+  ].join("\n");
+  // body unchanged
+}
+
+export function buildDiagnosticsExportFilename(platform: Platform, at: Date): string {
+  const stamp = at.toISOString().replaceAll("-", "").replaceAll(":", "").replace(/\.\d{3}Z$/, "Z");
+  return `lurkloot-diagnostics-${platform}-${stamp}.log`;
+}
+```
+
+Re-export `buildDiagnosticsExportFilename` from `packages/popup-ui/src/index.ts`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityView.test.ts`
+
+Expected: PASS. Existing copy tests still have no `coverage:` line.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/popup-ui/src/activity.logic.ts packages/popup-ui/src/index.ts packages/extension/tests/activityView.test.ts
+git commit -m "feat(popup): mark full diagnostic log coverage"
+```
+
+---
+
+### Task 4: Diagnostics toolbar — Copy loaded and Export all
+
+**Files:**
+
+- Modify: `packages/popup-ui/src/activity.tsx`
+- Modify: every `packages/locales/messages/*.json`
+- Test: `packages/extension/tests/activityLogView.test.tsx`
+
+**Interfaces:**
+
+- Consumes: locale keys below; optional `onExportAll(): Promise<number | undefined>`.
+- Produces: Diagnostics shows **Copy loaded** and **Export all**; Activity still shows **Copy log** and no export control. `onExportAll` missing hides **Export all**. Returning `undefined` is a stale no-op (no success, no error). Throwing shows **Could not export the log. Try again.** Success shows **Exported N events** for 2500ms.
+
+Locale keys (must not start with `diagnostic`):
+
+| key | en |
+| --- | --- |
+| `copyLoadedActivityLog` | Copy loaded |
+| `exportAllDiagnostics` | Export all |
+| `exportAllDiagnosticsDone` | Exported $1 events |
+| `exportAllDiagnosticsFailed` | Could not export the log. Try again. |
+
+Add the same four keys to `ar`, `de`, `es`, `fr`, `hi`, `it`, `pt_BR`, `ru`, `tr`, `zh_CN`:
+
+- de: `Geladene kopieren` / `Alle exportieren` / `$1 Ereignisse exportiert` / `Protokoll konnte nicht exportiert werden. Bitte erneut versuchen.`
+- es: `Copiar cargados` / `Exportar todo` / `$1 eventos exportados` / `No se pudo exportar el registro. Inténtalo de nuevo.`
+- fr: `Copier la page` / `Tout exporter` / `$1 événements exportés` / `Impossible d'exporter le journal. Réessayez.`
+- it: `Copia caricati` / `Esporta tutto` / `$1 eventi esportati` / `Impossibile esportare il registro. Riprova.`
+- pt_BR: `Copiar carregados` / `Exportar tudo` / `$1 eventos exportados` / `Não foi possível exportar o registro. Tente novamente.`
+- ru: `Копировать загруженное` / `Экспортировать всё` / `Экспортировано событий: $1` / `Не удалось экспортировать журнал. Попробуйте снова.`
+- tr: `Yüklenenleri kopyala` / `Tümünü dışa aktar` / `$1 olay dışa aktarıldı` / `Günlük dışa aktarılamadı. Yeniden deneyin.`
+- zh_CN: `复制已加载` / `全部导出` / `已导出 $1 条` / `无法导出日志。请重试。`
+- ar: `نسخ المحمّل` / `تصدير الكل` / `تم تصدير $1 من الإدخالات` / `تعذر تصدير السجل. حاول مرة أخرى.`
+- hi: `लोड की गई कॉपी करें` / `सभी निर्यात करें` / `$1 इवेंट निर्यात किए गए` / `लॉग निर्यात नहीं हो सका। फिर से कोशिश करें.`
+
+Place them next to `copyActivityLog*` in each catalog.
+
+- [ ] **Step 1: Write the failing view tests**
+
+Extend the `ActivityLog` mount helper with `onExportAll?` and `searchQuery?` / `searchingDiagnostics?`. Add the four strings to the `t()` map. Change `copyButton` to also match `"Copy loaded"`. Add:
+
+```ts
+const exportButton = (container: Element) =>
+  [...container.querySelectorAll<HTMLButtonElement>("button")]
+    .find((button) => button.textContent?.includes("Export all") || button.textContent?.includes("Exported"));
+```
+
+```ts
+it("relabels copy and offers export all only in diagnostics", () => {
+  const activity = mount({ showDiagnostics: false, onExportAll: vi.fn(async () => 0) });
+  expect(copyButton(activity.container)?.textContent).toContain("Copy log");
+  expect(exportButton(activity.container)).toBeUndefined();
+
+  act(() => root?.unmount());
+  const diagnostics = mount({ showDiagnostics: true, onExportAll: vi.fn(async () => 0) });
+  expect(copyButton(diagnostics.container)?.textContent).toContain("Copy loaded");
+  expect(exportButton(diagnostics.container)?.textContent).toContain("Export all");
+});
+
+it("hides export all when the host cannot download a file", () => {
+  const { container } = mount({ showDiagnostics: true });
+  expect(exportButton(container)).toBeUndefined();
+});
+
+it("keeps export all enabled when search has no matches", () => {
+  const { container } = mount({
+    showDiagnostics: true,
+    diagnosticEvents: [],
+    searchQuery: "timeout",
+    searchingDiagnostics: true,
+    onExportAll: vi.fn(async () => 0),
+  });
+  expect(exportButton(container)?.disabled).toBe(false);
+});
+
+it("exports through onExportAll and confirms the count", async () => {
+  const onExportAll = vi.fn(async () => 12);
+  const { container } = mount({ showDiagnostics: true, onExportAll });
+
+  await act(async () => { exportButton(container)?.click(); });
+
+  expect(onExportAll).toHaveBeenCalledOnce();
+  expect(exportButton(container)?.textContent).toContain("Exported 12 events");
+});
+
+it("reports a failed export instead of confirming", async () => {
+  const { container } = mount({
+    showDiagnostics: true,
+    onExportAll: vi.fn(async () => { throw new Error("nope"); }),
+  });
+
+  await act(async () => { exportButton(container)?.click(); });
+
+  expect(container.querySelector('[role="alert"]')?.textContent).toBe("Could not export the log. Try again.");
+  expect(exportButton(container)?.textContent).toContain("Export all");
+});
+
+it("treats an undefined export result as a stale no-op", async () => {
+  const { container } = mount({
+    showDiagnostics: true,
+    onExportAll: vi.fn(async () => undefined),
+  });
+
+  await act(async () => { exportButton(container)?.click(); });
+
+  expect(exportButton(container)?.textContent).toContain("Export all");
+  expect(container.querySelector('[role="alert"]')).toBeNull();
+});
+```
+
+Pass `searchQuery` / `searchingDiagnostics` through to `ActivityLog` in the mount helper. Existing diagnostics copy test still uses `copyButton` and should keep working after the finder accepts **Copy loaded**.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityLogView.test.tsx tests/i18n.test.ts tests/diagnosticsLocale.test.ts`
+
+Expected: FAIL because the export control and new keys are missing.
+
+- [ ] **Step 3: Implement the toolbar and catalogs**
+
+Add optional props to `ActivityLog`:
+
+```ts
+onExportAll?(): Promise<number | undefined>;
+```
+
+Keep `copied` / `copyFailed` as today. Add `exported: number | null`, `exportFailed`, `exporting`. Reset `exported` / `exportFailed` in the same `useEffect` that clears copy on `showDiagnostics` / `platform`. Reuse `COPY_FEEDBACK_MS` for export confirmation.
+
+Copy label: `t(showDiagnostics ? "copyLoadedActivityLog" : "copyActivityLog")`.
+
+Render **Export all** only when `showDiagnostics && onExportAll`. Disable it while `exporting`. Do not disable it for an empty list. On click:
+
+```ts
+async function exportAll(): Promise<void> {
+  if (!onExportAll || exporting) return;
+  setExporting(true);
+  setExportFailed(false);
+  setCopied(null);
+  try {
+    const count = await onExportAll();
+    setExported(count ?? null);
+  } catch {
+    setExportFailed(true);
+    setExported(null);
+  } finally {
+    setExporting(false);
+  }
+}
+```
+
+Show `exportAllDiagnosticsFailed` in an alert the same way as copy failure. Import `Download` from `lucide-react` for the idle export icon (use `Check` while confirmed), matching the copy button's `Clipboard` / `Check` pair.
+
+Add the four keys to every locale catalog.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityLogView.test.tsx tests/i18n.test.ts tests/diagnosticsLocale.test.ts`
+
+Expected: PASS. `diagnosticsLocale` stays green because none of the new keys start with `diagnostic`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/popup-ui/src/activity.tsx packages/extension/tests/activityLogView.test.tsx packages/locales/messages
+git commit -m "feat(popup): add diagnostics export all control"
+```
+
+---
+
+### Task 5: Download the full log from the popup
+
+**Files:**
+
+- Modify: `packages/popup-ui/src/types.ts`
+- Modify: `packages/popup-ui/src/activity.logic.ts`
+- Modify: `packages/popup-ui/src/index.ts`
+- Modify: `packages/popup-ui/src/Popup.tsx`
+- Modify: `packages/popup-ui/src/demo.ts`
+- Modify: `packages/extension/entrypoints/popup/app.tsx`
+- Test: `packages/extension/tests/activityView.test.ts`
+- Create: `packages/extension/tests/popupDiagnosticsExport.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `DiagnosticsExport` (Task 2), `buildActivityExport` / `buildDiagnosticsExportFilename` (Task 3), `onExportAll` (Task 4).
+- Produces:
+
+```ts
+downloadFile?(filename: string, contents: string, mimeType?: string): void;
+
+export type DiagnosticsExportRequest = { generation: number; platform: Platform };
+export function createDiagnosticsExportRequest(platform: Platform): DiagnosticsExportRequest;
+export function beginDiagnosticsExport(current: DiagnosticsExportRequest, platform: Platform): DiagnosticsExportRequest;
+export function isDiagnosticsExportCurrent(request: DiagnosticsExportRequest, current: DiagnosticsExportRequest): boolean;
+```
+
+`createDiagnosticsExportRequest` starts at `generation: 0`. `beginDiagnosticsExport` returns `{ generation: current.generation + 1, platform }`. Current means both generation and platform match.
+
+Demo omits `downloadFile` and handles `exportDiagnostics` with `{ events: [] }`.
+
+- [ ] **Step 1: Write the failing request-scope and popup tests**
+
+In `activityView.test.ts`:
+
+```ts
+it("does not treat a previous platform's diagnostics export as current", () => {
+  expect(isDiagnosticsExportCurrent(
+    { generation: 1, platform: "kick" },
+    { generation: 1, platform: "twitch" },
+  )).toBe(false);
+  expect(isDiagnosticsExportCurrent(
+    { generation: 1, platform: "kick" },
+    { generation: 2, platform: "kick" },
+  )).toBe(false);
+  expect(isDiagnosticsExportCurrent(
+    { generation: 2, platform: "kick" },
+    { generation: 2, platform: "kick" },
+  )).toBe(true);
+});
+```
+
+Create `packages/extension/tests/popupDiagnosticsExport.test.tsx` with the same `linkedom`, `@lurkloot/locales`, and `motion/react` mocks as `tests/popupActivitySearchRequests.test.tsx`, plus `waitForCatalog`, `waitForMessage`, and `waitForElement`.
+
+```ts
+async function mount(options?: {
+  downloadFile?: (filename: string, contents: string, mimeType?: string) => void;
+  pendingExport?: { finish?: (value: DiagnosticsExport) => void };
+}): Promise<{ container: HTMLElement; sent: RuntimeMessage[]; downloadFile: ReturnType<typeof vi.fn> }> {
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(Date.now());
+    return 1;
+  });
+  const demo = createDemoPopupAdapter();
+  const sent: RuntimeMessage[] = [];
+  const downloadFile = options?.downloadFile ?? vi.fn();
+  const adapter: PopupAdapter = {
+    ...demo,
+    downloadFile,
+    getStorage: async () => ({ "popup:selectedPlatform": "twitch" }),
+    send: async <T,>(message: RuntimeMessage): Promise<T> => {
+      sent.push(message);
+      if (message.type === "exportDiagnostics") {
+        if (options?.pendingExport) {
+          return await new Promise<DiagnosticsExport>((resolve) => {
+            options.pendingExport!.finish = resolve;
+          }) as T;
+        }
+        return {
+          events: [{
+            id: "d1",
+            at: "2026-08-16T00:00:00.000Z",
+            category: "diagnostic",
+            level: "info",
+            platform: "twitch",
+            message: "full history line",
+          }],
+        } as T;
+      }
+      return demo.send<T>(message);
+    },
+  };
+  const container = document.getElementById("app")!;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} />);
+  });
+  await waitForCatalog();
+  const openActivity = container.querySelector<HTMLButtonElement>('button[aria-label="Open activity"]');
+  if (!openActivity) throw new Error("Missing activity button");
+  await act(async () => openActivity.click());
+  const diagnosticsTab = await waitForElement(() =>
+    container.querySelector<HTMLButtonElement>('[role="tab"][aria-selected="false"]') ?? undefined);
+  await act(async () => diagnosticsTab.click());
+  return { container, sent, downloadFile: downloadFile as ReturnType<typeof vi.fn> };
+}
+
+it("requests a full diagnostics export for the selected platform and downloads a .log", async () => {
+  const { container, sent, downloadFile } = await mount();
+  const exportAll = await waitForElement(() =>
+    [...container.querySelectorAll<HTMLButtonElement>("button")]
+      .find((button) => button.textContent === "Export all"));
+  await act(async () => exportAll.click());
+  const request = await waitForMessage(sent, (message) => message.type === "exportDiagnostics");
+  expect(request).toEqual({ type: "exportDiagnostics", platform: "twitch" });
+  expect(downloadFile).toHaveBeenCalledOnce();
+  const [filename, contents, mimeType] = downloadFile.mock.calls[0];
+  expect(filename).toMatch(/^lurkloot-diagnostics-twitch-\d{8}T\d{6}Z\.log$/);
+  expect(contents).toContain("coverage: full");
+  expect(contents).toContain("full history line");
+  expect(mimeType).toBe("text/plain");
+});
+
+it("does not download a stale export after the platform changes", async () => {
+  const pendingExport: { finish?: (value: DiagnosticsExport) => void } = {};
+  const { container, downloadFile } = await mount({ pendingExport });
+  const exportAll = await waitForElement(() =>
+    [...container.querySelectorAll<HTMLButtonElement>("button")]
+      .find((button) => button.textContent === "Export all"));
+  await act(async () => exportAll.click());
+  const kick = [...container.querySelectorAll<HTMLButtonElement>("button")]
+    .find((button) => button.textContent?.includes("Kick"));
+  await act(async () => kick?.click());
+  await act(async () => {
+    pendingExport.finish?.({
+      events: [{
+        id: "late",
+        at: "2026-08-16T00:00:00.000Z",
+        category: "diagnostic",
+        level: "info",
+        message: "late",
+      }],
+    });
+  });
+  expect(downloadFile).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityView.test.ts tests/popupDiagnosticsExport.test.tsx`
+
+Expected: FAIL because the request helpers, `downloadFile`, and Popup wiring are missing.
+
+- [ ] **Step 3: Implement adapter, request generation, and Popup wiring**
+
+`packages/popup-ui/src/types.ts` — next to `writeClipboard`:
+
+```ts
+  // Optional: download a text file from the popup. The live extension implements
+  // it with a Blob URL; hosts that omit it (the site demo) hide Export all.
+  downloadFile?(filename: string, contents: string, mimeType?: string): void;
+```
+
+`packages/extension/entrypoints/popup/app.tsx` — next to `exportSettings`:
+
+```ts
+    downloadFile: (filename, contents, mimeType = "text/plain") => {
+      const url = URL.createObjectURL(new Blob([contents], { type: mimeType }));
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      anchor.click();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    },
+```
+
+In `activity.logic.ts`:
+
+```ts
+export type DiagnosticsExportRequest = { generation: number; platform: Platform };
+
+export function createDiagnosticsExportRequest(platform: Platform): DiagnosticsExportRequest {
+  return { generation: 0, platform };
+}
+
+export function beginDiagnosticsExport(
+  current: DiagnosticsExportRequest,
+  platform: Platform,
+): DiagnosticsExportRequest {
+  return { generation: current.generation + 1, platform };
+}
+
+export function isDiagnosticsExportCurrent(
+  request: DiagnosticsExportRequest,
+  current: DiagnosticsExportRequest,
+): boolean {
+  return request.generation === current.generation && request.platform === current.platform;
+}
+```
+
+Re-export those three functions and the type from `index.ts`.
+
+`demo.ts`: add `DiagnosticsExport` to the `handleDemoMessage` return union and:
+
+```ts
+    case "exportDiagnostics":
+      return { events: [] };
+```
+
+Do not add `downloadFile` on the demo adapter.
+
+`Popup.tsx`:
+
+- Import `DiagnosticsExport` from `@lurkloot/shared/messages`.
+- Import `beginDiagnosticsExport`, `buildActivityExport`, `buildDiagnosticsExportFilename`, `createDiagnosticsExportRequest`, `isDiagnosticsExportCurrent`.
+- Keep `const diagnosticsExportRequestRef = useRef(createDiagnosticsExportRequest(platform));` (not the diagnostic list mutation sequence).
+- Implement:
+
+```ts
+async function exportDiagnosticsLog(): Promise<number | undefined> {
+  const downloadFile = adapter.downloadFile;
+  if (!downloadFile) return undefined;
+  const request = beginDiagnosticsExport(diagnosticsExportRequestRef.current, platform);
+  diagnosticsExportRequestRef.current = request;
+  const exportedAt = new Date();
+  const result = await adapter.send<DiagnosticsExport>({ type: "exportDiagnostics", platform: request.platform });
+  if (!isDiagnosticsExportCurrent(request, diagnosticsExportRequestRef.current)) return undefined;
+  downloadFile(
+    buildDiagnosticsExportFilename(request.platform, exportedAt),
+    buildActivityExport({
+      events: result.events,
+      platform: request.platform,
+      diagnostics: true,
+      coverage: "full",
+      version: adapter.version,
+      userAgent: typeof navigator === "undefined" ? "unknown" : navigator.userAgent,
+      locale,
+      at: exportedAt.toISOString(),
+    }, t),
+    "text/plain",
+  );
+  return result.events.length;
+}
+```
+
+Pass `onExportAll={adapter.downloadFile ? exportDiagnosticsLog : undefined}` to `ActivityLog`. On platform change (`selectPlatform`) and when leaving Diagnostics / Activity (`handleShowDiagnosticsChange`, `closeActivityView`), bump the export request with `beginDiagnosticsExport` so an in-flight download is discarded.
+
+If `adapter.send` throws, let it reject so `ActivityLog` shows the failure alert.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @lurkloot/extension test tests/activityView.test.ts tests/popupDiagnosticsExport.test.tsx tests/activityLogView.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/popup-ui/src/types.ts packages/popup-ui/src/activity.logic.ts packages/popup-ui/src/index.ts packages/popup-ui/src/Popup.tsx packages/popup-ui/src/demo.ts packages/extension/entrypoints/popup/app.tsx packages/extension/tests/activityView.test.ts packages/extension/tests/popupDiagnosticsExport.test.tsx
+git commit -m "feat(popup): download full diagnostic history"
+```
+
+---
+
+### Task 6: Verify the integrated feature
+
+- [ ] **Step 1: Type-check**
+
+Run: `pnpm typecheck`
+
+Expected: PASS with no TypeScript errors. `handleDemoMessage` stays exhaustive after `exportDiagnostics`.
+
+- [ ] **Step 2: Run extension tests**
+
+Run: `pnpm test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Build the popup-consuming site**
+
+Run: `pnpm build:site`
+
+Expected: PASS; any existing Vite chunk-size advisory remains a warning.
+
+- [ ] **Step 4: Check the final diff**
+
+Run: `git diff origin/develop...HEAD --check && git status --short`
+
+Expected: no whitespace errors; only the feature, tests, locales, and the already-committed spec/plan.

--- a/docs/superpowers/specs/2026-08-16-diagnostics-full-export-design.md
+++ b/docs/superpowers/specs/2026-08-16-diagnostics-full-export-design.md
@@ -1,0 +1,55 @@
+# Diagnostics full-export design
+
+## Goal
+
+Let users download the complete retained diagnostic history for the selected platform from the popup Diagnostics view, while keeping the existing copy action as a pasteable snapshot of whatever is currently loaded.
+
+## Scope and behavior
+
+- Diagnostics toolbar becomes **Copy loaded**, **Export all**, and **Clear history**. Activity keeps today's **Copy log** and does not gain an export control.
+- **Copy loaded** still serializes only the on-screen diagnostic list (the loaded page, plus any **Load more** rows, including the current search results). Clipboard text is unchanged.
+- **Export all** downloads a `.log` file of every retained matching diagnostic for the selected platform, including platform-less unscoped events that already appear in that view. It ignores the search box.
+- Retention stays as today: latest 2,000 diagnostic records within seven days. Export does not add a second cap.
+- An empty store still downloads a valid log (`events: 0` and `(no events)`). **Export all** stays enabled when search has no matches, and is disabled only while an export is in flight.
+- Hosts without a file-download hook (the site demo) hide **Export all**. **Copy loaded** still follows the existing clipboard hook.
+- Core and the CLI are out of scope. Diagnostic line bodies remain English literals; only toolbar chrome is localized.
+
+## Architecture
+
+Export is a one-shot extension-host job, not another `getActivity` page.
+
+`RuntimeMessage` gains `{ type: "exportDiagnostics"; platform: Platform }`. The extension activity handler asks the IndexedDB repository for every retained diagnostic matching the current list's platform rule (`event.platform` missing or equal to the selected platform). The walk uses the existing diagnostic category index and retention cutoff, returns newest-first, and does not apply a text query or the 100-row `getActivity` limit.
+
+The handler returns a `DiagnosticsExport` of `{ events }` with no cursor. The popup formats that list with the existing `buildActivityExport` helper (oldest-first body, same `timestamp [level] message` lines as copy). Export passes `coverage: "full"` so the header includes `coverage: full`; copy omits that field so clipboard text does not change. `PopupAdapter` gains an optional `downloadFile(filename, contents, mimeType)` hook; the extension implements it with the same Blob URL + `<a download>` path used for settings and credentials, and the demo omits it. No new extension permissions.
+
+Export uses its own request generation, not the diagnostic list's mutation sequence, so a **Load more** or search refresh cannot adopt or cancel a download. A stale export whose platform or generation no longer matches is discarded and not downloaded. Switching platform or leaving Diagnostics clears the transient success state, matching copy.
+
+## File format
+
+Filename: `lurkloot-diagnostics-{platform}-{utc}.log`, for example `lurkloot-diagnostics-twitch-20260816T143327Z.log`. The UTC stamp uses `YYYYMMDDTHHMMSSZ` so it is a legal filename on Windows.
+
+Header (English, same fields as copy, plus coverage):
+
+```text
+Lurkloot diagnostics log
+version: …
+platform: twitch
+locale: …
+exported: …
+browser: …
+events: N
+coverage: full
+```
+
+Body: one oldest-first line per event, `2026-07-25T12:00:01.000Z [error] …`.
+
+## Error handling
+
+IndexedDB or message failures show a localized alert, **Could not export the log. Try again.**, and do not download a partial file. Success shows a transient **Exported N events** on the button (same 2.5s confirmation window as copy). Closing the popup during the IndexedDB read may abort the download; that is accepted.
+
+## Testing
+
+- Storage tests prove one-shot export returns more than a 100-row page, includes unscoped events, excludes the other platform, ignores a search query, is newest-first, and still respects the seven-day cutoff.
+- Message tests prove `exportDiagnostics` routes through the extension repository and returns `DiagnosticsExport`. `coreBoundary`'s history-API guard includes the new message name.
+- Popup tests prove Diagnostics shows **Copy loaded** and **Export all**; Activity still shows **Copy log** and no export control; hosts without a download hook hide **Export all**; the request is `{ type: "exportDiagnostics", platform }` with no search query; the file uses `buildActivityExport` with `coverage: full` and the `.log` filename; copy still serializes only the loaded list; export stays enabled when search has no matches; failure shows the alert; a stale result after a platform switch is not downloaded; success shows **Exported N events**.
+- Locale tests cover the new chrome strings only.

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -28,7 +28,7 @@ import { createKickFetcher, KickAdapter, KickClaimState, KickDiscoveryState } fr
 import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import { isMinorOrMajorBump } from "../src/core/version";
 import { savePendingChangelogVersion } from "../src/core/updateNotice";
-import { appendActivityEvents, clearActivityEvents, loadActivityEvents } from "../src/core/activityStorage";
+import { appendActivityEvents, clearActivityEvents, exportDiagnosticsEvents, loadActivityEvents } from "../src/core/activityStorage";
 import {
   createActivityEventReporter,
   createActivityMessageHandler,
@@ -42,6 +42,7 @@ const localeCatalogs = new Map<string, MessageCatalog | undefined>();
 const getMessage = browser.i18n.getMessage as (key: string, substitutions?: string | string[]) => string;
 const handleActivityMessage = createActivityMessageHandler({
   load: loadActivityEvents,
+  exportDiagnostics: exportDiagnosticsEvents,
   clear: clearActivityEvents,
 });
 const reportEvents = createActivityEventReporter({

--- a/packages/extension/entrypoints/popup/app.tsx
+++ b/packages/extension/entrypoints/popup/app.tsx
@@ -64,6 +64,14 @@ export function createExtensionPopupAdapter(): PopupAdapter {
       anchor.click();
       setTimeout(() => URL.revokeObjectURL(url), 0);
     },
+    downloadFile: (filename, contents, mimeType = "text/plain") => {
+      const url = URL.createObjectURL(new Blob([contents], { type: mimeType }));
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      anchor.click();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    },
     importSettings: () => new Promise<unknown | null>((resolve, reject) => {
       const input = document.createElement("input");
       input.type = "file";

--- a/packages/extension/src/core/activityMessages.ts
+++ b/packages/extension/src/core/activityMessages.ts
@@ -1,8 +1,10 @@
-import type { EngineEvent } from "@lurkloot/shared/events";
-import type { ActivityPage, ActivityQuery, CoreRuntimeMessage, RuntimeMessage } from "@lurkloot/shared/messages";
+import type { ActivityHistoryRecord, EngineEvent } from "@lurkloot/shared/events";
+import type { Platform } from "@lurkloot/shared/models";
+import type { ActivityPage, ActivityQuery, CoreRuntimeMessage, DiagnosticsExport, RuntimeMessage } from "@lurkloot/shared/messages";
 
 interface ActivityMessageRepository {
   load(query: ActivityQuery): Promise<ActivityPage>;
+  exportDiagnostics(platform: Platform): Promise<ActivityHistoryRecord[]>;
   clear(): Promise<void>;
 }
 
@@ -23,10 +25,13 @@ interface RuntimeMessageDispatcherDeps {
 }
 
 export function createActivityMessageHandler(repository: ActivityMessageRepository) {
-  return async (message: RuntimeMessage): Promise<ActivityPage | void | undefined> => {
+  return async (message: RuntimeMessage): Promise<ActivityPage | DiagnosticsExport | void | undefined> => {
     if (message.type === "getActivity") {
       const { type: _type, ...query } = message;
       return repository.load(query);
+    }
+    if (message.type === "exportDiagnostics") {
+      return { events: await repository.exportDiagnostics(message.platform) };
     }
     if (message.type === "clearActivity") {
       await repository.clear();
@@ -55,7 +60,7 @@ export function createRuntimeMessageDispatcher(deps: RuntimeMessageDispatcherDep
   return (message: RuntimeMessage, sender?: RuntimeMessageSender): Promise<unknown> => {
     if (message.type === "exportCliCredentials") return deps.exportCliCredentials();
     if (message.type === "resetExtension") return deps.resetExtension();
-    if (message.type === "getActivity" || message.type === "clearActivity") {
+    if (message.type === "getActivity" || message.type === "exportDiagnostics" || message.type === "clearActivity") {
       return deps.handleActivityMessage(message);
     }
     return deps.handleCoreMessage(message, sender);

--- a/packages/extension/src/core/activityStorage.ts
+++ b/packages/extension/src/core/activityStorage.ts
@@ -1,4 +1,5 @@
 import type { ActivityPage, ActivityQuery } from "@lurkloot/shared/messages";
+import type { Platform } from "@lurkloot/shared/models";
 import type {
   ActivityHistoryRecord,
   EngineEvent,
@@ -65,6 +66,7 @@ export interface ActivityRepository {
   append(events: readonly EngineEvent[]): Promise<void>;
   importLegacy(events: readonly StoredLegacyEvent[]): Promise<void>;
   load(query: ActivityQuery): Promise<ActivityPage>;
+  exportDiagnostics(platform: Platform): Promise<ActivityHistoryRecord[]>;
   clear(): Promise<void>;
   prune(): Promise<void>;
   count(category: EventCategory): Promise<number>;
@@ -234,6 +236,32 @@ class IndexedDbActivityRepository implements ActivityRepository {
     };
   }
 
+  async exportDiagnostics(platform: Platform): Promise<ActivityHistoryRecord[]> {
+    const database = await this.open();
+    const transaction = database.transaction(EVENT_STORE, "readonly");
+    const index = transaction.objectStore(EVENT_STORE).index(CATEGORY_INDEX);
+    const cutoff = new Date(Date.now() - retentionMs("diagnostic")).toISOString();
+    const range = IDBKeyRange.bound(["diagnostic", cutoff, ""], ["diagnostic", []]);
+    const request = index.openCursor(range, "prev");
+    const events: ActivityHistoryRecord[] = [];
+
+    await new Promise<void>((resolve, reject) => {
+      request.onerror = () => reject(request.error ?? new Error("Could not export diagnostics"));
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) {
+          resolve();
+          return;
+        }
+        const event = cursor.value as ActivityHistoryRecord;
+        if (!event.platform || event.platform === platform) events.push(event);
+        cursor.continue();
+      };
+    });
+    await transactionDone(transaction);
+    return events;
+  }
+
   async clear(): Promise<void> {
     const database = await this.open();
     const transaction = database.transaction([EVENT_STORE, META_STORE], "readwrite");
@@ -359,6 +387,10 @@ export function importLegacyActivityEvents(events: readonly StoredLegacyEvent[])
 
 export function loadActivityEvents(query: ActivityQuery): Promise<ActivityPage> {
   return repository.load(query);
+}
+
+export function exportDiagnosticsEvents(platform: Platform): Promise<ActivityHistoryRecord[]> {
+  return repository.exportDiagnostics(platform);
 }
 
 export function clearActivityEvents(): Promise<void> {

--- a/packages/extension/tests/activityLogView.test.tsx
+++ b/packages/extension/tests/activityLogView.test.tsx
@@ -52,6 +52,9 @@ function mount(options: {
   omitClipboard?: boolean;
   activityEvents?: ActivityHistoryRecord[];
   diagnosticEvents?: ActivityHistoryRecord[];
+  onExportAll?: () => Promise<number | undefined>;
+  searchQuery?: string;
+  searchingDiagnostics?: boolean;
 }) {
   const { document, window } = parseHTML("<div id=app></div>");
   vi.stubGlobal("window", window);
@@ -78,8 +81,12 @@ function mount(options: {
           noActivity: "No activity recorded yet.",
           noDiagnostics: "No diagnostics recorded yet.",
           copyActivityLog: "Copy log",
+          copyLoadedActivityLog: "Copy loaded",
           copyActivityLogCopied: `Copied ${String(substitutions)} events`,
           copyActivityLogFailed: "Could not copy the log. Try again.",
+          exportAllDiagnostics: "Export all",
+          exportAllDiagnosticsDone: `Exported ${String(substitutions)} events`,
+          exportAllDiagnosticsFailed: "Could not export the log. Try again.",
         })[key] ?? `${key}${substitutions ? "" : ""}`,
         dir: "ltr",
         locale: "en",
@@ -98,10 +105,13 @@ function mount(options: {
             clearing={false}
             version="1.9.0"
             locale="en"
+            searchQuery={options.searchQuery}
+            searchingDiagnostics={options.searchingDiagnostics}
             onShowDiagnosticsChange={onShowDiagnosticsChange}
             onLoadMore={() => undefined}
             onClear={() => undefined}
             writeClipboard={options.omitClipboard ? undefined : writeClipboard}
+            onExportAll={options.onExportAll}
           />
         </PopupRuntimeContext.Provider>
       </I18nContext.Provider>,
@@ -113,7 +123,11 @@ function mount(options: {
 
 const copyButton = (container: Element) =>
   [...container.querySelectorAll<HTMLButtonElement>("button")]
-    .find((button) => button.textContent?.includes("Copy log") || button.textContent?.includes("Copied"));
+    .find((button) => button.textContent?.includes("Copy log") || button.textContent?.includes("Copy loaded") || button.textContent?.includes("Copied"));
+
+const exportButton = (container: Element) =>
+  [...container.querySelectorAll<HTMLButtonElement>("button")]
+    .find((button) => button.textContent?.includes("Export all") || button.textContent?.includes("Exported"));
 
 describe("activity log view", () => {
   it("shows only activity entries while the activity view is selected", () => {
@@ -257,6 +271,67 @@ describe("activity log view", () => {
     const { container } = mount({ showDiagnostics: false, omitClipboard: true });
 
     expect(copyButton(container)).toBeUndefined();
+  });
+
+  it("relabels copy and offers export all only in diagnostics", () => {
+    const activity = mount({ showDiagnostics: false, onExportAll: vi.fn(async () => 0) });
+    expect(copyButton(activity.container)?.textContent).toContain("Copy log");
+    expect(exportButton(activity.container)).toBeUndefined();
+
+    act(() => root?.unmount());
+    const diagnostics = mount({ showDiagnostics: true, onExportAll: vi.fn(async () => 0) });
+    expect(copyButton(diagnostics.container)?.textContent).toContain("Copy loaded");
+    expect(exportButton(diagnostics.container)?.textContent).toContain("Export all");
+  });
+
+  it("hides export all when the host cannot download a file", () => {
+    const { container } = mount({ showDiagnostics: true });
+    expect(exportButton(container)).toBeUndefined();
+  });
+
+  it("keeps export all enabled when search has no matches", () => {
+    const { container } = mount({
+      showDiagnostics: true,
+      diagnosticEvents: [],
+      searchQuery: "timeout",
+      searchingDiagnostics: true,
+      onExportAll: vi.fn(async () => 0),
+    });
+    expect(exportButton(container)?.disabled).toBe(false);
+  });
+
+  it("exports through onExportAll and confirms the count", async () => {
+    const onExportAll = vi.fn(async () => 12);
+    const { container } = mount({ showDiagnostics: true, onExportAll });
+
+    await act(async () => { exportButton(container)?.click(); });
+
+    expect(onExportAll).toHaveBeenCalledOnce();
+    expect(exportButton(container)?.textContent).toContain("Exported 12 events");
+  });
+
+  it("reports a failed export instead of confirming", async () => {
+    const { container } = mount({
+      showDiagnostics: true,
+      onExportAll: vi.fn(async () => { throw new Error("nope"); }),
+    });
+
+    await act(async () => { exportButton(container)?.click(); });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("Could not export the log. Try again.");
+    expect(exportButton(container)?.textContent).toContain("Export all");
+  });
+
+  it("treats an undefined export result as a stale no-op", async () => {
+    const { container } = mount({
+      showDiagnostics: true,
+      onExportAll: vi.fn(async () => undefined),
+    });
+
+    await act(async () => { exportButton(container)?.click(); });
+
+    expect(exportButton(container)?.textContent).toContain("Export all");
+    expect(container.querySelector('[role="alert"]')).toBeNull();
   });
 
   it("renders a reward card with its image, method chip, and labelled campaign action", () => {

--- a/packages/extension/tests/activityMessages.test.ts
+++ b/packages/extension/tests/activityMessages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { EngineEvent } from "@lurkloot/shared/events";
+import type { ActivityHistoryRecord, EngineEvent } from "@lurkloot/shared/events";
 import {
   createActivityEventReporter,
   createActivityMessageHandler,
@@ -36,7 +36,9 @@ describe("activity message routing", () => {
   });
 
   it("exports diagnostics through the extension repository", async () => {
-    const events = [{ id: "d1", at: "2026-08-16T00:00:00.000Z", category: "diagnostic", level: "info", message: "hello" }];
+    const events: ActivityHistoryRecord[] = [
+      { id: "d1", at: "2026-08-16T00:00:00.000Z", category: "diagnostic", level: "info", message: "hello" },
+    ];
     const exportDiagnostics = vi.fn(async () => events);
     const handler = createActivityMessageHandler({
       load: vi.fn(),

--- a/packages/extension/tests/activityMessages.test.ts
+++ b/packages/extension/tests/activityMessages.test.ts
@@ -10,8 +10,9 @@ describe("activity message routing", () => {
   it("handles history messages through the extension repository", async () => {
     const page = { events: [], nextCursor: undefined };
     const load = vi.fn(async () => page);
+    const exportDiagnostics = vi.fn();
     const clear = vi.fn(async () => undefined);
-    const handler = createActivityMessageHandler({ load, clear });
+    const handler = createActivityMessageHandler({ load, exportDiagnostics, clear });
 
     await expect(handler({ type: "getActivity", category: "activity", platform: "twitch", limit: 80 }))
       .resolves.toBe(page);
@@ -23,13 +24,29 @@ describe("activity message routing", () => {
 
   it("returns undefined without using the repository for non-activity messages", async () => {
     const load = vi.fn();
+    const exportDiagnostics = vi.fn();
     const clear = vi.fn();
-    const handler = createActivityMessageHandler({ load, clear });
+    const handler = createActivityMessageHandler({ load, exportDiagnostics, clear });
 
     await expect(handler({ type: "getSnapshot" })).resolves.toBeUndefined();
 
     expect(load).not.toHaveBeenCalled();
+    expect(exportDiagnostics).not.toHaveBeenCalled();
     expect(clear).not.toHaveBeenCalled();
+  });
+
+  it("exports diagnostics through the extension repository", async () => {
+    const events = [{ id: "d1", at: "2026-08-16T00:00:00.000Z", category: "diagnostic", level: "info", message: "hello" }];
+    const exportDiagnostics = vi.fn(async () => events);
+    const handler = createActivityMessageHandler({
+      load: vi.fn(),
+      clear: vi.fn(),
+      exportDiagnostics,
+    });
+
+    await expect(handler({ type: "exportDiagnostics", platform: "kick" }))
+      .resolves.toEqual({ events });
+    expect(exportDiagnostics).toHaveBeenCalledWith("kick");
   });
 });
 
@@ -146,6 +163,7 @@ describe("runtime message dispatch", () => {
 
   it.each([
     { type: "getActivity", category: "activity" } as const,
+    { type: "exportDiagnostics", platform: "twitch" } as const,
     { type: "clearActivity" } as const,
   ])("routes $type without calling core", async (message) => {
     const env = setup();

--- a/packages/extension/tests/activityStorage.test.ts
+++ b/packages/extension/tests/activityStorage.test.ts
@@ -320,6 +320,54 @@ describe("activity repository", () => {
     expect([...first.events, ...second.events].some((event) => event.message === "KICK connection from Twitch")).toBe(false);
   });
 
+  it("exports every retained diagnostic for a platform without the page cap or search filter", async () => {
+    await repository.append([
+      ...Array.from({ length: 101 }, (_, index) => ({
+        category: "diagnostic" as const,
+        level: "debug" as const,
+        platform: "kick" as const,
+        message: `kick-${String(index).padStart(3, "0")}`,
+        emittedAt: new Date(NOW.getTime() - index * 1_000).toISOString(),
+      })),
+      {
+        category: "diagnostic",
+        level: "info",
+        platform: "twitch",
+        message: "twitch-only",
+        emittedAt: NOW.toISOString(),
+      },
+      {
+        category: "diagnostic",
+        level: "error",
+        message: "global",
+        emittedAt: new Date(NOW.getTime() + 1_000).toISOString(),
+      },
+    ]);
+
+    const page = await repository.load({ category: "diagnostic", platform: "kick", limit: 100 });
+    const searched = await repository.load({ category: "diagnostic", platform: "kick", query: "global" });
+    const exported = await repository.exportDiagnostics("kick");
+
+    expect(page.events).toHaveLength(100);
+    expect(page.nextCursor).toBeDefined();
+    expect(searched.events.map((event) => event.message)).toEqual(["global"]);
+    expect(exported.map((event) => event.message)).toEqual([
+      "global",
+      ...Array.from({ length: 101 }, (_, index) => `kick-${String(index).padStart(3, "0")}`),
+    ]);
+    expect(exported.some((event) => event.message === "twitch-only")).toBe(false);
+  });
+
+  it("omits diagnostics past the seven-day cutoff from a full export", async () => {
+    const eightDaysAgo = new Date(NOW.getTime() - 8 * DAY_MS).toISOString();
+    await repository.importLegacy([
+      { id: "old", at: eightDaysAgo, category: "diagnostic", level: "info", message: "expired", legacy: true },
+      { id: "current", at: NOW.toISOString(), category: "diagnostic", level: "info", platform: "kick", message: "current", legacy: true },
+    ]);
+
+    expect((await repository.exportDiagnostics("kick")).map((event) => event.message)).toEqual(["current"]);
+  });
+
   it("matches English diagnostic text independently of the browser locale", async () => {
     expect("KICK".toLocaleLowerCase("tr")).not.toBe("kick".toLocaleLowerCase("tr"));
     const originalToLocaleLowerCase = String.prototype.toLocaleLowerCase;

--- a/packages/extension/tests/activityView.test.ts
+++ b/packages/extension/tests/activityView.test.ts
@@ -14,6 +14,7 @@ import {
   createActivityStream,
   formatActivityEvent,
   isActivityRequestCurrent,
+  isDiagnosticsExportCurrent,
   isLatestActivityMutation,
   mergeActivityPages,
 } from "@lurkloot/popup-ui";
@@ -329,6 +330,21 @@ describe("activity view model", () => {
       { generation: 2, platform: "kick", query: "timeout" },
       { generation: 2, platform: "kick", query: "retry" },
     )).toBe(false);
+  });
+
+  it("does not treat a previous platform's diagnostics export as current", () => {
+    expect(isDiagnosticsExportCurrent(
+      { generation: 1, platform: "kick" },
+      { generation: 1, platform: "twitch" },
+    )).toBe(false);
+    expect(isDiagnosticsExportCurrent(
+      { generation: 1, platform: "kick" },
+      { generation: 2, platform: "kick" },
+    )).toBe(false);
+    expect(isDiagnosticsExportCurrent(
+      { generation: 2, platform: "kick" },
+      { generation: 2, platform: "kick" },
+    )).toBe(true);
   });
 
   it("rejects an older refresh response after a newer refresh was issued", () => {

--- a/packages/extension/tests/activityView.test.ts
+++ b/packages/extension/tests/activityView.test.ts
@@ -8,6 +8,7 @@ import {
   beginActivityMutation,
   buildActivityCard,
   buildActivityExport,
+  buildDiagnosticsExportFilename,
   createActivityMutationSequence,
   createActivityRequestScope,
   createActivityStream,
@@ -463,5 +464,30 @@ describe("activity export", () => {
     expect(text).toContain("Lurkloot diagnostics log");
     expect(text).toContain("events: 0");
     expect(text.trimEnd().endsWith("(no events)")).toBe(true);
+  });
+
+  it("adds coverage: full only when requested", () => {
+    const events = [{
+      id: "a",
+      at: "2026-07-14T11:00:00.000Z",
+      category: "diagnostic" as const,
+      level: "info" as const,
+      message: "first",
+    }];
+    const copied = buildActivityExport({ ...exportInput, diagnostics: true, events }, t);
+    const full = buildActivityExport({ ...exportInput, diagnostics: true, coverage: "full", events }, t);
+    const empty = buildActivityExport({ ...exportInput, diagnostics: true, coverage: "full", events: [] }, t);
+
+    expect(copied).not.toContain("coverage:");
+    expect(full.split("\n\n")[0].split("\n")).toContain("coverage: full");
+    expect(full).toContain("2026-07-14T11:00:00.000Z [info] first");
+    expect(empty).toContain("coverage: full");
+    expect(empty).toContain("events: 0");
+    expect(empty.trimEnd().endsWith("(no events)")).toBe(true);
+  });
+
+  it("builds a windows-safe diagnostics log filename", () => {
+    expect(buildDiagnosticsExportFilename("twitch", new Date("2026-08-16T14:33:27.000Z")))
+      .toBe("lurkloot-diagnostics-twitch-20260816T143327Z.log");
   });
 });

--- a/packages/extension/tests/coreBoundary.test.ts
+++ b/packages/extension/tests/coreBoundary.test.ts
@@ -20,7 +20,7 @@ function tsFiles(dir: string): string[] {
 }
 
 const FORBIDDEN = /\b(?:import|require)\b[^\n]*["'](wxt(?:\/[^"']*)?|webextension-polyfill)["']/;
-const HISTORY_API = /\b(?:ActivityPage|getActivity|clearActivity|activityStorage)\b/;
+const HISTORY_API = /\b(?:ActivityPage|DiagnosticsExport|getActivity|exportDiagnostics|clearActivity|activityStorage)\b/;
 const FULL_RUNTIME_MESSAGE = /\bRuntimeMessage\b/;
 const BROWSER_COOKIE_API = /\b(?:browser|chrome)\.cookies\b/;
 const EXTENSION_IMPORT = /\b(?:import|require)\b[^\n]*["'][^"']*packages\/extension|\b(?:import|require)\b[^\n]*["'][^"']*extension\/src/;

--- a/packages/extension/tests/popupDiagnosticsExport.test.tsx
+++ b/packages/extension/tests/popupDiagnosticsExport.test.tsx
@@ -1,0 +1,153 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DiagnosticsExport, RuntimeMessage } from "@lurkloot/shared/messages";
+import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
+import { resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
+
+vi.mock("motion/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("motion/react")>()),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
+
+let root: Root | undefined;
+
+afterEach(() => {
+  resetCatalogTracking();
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+async function waitForMessage(
+  sent: RuntimeMessage[],
+  predicate: (message: RuntimeMessage) => boolean,
+): Promise<RuntimeMessage> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const message = sent.find(predicate);
+    if (message) return message;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  throw new Error("Popup did not send the expected message");
+}
+
+async function waitForElement<T extends Element>(find: () => T | undefined): Promise<T> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const element = find();
+    if (element) return element;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error("Popup did not render the expected element");
+}
+
+async function mount(options?: {
+  downloadFile?: (filename: string, contents: string, mimeType?: string) => void;
+  pendingExport?: { finish?: (value: DiagnosticsExport) => void };
+}): Promise<{ container: HTMLElement; sent: RuntimeMessage[]; downloadFile: ReturnType<typeof vi.fn> }> {
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(Date.now());
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+
+  const demo = createDemoPopupAdapter();
+  const sent: RuntimeMessage[] = [];
+  const downloadFile = options?.downloadFile ?? vi.fn();
+  const adapter: PopupAdapter = {
+    ...demo,
+    downloadFile,
+    getStorage: async () => ({ "popup:selectedPlatform": "twitch" }),
+    send: async <T,>(message: RuntimeMessage): Promise<T> => {
+      sent.push(message);
+      if (message.type === "exportDiagnostics") {
+        if (options?.pendingExport) {
+          return await new Promise<DiagnosticsExport>((resolve) => {
+            options.pendingExport!.finish = resolve;
+          }) as T;
+        }
+        return {
+          events: [{
+            id: "d1",
+            at: "2026-08-16T00:00:00.000Z",
+            category: "diagnostic",
+            level: "info",
+            platform: "twitch",
+            message: "full history line",
+          }],
+        } as T;
+      }
+      return demo.send<T>(message);
+    },
+  };
+  const container = document.getElementById("app")!;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} />);
+  });
+  await waitForCatalog();
+  const openActivity = container.querySelector<HTMLButtonElement>('button[aria-label="Open activity"]');
+  if (!openActivity) throw new Error("Missing activity button");
+  await act(async () => openActivity.click());
+  const diagnosticsTab = await waitForElement(() =>
+    container.querySelector<HTMLButtonElement>('[role="tab"][aria-selected="false"]') ?? undefined);
+  await act(async () => diagnosticsTab.click());
+  return { container, sent, downloadFile: downloadFile as ReturnType<typeof vi.fn> };
+}
+
+describe("popup diagnostics export", () => {
+  it("requests a full diagnostics export for the selected platform and downloads a .log", async () => {
+    const { container, sent, downloadFile } = await mount();
+    const exportAll = await waitForElement(() =>
+      [...container.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent === "Export all"));
+    await act(async () => exportAll.click());
+    const request = await waitForMessage(sent, (message) => message.type === "exportDiagnostics");
+    expect(request).toEqual({ type: "exportDiagnostics", platform: "twitch" });
+    expect(downloadFile).toHaveBeenCalledOnce();
+    const [filename, contents, mimeType] = downloadFile.mock.calls[0];
+    expect(filename).toMatch(/^lurkloot-diagnostics-twitch-\d{8}T\d{6}Z\.log$/);
+    expect(contents).toContain("coverage: full");
+    expect(contents).toContain("full history line");
+    expect(mimeType).toBe("text/plain");
+  });
+
+  it("does not download a stale export after the platform changes", async () => {
+    const pendingExport: { finish?: (value: DiagnosticsExport) => void } = {};
+    const { container, downloadFile } = await mount({ pendingExport });
+    const exportAll = await waitForElement(() =>
+      [...container.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent === "Export all"));
+    await act(async () => exportAll.click());
+    const back = await waitForElement(() =>
+      container.querySelector<HTMLButtonElement>('button[aria-label="Back"]') ?? undefined);
+    await act(async () => back.click());
+    const kick = await waitForElement(() =>
+      container.querySelector<HTMLButtonElement>('[role="tab"][aria-label="Kick"]') ?? undefined);
+    await act(async () => kick.click());
+    await act(async () => {
+      pendingExport.finish?.({
+        events: [{
+          id: "late",
+          at: "2026-08-16T00:00:00.000Z",
+          category: "diagnostic",
+          level: "info",
+          message: "late",
+        }],
+      });
+    });
+    expect(downloadFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "نسخ السجل"
   },
+  "copyLoadedActivityLog": {
+    "message": "نسخ المحمّل"
+  },
   "copyActivityLogCopied": {
     "message": "تم نسخ $1 حدثًا"
   },
   "copyActivityLogFailed": {
     "message": "تعذّر نسخ السجل. حاول مرة أخرى."
+  },
+  "exportAllDiagnostics": {
+    "message": "تصدير الكل"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "تم تصدير $1 من الإدخالات"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "تعذر تصدير السجل. حاول مرة أخرى."
   },
   "activityViewTab": {
     "message": "النشاط"

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "Protokoll kopieren"
   },
+  "copyLoadedActivityLog": {
+    "message": "Geladene kopieren"
+  },
   "copyActivityLogCopied": {
     "message": "$1 Ereignisse kopiert"
   },
   "copyActivityLogFailed": {
     "message": "Das Protokoll konnte nicht kopiert werden. Bitte erneut versuchen."
+  },
+  "exportAllDiagnostics": {
+    "message": "Alle exportieren"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "$1 Ereignisse exportiert"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "Protokoll konnte nicht exportiert werden. Bitte erneut versuchen."
   },
   "activityViewTab": {
     "message": "Aktivität"

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "Copy log"
   },
+  "copyLoadedActivityLog": {
+    "message": "Copy loaded"
+  },
   "copyActivityLogCopied": {
     "message": "Copied $1 events"
   },
   "copyActivityLogFailed": {
     "message": "Could not copy the log. Try again."
+  },
+  "exportAllDiagnostics": {
+    "message": "Export all"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "Exported $1 events"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "Could not export the log. Try again."
   },
   "activityViewTab": {
     "message": "Activity"

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "Copiar registro"
   },
+  "copyLoadedActivityLog": {
+    "message": "Copiar cargados"
+  },
   "copyActivityLogCopied": {
     "message": "$1 eventos copiados"
   },
   "copyActivityLogFailed": {
     "message": "No se pudo copiar el registro. Inténtalo de nuevo."
+  },
+  "exportAllDiagnostics": {
+    "message": "Exportar todo"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "$1 eventos exportados"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "No se pudo exportar el registro. Inténtalo de nuevo."
   },
   "activityViewTab": {
     "message": "Actividad"

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "Copier le journal"
   },
+  "copyLoadedActivityLog": {
+    "message": "Copier la page"
+  },
   "copyActivityLogCopied": {
     "message": "$1 événements copiés"
   },
   "copyActivityLogFailed": {
     "message": "Impossible de copier le journal. Réessayez."
+  },
+  "exportAllDiagnostics": {
+    "message": "Tout exporter"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "$1 événements exportés"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "Impossible d'exporter le journal. Réessayez."
   },
   "activityViewTab": {
     "message": "Activité"

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "लॉग कॉपी करें"
   },
+  "copyLoadedActivityLog": {
+    "message": "लोड की गई कॉपी करें"
+  },
   "copyActivityLogCopied": {
     "message": "$1 इवेंट कॉपी किए गए"
   },
   "copyActivityLogFailed": {
     "message": "लॉग कॉपी नहीं हो सका। फिर से कोशिश करें।"
+  },
+  "exportAllDiagnostics": {
+    "message": "सभी निर्यात करें"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "$1 इवेंट निर्यात किए गए"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "लॉग निर्यात नहीं हो सका। फिर से कोशिश करें."
   },
   "activityViewTab": {
     "message": "गतिविधि"

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "Copia registro"
   },
+  "copyLoadedActivityLog": {
+    "message": "Copia caricati"
+  },
   "copyActivityLogCopied": {
     "message": "$1 eventi copiati"
   },
   "copyActivityLogFailed": {
     "message": "Impossibile copiare il registro. Riprova."
+  },
+  "exportAllDiagnostics": {
+    "message": "Esporta tutto"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "$1 eventi esportati"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "Impossibile esportare il registro. Riprova."
   },
   "activityViewTab": {
     "message": "Attività"

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "Copiar registro"
   },
+  "copyLoadedActivityLog": {
+    "message": "Copiar carregados"
+  },
   "copyActivityLogCopied": {
     "message": "$1 eventos copiados"
   },
   "copyActivityLogFailed": {
     "message": "Não foi possível copiar o registro. Tente novamente."
+  },
+  "exportAllDiagnostics": {
+    "message": "Exportar tudo"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "$1 eventos exportados"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "Não foi possível exportar o registro. Tente novamente."
   },
   "activityViewTab": {
     "message": "Atividade"

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "Копировать журнал"
   },
+  "copyLoadedActivityLog": {
+    "message": "Копировать загруженное"
+  },
   "copyActivityLogCopied": {
     "message": "Скопировано событий: $1"
   },
   "copyActivityLogFailed": {
     "message": "Не удалось скопировать журнал. Попробуйте ещё раз."
+  },
+  "exportAllDiagnostics": {
+    "message": "Экспортировать всё"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "Экспортировано событий: $1"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "Не удалось экспортировать журнал. Попробуйте снова."
   },
   "activityViewTab": {
     "message": "Активность"

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "Günlüğü kopyala"
   },
+  "copyLoadedActivityLog": {
+    "message": "Yüklenenleri kopyala"
+  },
   "copyActivityLogCopied": {
     "message": "$1 olay kopyalandı"
   },
   "copyActivityLogFailed": {
     "message": "Günlük kopyalanamadı. Tekrar deneyin."
+  },
+  "exportAllDiagnostics": {
+    "message": "Tümünü dışa aktar"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "$1 olay dışa aktarıldı"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "Günlük dışa aktarılamadı. Yeniden deneyin."
   },
   "activityViewTab": {
     "message": "Geçmiş"

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -1055,11 +1055,23 @@
   "copyActivityLog": {
     "message": "复制日志"
   },
+  "copyLoadedActivityLog": {
+    "message": "复制已加载"
+  },
   "copyActivityLogCopied": {
     "message": "已复制 $1 条事件"
   },
   "copyActivityLogFailed": {
     "message": "无法复制日志，请重试。"
+  },
+  "exportAllDiagnostics": {
+    "message": "全部导出"
+  },
+  "exportAllDiagnosticsDone": {
+    "message": "已导出 $1 条"
+  },
+  "exportAllDiagnosticsFailed": {
+    "message": "无法导出日志。请重试。"
   },
   "activityViewTab": {
     "message": "活动"

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -7,7 +7,7 @@ import {
   RotateCcw,
   Settings as SettingsIcon,
 } from "lucide-react";
-import type { ActivityPage, CategorySearchResult, CliCredentialBlob, RuntimeSnapshot } from "@lurkloot/shared/messages";
+import type { ActivityPage, CategorySearchResult, CliCredentialBlob, DiagnosticsExport, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import type { ActivityHistoryRecord } from "@lurkloot/shared/events";
 import type { CategorySelection, ExtensionSettings, Platform } from "@lurkloot/shared/models";
 import { applySettingsPatch, DEFAULT_SETTINGS, mergeSettings, type SettingsPatch } from "@lurkloot/shared/settings";
@@ -46,10 +46,15 @@ import {
   advanceActivityRequestScope,
   applyActivityMutationForRequest,
   beginActivityMutation,
+  beginDiagnosticsExport,
+  buildActivityExport,
+  buildDiagnosticsExportFilename,
   createActivityMutationSequence,
   createActivityRequestScope,
   createActivityStream,
+  createDiagnosticsExportRequest,
   isActivityRequestCurrent,
+  isDiagnosticsExportCurrent,
   type ActivityRequestScope,
   type ActivityStream,
 } from "./activity.logic";
@@ -106,6 +111,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const settingsSaveQueue = useRef<Promise<void>>(Promise.resolve());
   const snapshotRequestGenerationRef = useRef(0);
   const activityRequestScopeRef = useRef(createActivityRequestScope(platform));
+  const diagnosticsExportRequestRef = useRef(createDiagnosticsExportRequest(platform));
   const activityMutationSequenceRef = useRef(createActivityMutationSequence());
   const diagnosticMutationSequenceRef = useRef(createActivityMutationSequence());
   const activityClearInFlightRef = useRef(false);
@@ -402,7 +408,13 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   }, [adapter, preview]);
 
   function selectPlatform(nextPlatform: Platform): void {
-    if (nextPlatform !== activityRequestScopeRef.current.platform) invalidateActivityRequests(nextPlatform, "");
+    if (nextPlatform !== activityRequestScopeRef.current.platform) {
+      invalidateActivityRequests(nextPlatform, "");
+      diagnosticsExportRequestRef.current = beginDiagnosticsExport(
+        diagnosticsExportRequestRef.current,
+        nextPlatform,
+      );
+    }
     setDiagnosticSearchQuery("");
     setPlatform(nextPlatform);
     // The watchlist add form belongs to the platform it was opened on: leaving
@@ -412,7 +424,13 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   }
 
   function closeActivityView(): void {
-    if (activityOpen) invalidateActivityRequests(platform, "");
+    if (activityOpen) {
+      invalidateActivityRequests(platform, "");
+      diagnosticsExportRequestRef.current = beginDiagnosticsExport(
+        diagnosticsExportRequestRef.current,
+        platform,
+      );
+    }
     setClearActivityArmed(false);
     setClearActivityFailed(false);
     setDiagnosticSearchQuery("");
@@ -423,10 +441,39 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   function handleShowDiagnosticsChange(nextShowDiagnostics: boolean): void {
     if (showDiagnostics && !nextShowDiagnostics) {
       invalidateActivityRequests(platform, "");
+      diagnosticsExportRequestRef.current = beginDiagnosticsExport(
+        diagnosticsExportRequestRef.current,
+        platform,
+      );
       setDiagnosticSearchQuery("");
       setDiagnosticStream(createActivityStream());
     }
     setShowDiagnostics(nextShowDiagnostics);
+  }
+
+  async function exportDiagnosticsLog(): Promise<number | undefined> {
+    const downloadFile = adapter.downloadFile;
+    if (!downloadFile) return undefined;
+    const request = beginDiagnosticsExport(diagnosticsExportRequestRef.current, platform);
+    diagnosticsExportRequestRef.current = request;
+    const exportedAt = new Date();
+    const result = await adapter.send<DiagnosticsExport>({ type: "exportDiagnostics", platform: request.platform });
+    if (!isDiagnosticsExportCurrent(request, diagnosticsExportRequestRef.current)) return undefined;
+    downloadFile(
+      buildDiagnosticsExportFilename(request.platform, exportedAt),
+      buildActivityExport({
+        events: result.events,
+        platform: request.platform,
+        diagnostics: true,
+        coverage: "full",
+        version: adapter.version,
+        userAgent: typeof navigator === "undefined" ? "unknown" : navigator.userAgent,
+        locale,
+        at: exportedAt.toISOString(),
+      }, t),
+      "text/plain",
+    );
+    return result.events.length;
   }
 
   async function updateSettings(patch: SettingsPatch, options?: { tickAfterSave?: boolean; tickAfterSavePlatforms?: Platform[] }): Promise<void> {
@@ -726,6 +773,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                   onLoadMore={loadMoreActivity}
                   onClear={clearActivityHistory}
                   writeClipboard={adapter.writeClipboard}
+                  onExportAll={adapter.downloadFile ? exportDiagnosticsLog : undefined}
                 />
               </motion.div>
             ) : (

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -357,6 +357,7 @@ export interface ActivityExportInput {
   userAgent: string;
   locale: string;
   at: string;
+  coverage?: "full";
 }
 
 // Plain text, not markup: this is pasted into email, Discord and issue bodies,
@@ -373,6 +374,7 @@ export function buildActivityExport(input: ActivityExportInput, t: TFunction): s
     `exported: ${input.at}`,
     `browser: ${input.userAgent}`,
     `events: ${input.events.length}`,
+    ...(input.coverage === "full" ? ["coverage: full"] : []),
   ].join("\n");
 
   // Oldest first: a log is read top-down when you are reconstructing what
@@ -385,6 +387,11 @@ export function buildActivityExport(input: ActivityExportInput, t: TFunction): s
       .join("\n");
 
   return `${header}\n\n${body}\n`;
+}
+
+export function buildDiagnosticsExportFilename(platform: Platform, at: Date): string {
+  const stamp = at.toISOString().replaceAll("-", "").replaceAll(":", "").replace(/\.\d{3}Z$/, "Z");
+  return `lurkloot-diagnostics-${platform}-${stamp}.log`;
 }
 
 export function mergeActivityPages(

--- a/packages/popup-ui/src/activity.logic.ts
+++ b/packages/popup-ui/src/activity.logic.ts
@@ -22,6 +22,8 @@ export type ActivityRequestScope = {
   query: string;
 };
 
+export type DiagnosticsExportRequest = { generation: number; platform: Platform };
+
 export type ActivityCardIcon =
   | "gift"
   | "play"
@@ -105,6 +107,24 @@ export function isActivityRequestCurrent(
   return request.generation === current.generation
     && request.platform === current.platform
     && request.query === current.query;
+}
+
+export function createDiagnosticsExportRequest(platform: Platform): DiagnosticsExportRequest {
+  return { generation: 0, platform };
+}
+
+export function beginDiagnosticsExport(
+  current: DiagnosticsExportRequest,
+  platform: Platform,
+): DiagnosticsExportRequest {
+  return { generation: current.generation + 1, platform };
+}
+
+export function isDiagnosticsExportCurrent(
+  request: DiagnosticsExportRequest,
+  current: DiagnosticsExportRequest,
+): boolean {
+  return request.generation === current.generation && request.platform === current.platform;
 }
 
 export function applyActivityPageForRequest(

--- a/packages/popup-ui/src/activity.tsx
+++ b/packages/popup-ui/src/activity.tsx
@@ -4,6 +4,7 @@ import {
   Check,
   Clipboard,
   Clock3,
+  Download,
   ExternalLink,
   Gift,
   MonitorDown,
@@ -55,6 +56,7 @@ export function ActivityLog({
   onLoadMore,
   onClear,
   writeClipboard,
+  onExportAll,
 }: {
   activityEvents: ActivityHistoryRecord[];
   diagnosticEvents: ActivityHistoryRecord[];
@@ -78,6 +80,7 @@ export function ActivityLog({
   // Omitted by hosts without a clipboard (the site demo), which hides the copy
   // control rather than offering a button that can only fail.
   writeClipboard?(text: string): Promise<boolean>;
+  onExportAll?(): Promise<number | undefined>;
 }): React.ReactElement {
   const t = useT();
   const forPlatform = useMemo(
@@ -98,12 +101,17 @@ export function ActivityLog({
   const errorCount = visible.filter((event) => event.level === "error").length;
   const [copied, setCopied] = useState<number | null>(null);
   const [copyFailed, setCopyFailed] = useState(false);
+  const [exported, setExported] = useState<number | null>(null);
+  const [exportFailed, setExportFailed] = useState(false);
+  const [exporting, setExporting] = useState(false);
 
   // Confirmation is transient, and it must not survive a switch between the two
   // views: "Copied 42 events" next to a different list is a lie.
   useEffect(() => {
     setCopied(null);
     setCopyFailed(false);
+    setExported(null);
+    setExportFailed(false);
   }, [showDiagnostics, platform]);
 
   useEffect(() => {
@@ -111,6 +119,12 @@ export function ActivityLog({
     const timer = setTimeout(() => setCopied(null), COPY_FEEDBACK_MS);
     return () => clearTimeout(timer);
   }, [copied]);
+
+  useEffect(() => {
+    if (exported === null) return;
+    const timer = setTimeout(() => setExported(null), COPY_FEEDBACK_MS);
+    return () => clearTimeout(timer);
+  }, [exported]);
 
   async function copyVisible(): Promise<void> {
     if (!writeClipboard) return;
@@ -128,6 +142,22 @@ export function ActivityLog({
     const ok = await writeClipboard(text);
     setCopyFailed(!ok);
     setCopied(ok ? visible.length : null);
+  }
+
+  async function exportAll(): Promise<void> {
+    if (!onExportAll || exporting) return;
+    setExporting(true);
+    setExportFailed(false);
+    setCopied(null);
+    try {
+      const count = await onExportAll();
+      setExported(count ?? null);
+    } catch {
+      setExportFailed(true);
+      setExported(null);
+    } finally {
+      setExporting(false);
+    }
   }
 
   return (
@@ -171,7 +201,18 @@ export function ActivityLog({
             className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[9px] font-semibold transition disabled:opacity-50 ${copied === null ? "border-zinc-200 text-zinc-400 dark:border-zinc-700" : "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300"}`}
           >
             {copied === null ? <Clipboard size={10} /> : <Check size={10} />}
-            {copied === null ? t("copyActivityLog") : t("copyActivityLogCopied", String(copied))}
+            {copied === null ? t(showDiagnostics ? "copyLoadedActivityLog" : "copyActivityLog") : t("copyActivityLogCopied", String(copied))}
+          </button>
+        ) : null}
+        {showDiagnostics && onExportAll ? (
+          <button
+            type="button"
+            onClick={() => void exportAll()}
+            disabled={exporting}
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[9px] font-semibold transition disabled:opacity-50 ${exported === null ? "border-zinc-200 text-zinc-400 dark:border-zinc-700" : "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300"}`}
+          >
+            {exported === null ? <Download size={10} /> : <Check size={10} />}
+            {exported === null ? t("exportAllDiagnostics") : t("exportAllDiagnosticsDone", String(exported))}
           </button>
         ) : null}
         <button
@@ -188,6 +229,9 @@ export function ActivityLog({
       ) : null}
       {copyFailed ? (
         <p role="alert" className="px-0.5 text-[10px] font-medium text-red-500">{t("copyActivityLogFailed")}</p>
+      ) : null}
+      {exportFailed ? (
+        <p role="alert" className="px-0.5 text-[10px] font-medium text-red-500">{t("exportAllDiagnosticsFailed")}</p>
       ) : null}
       {showDiagnostics ? (
         <SearchBox compact value={searchQuery} onChange={onSearchQueryChange} placeholder={t("searchDiagnostics")} />

--- a/packages/popup-ui/src/demo.ts
+++ b/packages/popup-ui/src/demo.ts
@@ -1,10 +1,10 @@
-import type { ActivityPage, CategorySearchResult, PlaybackControl, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
+import type { ActivityPage, CategorySearchResult, DiagnosticsExport, PlaybackControl, RuntimeMessage, RuntimeSnapshot } from "@lurkloot/shared/messages";
 import type { DropCampaign, SupportedLocale } from "@lurkloot/shared/models";
 import { applySettingsPatch, DEFAULT_SETTINGS, mergeSettings } from "@lurkloot/shared/settings";
 import type { PopupAdapter } from "./types";
 import { openHttpsLink } from "./links";
 
-function handleDemoMessage(message: RuntimeMessage): RuntimeSnapshot | PlaybackControl | CategorySearchResult | ActivityPage | undefined {
+function handleDemoMessage(message: RuntimeMessage): RuntimeSnapshot | PlaybackControl | CategorySearchResult | ActivityPage | DiagnosticsExport | undefined {
   switch (message.type) {
     case "getSnapshot":
     case "tickNow":
@@ -56,6 +56,8 @@ function handleDemoMessage(message: RuntimeMessage): RuntimeSnapshot | PlaybackC
       return demoSnapshot();
     case "getActivity":
       return { events: [], nextCursor: undefined };
+    case "exportDiagnostics":
+      return { events: [] };
     case "getPlaybackControl":
       return { managed: true, keepVideosUnmuted: true };
   }

--- a/packages/popup-ui/src/index.ts
+++ b/packages/popup-ui/src/index.ts
@@ -12,16 +12,19 @@ export {
   applyActivityPage,
   applyActivityPageForRequest,
   beginActivityMutation,
+  beginDiagnosticsExport,
   buildActivityCard,
   buildActivityExport,
   buildDiagnosticsExportFilename,
   createActivityMutationSequence,
   createActivityRequestScope,
   createActivityStream,
+  createDiagnosticsExportRequest,
   formatActivityEvent,
   isActivityRequestCurrent,
+  isDiagnosticsExportCurrent,
   isLatestActivityMutation,
   mergeActivityPages,
 } from "./activity.logic";
-export type { ActivityCard, ActivityCardIcon, ActivityCardTone } from "./activity.logic";
+export type { ActivityCard, ActivityCardIcon, ActivityCardTone, DiagnosticsExportRequest } from "./activity.logic";
 export type { PopupAdapter, PopupInitialState, ScreenshotVariant } from "./types";

--- a/packages/popup-ui/src/index.ts
+++ b/packages/popup-ui/src/index.ts
@@ -14,6 +14,7 @@ export {
   beginActivityMutation,
   buildActivityCard,
   buildActivityExport,
+  buildDiagnosticsExportFilename,
   createActivityMutationSequence,
   createActivityRequestScope,
   createActivityStream,

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -141,6 +141,9 @@ export interface PopupAdapter {
   // worked. Hosts that omit it (the site demo) make the critical-failure panel
   // fall back to a selectable textarea instead of pretending the copy succeeded.
   writeClipboard?(text: string): Promise<boolean>;
+  // Optional: download a text file from the popup. The live extension implements
+  // it with a Blob URL; hosts that omit it (the site demo) hide Export all.
+  downloadFile?(filename: string, contents: string, mimeType?: string): void;
   resetExtension?(): Promise<RuntimeSnapshot>;
   compatibilityRegistry?: PopupCompatibilityRegistry;
   resolveCompatibility?(settings: CompatibilitySettings): PopupCompatibilityResolution;

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -24,6 +24,7 @@ export type CoreRuntimeMessage =
 export type RuntimeMessage =
   | CoreRuntimeMessage
   | ({ type: "getActivity" } & ActivityQuery)
+  | { type: "exportDiagnostics"; platform: Platform }
   | { type: "clearActivity" }
   | { type: "resetExtension" }
   | { type: "exportCliCredentials" };
@@ -68,4 +69,8 @@ export interface ActivityQuery {
 export interface ActivityPage {
   events: ActivityHistoryRecord[];
   nextCursor?: string;
+}
+
+export interface DiagnosticsExport {
+  events: ActivityHistoryRecord[];
 }


### PR DESCRIPTION
## Summary
- Add **Export all** on Diagnostics so users can download the complete retained diagnostic history for the selected platform (plus unscoped events) as a `.log` file, instead of only the loaded page.
- Keep **Copy log** on Activity; relabel it to **Copy loaded** on Diagnostics so the two actions are distinct. Clipboard text is unchanged; the file adds `coverage: full`.
- One-shot IndexedDB export via `exportDiagnostics` (no 100-row page cap, ignores search). Empty stores still download a valid log.

## Test plan
- [ ] Open Diagnostics: confirm **Copy loaded** and **Export all** appear; Activity still shows **Copy log** only.
- [ ] Copy loaded still copies only the on-screen list (including current search results).
- [ ] Export all downloads `lurkloot-diagnostics-{platform}-{utc}.log` with timestamped lines, both platforms independently, including unscoped events, ignoring search.
- [ ] Empty history still downloads a log with `events: 0` and `(no events)`.
- [ ] Failed export shows an error; switching away while an export is in flight does not download a stale file.
- [ ] Site demo still hides Export all (no download hook).