### PR TITLE
fix(twitch): pin refreshed integrity token

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -774,7 +774,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     let isNew = false;
     await withEventCollector(async (emit, events) => {
       isNew = integrity.integrity !== installedTwitchIntegrity?.integrity;
-      installTwitchIntegrity(integrity, isNew, emit, tabId);
+      const sourceTabId = tabId != null && tabId >= 0 ? tabId : undefined;
+      installTwitchIntegrity(integrity, isNew, emit, sourceTabId);
       await reportBestEffort(events);
     });
     // Persistence still takes the lock: persistedIntegrityToken is read and

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -456,9 +456,14 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       - integrityRefreshJitter(integrity.integrity);
   }
 
-  function installTwitchIntegrity(integrity: TwitchIntegrity, isNew = false, emit?: EventEmitter): void {
+  function installTwitchIntegrity(
+    integrity: TwitchIntegrity,
+    isNew = false,
+    emit?: EventEmitter,
+    sourceTabId?: number,
+  ): void {
     installedTwitchIntegrity = integrity;
-    setTwitchIntegrity(integrity, { isNew }, emit);
+    setTwitchIntegrity(integrity, { isNew, sourceTabId }, emit);
   }
 
   function currentInstalledTwitchIntegrity(): TwitchIntegrity | undefined {
@@ -744,7 +749,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // Client-Integrity header, so integrityFromHeaders returns undefined (and we
   // ignore) our own background fetch and anonymous queries.
   // `tabId` is optional so hosts that cannot attribute a request to a tab still
-  // capture tokens; it only feeds page-context boot instrumentation.
+  // capture tokens; when present it also lets a managed refresh distinguish its
+  // own replacement from a concurrent user-tab replay.
   async function captureTwitchIntegrity(headers: IntegrityHeader[] | undefined, tabId?: number): Promise<void> {
     // Noted before the integrity filter: an anonymous GQL request carries no
     // Client-Integrity header but still proves the SPA has booted.
@@ -768,7 +774,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     let isNew = false;
     await withEventCollector(async (emit, events) => {
       isNew = integrity.integrity !== installedTwitchIntegrity?.integrity;
-      installTwitchIntegrity(integrity, isNew, emit);
+      installTwitchIntegrity(integrity, isNew, emit, tabId);
       await reportBestEffort(events);
     });
     // Persistence still takes the lock: persistedIntegrityToken is read and

--- a/packages/core/src/core/tabs.ts
+++ b/packages/core/src/core/tabs.ts
@@ -495,6 +495,20 @@ let twitchClientSessionId: string | undefined;
 // queries keep working anonymously / without integrity until one is captured.
 let twitchIntegrity: TwitchIntegrity | undefined;
 
+interface TwitchIntegrityCapture {
+  value: TwitchIntegrity;
+  sourceTabId?: number;
+  generation: number;
+}
+
+// Keep the latest capture from each attributed tab long enough for a managed
+// helper wait to identify its own replacement even if a user tab immediately
+// replays the previous token into the ordinary global slot.
+let latestTwitchIntegrityCapture: TwitchIntegrityCapture | undefined;
+const twitchIntegrityCapturesBySourceTab = new Map<number, TwitchIntegrityCapture>();
+let twitchIntegrityCaptureGeneration = 0;
+const MAX_TWITCH_INTEGRITY_SOURCE_CAPTURES = 32;
+
 // Treat a token expiring within this window as already stale, so a claim never
 // ships with one that expires mid-flight (the captured token is replayed and
 // the round-trip plus Twitch-side clock skew can otherwise straddle expiry).
@@ -527,7 +541,7 @@ export const TWITCH_PAGE_CONTEXT_URL = "https://www.twitch.tv/drops/inventory";
 export const INTEGRITY_REFRESH_TIMEOUT_MS = 30_000;
 
 // Resolvers waiting for the next captured token (see waitForIntegrityCapture).
-let integrityWaiters: Array<() => void> = [];
+let integrityWaiters: Array<(capture?: TwitchIntegrityCapture) => void> = [];
 
 // Test seam for proving terminal paths release their process-global callbacks.
 export function currentTwitchIntegrityWaiterCount(): number {
@@ -576,8 +590,40 @@ export function hasValidTwitchIntegrity(now: number = Date.now()): boolean {
   return isValidTwitchIntegrity(twitchIntegrity, now);
 }
 
-export function setTwitchIntegrity(value: TwitchIntegrity | undefined, options?: { isNew?: boolean }, emit: EventEmitter = ignoreEvent): void {
+export interface TwitchIntegrityCaptureOptions {
+  isNew?: boolean;
+  sourceTabId?: number;
+}
+
+export function setTwitchIntegrity(
+  value: TwitchIntegrity | undefined,
+  options?: TwitchIntegrityCaptureOptions,
+  emit: EventEmitter = ignoreEvent,
+): void {
   twitchIntegrity = value;
+  const generation = ++twitchIntegrityCaptureGeneration;
+  if (value == null) {
+    latestTwitchIntegrityCapture = undefined;
+    twitchIntegrityCapturesBySourceTab.clear();
+  } else {
+    const capture: TwitchIntegrityCapture = {
+      value,
+      generation,
+      ...(options?.sourceTabId != null ? { sourceTabId: options.sourceTabId } : {}),
+    };
+    latestTwitchIntegrityCapture = capture;
+    if (capture.sourceTabId != null) {
+      // Delete first so the insertion order reflects capture recency; stale
+      // source entries must not grow without bound in a long-lived background.
+      twitchIntegrityCapturesBySourceTab.delete(capture.sourceTabId);
+      twitchIntegrityCapturesBySourceTab.set(capture.sourceTabId, capture);
+      while (twitchIntegrityCapturesBySourceTab.size > MAX_TWITCH_INTEGRITY_SOURCE_CAPTURES) {
+        const oldestSourceTabId = twitchIntegrityCapturesBySourceTab.keys().next().value;
+        if (oldestSourceTabId == null) break;
+        twitchIntegrityCapturesBySourceTab.delete(oldestSourceTabId);
+      }
+    }
+  }
   if (value && options?.isNew) {
     const ttlSeconds = Math.max(0, Math.round((value.expiresAt - Date.now()) / 1000));
     diagnostic(emit, "info", `Captured a fresh Twitch integrity token (expires ${new Date(value.expiresAt).toISOString()}, in ${ttlSeconds}s)`, "twitch");
@@ -585,7 +631,7 @@ export function setTwitchIntegrity(value: TwitchIntegrity | undefined, options?:
   if (value != null && integrityWaiters.length > 0) {
     const waiters = integrityWaiters;
     integrityWaiters = [];
-    for (const resolve of waiters) resolve();
+    for (const resolve of waiters) resolve(latestTwitchIntegrityCapture);
   }
 }
 
@@ -597,6 +643,10 @@ export interface TwitchIntegrityRequest {
   signal?: AbortSignal;
   reason?: "readiness" | "proactive_refresh" | "rejection_recovery";
   onManagedPageContextOpen?: () => void | Promise<void>;
+  // Receives the exact bundle captured by the managed context. A forced GQL
+  // retry uses this callback to pin the trio it sends instead of reading the
+  // last-writer-wins global after a concurrent page capture.
+  onIntegrityCaptured?: (value: TwitchIntegrity) => void;
   // The token the rejected request actually sent, captured before it was issued.
   // Without it a forced refresh cannot tell "this caller was rejected on a token
   // someone has already replaced" from "this caller was rejected on the token we
@@ -617,12 +667,17 @@ export function currentValidTwitchIntegrity(): TwitchIntegrity | undefined {
   return hasValidTwitchIntegrity() ? twitchIntegrity : undefined;
 }
 
+interface TwitchIntegrityAcquisitionResult {
+  value: TwitchIntegrity;
+  managedContext: boolean;
+}
+
 // Minting boots a twitch.tv context and may wait ~22s for Kasada's proof-of-work,
 // so every caller shares one owned acquisition. The owned abort cancels the
 // underlying page context; only the creator's signal owns that lifecycle, while
 // later joiners race their own signal without disturbing everyone else.
 interface TwitchIntegrityAcquisition {
-  promise: Promise<boolean>;
+  promise: Promise<TwitchIntegrityAcquisitionResult | undefined>;
   abort: AbortController;
 }
 
@@ -639,6 +694,7 @@ export function resetTwitchIntegrityRefreshBounds(): void {
   inFlightIntegrityAcquisition?.abort.abort();
   inFlightIntegrityAcquisition = undefined;
   integrityWaiters = [];
+  twitchIntegrityCapturesBySourceTab.clear();
 }
 
 function hasReplacementTwitchIntegrity(rejectedToken?: string): boolean {
@@ -646,18 +702,45 @@ function hasReplacementTwitchIntegrity(rejectedToken?: string): boolean {
   return rejectedToken == null || twitchIntegrity?.integrity !== rejectedToken;
 }
 
-// Resolves true once a usable token is present, or after timeoutMs (re-checking
-// validity at the deadline). A captured token can be near-expiry — captureTwitch-
-// Integrity does not gate on expiry — so resolvers re-check hasValidTwitchIntegrity.
-// When rejectedToken is set, re-capturing that same token does not settle the
-// wait; the page may replay it before minting a replacement.
+function isReplacementCapture(capture: TwitchIntegrityCapture | undefined, rejectedToken?: string): boolean {
+  if (!capture || !isValidTwitchIntegrity(capture.value)) return false;
+  return rejectedToken == null || capture.value.integrity !== rejectedToken;
+}
+
+function captureForIntegrityWait(
+  rejectedToken: string | undefined,
+  sourceTabId: number | undefined,
+  latestCapture?: TwitchIntegrityCapture,
+  minimumGeneration = 0,
+): TwitchIntegrityCapture | undefined {
+  if (sourceTabId != null) {
+    const sourceCapture = twitchIntegrityCapturesBySourceTab.get(sourceTabId);
+    if (sourceCapture != null && sourceCapture.generation > minimumGeneration && isReplacementCapture(sourceCapture, rejectedToken)) return sourceCapture;
+    // Unattributed captures retain the historic global behavior. Once a
+    // capture has an explicit source, however, a different tab cannot satisfy
+    // this managed-context wait.
+    if (latestCapture != null && latestCapture.generation > minimumGeneration && isReplacementCapture(latestCapture, rejectedToken) && latestCapture.sourceTabId == null) return latestCapture;
+    return undefined;
+  }
+  const capture = latestCapture ?? latestTwitchIntegrityCapture;
+  return capture != null && capture.generation > minimumGeneration && isReplacementCapture(capture, rejectedToken) ? capture : undefined;
+}
+
+// Resolves with the exact usable capture, or undefined after timeoutMs. A
+// captured token can be near-expiry — captureTwitchIntegrity does not gate on
+// expiry — so resolvers re-check validity. When rejectedToken is set,
+// re-capturing that same token does not settle the wait; the page may replay it
+// before minting a replacement.
 function waitForIntegrityCapture(
   timeoutMs: number,
   rejectedToken?: string,
   signal?: AbortSignal,
-): Promise<boolean> {
+  sourceTabId?: number,
+  minimumGeneration = 0,
+): Promise<TwitchIntegrityCapture | undefined> {
   signal?.throwIfAborted();
-  if (hasReplacementTwitchIntegrity(rejectedToken)) return Promise.resolve(true);
+  const alreadyCaptured = captureForIntegrityWait(rejectedToken, sourceTabId, undefined, minimumGeneration);
+  if (alreadyCaptured) return Promise.resolve(alreadyCaptured);
   return new Promise((resolve, reject) => {
     let settled = false;
     const removeWaiter = () => {
@@ -668,21 +751,22 @@ function waitForIntegrityCapture(
       signal?.removeEventListener("abort", onAbort);
       removeWaiter();
     };
-    const finish = () => {
+    const finish = (capture?: TwitchIntegrityCapture) => {
       if (settled) return;
       settled = true;
       cleanup();
-      resolve(hasReplacementTwitchIntegrity(rejectedToken));
+      resolve(capture);
     };
-    const onCapture = () => {
+    const onCapture = (capture?: TwitchIntegrityCapture) => {
       if (settled) return;
       // Not a replacement yet — keep waiting until the deadline instead of
       // reporting the rejected token back as a successful refresh.
-      if (!hasReplacementTwitchIntegrity(rejectedToken)) {
+      const replacement = captureForIntegrityWait(rejectedToken, sourceTabId, capture, minimumGeneration);
+      if (!replacement) {
         integrityWaiters.push(onCapture);
         return;
       }
-      finish();
+      finish(replacement);
     };
     const onAbort = () => {
       if (settled) return;
@@ -717,7 +801,7 @@ export async function ensureTwitchIntegrityWithBrowser(
     ?? (forceRefresh ? "rejection_recovery" : "readiness");
   if (!forceRefresh) {
     if (hasValidTwitchIntegrity()) return true;
-    return startTwitchIntegrityAcquisition(
+    const captured = await startTwitchIntegrityAcquisition(
       browserApi,
       originUrl,
       timeoutMs,
@@ -728,6 +812,8 @@ export async function ensureTwitchIntegrityWithBrowser(
       request?.onManagedPageContextOpen,
       request?.signal,
     );
+    if (captured) request?.onIntegrityCaptured?.(captured.value);
+    return captured != null;
   }
 
   // Another operation's refresh already replaced the token this caller was
@@ -735,11 +821,12 @@ export async function ensureTwitchIntegrityWithBrowser(
   // help it — and would cost another cold boot.
   if (request?.rejectedToken != null && hasReplacementTwitchIntegrity(request.rejectedToken)) {
     diagnostic(emit, "debug", "Reusing the Twitch integrity token another operation just minted instead of booting another page context", "twitch");
+    request.onIntegrityCaptured?.(latestTwitchIntegrityCapture?.value ?? twitchIntegrity!);
     return true;
   }
 
   const rejectedToken = request?.rejectedToken ?? twitchIntegrity?.integrity;
-  return startTwitchIntegrityAcquisition(
+  const captured = await startTwitchIntegrityAcquisition(
     browserApi,
     originUrl,
     timeoutMs,
@@ -750,6 +837,8 @@ export async function ensureTwitchIntegrityWithBrowser(
     request?.onManagedPageContextOpen,
     request?.signal,
   );
+  if (captured) request?.onIntegrityCaptured?.(captured.value);
+  return captured != null;
 }
 
 function startTwitchIntegrityAcquisition(
@@ -762,14 +851,14 @@ function startTwitchIntegrityAcquisition(
   reason: NonNullable<TwitchIntegrityRequest["reason"]>,
   onManagedPageContextOpen?: () => void | Promise<void>,
   ownerSignal?: AbortSignal,
-): Promise<boolean> {
+): Promise<TwitchIntegrityAcquisitionResult | undefined> {
   if (inFlightIntegrityAcquisition) {
     diagnostic(emit, "debug", "Joining the Twitch integrity acquisition already in flight", "twitch");
     const joined = withAbortSignal(inFlightIntegrityAcquisition.promise, ownerSignal);
     if (!forceRefresh) return joined;
     return joined.then((captured) => {
       ownerSignal?.throwIfAborted();
-      if (captured && hasReplacementTwitchIntegrity(rejectedToken)) return true;
+      if (captured && captured.managedContext && captured.value.integrity !== rejectedToken && isValidTwitchIntegrity(captured.value)) return captured;
       return startTwitchIntegrityAcquisition(
         browserApi,
         originUrl,
@@ -800,6 +889,7 @@ function startTwitchIntegrityAcquisition(
     abort.signal,
   ).finally(() => {
     ownerSignal?.removeEventListener("abort", abortFromOwner);
+    twitchIntegrityCapturesBySourceTab.clear();
     if (inFlightIntegrityAcquisition?.promise === promise) {
       inFlightIntegrityAcquisition = undefined;
     }
@@ -826,7 +916,7 @@ async function mintTwitchIntegrity(
   reason: NonNullable<TwitchIntegrityRequest["reason"]>,
   onManagedPageContextOpen?: () => void | Promise<void>,
   signal?: AbortSignal,
-): Promise<boolean> {
+): Promise<TwitchIntegrityAcquisitionResult | undefined> {
   diagnostic(
     emit,
     "info",
@@ -838,6 +928,7 @@ async function mintTwitchIntegrity(
     "twitch",
   );
   const origin = new URL(originUrl).origin;
+  const minimumCaptureGeneration = twitchIntegrityCaptureGeneration;
   let pageContext: PageContextTab | undefined;
   try {
     pageContext = await acquirePageContextTab(browserApi, originUrl, origin, {
@@ -869,7 +960,13 @@ async function mintTwitchIntegrity(
     // On success the capture itself is logged once by setTwitchIntegrity (info);
     // here we only surface the failure case so the log isn't doubled up.
     const startedAt = Date.now();
-    const captured = await waitForIntegrityCapture(timeoutMs, rejectedToken, signal);
+    const captured = await waitForIntegrityCapture(
+      timeoutMs,
+      rejectedToken,
+      signal,
+      forceRefresh ? pageContext.tabId : undefined,
+      forceRefresh ? minimumCaptureGeneration : 0,
+    );
     const settledAt = Date.now();
     // Logged on both outcomes, not just the failure: a success that took 20s is
     // the same latency problem as a timeout, and only the phase split says which
@@ -881,12 +978,17 @@ async function mintTwitchIntegrity(
     } else {
       diagnostic(emit, "debug", `Waited ${settledAt - startedAt}ms for a Twitch integrity token from a ${source} page context${phases}`, "twitch");
     }
-    return captured;
+    return captured
+      ? {
+          value: captured.value,
+          managedContext: pageContext.createdByExtension,
+        }
+      : undefined;
   } catch (error) {
     signal?.throwIfAborted();
     const message = error instanceof Error ? error.message : String(error);
     diagnostic(emit, reason === "proactive_refresh" ? "debug" : "warn", `Could not open a twitch.tv tab to capture an integrity token: ${message}`, "twitch");
-    return false;
+    return undefined;
   } finally {
     if (pageContext) {
       await releasePageContextTab(browserApi, origin, pageContext, emit, signal?.aborted === true);

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -632,6 +632,9 @@ export type TwitchGqlTransport = <T>(
   credentials?: RequestCredentials,
   emit?: EventEmitter,
   signal?: AbortSignal,
+  // Optional one-attempt bundle pin used by integrity recovery. When absent,
+  // the transport reads the current global capture as before.
+  integrityOverride?: TwitchIntegrity,
 ) => Promise<TwitchGqlResponse<T>>;
 
 // Reporter-neutral transport: it captures only the request transport and
@@ -651,6 +654,7 @@ export function createTwitchGqlTransport(
     credentials?: RequestCredentials,
     emit: EventEmitter = ignoreEvent,
     signal?: AbortSignal,
+    integrityOverride?: TwitchIntegrity,
   ): Promise<TwitchGqlResponse<T>> => {
     // Read once per attempt and reused for both the headers and the failure
     // stamp, so the two can never disagree.
@@ -696,7 +700,7 @@ export function createTwitchGqlTransport(
     } satisfies RequestInit);
     const fetchOnce = async (queryText?: string): Promise<TwitchGqlResponse<T> | null> => {
       // Anonymous queries deliberately carry no identity at all.
-      sentIntegrity = credentials === "omit" ? undefined : options.currentIntegrity?.();
+      sentIntegrity = credentials === "omit" ? undefined : integrityOverride ?? options.currentIntegrity?.();
       const request = buildRequest(queryText);
       let raw: unknown;
       try {
@@ -1909,18 +1913,20 @@ export class TwitchAdapter implements PlatformAdapter {
       // only a forced refresh replaces it. Retry exactly once; a second failure
       // propagates.
       const rejectedToken = sentIntegrityToken(error);
+      let retryIntegrity: TwitchIntegrity | undefined;
       const refreshed = await this.ensureIntegrity({
         forceRefresh: true,
         reason: "rejection_recovery",
         rejectedToken,
+        onIntegrityCaptured: (value) => { retryIntegrity = value; },
         signal,
       });
-      if (refreshed) return await this.runClaim(reward, signal);
+      if (refreshed) return await this.runClaim(reward, signal, retryIntegrity);
       throw new Error(`Twitch rejected the claim for ${reward.name} (${message}). Keep a logged-in twitch.tv tab open so the extension can capture a valid integrity token, then retry.`);
     }
   }
 
-  private async runClaim(reward: DropReward, signal?: AbortSignal): Promise<boolean> {
+  private async runClaim(reward: DropReward, signal?: AbortSignal, integrityOverride?: TwitchIntegrity): Promise<boolean> {
     const result = await this.gql<{ claimDropRewards?: { status?: string } }>(
       "DropsPage_ClaimDropRewards",
       TWITCH_QUERIES.claimHash,
@@ -1929,6 +1935,7 @@ export class TwitchAdapter implements PlatformAdapter {
       undefined,
       this.emit,
       signal,
+      integrityOverride,
     );
     const status = result.data?.claimDropRewards?.status;
     if (status === "ELIGIBLE_FOR_ALL" || status === "DROP_INSTANCE_ALREADY_CLAIMED") return true;
@@ -1965,17 +1972,24 @@ export class TwitchAdapter implements PlatformAdapter {
       if (!isIntegrityRejection(error)) throw error;
       diagnostic(this.emit, "warn", `Channel-points claim for ${channel.username} was rejected for integrity; refreshing the token and retrying once`, "twitch");
       const rejectedToken = sentIntegrityToken(error);
+      let retryIntegrity: TwitchIntegrity | undefined;
       if (!await this.ensureIntegrity({
         forceRefresh: true,
         reason: "rejection_recovery",
         rejectedToken,
+        onIntegrityCaptured: (value) => { retryIntegrity = value; },
         signal,
       })) throw error;
-      return await this.runChannelPointsClaim(claimId, channelId, signal);
+      return await this.runChannelPointsClaim(claimId, channelId, signal, retryIntegrity);
     }
   }
 
-  private async runChannelPointsClaim(claimId: string, channelId: string, signal?: AbortSignal): Promise<boolean> {
+  private async runChannelPointsClaim(
+    claimId: string,
+    channelId: string,
+    signal?: AbortSignal,
+    integrityOverride?: TwitchIntegrity,
+  ): Promise<boolean> {
     const result = await this.gql<{ claimCommunityPoints?: { status?: string } }>(
       "ClaimCommunityPoints",
       TWITCH_QUERIES.claimCommunityPointsHash,
@@ -1984,6 +1998,7 @@ export class TwitchAdapter implements PlatformAdapter {
       undefined,
       this.emit,
       signal,
+      integrityOverride,
     );
     return result.data?.claimCommunityPoints?.status !== "CLAIM_NOT_AVAILABLE";
   }
@@ -2113,8 +2128,11 @@ export class TwitchAdapter implements PlatformAdapter {
     credentials?: RequestCredentials,
     emit: EventEmitter = this.emit,
     signal?: AbortSignal,
+    integrityOverride?: TwitchIntegrity,
   ): Promise<TwitchGqlResponse<T>> {
-    return this.gqlTransport(operationName, sha256Hash, variables, query, credentials, emit, signal);
+    return integrityOverride
+      ? this.gqlTransport(operationName, sha256Hash, variables, query, credentials, emit, signal, integrityOverride)
+      : this.gqlTransport(operationName, sha256Hash, variables, query, credentials, emit, signal);
   }
 
   // Twitch can reject an authenticated request for Client-Integrity while the
@@ -2143,13 +2161,15 @@ export class TwitchAdapter implements PlatformAdapter {
       // sent. Re-reading it here would race a concurrent capture and could
       // report a token this request never used.
       const rejectedToken = sentIntegrityToken(error);
+      let retryIntegrity: TwitchIntegrity | undefined;
       if (!await this.ensureIntegrity({
         forceRefresh: true,
         reason: "rejection_recovery",
         rejectedToken,
+        onIntegrityCaptured: (value) => { retryIntegrity = value; },
         signal,
       })) throw error;
-      return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal);
+      return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal, retryIntegrity);
     }
   }
 
@@ -2282,7 +2302,16 @@ class TwitchWatcher implements TablessWatchController {
 
   private async resolveUserId(): Promise<string | undefined> {
     if (this.viewerUserId) return this.viewerUserId;
-    const currentUser = () => this.gql<{ currentUser?: { id?: string } }>("CurrentUser", "", {}, CURRENT_USER_QUERY, undefined, this.diagnostics.emit);
+    const currentUser = (integrityOverride?: TwitchIntegrity) => this.gql<{ currentUser?: { id?: string } }>(
+      "CurrentUser",
+      "",
+      {},
+      CURRENT_USER_QUERY,
+      undefined,
+      this.diagnostics.emit,
+      undefined,
+      integrityOverride,
+    );
     try {
       let response;
       try {
@@ -2292,12 +2321,14 @@ class TwitchWatcher implements TablessWatchController {
         // adapter's safe authenticated reads.
         if (!isIntegrityRejection(error)) throw error;
         this.log("debug", "Twitch viewer id lookup was rejected for integrity; refreshing the token and retrying once");
+        let retryIntegrity: TwitchIntegrity | undefined;
         if (!await this.ensureIntegrity({
           forceRefresh: true,
           reason: "rejection_recovery",
           rejectedToken: sentIntegrityToken(error),
+          onIntegrityCaptured: (value) => { retryIntegrity = value; },
         })) throw error;
-        response = await currentUser();
+        response = await currentUser(retryIntegrity);
       }
       this.viewerUserId = response.data?.currentUser?.id;
     } catch (error) {

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -260,6 +260,22 @@ function sentIntegrityToken(error: unknown): string | undefined {
   return error instanceof TwitchGqlFailure ? error.sentIntegrityToken : undefined;
 }
 
+async function refreshIntegrityForRetry(
+  ensureIntegrity: (request?: TwitchIntegrityRequest) => Promise<boolean>,
+  rejectedToken: string | undefined,
+  signal?: AbortSignal,
+): Promise<{ refreshed: boolean; integrity: TwitchIntegrity | undefined }> {
+  let integrity: TwitchIntegrity | undefined;
+  const refreshed = await ensureIntegrity({
+    forceRefresh: true,
+    reason: "rejection_recovery",
+    rejectedToken,
+    onIntegrityCaptured: (value) => { integrity = value; },
+    signal,
+  });
+  return { refreshed, integrity };
+}
+
 function isCredentialRejection(message: string | undefined): boolean {
   return message != null && /unauthenticated|unauthorized|(?:the )?oauth token (?:(?:is|was) )?invalid|invalid oauth token|token (?:has )?expired/i.test(message);
 }
@@ -1913,15 +1929,8 @@ export class TwitchAdapter implements PlatformAdapter {
       // only a forced refresh replaces it. Retry exactly once; a second failure
       // propagates.
       const rejectedToken = sentIntegrityToken(error);
-      let retryIntegrity: TwitchIntegrity | undefined;
-      const refreshed = await this.ensureIntegrity({
-        forceRefresh: true,
-        reason: "rejection_recovery",
-        rejectedToken,
-        onIntegrityCaptured: (value) => { retryIntegrity = value; },
-        signal,
-      });
-      if (refreshed) return await this.runClaim(reward, signal, retryIntegrity);
+      const retry = await refreshIntegrityForRetry(this.ensureIntegrity, rejectedToken, signal);
+      if (retry.refreshed) return await this.runClaim(reward, signal, retry.integrity);
       throw new Error(`Twitch rejected the claim for ${reward.name} (${message}). Keep a logged-in twitch.tv tab open so the extension can capture a valid integrity token, then retry.`);
     }
   }
@@ -1972,15 +1981,9 @@ export class TwitchAdapter implements PlatformAdapter {
       if (!isIntegrityRejection(error)) throw error;
       diagnostic(this.emit, "warn", `Channel-points claim for ${channel.username} was rejected for integrity; refreshing the token and retrying once`, "twitch");
       const rejectedToken = sentIntegrityToken(error);
-      let retryIntegrity: TwitchIntegrity | undefined;
-      if (!await this.ensureIntegrity({
-        forceRefresh: true,
-        reason: "rejection_recovery",
-        rejectedToken,
-        onIntegrityCaptured: (value) => { retryIntegrity = value; },
-        signal,
-      })) throw error;
-      return await this.runChannelPointsClaim(claimId, channelId, signal, retryIntegrity);
+      const retry = await refreshIntegrityForRetry(this.ensureIntegrity, rejectedToken, signal);
+      if (!retry.refreshed) throw error;
+      return await this.runChannelPointsClaim(claimId, channelId, signal, retry.integrity);
     }
   }
 
@@ -2161,15 +2164,9 @@ export class TwitchAdapter implements PlatformAdapter {
       // sent. Re-reading it here would race a concurrent capture and could
       // report a token this request never used.
       const rejectedToken = sentIntegrityToken(error);
-      let retryIntegrity: TwitchIntegrity | undefined;
-      if (!await this.ensureIntegrity({
-        forceRefresh: true,
-        reason: "rejection_recovery",
-        rejectedToken,
-        onIntegrityCaptured: (value) => { retryIntegrity = value; },
-        signal,
-      })) throw error;
-      return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal, retryIntegrity);
+      const retry = await refreshIntegrityForRetry(this.ensureIntegrity, rejectedToken, signal);
+      if (!retry.refreshed) throw error;
+      return this.gql<T>(operationName, sha256Hash, variables, query, credentials, emit, signal, retry.integrity);
     }
   }
 
@@ -2321,14 +2318,9 @@ class TwitchWatcher implements TablessWatchController {
         // adapter's safe authenticated reads.
         if (!isIntegrityRejection(error)) throw error;
         this.log("debug", "Twitch viewer id lookup was rejected for integrity; refreshing the token and retrying once");
-        let retryIntegrity: TwitchIntegrity | undefined;
-        if (!await this.ensureIntegrity({
-          forceRefresh: true,
-          reason: "rejection_recovery",
-          rejectedToken: sentIntegrityToken(error),
-          onIntegrityCaptured: (value) => { retryIntegrity = value; },
-        })) throw error;
-        response = await currentUser(retryIntegrity);
+        const retry = await refreshIntegrityForRetry(this.ensureIntegrity, sentIntegrityToken(error));
+        if (!retry.refreshed) throw error;
+        response = await currentUser(retry.integrity);
       }
       this.viewerUserId = response.data?.currentUser?.id;
     } catch (error) {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
 import { createKickClaimCapability, createKickFetcher, KickAdapter, KickClaimState, KickDiscoveryState } from "@lurkloot/core/kick";
 import { fetchTwitchInBackgroundWith, KickWafBlockedError } from "@lurkloot/core/tabs";
+import type { TwitchIntegrityRequest } from "@lurkloot/core/tabs";
 import { readFileSync } from "node:fs";
 import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import type { EngineEvent } from "@lurkloot/shared/events";
@@ -4659,6 +4660,46 @@ describe("TwitchAdapter integrity recovery", () => {
     }));
   });
 
+  it("pins the managed replacement for the immediate retry when the global capture is replayed", async () => {
+    const rejected = {
+      integrity: "rejected-token",
+      deviceId: "rejected-device",
+      clientSessionId: "rejected-session",
+      expiresAt: Date.now() + 60_000,
+    };
+    const replacement = {
+      integrity: "replacement-token",
+      deviceId: "replacement-device",
+      clientSessionId: "replacement-session",
+      expiresAt: Date.now() + 60_000,
+    };
+    const sent: string[] = [];
+    const ensureIntegrity = vi.fn(async (request?: TwitchIntegrityRequest) => {
+      if (request?.forceRefresh) {
+        // A concurrent user tab replays the rejected bundle into the ordinary
+        // global slot after the helper capture; only the callback's exact
+        // bundle is safe for this immediate retry.
+        request.onIntegrityCaptured?.(replacement);
+      }
+      return true;
+    });
+    let attempts = 0;
+    const fetcher = jsonFetcher((_url, init) => {
+      const headers = new Headers(init?.headers as HeadersInit);
+      sent.push(headers.get("client-integrity") ?? "");
+      attempts += 1;
+      return attempts === 1
+        ? INTEGRITY_REJECTION
+        : { data: { currentUser: { id: "u" } } };
+    });
+
+    await expect(twitchAdapter(fetcher, ensureIntegrity, undefined, {
+      currentIntegrity: () => rejected,
+    }).checkAuthHealth()).resolves.toMatchObject({ status: "healthy" });
+
+    expect(sent).toEqual([rejected.integrity, replacement.integrity]);
+  });
+
   it("sends the integrity trio together so the replayed token stays bound to its identity", async () => {
     const currentIntegrity = () => ({
       integrity: "bound-token",
@@ -4950,6 +4991,7 @@ describe("TwitchAdapter integrity recovery", () => {
           forceRefresh: true,
           reason: "rejection_recovery",
           rejectedToken: undefined,
+          onIntegrityCaptured: expect.any(Function),
           signal: undefined,
         }],
       ]);
@@ -5003,6 +5045,7 @@ describe("TwitchAdapter integrity recovery", () => {
           forceRefresh: true,
           reason: "rejection_recovery",
           rejectedToken: undefined,
+          onIntegrityCaptured: expect.any(Function),
           signal: undefined,
         }],
       ]);

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -819,6 +819,36 @@ describe("background controller", () => {
       setTwitchIntegrity(undefined);
     });
 
+    it("keeps a user-tab capture from satisfying a managed refresh wait", async () => {
+      const browser = {
+        tabs: {
+          get: vi.fn(),
+          update: vi.fn(async () => undefined),
+          remove: vi.fn(async () => undefined),
+          query: vi.fn(async () => []),
+          create: vi.fn(async () => ({ id: 42 })),
+        },
+      } satisfies BrowserTabApi;
+      const rejected = integrityBundle({ integrity: "controller-rejected-token" });
+      const replacement = integrityBundle({ integrity: "controller-user-token" });
+      const env = harness(undefined, { loadTwitchIntegrity: async () => undefined });
+      await env.controller.settleBackgroundWork();
+      setTwitchIntegrity(rejected, { sourceTabId: 7 });
+
+      const pending = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        50,
+        undefined,
+        { forceRefresh: true, rejectedToken: rejected.integrity },
+      );
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+
+      await env.controller.captureTwitchIntegrity(integrityHeaders(replacement), 7);
+
+      await expect(pending).resolves.toBe(false);
+    });
+
     it("acquires integrity before Twitch auth and scheduler work", async () => {
       const order: string[] = [];
       const env = harness(undefined, {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -849,6 +849,36 @@ describe("background controller", () => {
       await expect(pending).resolves.toBe(false);
     });
 
+    it("treats negative tab ids as unattributed integrity captures", async () => {
+      const browser = {
+        tabs: {
+          get: vi.fn(),
+          update: vi.fn(async () => undefined),
+          remove: vi.fn(async () => undefined),
+          query: vi.fn(async () => []),
+          create: vi.fn(async () => ({ id: 42 })),
+        },
+      } satisfies BrowserTabApi;
+      const rejected = integrityBundle({ integrity: "controller-rejected-token" });
+      const replacement = integrityBundle({ integrity: "controller-unattributed-token" });
+      const env = harness(undefined, { loadTwitchIntegrity: async () => undefined });
+      await env.controller.settleBackgroundWork();
+      setTwitchIntegrity(rejected, { sourceTabId: 7 });
+
+      const pending = ensureTwitchIntegrityWithBrowser(
+        browser,
+        "https://www.twitch.tv/drops/inventory",
+        50,
+        undefined,
+        { forceRefresh: true, rejectedToken: rejected.integrity },
+      );
+      await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+
+      await env.controller.captureTwitchIntegrity(integrityHeaders(replacement), -1);
+
+      await expect(pending).resolves.toBe(true);
+    });
+
     it("acquires integrity before Twitch auth and scheduler work", async () => {
       const order: string[] = [];
       const env = harness(undefined, {

--- a/packages/extension/tests/tabs.test.ts
+++ b/packages/extension/tests/tabs.test.ts
@@ -7,6 +7,7 @@ import {
   applyAdFocusWithBrowser,
   cancelTwitchIntegrityAcquisition,
   currentManagedPageContextTabs,
+  currentValidTwitchIntegrity,
   currentTwitchIntegrityWaiterCount,
   ensureTwitchIntegrityWithBrowser,
   fetchJsonInPageWithBrowser,
@@ -1391,6 +1392,7 @@ describe("twitch integrity refresh", () => {
       setTwitchIntegrity(rejected, { isNew: true });
       await expect(ordinary).resolves.toBe(true);
       await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(currentTwitchIntegrityWaiterCount()).toBeGreaterThan(0));
       expect(forcedSettled).toBe(false);
       expect(browser.tabs.create).toHaveBeenCalledWith({
         url: "https://www.twitch.tv/drops/inventory",
@@ -1822,6 +1824,80 @@ describe("twitch integrity refresh", () => {
         );
 
         expect(ok).toBe(false);
+      });
+
+      it("does not reopen helper tabs when a concurrent user tab replays the rejected token", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 32 });
+        setTwitchIntegrity(rejected(), { sourceTabId: 7 });
+        let capturedIntegrity: string | undefined;
+
+        const pending = ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          5_000,
+          undefined,
+          {
+            forceRefresh: true,
+            rejectedToken: rejected().integrity,
+            onIntegrityCaptured: (value) => { capturedIntegrity = value.integrity; },
+          },
+        );
+        await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+
+        // Lurkloot's helper tab mints the replacement and wakes the waiter,
+        // but another already-open Twitch tab can immediately issue GQL with
+        // the old bundle before the awaiting retry gets its next microtask.
+        setTwitchIntegrity(replacement(), { isNew: true, sourceTabId: 32 });
+        setTwitchIntegrity(rejected(), { isNew: true, sourceTabId: 7 });
+
+        await expect(pending).resolves.toBe(true);
+
+        expect(browser.tabs.create).toHaveBeenCalledTimes(1);
+        expect(browser.tabs.remove).toHaveBeenCalledTimes(1);
+        expect(capturedIntegrity).toBe(replacement().integrity);
+        // Ordinary capture remains last-writer-wins; the pinned callback above
+        // is what protects the immediate retry from this user-tab replay.
+        expect(currentValidTwitchIntegrity()?.integrity).toBe(rejected().integrity);
+      });
+
+      it("does not let a user-tab capture satisfy a managed helper wait", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 33 });
+        setTwitchIntegrity(rejected(), { sourceTabId: 7 });
+
+        const pending = ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          50,
+          undefined,
+          { forceRefresh: true, rejectedToken: rejected().integrity },
+        );
+        await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+
+        setTwitchIntegrity(replacement(), { isNew: true, sourceTabId: 7 });
+
+        await expect(pending).resolves.toBe(false);
+        expect(browser.tabs.create).toHaveBeenCalledOnce();
+      });
+
+      it("does not reuse a prior capture when a helper tab id is recycled", async () => {
+        const browser = browserMock();
+        browser.tabs.create.mockResolvedValue({ id: 34 });
+        setTwitchIntegrity(replacement(), { sourceTabId: 34 });
+        setTwitchIntegrity(rejected(), { sourceTabId: 7 });
+
+        const pending = ensureTwitchIntegrityWithBrowser(
+          browser,
+          "https://www.twitch.tv/drops/inventory",
+          50,
+          undefined,
+          { forceRefresh: true, rejectedToken: rejected().integrity },
+        );
+        await vi.waitFor(() => expect(browser.tabs.create).toHaveBeenCalledOnce());
+
+        await expect(pending).resolves.toBe(false);
+        expect(browser.tabs.create).toHaveBeenCalledOnce();
       });
 
       it("creates a fresh inactive page context instead of reusing a user-owned tab", async () => {


### PR DESCRIPTION
## Summary

- attribute captured Twitch integrity bundles to their source tab and acquisition generation
- accept managed refresh results only from the relevant helper context
- pin the exact replacement bundle through the immediate GQL, drop-claim, channel-points, and tabless-watcher retries
- add regression coverage for concurrent user-tab replays, unrelated captures, and recycled tab IDs

## Root cause

Twitch integrity state was globally last-writer-wins. After a managed helper tab captured a valid replacement, another open Twitch tab could replay the rejected bundle before the retry resumed. The retry then re-read that rejected global value, failed again, and caused another helper-tab open/close cycle.

## Impact

Recovery now retries with the exact bundle captured for that acquisition while ordinary capture behavior remains unchanged. Concurrent Twitch tabs can no longer swap the refreshed token out from under the immediate retry.

## Testing

- `pnpm check`
- `git diff --check`

All workspace typechecks passed. The extension suite passed 69 files and 1541 tests; CLI, site, release, and Chrome Web Store script checks also passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch authentication recovery by ensuring retries use the exact newly captured integrity token.
  * Prevented tokens captured from user tabs or recycled helper tabs from being incorrectly reused for managed-page refreshes.
  * Improved reliability when refreshing tokens during simultaneous requests and recovery flows.
* **Tests**
  * Added coverage for tab attribution, refresh races, token replacement, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->