### PR TITLE
fix(kick): complete short-lived drops

### DIFF
--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -1448,6 +1448,17 @@ function campaignDiagnosticFingerprint(campaigns: readonly DropCampaign[]): stri
     .join("|");
 }
 
+function hasHigherExplicitCampaignPriority(
+  candidate: DropCampaign,
+  current: DropCampaign,
+  settings: EngineSettings,
+): boolean {
+  const candidatePriority = settings.campaignPriorities[candidate.id];
+  if (candidatePriority == null) return false;
+  const currentPriority = settings.campaignPriorities[current.id];
+  return currentPriority == null || candidatePriority > currentPriority;
+}
+
 async function evaluatePreferredCurrentWatch(
   previous: WatchSession,
   campaigns: readonly DropCampaign[],
@@ -1465,17 +1476,35 @@ async function evaluatePreferredCurrentWatch(
     campaigns.filter((campaign) => isEligible(campaign, settings)),
     settings,
   ).find((campaign) => activeReward(campaign, settings));
-  const preferredReward = preferredCampaign ? activeReward(preferredCampaign, settings) : undefined;
-  if (preferredCampaign?.id !== previous.campaignId || preferredReward?.id !== previous.rewardId) {
-    return undefined;
+  let retainedCampaign = preferredCampaign;
+  let retainedReward = preferredCampaign ? activeReward(preferredCampaign, settings) : undefined;
+  if (retainedCampaign?.id !== previous.campaignId || retainedReward?.id !== previous.rewardId) {
+    // Automatic ranking chooses the next reward to start; it must not discard
+    // progress already earned on a healthy, still-eligible reward. An explicit
+    // user priority remains an intentional override.
+    const currentCampaign = campaigns.find((campaign) => campaign.id === previous.campaignId);
+    const currentReward = currentCampaign?.rewards.find((reward) => reward.id === previous.rewardId);
+    const currentActiveReward = currentCampaign && isEligible(currentCampaign, settings)
+      ? activeReward(currentCampaign, settings)
+      : undefined;
+    const shouldRetainProgress = currentCampaign != null
+      && currentReward?.status === "in_progress"
+      && currentActiveReward?.id === currentReward.id
+      && (preferredCampaign == null
+        || !hasHigherExplicitCampaignPriority(preferredCampaign, currentCampaign, settings));
+    if (!shouldRetainProgress) return undefined;
+    retainedCampaign = currentCampaign;
+    retainedReward = currentReward;
   }
   const decision: WatchDecision = {
     platform: previous.platform,
     action: "watch",
-    campaign: preferredCampaign,
-    reward: preferredReward,
+    campaign: retainedCampaign,
+    reward: retainedReward,
     channel: previous.channel,
-    reason: "Current campaign remains highest priority",
+    reason: retainedCampaign?.id === preferredCampaign?.id
+      ? "Current campaign remains highest priority"
+      : "Current reward is already in progress",
     reasonCode: "keeping_current_watch",
   };
   const keep = await shouldKeepWatching(previous, decision, campaigns, settings, adapter, signal);

--- a/packages/core/src/platforms/kick/parser.ts
+++ b/packages/core/src/platforms/kick/parser.ts
@@ -171,6 +171,14 @@ export function parseKickCampaigns(input: KickCampaignResponse | KickCampaign[])
 // popup's <img> doesn't 404 against the extension origin and fall back to the
 // gradient+initials placeholder.
 const KICK_ASSET_BASE = "https://ext.kick.com";
+// Kick's drops API measures `*_units` in 30-second intervals. The shared
+// contracts measure watch progress in minutes, so normalize at the adapter
+// boundary and leave explicitly named minute fields untouched.
+const KICK_MINUTES_PER_UNIT = 0.5;
+
+function kickUnitsToMinutes(units: number): number {
+  return units * KICK_MINUTES_PER_UNIT;
+}
 
 export function kickRewardImageUrl(value: string | undefined): string | undefined {
   if (!value) return undefined;
@@ -179,8 +187,9 @@ export function kickRewardImageUrl(value: string | undefined): string | undefine
 }
 
 function parseKickReward(reward: KickReward): DropReward {
-  const requiredMinutes =
-    reward.required_units ?? reward.required_minutes ?? reward.minutes_required ?? reward.watch_time_required ?? 0;
+  const requiredMinutes = reward.required_units != null
+    ? kickUnitsToMinutes(reward.required_units)
+    : reward.required_minutes ?? reward.minutes_required ?? reward.watch_time_required ?? 0;
   const requirement = requiredMinutes > 0 ? "watch" as const : "action" as const;
   return {
     id: String(reward.id),
@@ -200,11 +209,13 @@ export function mergeKickProgress(campaigns: DropCampaign[], input: KickProgress
   return campaigns.map((campaign) => {
     const campaignProgress = progressItems.find((item) => String(item.id ?? item.campaign_id ?? item.drop_campaign_id) === campaign.id);
     // Kick's live drops API returns a single cumulative watch counter per
-    // campaign (`progress_units`, in minutes); tiered rewards share it, so each
-    // reward's watched minutes is the cumulative capped at its requirement. This
+    // campaign (`progress_units`, in 30-second units); tiered rewards share it,
+    // so each reward's watched minutes is the cumulative capped at its requirement. This
     // is the reliable signal — the per-reward `progress` is only a 0..1 fraction.
     // (Confirmed against the live /api/v1/drops/progress response.)
-    const campaignUnits = typeof campaignProgress?.progress_units === "number" ? campaignProgress.progress_units : undefined;
+    const campaignMinutes = typeof campaignProgress?.progress_units === "number"
+      ? kickUnitsToMinutes(campaignProgress.progress_units)
+      : undefined;
     const rewards = campaign.rewards.map((reward) => {
       const flatProgress = progressItems.find((item) => {
         const campaignId = item.campaign_id ?? item.drop_campaign_id;
@@ -216,10 +227,10 @@ export function mergeKickProgress(campaigns: DropCampaign[], input: KickProgress
         return String(rewardId) === reward.id;
       });
       const progress = nestedProgress ?? flatProgress;
-      if (!progress && campaignUnits == null) return reward;
+      if (!progress && campaignMinutes == null) return reward;
 
-      const watchedMinutes = campaignUnits != null
-        ? Math.min(campaignUnits, reward.requiredMinutes)
+      const watchedMinutes = campaignMinutes != null
+        ? Math.min(campaignMinutes, reward.requiredMinutes)
         : progressMinutes(progress!, reward);
       const rawStatus = progress?.status?.toLowerCase();
       const status = progress?.claimed || progress?.is_claimed
@@ -282,14 +293,13 @@ function progressMinutes(progress: KickProgress | KickProgressReward, reward: Dr
   if ("watched_minutes" in progress || "current_minutes" in progress || "progress_minutes" in progress) {
     return progress.watched_minutes ?? progress.current_minutes ?? progress.progress_minutes ?? reward.watchedMinutes;
   }
-  if (progress.progress_units != null) return progress.progress_units;
+  if (progress.progress_units != null) return kickUnitsToMinutes(progress.progress_units);
   if ("percentage" in progress && progress.percentage != null) {
-    return Math.round((progress.percentage / 100) * reward.requiredMinutes);
+    return (progress.percentage / 100) * reward.requiredMinutes;
   }
   if (progress.progress != null) {
-    const required = progress.required_units ?? reward.requiredMinutes;
     const multiplier = progress.progress > 1 ? progress.progress / 100 : progress.progress;
-    return Math.round(multiplier * required);
+    return multiplier * reward.requiredMinutes;
   }
   return reward.watchedMinutes;
 }

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -707,7 +707,7 @@ describe("KickAdapter", () => {
     await expect(adapter.claimReward(ambiguous[0], ambiguous[0].rewards[0])).resolves.toBe(false);
     expect(claimPosts).toBe(1);
 
-    progress = { data: [{ campaign_id: "campaign", user_app_connected: true, progress_units: 1 }] };
+    progress = { data: [{ campaign_id: "campaign", user_app_connected: true, progress_units: 2 }] };
     const linked = await adapter.refreshCampaigns();
     expect(linked[0].accountLinked).toBe(true);
     expect(linked[0].claimGuidance).toBeUndefined();
@@ -753,7 +753,7 @@ describe("KickAdapter", () => {
     } as DropCampaign;
 
     await adapter.claimReward(campaign, campaign.rewards[0]);
-    progress = [{ campaign_id: "campaign", user_app_connected: true, progress_units: 1 }];
+    progress = [{ campaign_id: "campaign", user_app_connected: true, progress_units: 2 }];
     const refreshed = await adapter.refreshCampaigns();
     await adapter.claimReward(refreshed[0], refreshed[0].rewards[0]);
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -3513,7 +3513,7 @@ describe("background controller", () => {
           return {
             data: [{
               campaign_id: "kick-campaign",
-              progress_units: 1,
+              progress_units: 2,
               ...(affirmativelyLinked ? { user_app_connected: true } : {}),
             }],
           };

--- a/packages/extension/tests/parsers.test.ts
+++ b/packages/extension/tests/parsers.test.ts
@@ -89,7 +89,7 @@ describe("Kick parsers", () => {
     expect(merged[0].rewards[0].status).toBe("in_progress");
   });
 
-  it("uses the campaign-level progress_units counter for tiered Kick rewards", () => {
+  it("converts campaign-level Kick progress units into minutes for tiered rewards", () => {
     // Mirrors the live /api/v1/drops/progress shape: one cumulative counter,
     // tiered rewards sharing it, no per-reward minutes or claim_id.
     const campaigns = parseKickCampaigns({
@@ -119,10 +119,13 @@ describe("Kick parsers", () => {
     });
 
     expect(merged[0].accountLinked).toBe(true);
-    // Cumulative 150 min: first tier (120) complete and claimed, second (240) partway.
-    expect(merged[0].rewards[0].watchedMinutes).toBe(120);
+    // Kick units are 30-second intervals: 150 units is 75 minutes. The first
+    // 60-minute tier is complete and claimed; the 120-minute tier is partway.
+    expect(merged[0].rewards[0].requiredMinutes).toBe(60);
+    expect(merged[0].rewards[0].watchedMinutes).toBe(60);
     expect(merged[0].rewards[0].status).toBe("claimed");
-    expect(merged[0].rewards[1].watchedMinutes).toBe(150);
+    expect(merged[0].rewards[1].requiredMinutes).toBe(120);
+    expect(merged[0].rewards[1].watchedMinutes).toBe(75);
     expect(merged[0].rewards[1].status).toBe("in_progress");
   });
 
@@ -258,7 +261,7 @@ describe("Kick parsers", () => {
     expect(merged[0].rewards[0].status).toBe("in_progress");
   });
 
-  it("reads Kick reward durations from required_units", () => {
+  it("converts Kick reward duration units into minutes", () => {
     const campaigns = parseKickCampaigns({
       data: [{
         id: "campaign",
@@ -267,7 +270,54 @@ describe("Kick parsers", () => {
       }],
     });
 
-    expect(campaigns[0].rewards[0].requiredMinutes).toBe(90);
+    expect(campaigns[0].rewards[0].requiredMinutes).toBe(45);
+  });
+
+  it("derives fractional Kick progress from the normalized requirement", () => {
+    const campaigns = parseKickCampaigns({
+      data: [{
+        id: "campaign",
+        status: "active",
+        rewards: [{ id: "reward", required_units: 4 }],
+      }],
+    });
+
+    const merged = mergeKickProgress(campaigns, {
+      data: [{
+        id: "campaign",
+        rewards: [{ id: "reward", progress: 0.25, required_units: 4 }],
+      }],
+    });
+
+    expect(merged[0].rewards[0]).toMatchObject({
+      requiredMinutes: 2,
+      watchedMinutes: 0.5,
+      status: "in_progress",
+    });
+  });
+
+  it("keeps explicit Kick minute fields in minutes", () => {
+    const campaigns = parseKickCampaigns({
+      data: [{
+        id: "campaign",
+        status: "active",
+        rewards: [{ id: "reward", required_minutes: 4 }],
+      }],
+    });
+
+    const merged = mergeKickProgress(campaigns, {
+      data: [{
+        id: "campaign",
+        progress: 0.25,
+        rewards: [{ id: "reward", progress: 0.25 }],
+      }],
+    });
+
+    expect(merged[0].rewards[0]).toMatchObject({
+      requiredMinutes: 4,
+      watchedMinutes: 1,
+      status: "in_progress",
+    });
   });
 
   it("marks zero-duration Kick rewards as non-watch rewards", () => {

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -1776,6 +1776,68 @@ describe("scheduler tick", () => {
     }));
   });
 
+  it.each(["ending_soonest", "lowest_availability"] as const)(
+    "keeps an in-progress Kick reward when %s ranks a new campaign first",
+    async (priorityMode) => {
+      const currentChannel = channel("current", {
+        platform: "kick",
+        url: "https://kick.com/current",
+      });
+      const current = campaign("current", {
+        platform: "kick",
+        endsAt: "2099-02-01T00:00:00.000Z",
+        allowedChannels: ["current", "other"],
+      });
+      const replacement = campaign("replacement", {
+        platform: "kick",
+        endsAt: "2099-01-01T00:00:00.000Z",
+        allowedChannels: ["replacement"],
+        rewards: [{ ...reward("locked"), id: "replacement-reward" }],
+      });
+      const kick = adapter(
+        "kick",
+        [current, replacement],
+        [channel("replacement", { platform: "kick", url: "https://kick.com/replacement" })],
+      );
+
+      const result = await runSchedulerTick(
+        {
+          ...baseState,
+          sessions: {
+            ...baseState.sessions,
+            kick: {
+              platform: "kick",
+              status: "watching",
+              channel: currentChannel,
+              campaignId: "current",
+              rewardId: "reward-in_progress",
+              offlineChecks: 0,
+              playbackChecks: 0,
+              watchMode: "tabless",
+            },
+          },
+        },
+        settings({
+          priorityMode,
+          platform: {
+            twitch: { enabled: false, idleWatchlistChannels: [] },
+            kick: { enabled: true, idleWatchlistChannels: [] },
+          },
+        }),
+        { twitch: adapter("twitch", [], []), kick },
+        { platforms: ["kick"] },
+      );
+
+      expect(kick.listCandidateChannels).not.toHaveBeenCalled();
+      expect(result.state.sessions.kick).toMatchObject({
+        status: "watching",
+        campaignId: "current",
+        rewardId: "reward-in_progress",
+        reasonCode: "keeping_current_watch",
+      });
+    },
+  );
+
   it("bypasses current-watch retention when a higher-priority campaign is available", async () => {
     const current = channel("current");
     const replacement = channel("replacement");


### PR DESCRIPTION
## Summary

- normalize Kick's `required_units` and `progress_units` from 30-second units to minutes while preserving explicit minute fields
- keep a healthy eligible in-progress reward active when automatic priority modes rerank campaigns
- preserve explicit campaign priority overrides and add parser, scheduler, adapter, and controller regressions

## Root cause

Kick reports drop durations and progress in 30-second units, but the parser treated those values as minutes. The scheduler also reevaluated automatic campaign ordering on every refresh and could preempt a reward that had already started when a newer campaign ranked higher.

## Impact

Short-lived and consecutive Kick drops now use the correct duration/progress and continue farming once progress starts. Users can still explicitly prioritize another campaign to override the current watch.

## Testing

- `pnpm check`
- `git diff --check`

Closes #413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kick progress tracking by accurately converting progress units into minutes, including fractional progress.
  * Preserved in-progress rewards when campaign rankings change, unless a higher-priority campaign is selected.
  * Prevented unnecessary replacement campaign suggestions while an eligible reward is already in progress.
* **Tests**
  * Added coverage for campaign switching, progress calculations, and reward retention across ranking modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->