### PR TITLE
fix(controller): pause immediately on manual watch

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -71,6 +71,7 @@ export type TickTrigger =
   | "automation_toggle"
   | "platform_toggle"
   | "settings_saved"
+  | "manual_watch"
   | "manual_resume"
   | "manual_tick"
   | "critical_failure_dismissed"
@@ -2462,6 +2463,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     message: Extract<CoreRuntimeMessage, { type: "playbackTelemetry" }>,
     senderTabId?: number,
   ): Promise<void> {
+    let manualWatchStarted = false;
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
       const session = state.sessions[message.platform];
@@ -2472,9 +2474,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
       if (!isManagedWatchTab) {
         if (senderTabId != null) {
+          const manualWatch = recordManualWatchTelemetry(state, settings, message, senderTabId);
+          manualWatchStarted = manualWatch.started;
           await persistPlatformAndReport(
             message.platform,
-            recordManualWatchTelemetry(state, settings, message, senderTabId),
+            manualWatch.state,
             events,
           );
         }
@@ -2520,6 +2524,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         await reportBestEffort(events);
       }
     }), [message.platform]);
+    if (manualWatchStarted) tickInBackground([message.platform], "manual_watch");
   }
 
   function recordManualWatchTelemetry(
@@ -2527,17 +2532,19 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     settings: EngineSettings,
     message: Extract<CoreRuntimeMessage, { type: "playbackTelemetry" }>,
     senderTabId: number,
-  ): SchedulerState {
+  ): { state: SchedulerState; started: boolean } {
     const manualWatch = { ...state.manualWatch };
     if (!settings.pauseOnManualWatch) {
       delete manualWatch[message.platform];
-      return { ...state, manualWatch };
+      return { state: { ...state, manualWatch }, started: false };
     }
 
     const active = message.telemetry.playingVideoCount > 0 && !message.telemetry.documentHidden;
     const previous = manualWatch[message.platform];
     const recentPrevious = previous?.active && !isTimestampStale(previous.checkedAt, MANUAL_WATCH_TTL_MS, Date.now());
-    if (!active && previous?.tabId !== senderTabId && recentPrevious) return state;
+    if (!active && previous?.tabId !== senderTabId && recentPrevious) {
+      return { state, started: false };
+    }
 
     manualWatch[message.platform] = {
       platform: message.platform,
@@ -2545,7 +2552,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       checkedAt: new Date().toISOString(),
       active,
     };
-    return { ...state, manualWatch };
+    return {
+      state: { ...state, manualWatch },
+      started: active && !recentPrevious,
+    };
   }
 
   async function applyAdFocusForState(

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -4707,9 +4707,10 @@ describe("background controller", () => {
     expect(env.state.sessions.twitch.playbackChecks).toBe(0);
   });
 
-  it("records visible playback in a non-managed tab as manual watch activity", async () => {
+  it("pauses Twitch immediately when visible playback starts in a non-managed tab", async () => {
     const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
-    await env.controller.handleMessage({ type: "setAutomation", platform: "twitch", enabled: true });
+    await env.controller.tick();
+    vi.mocked(env.kick.refreshCampaigns).mockClear();
 
     await env.controller.handleMessage({
       type: "playbackTelemetry",
@@ -4729,7 +4730,58 @@ describe("background controller", () => {
       tabId: 999,
       active: true,
     });
+    expect(env.state.sessions.twitch).toMatchObject({
+      status: "paused",
+      reasonCode: "manual_watch",
+      channel: undefined,
+    });
+    expect(env.state.sessions.kick.status).toBe("watching");
+    expect(env.kick.refreshCampaigns).not.toHaveBeenCalled();
     expect(env.state.sessions.twitch.playback).toBeUndefined();
+  });
+
+  it("runs only one immediate tick while the same manual playback stays active", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+    await env.controller.tick(["twitch"]);
+    env.reportEvents.mockClear();
+    const telemetry = {
+      videoCount: 1,
+      mutedVideoCount: 0,
+      unmutedVideoCount: 1,
+      playingVideoCount: 1,
+      blockedPlaybackCount: 0,
+      documentHidden: false,
+    };
+
+    await env.controller.handleMessage({ type: "playbackTelemetry", platform: "twitch", telemetry }, { tab: { id: 999 } });
+    await env.controller.handleMessage({ type: "playbackTelemetry", platform: "twitch", telemetry }, { tab: { id: 999 } });
+
+    const immediateTickStarts = allDiagnostics(env).filter((event) =>
+      event.message.includes("started (trigger=manual_watch"));
+    expect(immediateTickStarts).toHaveLength(1);
+  });
+
+  it("does not tick when non-managed Twitch playback is inactive", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+    await env.controller.tick(["twitch"]);
+    env.reportEvents.mockClear();
+
+    await env.controller.handleMessage({
+      type: "playbackTelemetry",
+      platform: "twitch",
+      telemetry: {
+        videoCount: 1,
+        mutedVideoCount: 0,
+        unmutedVideoCount: 1,
+        playingVideoCount: 0,
+        blockedPlaybackCount: 0,
+        documentHidden: false,
+      },
+    }, { tab: { id: 999 } });
+
+    expect(env.state.sessions.twitch.status).toBe("watching");
+    expect(allDiagnostics(env).some((event) =>
+      event.message.includes("started (trigger=manual_watch"))).toBe(false);
   });
 
   it("clears manual watch activity when the source tab is closed", async () => {
@@ -5016,7 +5068,12 @@ describe("background controller", () => {
       tabId: 10,
       active: true,
     });
-    expect(env.deps.applyAdFocus).not.toHaveBeenCalled();
+    expect(env.deps.applyAdFocus).not.toHaveBeenCalledWith(
+      "twitch",
+      10,
+      true,
+      expect.any(Function),
+    );
   });
 
   it("re-applies ad focus from playback state on each scheduler tick", async () => {


### PR DESCRIPTION
## Summary

- trigger an immediate platform-scoped scheduler tick when manual playback becomes active
- persist telemetry before scheduling the tick and run it outside the state lock
- deduplicate recurring active telemetry while leaving inactive playback and the sibling platform untouched

## Root cause

Manual-watch telemetry was recorded every five seconds, but the controller only reconciled it during the next scheduled farming tick. The popup could therefore continue showing an active farming session after the user had started watching a visible Twitch stream.

## Impact

Visible manual playback now prompts the existing scheduler manual-watch gate immediately. The scheduler remains the authority for pausing and cleanup, and repeated telemetry does not create a tick storm.

## Testing

- `pnpm verify`
- 1,697 tests passed
- workspace TypeScript checks passed
- Chromium and Firefox production builds passed
- independent read-only code review found no issues
