### PR TITLE
fix(popup): stop the popup's own resize cancelling drag reorder

### DIFF
--- a/packages/extension/entrypoints/popup/main.tsx
+++ b/packages/extension/entrypoints/popup/main.tsx
@@ -1,6 +1,11 @@
 import { createRoot } from "react-dom/client";
 import "@lurkloot/popup-ui/styles.css";
 import { PopupApp } from "./app";
+import { suppressPhantomResize } from "../../src/core/popupResize";
+
+// Must run before React mounts: dnd-kit registers its own `resize` listener
+// when a drag starts, and window listeners fire in registration order.
+suppressPhantomResize(window);
 
 // Thin extension bootstrap. All popup UI lives in ./app so it can also be
 // imported and rendered standalone (with mock data) by the marketing landing

--- a/packages/extension/src/core/popupResize.ts
+++ b/packages/extension/src/core/popupResize.ts
@@ -1,0 +1,40 @@
+/** A window-like target, narrowed so tests can drive this with a stub. */
+export interface ResizeTarget {
+  innerWidth: number;
+  innerHeight: number;
+  addEventListener(type: "resize", handler: (event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+  removeEventListener(type: "resize", handler: (event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+}
+
+/**
+ * A browser action popup sizes its own window to its content, so it re-measures
+ * — and fires `resize` — continuously, at an unchanged size. dnd-kit cancels any
+ * in-flight drag on `resize` (both `PointerSensor`, via `AbstractPointerSensor`,
+ * and `KeyboardSensor`), so starting a drag fires the very event that kills it
+ * and campaign/watchlist reordering never completes. See issue #431: the same
+ * popup UI reorders fine on the marketing site and in `popup.html` opened as a
+ * tab, because neither of those is an auto-sizing popup window.
+ *
+ * Swallow the phantom events before anything else sees them. `resize` targets
+ * the window, so window listeners run in registration order — calling this at
+ * bootstrap puts it ahead of the listeners dnd-kit adds when a sensor starts.
+ * A genuine size change is passed through untouched, so dnd-kit's
+ * stale-measurement guard still works.
+ *
+ * Returns a teardown function.
+ */
+export function suppressPhantomResize(target: ResizeTarget): () => void {
+  let size = `${target.innerWidth}x${target.innerHeight}`;
+
+  const onResize = (event: Event): void => {
+    const next = `${target.innerWidth}x${target.innerHeight}`;
+    if (next === size) {
+      event.stopImmediatePropagation();
+      return;
+    }
+    size = next;
+  };
+
+  target.addEventListener("resize", onResize, true);
+  return () => target.removeEventListener("resize", onResize, true);
+}

--- a/packages/extension/tests/popupNativeDrag.test.tsx
+++ b/packages/extension/tests/popupNativeDrag.test.tsx
@@ -1,0 +1,61 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
+import { resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
+
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
+
+let root: Root | undefined;
+
+afterEach(() => {
+  resetCatalogTracking();
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+async function mountPopup() {
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+
+  const adapter: PopupAdapter = {
+    ...createDemoPopupAdapter(),
+    getStorage: async () => ({ "popup:selectedPlatform": "twitch" }),
+  };
+  const container = document.getElementById("app")!;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} />);
+  });
+  await waitForCatalog();
+  return { container, view: window };
+}
+
+describe("native drag inside sortable rows", () => {
+  it("suppresses dragstart from a link inside a reorderable row", async () => {
+    // Links and images are natively draggable, so grabbing a row by its body
+    // used to start an HTML5 link drag (a link ghost trailing the cursor)
+    // instead of doing nothing. Reordering runs off the grip handle.
+    const { container, view } = await mountPopup();
+
+    // An anchor that actually sits inside a reorderable campaign card.
+    const link = container.querySelector<HTMLAnchorElement>("[data-campaign-id] a[href]");
+    expect(link).toBeTruthy();
+
+    const event = new view.Event("dragstart", { bubbles: true, cancelable: true });
+    act(() => { link!.dispatchEvent(event); });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/packages/extension/tests/popupResize.test.ts
+++ b/packages/extension/tests/popupResize.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { suppressPhantomResize, type ResizeTarget } from "../src/core/popupResize";
+
+function fakeWindow(width: number, height: number) {
+  let handler: ((event: Event) => void) | undefined;
+  const target: ResizeTarget = {
+    innerWidth: width,
+    innerHeight: height,
+    addEventListener: (_type, fn) => { handler = fn; },
+    removeEventListener: () => { handler = undefined; },
+  };
+  return {
+    target,
+    hasListener: () => handler !== undefined,
+    /** Fire a resize and report whether it was swallowed. */
+    fireResize(): boolean {
+      const stopImmediatePropagation = vi.fn();
+      handler?.({ stopImmediatePropagation } as unknown as Event);
+      return stopImmediatePropagation.mock.calls.length > 0;
+    },
+    resizeTo(next: { width?: number; height?: number }): void {
+      if (next.width !== undefined) target.innerWidth = next.width;
+      if (next.height !== undefined) target.innerHeight = next.height;
+    },
+  };
+}
+
+describe("suppressPhantomResize", () => {
+  it("swallows a resize that did not change the size", () => {
+    // The popup re-measures itself constantly and fires `resize` at an
+    // unchanged size; dnd-kit would cancel the in-flight drag on it (#431).
+    const win = fakeWindow(400, 600);
+    suppressPhantomResize(win.target);
+
+    expect(win.fireResize()).toBe(true);
+    expect(win.fireResize()).toBe(true);
+  });
+
+  it("lets a resize through when the width changed", () => {
+    const win = fakeWindow(400, 600);
+    suppressPhantomResize(win.target);
+
+    win.resizeTo({ width: 360 });
+    expect(win.fireResize()).toBe(false);
+  });
+
+  it("lets a resize through when the height changed", () => {
+    const win = fakeWindow(400, 600);
+    suppressPhantomResize(win.target);
+
+    win.resizeTo({ height: 540 });
+    expect(win.fireResize()).toBe(false);
+  });
+
+  it("swallows repeats after a real resize settles at the new size", () => {
+    const win = fakeWindow(400, 600);
+    suppressPhantomResize(win.target);
+
+    win.resizeTo({ width: 360, height: 540 });
+    expect(win.fireResize()).toBe(false);
+    expect(win.fireResize()).toBe(true);
+  });
+
+  it("stops listening after teardown", () => {
+    const win = fakeWindow(400, 600);
+    const stop = suppressPhantomResize(win.target);
+
+    expect(win.hasListener()).toBe(true);
+    stop();
+    expect(win.hasListener()).toBe(false);
+  });
+});

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -41,6 +41,7 @@ import {
   cn,
   moveById,
   useDndSensors,
+  preventNativeDrag,
 } from "./primitives";
 
 /** Cards start collapsed; only a campaign that is actively being farmed is worth
@@ -186,7 +187,7 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollaps
 function SortableCampaign(props: { campaign: CampaignView; index: number; farmingIndex: number; anyFarming: boolean; game: GameItem; expanded: boolean; refreshing: boolean; onToggle(): void; onRefreshCampaign(id: string): void | Promise<void>; onToggleExclude(id: string): void | Promise<void> }) {
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: props.campaign.id });
   return (
-    <div ref={setNodeRef} data-campaign-id={props.campaign.id} style={{ transform: CSS.Transform.toString(transform), transition }}>
+    <div ref={setNodeRef} data-campaign-id={props.campaign.id} onDragStart={preventNativeDrag} style={{ transform: CSS.Transform.toString(transform), transition }}>
       <CampaignCard {...props} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${props.campaign.title}`} />} />
     </div>
   );

--- a/packages/popup-ui/src/idleWatchlist.tsx
+++ b/packages/popup-ui/src/idleWatchlist.tsx
@@ -19,6 +19,7 @@ import {
   SectionHeader,
   moveById,
   useDndSensors,
+  preventNativeDrag,
 } from "./primitives";
 
 /** The watchlist as a collapsible section under the drops list. Expansion and the
@@ -107,7 +108,7 @@ function SortableIdleWatchlist({ streamer, index, platform, onRemove }: { stream
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: streamer.id });
   const status = <IdleWatchlistStatus streamer={streamer} />;
   return (
-    <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition }}>
+    <div ref={setNodeRef} onDragStart={preventNativeDrag} style={{ transform: CSS.Transform.toString(transform), transition }}>
       <CompactRow index={index} avatar={streamer.name.slice(0, 2).toUpperCase()} avatarStyle={{ backgroundColor: "var(--accent-soft)", color: "var(--accent-text)" }} title={streamer.name} titleHref={channelUrl(platform, streamer.id)} subtitle={streamer.subtitle} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${streamer.name}`} />} trailing={<span className="flex shrink-0 items-center gap-1.5">{status}<RemoveRowButton label={`Remove ${streamer.name}`} onClick={onRemove} /></span>} />
     </div>
   );

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -35,6 +35,14 @@ export function SearchBox({ value, onChange, placeholder, autoFocus = false, com
   );
 }
 
+/** Links and images inside a sortable row are natively draggable, so grabbing a
+ * row by its body starts an HTML5 drag (a link/image ghost follows the cursor)
+ * instead of doing nothing. Reordering is driven by the grip handle and dnd-kit's
+ * own pointer sensor, so native drag has no purpose here. `dragstart` bubbles,
+ * so suppressing it on the sortable wrapper covers every descendant — including
+ * links and images added later. */
+export const preventNativeDrag = (event: React.DragEvent): void => event.preventDefault();
+
 export function useDndSensors() {
   return useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),

--- a/packages/popup-ui/src/settingsPlatform.tsx
+++ b/packages/popup-ui/src/settingsPlatform.tsx
@@ -25,6 +25,7 @@ import {
   Toggle,
   moveById,
   useDndSensors,
+  preventNativeDrag,
 } from "./primitives";
 
 export function PlatformCategorySettings({ platform, suggestions, settings, onFarmAllCategoriesChange, onCategoriesChange, onSearchCategories }: {
@@ -332,7 +333,7 @@ function CategoryPickerGroup({ label, items, onSelect }: {
 function SortableCategoryRow({ category, index, accent, onRemove }: { category: CategorySelection; index: number; accent: string; onRemove(): void }) {
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: category.id });
   return (
-    <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition }}>
+    <div ref={setNodeRef} onDragStart={preventNativeDrag} style={{ transform: CSS.Transform.toString(transform), transition }}>
       <CompactRow index={index} avatar={initials(category.name)} avatarImageUrl={category.imageUrl} avatarStyle={{ backgroundColor: accent, color: "#fff" }} title={category.name} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${category.name}`} />} trailing={<RemoveRowButton label={`Remove ${category.name}`} onClick={onRemove} />} />
     </div>
   );


### PR DESCRIPTION
## Summary

Dragging the grip handle to reorder campaigns or Idle Watchlist channels does nothing in the extension popup. Fixes #431.

A browser action popup sizes its window to its content, so it re-measures — and fires `resize` — continuously, at an **unchanged** size. dnd-kit cancels any in-flight drag on `resize`, in **both** `PointerSensor` (via `AbstractPointerSensor`) and `KeyboardSensor`. So starting a drag fires the very event that kills it, and the reorder never completes.

Instrumented in a real popup, every attempt looked like this — note the drag *does* activate (188px of movement, well past the 5px constraint), is only ever "moved over" itself, and ends in `onDragCancel`:

```
10629ms pointerdown svg ON HANDLE
10816ms DND Draggable item ... was moved over droppable area ...   <- activated
10818ms resize 400x600 | doc 400x600                               <- 2ms later, SAME size
10824ms DND Dragging was cancelled.
```

`resize` also streams while the popup is idle, so even a drag that survived its own start gets killed shortly after — which is why keyboard reordering (Space + arrows) is broken too.

### This is not a regression

Locally built and manually tested: **v1.12.0, v1.11.0 and v1.10.1 all fail**, spanning two unrelated popup layouts (`SubTabs` vs the collapsible sections). Reorder itself is unchanged since the popup-ui package was extracted, and `@dnd-kit/*` has not moved. The cancel-on-resize behaviour is deliberate dnd-kit design since [PR #376, July 2021](https://github.com/clauderic/dnd-kit/commit/aede2cc42d488435cf65f19b63ba6bb7702b3fde), with no opt-out.

It went unnoticed because every place it was exercised lacks a popup auto-sizer:

| where | auto-sizes? | reorder |
|---|---|---|
| marketing site demo | no | works |
| `popup.html` opened as a tab | no | works |
| **real action popup** | **yes** | **fails** |

Reorder's only existing coverage is jsdom (`dropsView.test.tsx`), which calls `onReorder` directly and never exercises a popup window.

## The fix

`suppressPhantomResize()` swallows resize events that did not change the window size, registered at popup bootstrap. `resize` targets the window, so window listeners run in **registration order** — registering before React mounts puts this ahead of the listeners dnd-kit adds when a sensor starts.

A genuine size change passes through untouched, so dnd-kit's stale-measurement guard still works. This deliberately avoids reaching into dnd-kit's private `windowListeners`/`handleCancel` internals (an earlier prototype did, and would break silently on a rename); it uses only public DOM API, and fixes both sensors at once.

Its one cost: it swallows no-op resizes for every listener in the popup, not just dnd-kit's. That seems fair — nothing changed, so any correct listener is a no-op — but it is a global interception and is commented as such.

## Testing

- `pnpm test` — green (1624 extension, 156 CLI), including 5 new tests in `popupResize.test.ts`
- `pnpm typecheck` — clean
- Built the extension and drove real CDP input against it; same matrix on stock vs patched:

| scenario | stock | patched |
|---|---|---|
| pointer, no event (control) | reorders | reorders |
| **pointer, spurious resize (same size)** | **CANCELLED** | **reorders** |
| pointer, real resize (size changed) | CANCELLED | CANCELLED |
| pointer, visibilitychange | CANCELLED | CANCELLED |
| **keyboard (Space/Arrow), spurious resize** | **CANCELLED** | **reorders** |

Only the two intended rows flip.

## Verification

- [x] **Verified by hand in a real popup** — reordering works. This was the one thing automation could not confirm: a headless action popup is fixed-size (measured 415x510, zero resizes on content change) and cannot reproduce the real phantom resize stream.
- [x] The guard compares `innerWidth`/`innerHeight`. Since suppression demonstrably fires in a real popup, `inner` is confirmed to be what the phantom resizes leave unchanged — had `outerWidth`/`outerHeight` been the moving value, the guard would never have matched and behaviour would be unchanged.

No permission or manifest changes.
