### PR TITLE
fix(twitch): apply availability ttl per campaign

### DIFF
--- a/docs/superpowers/plans/2026-08-18-available-drops-cache-ttl.md
+++ b/docs/superpowers/plans/2026-08-18-available-drops-cache-ttl.md
@@ -1,0 +1,89 @@
+# AvailableDrops Cache TTL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply Twitch strict-availability cache expiry relative to the campaign being checked so omitted campaigns expire after 30 seconds while listed campaigns remain cached for two minutes.
+
+**Architecture:** Keep one complete `viewerDropCampaigns` snapshot per channel and broadcast, but record when the snapshot was fetched and evaluate its lifetime against membership of the requested campaign. A negative lookup may expire while the same snapshot remains reusable for a listed campaign; only delete the whole snapshot once no positive lookup can still be valid.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-available-drops-cache-ttl.md`
+
+## Global Constraints
+
+- `packages/core` remains browser-free and must not import WXT or browser globals.
+- Diagnostic messages remain English literals; add no locale keys.
+- Do not log OAuth tokens, cookies, authorization headers, integrity tokens, or raw authenticated responses.
+- `strictCampaignAvailability` remains off by default.
+- Preserve fail-open handling for malformed, mismatched, and errored `AvailableDrops` responses.
+- Preserve broadcast invalidation, authenticated-identity generation guards, the 128-entry bound, and progress-confirmed overrides.
+- Follow strict TDD: add the regression test and observe the expected failure before changing production code.
+- Use pnpm for all commands and Conventional Commits for the final commit.
+
+---
+
+### Task 1: Make channel-availability expiry campaign-relative
+
+**Files:**
+- Modify: `packages/core/src/platforms/twitch/index.ts`
+- Test: `packages/extension/tests/adapters.test.ts`
+
+**Interfaces:**
+- Consumes: `TwitchDiscoveryState.rememberChannelAvailability(channelId, broadcastId, campaignIds, requestIdentity)` and both strict `AvailableDrops` callers.
+- Produces: a campaign-aware cache lookup used identically by batch and single-channel availability checks.
+
+- [ ] **Step 1: Add the failing regression coverage**
+
+Add deterministic fake-timer coverage around the real `TwitchDiscoveryState`/`TwitchAdapter` behavior. Use a valid `AvailableDrops` snapshot containing `campaign-b` while strict selection asks for `campaign-a`. Prove all of the following with literal expectations:
+
+1. Before 30 seconds, campaign A's omission is a cached negative.
+2. After 30,001 ms, campaign A's negative is expired and the next strict lookup refetches.
+3. At that same boundary, campaign B from the original snapshot remains a positive cache hit and does not refetch.
+4. A listed campaign expires at the two-minute boundary.
+5. An empty valid snapshot still behaves as a 30-second negative.
+
+The tests must exercise observable cache/adapter behavior, not inspect private fields or source text.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/adapters.test.ts
+```
+
+Expected: the non-empty snapshot test fails because campaign A remains cached after 30,001 ms. Record the relevant failure in the task report before editing production code.
+
+- [ ] **Step 3: Implement the minimal membership-relative expiry**
+
+Update the cached snapshot representation to retain its fetch time rather than committing the entire set to one TTL. Make `cachedChannelAvailability` accept the requested campaign ID and choose the effective TTL from `campaignIds.has(campaignId)`:
+
+```ts
+const isPositive = cached.campaignIds.has(campaignId);
+const ttl = isPositive
+  ? POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS
+  : NEGATIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS;
+```
+
+When a negative lookup expires before the positive lifetime of the snapshot, return `expired` without deleting the snapshot. Delete it only once the positive lifetime has also elapsed. Update every production caller and direct state test to pass the campaign ID. When progress confirmation promotes a campaign into a cached snapshot, reset the snapshot fetch time so the promoted positive receives the full positive TTL.
+
+- [ ] **Step 4: Verify GREEN and regression safety**
+
+Run the focused test again and confirm it passes, then run:
+
+```bash
+pnpm typecheck
+pnpm test
+```
+
+Confirm workspace typechecks and all package tests pass. Report exact commands and counts.
+
+- [ ] **Step 5: Self-review and commit**
+
+Review the diff for unnecessary API churn, duplicated expiry logic, loss of existing cache guards, and tests that assert mocks instead of behavior. Commit only the plan/spec, implementation, and regression tests:
+
+```bash
+git add docs/superpowers/specs/2026-08-18-available-drops-cache-ttl.md docs/superpowers/plans/2026-08-18-available-drops-cache-ttl.md packages/core/src/platforms/twitch/index.ts packages/extension/tests/adapters.test.ts
+git commit -m "fix(twitch): apply availability ttl per campaign"
+```

--- a/docs/superpowers/specs/2026-08-18-available-drops-cache-ttl.md
+++ b/docs/superpowers/specs/2026-08-18-available-drops-cache-ttl.md
@@ -1,0 +1,34 @@
+# AvailableDrops Cache TTL Design
+
+## Problem
+
+The strict Twitch campaign-availability cache currently chooses its expiry from whether
+`DropsHighlightService_AvailableDrops` returned any campaign. That is not the question the
+caller asks. When Lurkloot checks campaign A and Twitch returns only campaign B, A is a negative
+result even though the returned set is non-empty. The current implementation consequently keeps
+that negative for the two-minute positive TTL instead of the intended 30-second negative TTL.
+
+This affects only users who explicitly enable `strictCampaignAvailability`; the production
+default remains off.
+
+## Required behavior
+
+- A requested campaign present in a valid `viewerDropCampaigns` snapshot is reusable for two
+  minutes.
+- A requested campaign absent from a valid snapshot is reusable for only 30 seconds, whether the
+  returned array is empty or contains other campaign IDs.
+- Expiring a negative lookup for campaign A must not prematurely expire a still-positive lookup
+  for campaign B from the same snapshot.
+- Malformed, mismatched, or errored responses remain uncached and fail open.
+- Batch and single-channel paths use the same membership-relative cache behavior.
+- Existing broadcast invalidation, authenticated-identity generation guards, bounded storage,
+  and progress-confirmed availability overrides remain intact.
+
+## Scope
+
+Implement only the membership-relative TTL correction and deterministic regression coverage.
+Batch request retry/fallback optimization is outside this issue.
+
+## Source
+
+GitHub issue: https://github.com/jamezrin/lurkloot/issues/414

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -375,7 +375,7 @@ interface TwitchAvailableDropsData {
 interface CachedAvailableCampaigns {
   broadcastId: string;
   campaignIds: Set<string>;
-  expiresAt: number;
+  fetchedAt: number;
 }
 
 interface ProgressConfirmedAvailability {
@@ -546,15 +546,26 @@ export class TwitchDiscoveryState {
   // Lives here rather than on TwitchAdapter so it survives the per-tick
   // adapter reconstruction (see the class comment on followedChannels above)
   // — without that, the cache is structurally incapable of ever hitting.
-  cachedChannelAvailability(channelId: string, broadcastId: string): ChannelAvailabilityLookup {
+  cachedChannelAvailability(
+    channelId: string,
+    broadcastId: string,
+    campaignId: string,
+  ): ChannelAvailabilityLookup {
     const cached = this.availableCampaignsByChannel.get(channelId);
     if (!cached) return { status: "miss" };
     if (cached.broadcastId !== broadcastId) {
       this.availableCampaignsByChannel.delete(channelId);
       return { status: "broadcast_changed" };
     }
-    if (cached.expiresAt <= Date.now()) {
-      this.availableCampaignsByChannel.delete(channelId);
+    const now = Date.now();
+    const isPositive = cached.campaignIds.has(campaignId);
+    const ttl = isPositive
+      ? POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS
+      : NEGATIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS;
+    if (cached.fetchedAt + ttl <= now) {
+      if (cached.fetchedAt + POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS <= now) {
+        this.availableCampaignsByChannel.delete(channelId);
+      }
       return { status: "expired" };
     }
     return { status: "hit", campaignIds: cached.campaignIds };
@@ -589,9 +600,7 @@ export class TwitchDiscoveryState {
     this.availableCampaignsByChannel.set(channelId, {
       broadcastId,
       campaignIds: new Set(campaignIds),
-      expiresAt: Date.now() + (campaignIds.size > 0
-        ? POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS
-        : NEGATIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS),
+      fetchedAt: Date.now(),
     });
     return true;
   }
@@ -634,7 +643,7 @@ export class TwitchDiscoveryState {
     const cachedAvailability = this.availableCampaignsByChannel.get(channelId);
     if (cachedAvailability && !cachedAvailability.campaignIds.has(campaignId)) {
       cachedAvailability.campaignIds.add(campaignId);
-      cachedAvailability.expiresAt = Date.now() + POSITIVE_CHANNEL_CAMPAIGN_CACHE_TTL_MS;
+      cachedAvailability.fetchedAt = Date.now();
     }
     return true;
   }
@@ -1416,7 +1425,7 @@ export class TwitchAdapter implements PlatformAdapter {
         matches.set(candidate.channelId, true);
         continue;
       }
-      const lookup = this.discoveryState.cachedChannelAvailability(candidate.channelId, candidate.broadcastId);
+      const lookup = this.discoveryState.cachedChannelAvailability(candidate.channelId, candidate.broadcastId, campaignId);
       if (lookup.status === "hit") {
         cacheHits += 1;
         matches.set(candidate.channelId, lookup.campaignIds.has(campaignId));
@@ -1430,9 +1439,10 @@ export class TwitchAdapter implements PlatformAdapter {
     if (uncached.length === 1) {
       const candidate = uncached[0];
       // checkCampaignAvailability does not get to classify this lookup itself:
-      // the loop above already read (and, if expired, deleted) this entry, so
-      // a second read here would see a plain miss even for the expired case —
-      // the classification above is the only correct one available.
+      // the loop above already read this entry, so a second read here would
+      // either repeat an expired negative lookup while retained or see a plain
+      // miss after the whole snapshot expires — the classification above is
+      // the only correct one available.
       const metrics = { checks: 0, cacheHits: 0 };
       matches.set(
         candidate.channelId,
@@ -1779,7 +1789,7 @@ export class TwitchAdapter implements PlatformAdapter {
     metrics?: { checks: number; cacheHits: number },
   ): Promise<boolean | undefined> {
     if (this.discoveryState.hasProgressConfirmedAvailability(channelId, campaignId)) return true;
-    const lookup = this.discoveryState.cachedChannelAvailability(channelId, broadcastId);
+    const lookup = this.discoveryState.cachedChannelAvailability(channelId, broadcastId, campaignId);
     if (lookup.status === "hit") {
       if (metrics) metrics.cacheHits += 1;
       return lookup.campaignIds.has(campaignId);
@@ -2077,7 +2087,7 @@ export class TwitchAdapter implements PlatformAdapter {
         );
         const broadcastId = streamInfo.data?.user?.stream?.id;
         const availability = broadcastId
-          ? this.discoveryState.cachedChannelAvailability(channelId, broadcastId)
+          ? this.discoveryState.cachedChannelAvailability(channelId, broadcastId, matchingCampaign.id)
           : { status: "miss" as const };
         const overridesNegativeAvailability = availability.status === "hit"
           && !availability.campaignIds.has(matchingCampaign.id);

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2796,6 +2796,92 @@ describe("TwitchAdapter", () => {
     expect(availabilityCalls).toBe(1);
   });
 
+  it("expires strict Twitch availability relative to the requested campaign", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T15:00:00.000Z"));
+      const availabilityCalls = new Map<string, number>();
+      const fetcher = jsonFetcher((_url, init) => {
+        const op = operation(init);
+        if (op === "StreamInfo") {
+          const channel = String((requestBody(init).variables as { channel?: string }).channel);
+          const channelId = channel === "positive" ? "positive-channel" : channel === "empty" ? "empty-channel" : "mixed-channel";
+          return {
+            data: {
+              user: {
+                id: channelId,
+                stream: { id: `${channelId}-broadcast`, game: { id: "game" } },
+              },
+            },
+          };
+        }
+        if (op === "DropsHighlightService_AvailableDrops") {
+          const channelId = String((requestBody(init).variables as { channelID?: string }).channelID);
+          availabilityCalls.set(channelId, (availabilityCalls.get(channelId) ?? 0) + 1);
+          return {
+            data: {
+              channel: {
+                id: channelId,
+                viewerDropCampaigns: channelId === "empty-channel" ? [] : [{ id: "campaign-b" }],
+              },
+            },
+          };
+        }
+        throw new Error(`Unexpected op ${op}`);
+      });
+      const discoveryState = new TwitchDiscoveryState();
+      const adapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
+      const mixedCandidate = { platform: "twitch", username: "mixed", url: "https://www.twitch.tv/mixed" } as const;
+      const positiveCandidate = { platform: "twitch", username: "positive", url: "https://www.twitch.tv/positive" } as const;
+      const emptyCandidate = { platform: "twitch", username: "empty", url: "https://www.twitch.tv/empty" } as const;
+      const campaignA = { id: "campaign-a", categoryId: "game" } as DropCampaign;
+      const campaignB = { id: "campaign-b", categoryId: "game" } as DropCampaign;
+
+      await expect(adapter.checkChannel(mixedCandidate, { campaign: campaignA }))
+        .resolves.toMatchObject({ campaignMatches: false });
+      expect(availabilityCalls.get("mixed-channel")).toBe(1);
+
+      await expect(adapter.checkChannel(mixedCandidate, { campaign: campaignA }))
+        .resolves.toMatchObject({ campaignMatches: false });
+      expect(availabilityCalls.get("mixed-channel")).toBe(1);
+
+      vi.advanceTimersByTime(30_001);
+      await expect(adapter.checkChannel(mixedCandidate, { campaign: campaignB }))
+        .resolves.toMatchObject({ campaignMatches: true });
+      expect(availabilityCalls.get("mixed-channel")).toBe(1);
+
+      await expect(adapter.checkChannel(mixedCandidate, { campaign: campaignA }))
+        .resolves.toMatchObject({ campaignMatches: false });
+      expect(availabilityCalls.get("mixed-channel")).toBe(2);
+
+      await expect(adapter.checkChannel(positiveCandidate, { campaign: campaignB }))
+        .resolves.toMatchObject({ campaignMatches: true });
+      expect(availabilityCalls.get("positive-channel")).toBe(1);
+      vi.advanceTimersByTime(2 * 60_000 - 1);
+      await expect(adapter.checkChannel(positiveCandidate, { campaign: campaignB }))
+        .resolves.toMatchObject({ campaignMatches: true });
+      expect(availabilityCalls.get("positive-channel")).toBe(1);
+      vi.advanceTimersByTime(1);
+      await expect(adapter.checkChannel(positiveCandidate, { campaign: campaignB }))
+        .resolves.toMatchObject({ campaignMatches: true });
+      expect(availabilityCalls.get("positive-channel")).toBe(2);
+
+      await expect(adapter.checkChannel(emptyCandidate, { campaign: campaignA }))
+        .resolves.toMatchObject({ campaignMatches: false });
+      expect(availabilityCalls.get("empty-channel")).toBe(1);
+      vi.advanceTimersByTime(30_000 - 1);
+      await expect(adapter.checkChannel(emptyCandidate, { campaign: campaignA }))
+        .resolves.toMatchObject({ campaignMatches: false });
+      expect(availabilityCalls.get("empty-channel")).toBe(1);
+      vi.advanceTimersByTime(1);
+      await expect(adapter.checkChannel(emptyCandidate, { campaign: campaignA }))
+        .resolves.toMatchObject({ campaignMatches: false });
+      expect(availabilityCalls.get("empty-channel")).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("recovers a contradictory Twitch availability negative after material progress", async () => {
     vi.useFakeTimers();
     try {
@@ -2977,7 +3063,7 @@ describe("TwitchAdapter", () => {
     for (let index = 0; index < 128; index += 1) {
       discoveryState.rememberChannelAvailability(`channel-${index}`, `broadcast-${index}`, new Set(["campaign"]), requestIdentity);
     }
-    expect(discoveryState.cachedChannelAvailability("channel-0", "broadcast-0")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-0", "broadcast-0", "campaign")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });
@@ -2986,8 +3072,8 @@ describe("TwitchAdapter", () => {
     // an arbitrary or most-recent one.
     discoveryState.rememberChannelAvailability("channel-128", "broadcast-128", new Set(["campaign"]), requestIdentity);
 
-    expect(discoveryState.cachedChannelAvailability("channel-0", "broadcast-0")).toEqual({ status: "miss" });
-    expect(discoveryState.cachedChannelAvailability("channel-128", "broadcast-128")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-0", "broadcast-0", "campaign")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-128", "broadcast-128", "campaign")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });
@@ -3007,7 +3093,7 @@ describe("TwitchAdapter", () => {
     expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-a")).toBe(true);
     expect(discoveryState.hasProgressConfirmedAvailability("channel-a", "campaign-b")).toBe(false);
     expect(discoveryState.hasProgressConfirmedAvailability("channel-b", "campaign-a")).toBe(false);
-    expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a", "campaign-a")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign-a"]),
     });
@@ -3023,19 +3109,19 @@ describe("TwitchAdapter", () => {
       discoveryState.rememberProgressConfirmedAvailability("channel-a", "campaign-a", identity);
 
       vi.advanceTimersByTime(30_001);
-      expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({
+      expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a", "campaign-a")).toEqual({
         status: "hit",
         campaignIds: new Set(["campaign-a"]),
       });
 
       vi.advanceTimersByTime(89_998);
-      expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({
+      expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a", "campaign-a")).toEqual({
         status: "hit",
         campaignIds: new Set(["campaign-a"]),
       });
 
       vi.advanceTimersByTime(1);
-      expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({ status: "expired" });
+      expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a", "campaign-a")).toEqual({ status: "expired" });
     } finally {
       vi.useRealTimers();
     }
@@ -3114,11 +3200,11 @@ describe("TwitchAdapter", () => {
       identity,
     );
 
-    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-a"))
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-a", "campaign-a"))
       .toEqual({ status: "hit", campaignIds: new Set() });
-    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-b"))
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-b", "campaign-a"))
       .toEqual({ status: "broadcast_changed" });
-    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-a"))
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-a", "campaign-a"))
       .toEqual({ status: "miss" });
   });
 
@@ -3133,9 +3219,9 @@ describe("TwitchAdapter", () => {
       discoveryState.rememberChannelAvailability("positive", "broadcast-p", new Set(["campaign"]), identity);
       vi.advanceTimersByTime(30_001);
 
-      expect(discoveryState.cachedChannelAvailability("negative", "broadcast-n"))
+      expect(discoveryState.cachedChannelAvailability("negative", "broadcast-n", "campaign"))
         .toEqual({ status: "expired" });
-      expect(discoveryState.cachedChannelAvailability("positive", "broadcast-p"))
+      expect(discoveryState.cachedChannelAvailability("positive", "broadcast-p", "campaign"))
         .toEqual({ status: "hit", campaignIds: new Set(["campaign"]) });
     } finally {
       vi.useRealTimers();
@@ -3462,7 +3548,7 @@ describe("TwitchAdapter", () => {
     await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).checkChannel(candidate, { campaign });
 
     expect(availabilityCalls).toBe(2);
-    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id", "campaign")).toEqual({ status: "miss" });
   });
 
   it("treats a missing availability response channel id as ambiguous and never caches it", async () => {
@@ -3582,8 +3668,8 @@ describe("TwitchAdapter", () => {
     // so the selection still lands on the first (unconfirmed) candidate.
     expect(selection?.channel?.username).toBe("directory-a");
     expect(singleFallbackCalls).toBe(1);
-    expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({ status: "miss" });
-    expect(discoveryState.cachedChannelAvailability("channel-b", "broadcast-b")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a", "campaign")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-b", "broadcast-b", "campaign")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });
@@ -3690,8 +3776,8 @@ describe("TwitchAdapter", () => {
     // had been ignored, this response would have cached directly and the
     // fallback would never have been called.
     expect(singleFallbackCalls).toBe(1);
-    expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a")).toEqual({ status: "miss" });
-    expect(discoveryState.cachedChannelAvailability("channel-b", "broadcast-b")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-a", "broadcast-a", "campaign")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-b", "broadcast-b", "campaign")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });
@@ -3744,7 +3830,7 @@ describe("TwitchAdapter", () => {
     // Request A still answers its own caller correctly...
     await expect(pendingA).resolves.toMatchObject({ campaignMatches: true });
     // ...but must not have repopulated the shared cache under user-b.
-    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id", "campaign")).toEqual({ status: "miss" });
 
     // A fresh request under user-b reaches the network and populates the cache.
     await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState })
@@ -3773,7 +3859,7 @@ describe("TwitchAdapter", () => {
       new Set(["campaign"]),
       staleIdentity,
     )).toBe(false);
-    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id")).toEqual({ status: "miss" });
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id", "campaign")).toEqual({ status: "miss" });
 
     expect(discoveryState.rememberChannelAvailability(
       "channel-id",
@@ -3781,7 +3867,7 @@ describe("TwitchAdapter", () => {
       new Set(["campaign"]),
       discoveryState.availabilityRequestIdentity(),
     )).toBe(true);
-    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id")).toEqual({
+    expect(discoveryState.cachedChannelAvailability("channel-id", "broadcast-id", "campaign")).toEqual({
       status: "hit",
       campaignIds: new Set(["campaign"]),
     });

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -3106,6 +3106,7 @@ describe("TwitchAdapter", () => {
       const discoveryState = new TwitchDiscoveryState();
       const identity = discoveryState.availabilityRequestIdentity();
       discoveryState.rememberChannelAvailability("channel-a", "broadcast-a", new Set(), identity);
+      vi.advanceTimersByTime(20_000);
       discoveryState.rememberProgressConfirmedAvailability("channel-a", "campaign-a", identity);
 
       vi.advanceTimersByTime(30_001);


### PR DESCRIPTION
## Summary

- apply the strict Twitch AvailableDrops cache TTL to the specific requested campaign
- retry a missing campaign after 30 seconds while preserving the shared channel snapshot for campaigns that were present
- refresh the snapshot timestamp when progress confirms campaign availability
- add deterministic regression coverage for positive, negative, mixed-campaign, and promotion behavior

## Root cause

The cache selected the two-minute positive TTL whenever the AvailableDrops response contained any campaign ID. When checking campaign A, a response containing only campaign B therefore cached A's negative result for two minutes instead of the intended 30 seconds.

## Impact

Strict availability mode now retries campaign-specific misses promptly without losing batching, identity isolation, broadcast behavior, FIFO mapping, or the longer cache lifetime for campaigns known to be available. Strict mode remains disabled by default.

## Testing

- `pnpm typecheck`
- `pnpm test` — CLI 156/156, extension 1545/1545, site 3/3
- focused adapter tests — 196/196
- `git diff --check`
- task-level and final whole-branch reviews

Fixes #414