### PR TITLE
refactor(popup): migrate to @dnd-kit/react

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -22,9 +22,8 @@
     "promo:store": "pnpm build && node scripts/capture-store-promo.mjs"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
+    "@dnd-kit/helpers": "^0.5.0",
+    "@dnd-kit/react": "^0.5.0",
     "@lurkloot/core": "workspace:*",
     "@lurkloot/locales": "workspace:*",
     "@lurkloot/popup-ui": "workspace:*",

--- a/packages/extension/tests/popupNativeDrag.test.tsx
+++ b/packages/extension/tests/popupNativeDrag.test.tsx
@@ -1,0 +1,61 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDemoPopupAdapter, Popup, type PopupAdapter } from "@lurkloot/popup-ui";
+import { resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
+
+vi.mock("@lurkloot/locales", async (importOriginal) =>
+  (await import("./helpers/popupCatalog")).delayedLocales(importOriginal));
+
+let root: Root | undefined;
+
+afterEach(() => {
+  resetCatalogTracking();
+  if (root) act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+async function mountPopup() {
+  const { document, window } = parseHTML("<div id=app></div>");
+  vi.stubGlobal("window", window);
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+  vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+
+  const adapter: PopupAdapter = {
+    ...createDemoPopupAdapter(),
+    getStorage: async () => ({ "popup:selectedPlatform": "twitch" }),
+  };
+  const container = document.getElementById("app")!;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Popup adapter={adapter} />);
+  });
+  await waitForCatalog();
+  return { container, view: window };
+}
+
+describe("native drag inside sortable rows", () => {
+  it("suppresses dragstart from a link inside a reorderable row", async () => {
+    // Links and images are natively draggable, so grabbing a row by its body
+    // used to start an HTML5 link drag (a link ghost trailing the cursor)
+    // instead of doing nothing. Reordering runs off the grip handle.
+    const { container, view } = await mountPopup();
+
+    // An anchor that actually sits inside a reorderable campaign card.
+    const link = container.querySelector<HTMLAnchorElement>("[data-campaign-id] a[href]");
+    expect(link).toBeTruthy();
+
+    const event = new view.Event("dragstart", { bubbles: true, cancelable: true });
+    act(() => { link!.dispatchEvent(event); });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/packages/popup-ui/package.json
+++ b/packages/popup-ui/package.json
@@ -13,9 +13,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
+    "@dnd-kit/helpers": "^0.5.0",
+    "@dnd-kit/react": "^0.5.0",
     "@lurkloot/locales": "workspace:*",
     "@lurkloot/shared": "workspace:*",
     "motion": "^13.0.0",

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { DndContext, DragOverlay, closestCenter, type DragEndEvent, type DragStartEvent } from "@dnd-kit/core";
-import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { DragDropProvider } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
 import { AnimatePresence, motion } from "motion/react";
 import {
   AlertTriangle,
@@ -40,8 +39,8 @@ import {
   SectionHeader,
   cn,
   moveById,
-  useDndSensors,
   preventNativeDrag,
+  type SortableDragEndEvent,
 } from "./primitives";
 
 /** Cards start collapsed; only a campaign that is actively being farmed is worth
@@ -59,8 +58,6 @@ function farmingCampaignId(campaigns: CampaignView[]): string | undefined {
 
 export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollapsed = false, onRefreshCampaign, onReorder, onToggleExclude }: { campaigns: CampaignView[]; gameMap: Record<string, GameItem>; focus?: { id: string; seq: number } | null; refreshing: boolean; startCollapsed?: boolean; onRefreshCampaign(id: string): void | Promise<void>; onReorder(campaigns: CampaignView[]): void | Promise<void>; onToggleExclude(id: string): void | Promise<void> }) {
   const t = useT();
-  const sensors = useDndSensors();
-  const [activeId, setActiveId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
   const [sectionExpanded, setSectionExpanded] = useState(true);
@@ -106,16 +103,13 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollaps
     });
     return () => cancelAnimationFrame(frame);
   }, [focus?.id, focus?.seq, searching, searchOpen, sectionExpanded]);
-  const activeCampaign = campaigns.find((campaign) => campaign.id === activeId);
-  const activeIndex = campaigns.findIndex((campaign) => campaign.id === activeId);
   const anyFarming = campaigns.some((campaign) => Boolean(campaign.farmingChannel));
 
-  function endDrag(event: DragEndEvent): void {
-    setActiveId(null);
-    const active = String(event.active.id);
-    const over = event.over?.id == null ? undefined : String(event.over.id);
-    if (!over || active === over) return;
-    void onReorder(moveById(campaigns, active, over));
+  function endDrag(event: SortableDragEndEvent): void {
+    if (event.canceled) return;
+    const { source, target } = event.operation;
+    if (!source || !target) return;
+    void onReorder(moveById(campaigns, String(source.id), String(target.id)));
   }
 
   return (
@@ -164,18 +158,13 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollaps
                 </div>
               )
             ) : (
-              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={(event: DragStartEvent) => setActiveId(String(event.active.id))} onDragEnd={endDrag} onDragCancel={() => setActiveId(null)}>
-                <SortableContext items={campaigns.map((campaign) => campaign.id)} strategy={verticalListSortingStrategy}>
-                  <div ref={listRef} className="space-y-1">
-                    {campaigns.map((campaign, index) => (
-                      <SortableCampaign key={campaign.id} campaign={campaign} index={index} farmingIndex={farmingIndex} anyFarming={anyFarming} game={gameMap[campaign.gameId] ?? fallbackGame(campaign, index, t)} expanded={Boolean(expandedIds[campaign.id])} refreshing={refreshing} onToggle={() => setExpandedIds((current) => ({ ...current, [campaign.id]: !current[campaign.id] }))} onRefreshCampaign={onRefreshCampaign} onToggleExclude={onToggleExclude} />
-                    ))}
-                  </div>
-                </SortableContext>
-                <DragOverlay dropAnimation={null}>
-                  {activeCampaign ? <CampaignCard campaign={activeCampaign} index={activeIndex} farmingIndex={farmingIndex} anyFarming={anyFarming} game={gameMap[activeCampaign.gameId] ?? fallbackGame(activeCampaign, activeIndex, t)} expanded={false} refreshing={refreshing} onToggle={() => undefined} onRefreshCampaign={onRefreshCampaign} isOverlay dragHandle={<GripVertical size={16} className="text-zinc-400" />} /> : null}
-                </DragOverlay>
-              </DndContext>
+              <DragDropProvider onDragEnd={endDrag}>
+                <div ref={listRef} className="space-y-1">
+                  {campaigns.map((campaign, index) => (
+                    <SortableCampaign key={campaign.id} campaign={campaign} index={index} farmingIndex={farmingIndex} anyFarming={anyFarming} game={gameMap[campaign.gameId] ?? fallbackGame(campaign, index, t)} expanded={Boolean(expandedIds[campaign.id])} refreshing={refreshing} onToggle={() => setExpandedIds((current) => ({ ...current, [campaign.id]: !current[campaign.id] }))} onRefreshCampaign={onRefreshCampaign} onToggleExclude={onToggleExclude} />
+                  ))}
+                </div>
+              </DragDropProvider>
             )}
           </motion.div>
         ) : null}
@@ -185,10 +174,12 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollaps
 }
 
 function SortableCampaign(props: { campaign: CampaignView; index: number; farmingIndex: number; anyFarming: boolean; game: GameItem; expanded: boolean; refreshing: boolean; onToggle(): void; onRefreshCampaign(id: string): void | Promise<void>; onToggleExclude(id: string): void | Promise<void> }) {
-  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: props.campaign.id });
+  // The new dnd-kit animates the real element, so there is no DragOverlay copy
+  // and no transform/transition to apply by hand.
+  const { ref, handleRef, isDragging } = useSortable({ id: props.campaign.id, index: props.index });
   return (
-    <div ref={setNodeRef} data-campaign-id={props.campaign.id} onDragStart={preventNativeDrag} style={{ transform: CSS.Transform.toString(transform), transition }}>
-      <CampaignCard {...props} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${props.campaign.title}`} />} />
+    <div ref={ref} data-campaign-id={props.campaign.id} onDragStart={preventNativeDrag}>
+      <CampaignCard {...props} dimmed={isDragging} dragHandle={<DragHandle handleRef={handleRef} label={`Reorder ${props.campaign.title}`} />} />
     </div>
   );
 }

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -41,6 +41,7 @@ import {
   cn,
   moveById,
   useDndSensors,
+  preventNativeDrag,
 } from "./primitives";
 
 /** Cards start collapsed; only a campaign that is actively being farmed is worth
@@ -186,7 +187,7 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollaps
 function SortableCampaign(props: { campaign: CampaignView; index: number; farmingIndex: number; anyFarming: boolean; game: GameItem; expanded: boolean; refreshing: boolean; onToggle(): void; onRefreshCampaign(id: string): void | Promise<void>; onToggleExclude(id: string): void | Promise<void> }) {
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: props.campaign.id });
   return (
-    <div ref={setNodeRef} data-campaign-id={props.campaign.id} style={{ transform: CSS.Transform.toString(transform), transition }}>
+    <div ref={setNodeRef} data-campaign-id={props.campaign.id} onDragStart={preventNativeDrag} style={{ transform: CSS.Transform.toString(transform), transition }}>
       <CampaignCard {...props} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${props.campaign.title}`} />} />
     </div>
   );

--- a/packages/popup-ui/src/idleWatchlist.tsx
+++ b/packages/popup-ui/src/idleWatchlist.tsx
@@ -19,6 +19,7 @@ import {
   SectionHeader,
   moveById,
   useDndSensors,
+  preventNativeDrag,
 } from "./primitives";
 
 /** The watchlist as a collapsible section under the drops list. Expansion and the
@@ -107,7 +108,7 @@ function SortableIdleWatchlist({ streamer, index, platform, onRemove }: { stream
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: streamer.id });
   const status = <IdleWatchlistStatus streamer={streamer} />;
   return (
-    <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition }}>
+    <div ref={setNodeRef} onDragStart={preventNativeDrag} style={{ transform: CSS.Transform.toString(transform), transition }}>
       <CompactRow index={index} avatar={streamer.name.slice(0, 2).toUpperCase()} avatarStyle={{ backgroundColor: "var(--accent-soft)", color: "var(--accent-text)" }} title={streamer.name} titleHref={channelUrl(platform, streamer.id)} subtitle={streamer.subtitle} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${streamer.name}`} />} trailing={<span className="flex shrink-0 items-center gap-1.5">{status}<RemoveRowButton label={`Remove ${streamer.name}`} onClick={onRemove} /></span>} />
     </div>
   );

--- a/packages/popup-ui/src/idleWatchlist.tsx
+++ b/packages/popup-ui/src/idleWatchlist.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
-import { DndContext, DragOverlay, closestCenter, type DragEndEvent } from "@dnd-kit/core";
-import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import { Eye, GripVertical, Play, Plus } from "lucide-react";
+import { DragDropProvider } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
+import { Eye, Play, Plus } from "lucide-react";
 import type { Platform } from "@lurkloot/shared/models";
 import { useT } from "./context";
 import { formatViewers } from "./format";
@@ -18,8 +17,8 @@ import {
   RemoveRowButton,
   SectionHeader,
   moveById,
-  useDndSensors,
   preventNativeDrag,
+  type SortableDragEndEvent,
 } from "./primitives";
 
 /** The watchlist as a collapsible section under the drops list. Expansion and the
@@ -27,18 +26,13 @@ import {
  * both — that toolbar is what replaced the Drops/Idle Watchlist tab pair. */
 export function IdleWatchlistPanel({ platform, streamers, expanded, adding, onExpandedChange, onAddingChange, onChange }: { platform: Platform; streamers: StreamerItem[]; expanded: boolean; adding: boolean; onExpandedChange(expanded: boolean): void; onAddingChange(adding: boolean): void; onChange(streamers: StreamerItem[]): void | Promise<void> }) {
   const t = useT();
-  const sensors = useDndSensors();
-  const [activeId, setActiveId] = useState<string | null>(null);
   const [value, setValue] = useState("");
-  const active = streamers.find((streamer) => streamer.id === activeId);
-  const activeIndex = streamers.findIndex((streamer) => streamer.id === activeId);
 
-  function endDrag(event: DragEndEvent): void {
-    setActiveId(null);
-    const active = String(event.active.id);
-    const over = event.over?.id == null ? undefined : String(event.over.id);
-    if (!over || active === over) return;
-    void onChange(moveById(streamers, active, over));
+  function endDrag(event: SortableDragEndEvent): void {
+    if (event.canceled) return;
+    const { source, target } = event.operation;
+    if (!source || !target) return;
+    void onChange(moveById(streamers, String(source.id), String(target.id)));
   }
 
   function addChannel(): void {
@@ -79,16 +73,11 @@ export function IdleWatchlistPanel({ platform, streamers, expanded, adding, onEx
           <motion.div key="watchlist" initial={{ height: 0, opacity: 0 }} animate={{ height: "auto", opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.2 }} className="overflow-hidden">
             <div className="space-y-1.5">
               {streamers.length === 0 ? <EmptyPanel>{t("noIdleWatchlist")}</EmptyPanel> : (
-                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={(event) => setActiveId(String(event.active.id))} onDragEnd={endDrag} onDragCancel={() => setActiveId(null)}>
-                  <SortableContext items={streamers.map((streamer) => streamer.id)} strategy={verticalListSortingStrategy}>
-                    <div className="space-y-1.5">
-                      {streamers.map((streamer, index) => <SortableIdleWatchlist key={streamer.id} streamer={streamer} index={index} platform={platform} onRemove={() => removeChannel(streamer.id)} />)}
-                    </div>
-                  </SortableContext>
-                  <DragOverlay dropAnimation={null}>
-                    {active ? <CompactRow isOverlay index={activeIndex} avatar={active.name.slice(0, 2).toUpperCase()} avatarStyle={{ backgroundColor: "var(--accent-soft)", color: "var(--accent-text)" }} title={active.name} titleHref={channelUrl(platform, active.id)} subtitle={active.subtitle} dragHandle={<GripVertical size={16} className="text-zinc-400" />} trailing={<IdleWatchlistStatus streamer={active} />} /> : null}
-                  </DragOverlay>
-                </DndContext>
+                <DragDropProvider onDragEnd={endDrag}>
+                  <div className="space-y-1.5">
+                    {streamers.map((streamer, index) => <SortableIdleWatchlist key={streamer.id} streamer={streamer} index={index} platform={platform} onRemove={() => removeChannel(streamer.id)} />)}
+                  </div>
+                </DragDropProvider>
               )}
               {adding ? (
                 <form className="flex gap-2" onSubmit={(event) => { event.preventDefault(); addChannel(); }}>
@@ -105,11 +94,13 @@ export function IdleWatchlistPanel({ platform, streamers, expanded, adding, onEx
 }
 
 function SortableIdleWatchlist({ streamer, index, platform, onRemove }: { streamer: StreamerItem; index: number; platform: Platform; onRemove(): void }) {
-  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: streamer.id });
+  // The new dnd-kit animates the real element, so there is no DragOverlay copy
+  // and no transform/transition to apply by hand.
+  const { ref, handleRef, isDragging } = useSortable({ id: streamer.id, index });
   const status = <IdleWatchlistStatus streamer={streamer} />;
   return (
-    <div ref={setNodeRef} onDragStart={preventNativeDrag} style={{ transform: CSS.Transform.toString(transform), transition }}>
-      <CompactRow index={index} avatar={streamer.name.slice(0, 2).toUpperCase()} avatarStyle={{ backgroundColor: "var(--accent-soft)", color: "var(--accent-text)" }} title={streamer.name} titleHref={channelUrl(platform, streamer.id)} subtitle={streamer.subtitle} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${streamer.name}`} />} trailing={<span className="flex shrink-0 items-center gap-1.5">{status}<RemoveRowButton label={`Remove ${streamer.name}`} onClick={onRemove} /></span>} />
+    <div ref={ref} onDragStart={preventNativeDrag}>
+      <CompactRow index={index} avatar={streamer.name.slice(0, 2).toUpperCase()} avatarStyle={{ backgroundColor: "var(--accent-soft)", color: "var(--accent-text)" }} title={streamer.name} titleHref={channelUrl(platform, streamer.id)} subtitle={streamer.subtitle} dimmed={isDragging} dragHandle={<DragHandle handleRef={handleRef} label={`Reorder ${streamer.name}`} />} trailing={<span className="flex shrink-0 items-center gap-1.5">{status}<RemoveRowButton label={`Remove ${streamer.name}`} onClick={onRemove} /></span>} />
     </div>
   );
 }

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -1,12 +1,16 @@
 import React from "react";
-import { KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
-import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { arrayMove } from "@dnd-kit/helpers";
+import type { DragDropProvider } from "@dnd-kit/react";
 import { motion } from "motion/react";
 import { ChevronRight, GripVertical, Search, X, type LucideIcon } from "lucide-react";
 
 export function cn(...classes: Array<string | false | null | undefined>): string {
   return classes.filter(Boolean).join(" ");
 }
+
+/** The `onDragEnd` payload, derived from the provider so it tracks the library
+ * rather than pinning a hand-written shape. */
+export type SortableDragEndEvent = Parameters<NonNullable<React.ComponentProps<typeof DragDropProvider>["onDragEnd"]>>[0];
 
 export function moveById<T extends { id: string }>(list: T[], activeId: string, overId: string): T[] {
   if (activeId === overId) return list;
@@ -42,13 +46,6 @@ export function SearchBox({ value, onChange, placeholder, autoFocus = false, com
  * so suppressing it on the sortable wrapper covers every descendant — including
  * links and images added later. */
 export const preventNativeDrag = (event: React.DragEvent): void => event.preventDefault();
-
-export function useDndSensors() {
-  return useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  );
-}
 
 export function ImageWithFallback({ src, alt, className, fit = "cover", fallback }: { src?: string; alt: string; className?: string; fit?: "cover" | "contain"; fallback: React.ReactNode }) {
   const [failed, setFailed] = React.useState(false);
@@ -101,9 +98,11 @@ export function RemoveRowButton({ label, onClick }: { label: string; onClick(): 
   );
 }
 
-export function DragHandle({ setActivatorNodeRef, attributes, listeners, label }: { setActivatorNodeRef(element: HTMLElement | null): void; attributes: React.ButtonHTMLAttributes<HTMLButtonElement>; listeners?: Record<string, unknown>; label: string }) {
+/** The grip. The new dnd-kit wires the activator through a single `handleRef`
+ * — there are no `attributes`/`listeners` props to spread any more. */
+export function DragHandle({ handleRef, label }: { handleRef(element: Element | null): void; label: string }) {
   return (
-    <button ref={setActivatorNodeRef} type="button" aria-label={label} {...attributes} {...listeners} onClick={(event) => event.stopPropagation()} className="flex cursor-grab touch-none items-center justify-center rounded-md text-zinc-300 transition-colors outline-none hover:text-zinc-500 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] active:cursor-grabbing dark:text-zinc-600 dark:hover:text-zinc-400" style={{ touchAction: "none", userSelect: "none" }}>
+    <button ref={handleRef} type="button" aria-label={label} onClick={(event) => event.stopPropagation()} className="flex cursor-grab touch-none items-center justify-center rounded-md text-zinc-300 transition-colors outline-none hover:text-zinc-500 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] active:cursor-grabbing dark:text-zinc-600 dark:hover:text-zinc-400" style={{ touchAction: "none", userSelect: "none" }}>
       <GripVertical size={16} />
     </button>
   );

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -35,6 +35,14 @@ export function SearchBox({ value, onChange, placeholder, autoFocus = false, com
   );
 }
 
+/** Links and images inside a sortable row are natively draggable, so grabbing a
+ * row by its body starts an HTML5 drag (a link/image ghost follows the cursor)
+ * instead of doing nothing. Reordering is driven by the grip handle and dnd-kit's
+ * own pointer sensor, so native drag has no purpose here. `dragstart` bubbles,
+ * so suppressing it on the sortable wrapper covers every descendant — including
+ * links and images added later. */
+export const preventNativeDrag = (event: React.DragEvent): void => event.preventDefault();
+
 export function useDndSensors() {
   return useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),

--- a/packages/popup-ui/src/settingsPlatform.tsx
+++ b/packages/popup-ui/src/settingsPlatform.tsx
@@ -25,6 +25,7 @@ import {
   Toggle,
   moveById,
   useDndSensors,
+  preventNativeDrag,
 } from "./primitives";
 
 export function PlatformCategorySettings({ platform, suggestions, settings, onFarmAllCategoriesChange, onCategoriesChange, onSearchCategories }: {
@@ -332,7 +333,7 @@ function CategoryPickerGroup({ label, items, onSelect }: {
 function SortableCategoryRow({ category, index, accent, onRemove }: { category: CategorySelection; index: number; accent: string; onRemove(): void }) {
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: category.id });
   return (
-    <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition }}>
+    <div ref={setNodeRef} onDragStart={preventNativeDrag} style={{ transform: CSS.Transform.toString(transform), transition }}>
       <CompactRow index={index} avatar={initials(category.name)} avatarImageUrl={category.imageUrl} avatarStyle={{ backgroundColor: accent, color: "#fff" }} title={category.name} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${category.name}`} />} trailing={<RemoveRowButton label={`Remove ${category.name}`} onClick={onRemove} />} />
     </div>
   );

--- a/packages/popup-ui/src/settingsPlatform.tsx
+++ b/packages/popup-ui/src/settingsPlatform.tsx
@@ -1,17 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import {
-  DndContext,
-  DragOverlay,
-  closestCenter,
-  type DragEndEvent,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import { AlertTriangle, GripVertical, Plus, Search } from "lucide-react";
+import { DragDropProvider } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
+import { AlertTriangle, Plus, Search } from "lucide-react";
 import type { CategorySelection, ExtensionSettings, Platform } from "@lurkloot/shared/models";
 import { GAME_ACCENTS, PLATFORMS } from "./constants";
 import { useT } from "./context";
@@ -24,8 +14,8 @@ import {
   RemoveRowButton,
   Toggle,
   moveById,
-  useDndSensors,
   preventNativeDrag,
+  type SortableDragEndEvent,
 } from "./primitives";
 
 export function PlatformCategorySettings({ platform, suggestions, settings, onFarmAllCategoriesChange, onCategoriesChange, onSearchCategories }: {
@@ -145,24 +135,19 @@ function CategoryFilterEditor({ platform, categories, suggestions, onChange, onS
   onSearch(query: string): Promise<CategorySelection[]>;
 }) {
   const t = useT();
-  const sensors = useDndSensors();
-  const [activeId, setActiveId] = useState<string | null>(null);
 
   const selectedIds = useMemo(() => new Set(categories.map((category) => category.id.toLowerCase())), [categories]);
-  const active = categories.find((category) => category.id === activeId);
-  const activeIndex = categories.findIndex((category) => category.id === activeId);
 
   function addCategory(category: CategorySelection): void {
     if (selectedIds.has(category.id.toLowerCase())) return;
     void onChange([...categories, category]);
   }
 
-  function endDrag(event: DragEndEvent): void {
-    setActiveId(null);
-    const from = String(event.active.id);
-    const over = event.over?.id == null ? undefined : String(event.over.id);
-    if (!over || from === over) return;
-    void onChange(moveById(categories, from, over));
+  function endDrag(event: SortableDragEndEvent): void {
+    if (event.canceled) return;
+    const { source, target } = event.operation;
+    if (!source || !target) return;
+    void onChange(moveById(categories, String(source.id), String(target.id)));
   }
 
   const accentFor = (index: number): string => GAME_ACCENTS[index % GAME_ACCENTS.length];
@@ -180,12 +165,9 @@ function CategoryFilterEditor({ platform, categories, suggestions, onChange, onS
           <span>{t("noCategoriesSelected", PLATFORMS[platform].label)}</span>
         </div>
       ) : (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={(event) => setActiveId(String(event.active.id))} onDragEnd={endDrag} onDragCancel={() => setActiveId(null)}>
-          <SortableContext items={categories.map((category) => category.id)} strategy={verticalListSortingStrategy}>
-            <div className="space-y-1.5">{categories.map((category, index) => <SortableCategoryRow key={category.id} category={category} index={index} accent={accentFor(index)} onRemove={() => void onChange(categories.filter((entry) => entry.id !== category.id))} />)}</div>
-          </SortableContext>
-          <DragOverlay dropAnimation={null}>{active ? <CompactRow isOverlay index={activeIndex} avatar={initials(active.name)} avatarImageUrl={active.imageUrl} avatarStyle={{ backgroundColor: accentFor(activeIndex), color: "#fff" }} title={active.name} dragHandle={<GripVertical size={16} className="text-zinc-400" />} trailing={<span className="w-4" />} /> : null}</DragOverlay>
-        </DndContext>
+        <DragDropProvider onDragEnd={endDrag}>
+          <div className="space-y-1.5">{categories.map((category, index) => <SortableCategoryRow key={category.id} category={category} index={index} accent={accentFor(index)} onRemove={() => void onChange(categories.filter((entry) => entry.id !== category.id))} />)}</div>
+        </DragDropProvider>
       )}
 
       <CategoryPickerCombobox platform={platform} suggestions={suggestions} selectedIds={selectedIds} onSearch={onSearch} onSelect={addCategory} />
@@ -331,10 +313,10 @@ function CategoryPickerGroup({ label, items, onSelect }: {
 }
 
 function SortableCategoryRow({ category, index, accent, onRemove }: { category: CategorySelection; index: number; accent: string; onRemove(): void }) {
-  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: category.id });
+  const { ref, handleRef, isDragging } = useSortable({ id: category.id, index });
   return (
-    <div ref={setNodeRef} onDragStart={preventNativeDrag} style={{ transform: CSS.Transform.toString(transform), transition }}>
-      <CompactRow index={index} avatar={initials(category.name)} avatarImageUrl={category.imageUrl} avatarStyle={{ backgroundColor: accent, color: "#fff" }} title={category.name} dimmed={isDragging} dragHandle={<DragHandle setActivatorNodeRef={setActivatorNodeRef} attributes={attributes} listeners={listeners} label={`Reorder ${category.name}`} />} trailing={<RemoveRowButton label={`Remove ${category.name}`} onClick={onRemove} />} />
+    <div ref={ref} onDragStart={preventNativeDrag}>
+      <CompactRow index={index} avatar={initials(category.name)} avatarImageUrl={category.imageUrl} avatarStyle={{ backgroundColor: accent, color: "#fff" }} title={category.name} dimmed={isDragging} dragHandle={<DragHandle handleRef={handleRef} label={`Reorder ${category.name}`} />} trailing={<RemoveRowButton label={`Remove ${category.name}`} onClick={onRemove} />} />
     </div>
   );
 }

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -17,9 +17,8 @@
   "dependencies": {
     "@astrojs/react": "^6.0.0",
     "@astrojs/sitemap": "^3.2.1",
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
+    "@dnd-kit/helpers": "^0.5.0",
+    "@dnd-kit/react": "^0.5.0",
     "@fontsource-variable/bricolage-grotesque": "^5.1.1",
     "@fontsource-variable/geist": "^5.1.0",
     "@fontsource-variable/geist-mono": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,15 +64,12 @@ importers:
 
   packages/extension:
     dependencies:
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.2.8)
+      '@dnd-kit/helpers':
+        specifier: ^0.5.0
+        version: 0.5.0
+      '@dnd-kit/react':
+        specifier: ^0.5.0
+        version: 0.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@lurkloot/core':
         specifier: workspace:*
         version: link:../core
@@ -156,15 +153,12 @@ importers:
 
   packages/popup-ui:
     dependencies:
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.2.8)
+      '@dnd-kit/helpers':
+        specifier: ^0.5.0
+        version: 0.5.0
+      '@dnd-kit/react':
+        specifier: ^0.5.0
+        version: 0.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@lurkloot/locales':
         specifier: workspace:*
         version: link:../locales
@@ -211,15 +205,12 @@ importers:
       '@astrojs/sitemap':
         specifier: ^3.2.1
         version: 3.7.3
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.2.8)
+      '@dnd-kit/helpers':
+        specifier: ^0.5.0
+        version: 0.5.0
+      '@dnd-kit/react':
+        specifier: ^0.5.0
+        version: 0.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fontsource-variable/bricolage-grotesque':
         specifier: ^5.1.1
         version: 5.3.0
@@ -608,27 +599,29 @@ packages:
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
-  '@dnd-kit/accessibility@3.1.1':
-    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
-    peerDependencies:
-      react: '>=16.8.0'
+  '@dnd-kit/abstract@0.5.0':
+    resolution: {integrity: sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA==}
 
-  '@dnd-kit/core@6.3.1':
-    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+  '@dnd-kit/collision@0.5.0':
+    resolution: {integrity: sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ==}
 
-  '@dnd-kit/sortable@10.0.0':
-    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
-    peerDependencies:
-      '@dnd-kit/core': ^6.3.0
-      react: '>=16.8.0'
+  '@dnd-kit/dom@0.5.0':
+    resolution: {integrity: sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw==}
 
-  '@dnd-kit/utilities@3.2.2':
-    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+  '@dnd-kit/geometry@0.5.0':
+    resolution: {integrity: sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A==}
+
+  '@dnd-kit/helpers@0.5.0':
+    resolution: {integrity: sha512-i4y+51/icSw+OHMr/su19qhnmNhAzh8PnBwXvapFYTd+64oodIyJRiRkB+hhfxAfnur7RYSW8qacDTrXjg2XOg==}
+
+  '@dnd-kit/react@0.5.0':
+    resolution: {integrity: sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.5.0':
+    resolution: {integrity: sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -1491,6 +1484,9 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@preact/signals-core@1.14.4':
+    resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
 
   '@rolldown/binding-android-arm-eabi@1.2.5':
     resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
@@ -4628,7 +4624,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
@@ -4661,17 +4657,17 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -4830,29 +4826,48 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@dnd-kit/accessibility@3.1.1(react@19.2.8)':
+  '@dnd-kit/abstract@0.5.0':
     dependencies:
-      react: 19.2.8
+      '@dnd-kit/geometry': 0.5.0
+      '@dnd-kit/state': 0.5.0
       tslib: 2.8.1
 
-  '@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@dnd-kit/collision@0.5.0':
     dependencies:
-      '@dnd-kit/accessibility': 3.1.1(react@19.2.8)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/geometry': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.5.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/collision': 0.5.0
+      '@dnd-kit/geometry': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.5.0':
+    dependencies:
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/helpers@0.5.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/dom': 0.5.0
+      '@dnd-kit/state': 0.5.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
 
-  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@dnd-kit/state@0.5.0':
     dependencies:
-      '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
-      react: 19.2.8
-      tslib: 2.8.1
-
-  '@dnd-kit/utilities@3.2.2(react@19.2.8)':
-    dependencies:
-      react: 19.2.8
+      '@preact/signals-core': 1.14.4
       tslib: 2.8.1
 
   '@emnapi/core@1.11.1':
@@ -5391,6 +5406,8 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@preact/signals-core@1.14.4': {}
 
   '@rolldown/binding-android-arm-eabi@1.2.5':
     optional: true


### PR DESCRIPTION
## Why

`@dnd-kit/core` has not shipped since **2024-12-05** and cancels any in-flight drag on window `resize` *and* `visibilitychange` (`core.esm.js:1444`, and again in `KeyboardSensor` at `:1133`). An extension action popup sizes its window to its content, so it re-measures and fires `resize` constantly — which is the root cause of #431. There is no option to opt out: `AbstractPointerSensorOptions` exposes only `activationConstraint`, `bypassActivationConstraint` and `onActivation`.

`@dnd-kit/react` re-measures on resize instead of cancelling. Verified by reading the published package: `@dnd-kit/dom@0.5.0` uses `resize` only for `getWindowBoundingRectangle`/`handleWindowResize`, and has no `visibilitychange` handling at all.

For comparison, `@hello-pangea/dnd@18.0.1` has `eventName: 'resize', fn: cancel` in all three sensor sets — migrating there would have reproduced #431 exactly.

## No workaround needed

#435 proposed a `suppressPhantomResize` workaround for this. It has been closed in favour of this PR, and nothing equivalent is carried here. That is not an assumption — I built the migrated extension with no workaround of any kind and confirmed reordering works.

| scenario | @dnd-kit/core (stock) | @dnd-kit/react (no workaround) |
|---|---|---|
| pointer, control | reorders | reorders |
| pointer, spurious resize (same size) | **CANCELLED** | **reorders** |
| pointer, real resize (size changed) | CANCELLED | reorders |
| pointer, visibilitychange | CANCELLED | reorders |
| keyboard (Space/Arrow), spurious resize | **CANCELLED** | **reorders** |

Note rows 3 and 4: the new library no longer cancels on a genuine resize or on visibilitychange either. For a fixed-size popup that is immaterial, but it is a real behaviour change worth knowing.

## API changes

- `DndContext` + `SortableContext` → `DragDropProvider`; sensors and collision detection are built in, so `useDndSensors` is gone
- `useSortable({ id, index })` returns `{ ref, handleRef, isDragging }`; `DragHandle` now takes a single `handleRef` instead of `attributes`/`listeners`/`setActivatorNodeRef`
- the library animates the real element, so the `DragOverlay` copies and the manual `CSS.Transform`/`transition` wiring are deleted
- `arrayMove` moves to `@dnd-kit/helpers`; `moveById` keeps identical semantics
- `SortableDragEndEvent` is derived from `DragDropProvider`'s own props rather than hand-written, so it tracks the library

This PR also carries the native-drag fix originally raised in #435: links and images inside a sortable row are natively draggable, so grabbing a row by its body started an HTML5 link drag. `dragstart` bubbles, so it is suppressed on each sortable wrapper.

## Testing

- `pnpm test` green (1620 extension, 156 CLI)
- `pnpm typecheck` clean
- `pnpm build`, `pnpm build:firefox`, `pnpm build:site` all succeed
- CDP-driven drags against the built extension — the table above

## Risk worth stating plainly

`@dnd-kit/react` is **0.5.0, pre-1.0**. This pins the popup to an API that may still break between minors. I raised that and the call was made to migrate now; recording it here so the trade-off is visible at review time.

Still needs a manual check in a real popup before merge — headless action popups are fixed-size and cannot reproduce the phantom resize stream that caused #431.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drag-and-drop behavior across campaign lists, watchlists, and category filters.
  - Prevented links within reorderable rows from triggering unintended native browser dragging.
  - Improved handling of canceled drag operations.

- **Refactor**
  - Updated drag-and-drop interactions to provide more consistent sorting and drag-handle behavior across the extension, popup, and site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->