### PR TITLE
ci: stop installing playwright system deps

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -72,8 +72,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # The store screenshot dashboard tests drive a real Chromium against local
-      # HTML fixtures, and the runner ships no Playwright browsers.
-      - run: pnpm --filter @lurkloot/extension exec playwright install --with-deps chromium
+      # HTML fixtures, and the runner ships no Playwright browsers. Do not add
+      # --with-deps: the runner image already carries every Chromium system
+      # library, so it only pulls CJK font packages that these DOM-assertion
+      # tests never render, at the cost of a 1-8 minute apt fetch.
+      - run: pnpm --filter @lurkloot/extension exec playwright install chromium
       - run: pnpm check
 
   extension:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -25,8 +25,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # The store screenshot dashboard tests drive a real Chromium against local
-      # HTML fixtures, and the runner ships no Playwright browsers.
-      - run: pnpm --filter @lurkloot/extension exec playwright install --with-deps chromium
+      # HTML fixtures, and the runner ships no Playwright browsers. Do not add
+      # --with-deps: the runner image already carries every Chromium system
+      # library, so it only pulls CJK font packages that these DOM-assertion
+      # tests never render, at the cost of a 1-8 minute apt fetch.
+      - run: pnpm --filter @lurkloot/extension exec playwright install chromium
       - run: pnpm release:check
       - run: pnpm check
 


### PR DESCRIPTION
## Summary

`pnpm check`'s Playwright step became the slowest part of CI after #404. `--with-deps` runs `apt-get install`, and on the GitHub runner image every actual Chromium library reports `already the newest version` — the flag's only effect is pulling nine CJK/X font packages (21.1 MB) from `azure.archive.ubuntu.com`.

That fetch is a lottery. Observed on PR #397:

| run | playwright step | verify job |
| --- | --- | --- |
| 32288166154 | 32s | 89s |
| 32288169235 | ~180s | 207s |
| 32288636912 | **515s** (6min48s of it apt, at 51.7 kB/s) | **578s** |

For comparison, `verify` totalled 58–79s before #404.

The tests that need Chromium (`storeScreenshotDashboard.test.ts`) assert on DOM text and aria-labels against ASCII fixtures — no screenshots, no snapshots, no CJK. The real screenshot capture scripts are not part of `pnpm check`. So the fonts buy nothing.

## Testing

- `playwright install chromium` (no `--with-deps`) then `vitest run tests/storeScreenshotDashboard.test.ts` — 24/24 pass.

## Follow-up, not in this PR

Every push to a `develop → main` PR runs `verify`, the extension build and the Docker matrix twice — once from **Pull request validation**, once from **Prepare release**'s preview. It doesn't add wall-clock, but it doubles the runner minutes and the odds of drawing a slow apt/CDN mirror.