### PR TITLE
fix(release): install Playwright Chromium before branch-sync verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,11 @@ jobs:
           # demand, which rewrites package.json. Synchronization switches branches, so it aborts on a
           # dirty tree. Everything is already published by now, so tracked edits are discarded.
           git restore --staged --worktree -- .
+          # Playwright browsers live in the runner cache, not the worktree, so they survive the
+          # branch switch inside sync-branches. Candidate and PR verify jobs already install
+          # Chromium; this publish checkout may be an older release SHA whose defaultVerify does not.
+          pnpm install --frozen-lockfile
+          pnpm --filter @lurkloot/extension exec playwright install chromium
           node scripts/release/cli.mjs sync-branches --remote origin
       - name: Report stable publication
         run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,13 @@ jobs:
             echo
             echo "To load this pre-release in Chrome from the zip, see [Installing a pre-release build]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/v$VERSION/docs/install-prerelease.md)."
           } >> notes.md
-          node scripts/release/cli.mjs promote-release --pr "$RELEASE_PR" --version "$VERSION" --notes notes.md
+          # Promotion strips the candidate marker, so a recovery checkout of the merged
+          # SHA cannot satisfy promote-release's ownership check. Skip when already stable.
+          if [ "$(gh release view "v$VERSION" --json isPrerelease --jq .isPrerelease)" = true ]; then
+            node scripts/release/cli.mjs promote-release --pr "$RELEASE_PR" --version "$VERSION" --notes notes.md
+          else
+            echo "v$VERSION is already the stable release"
+          fi
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -194,6 +200,12 @@ jobs:
           cd docker-images
           sha256sum -c image-amd64.tar.sha256
           sha256sum -c image-arm64.tar.sha256
+          # Recovery rebuilds OCI archives; those digests are not guaranteed to match the
+          # already-published immutable tag. Leave X.Y.Z in place when it exists.
+          if docker buildx imagetools inspect "$IMAGE:$VERSION" --raw >/dev/null 2>&1; then
+            echo "$IMAGE:$VERSION already published; leaving the immutable digest in place"
+            exit 0
+          fi
           for arch in amd64 arm64; do
             docker load --input "image-$arch.tar"
             docker tag "$IMAGE:$VERSION-$arch" "$IMAGE:$staging-$arch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,11 @@ jobs:
             pr_number=$EVENT_PR
             labels=$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")
           else
-            test "$GITHUB_REF" = refs/heads/main
+            # Dispatch always checkouts main first, then re-resolves that version's
+            # merged release SHA. Do not require GITHUB_REF to be main: a failed
+            # stable run's YAML is frozen on that SHA, so recovery must be able to
+            # run a fixed workflow file from another branch while publication still
+            # operates on the original merged commit. Production still approves.
             pr_number=$(gh pr list --base main --head "release/$version" --state merged --limit 1 --json number --jq '.[0].number // ""')
             test -n "$pr_number"
             release_ref=$(gh pr view "$pr_number" --json mergeCommit --jq '.mergeCommit.oid // ""')

--- a/scripts/release/github.mjs
+++ b/scripts/release/github.mjs
@@ -196,7 +196,9 @@ export async function promotePrerelease({ client, pr, version, notes }) {
   if (!release) throw new Error(`cannot promote ${tag}: no candidate release exists`);
   if (!release.prerelease) {
     const ownership = parseCandidateMarker(release.body);
-    if (ownership?.version !== version || ownership.head !== `release/${version}`) {
+    // Promotion writes notes without the candidate marker. A stable release at this
+    // tag is the terminal state; recovery must no-op even when that marker is gone.
+    if (ownership && (ownership.version !== version || ownership.head !== `release/${version}`)) {
       throw new Error(`refusing to promote ${tag}: release does not belong to release/${version}`);
     }
     return { release, tag, promoted: false };

--- a/scripts/release/github.test.mjs
+++ b/scripts/release/github.test.mjs
@@ -201,6 +201,20 @@ test("promoting an already promoted release is a no-op", async () => {
   assert.ok(!routes.calls.some(({ method }) => method === "PATCH"));
 });
 
+test("promoting an already stable release without a candidate marker is a no-op", async () => {
+  const routes = recordingFetch({
+    "GET /repos/jamezrin/lurkloot/releases/tags/v1.6.0": response(200, {
+      id: 12,
+      prerelease: false,
+      body: "## Fixed\n- A bug.\n",
+    }),
+  });
+  const client = new GitHubClient({ repository: "jamezrin/lurkloot", token: "token", fetchImpl: routes.fetchImpl });
+  const result = await promotePrerelease({ client, pr: 132, version: "1.6.0", notes: "notes" });
+  assert.equal(result.promoted, false);
+  assert.ok(!routes.calls.some(({ method }) => method === "PATCH"));
+});
+
 test("refuses to promote a release belonging to another release branch", async () => {
   const marker = candidateMarker({ pr: 999, version: "1.7.0", head: "release/1.7.0" });
   const routes = recordingFetch({

--- a/scripts/release/sync.mjs
+++ b/scripts/release/sync.mjs
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 
 const exec = promisify(execFile);
@@ -17,9 +17,32 @@ async function isAncestor(cwd, ancestor, descendant) {
   }
 }
 
-async function defaultVerify(cwd) {
-  await exec("pnpm", ["install", "--frozen-lockfile"], { cwd });
-  await exec("pnpm", ["verify"], { cwd });
+function commandFailure(error) {
+  const details = [error.message, error.stdout, error.stderr].filter(Boolean).join("\n");
+  return new Error(details);
+}
+
+export async function defaultVerify(cwd, run = execPnpm) {
+  try {
+    await run(cwd, ["install", "--frozen-lockfile"]);
+    // Same Chromium the PR and candidate verify jobs install. storeScreenshotDashboard
+    // tests launch it; GitHub-hosted runners do not ship Playwright browsers.
+    await run(cwd, ["--filter", "@lurkloot/extension", "exec", "playwright", "install", "chromium"]);
+    await run(cwd, ["verify"]);
+  } catch (error) {
+    throw commandFailure(error);
+  }
+}
+
+function execPnpm(cwd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("pnpm", args, { cwd, stdio: "inherit" });
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(signal ? `pnpm ${args.join(" ")} killed by ${signal}` : `Command failed: pnpm ${args.join(" ")}`));
+    });
+  });
 }
 
 export async function syncBranches({ cwd = process.cwd(), remote = "origin", verify = defaultVerify }) {

--- a/scripts/release/sync.test.mjs
+++ b/scripts/release/sync.test.mjs
@@ -150,3 +150,12 @@ test("publish installs Playwright Chromium before synchronizing develop", async 
     /playwright install chromium\s+node scripts\/release\/cli\.mjs sync-branches/,
   );
 });
+
+test("recovery dispatch is not gated on the workflow ref being main", async () => {
+  const yaml = await readFile(new URL("../../.github/workflows/release.yml", import.meta.url), "utf8");
+  assert.doesNotMatch(yaml, /test "\$GITHUB_REF" = refs\/heads\/main/);
+  assert.match(
+    yaml,
+    /github\.event_name == 'pull_request' && github\.event\.pull_request\.merge_commit_sha \|\| 'main'/,
+  );
+});

--- a/scripts/release/sync.test.mjs
+++ b/scripts/release/sync.test.mjs
@@ -1,11 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { syncBranches } from "./sync.mjs";
+import { defaultVerify, syncBranches } from "./sync.mjs";
 
 const exec = promisify(execFile);
 
@@ -116,4 +116,37 @@ test("untracked files do not block synchronization", async () => {
   await writeFile(join(seed, "notes.md"), "left behind by publication\n");
   const result = await syncBranches({ cwd: seed, verify: async () => {} });
   assert.equal(result.mode, "fast-forward");
+});
+
+test("defaultVerify installs Playwright Chromium before pnpm verify", async () => {
+  const commands = [];
+  await defaultVerify("/repo", async (cwd, args) => {
+    commands.push([cwd, ...args]);
+  });
+  assert.deepEqual(commands, [
+    ["/repo", "install", "--frozen-lockfile"],
+    ["/repo", "--filter", "@lurkloot/extension", "exec", "playwright", "install", "chromium"],
+    ["/repo", "verify"],
+  ]);
+});
+
+test("defaultVerify includes command stdout when verification fails", async () => {
+  const failure = Object.assign(new Error("Command failed: pnpm verify"), {
+    stdout: "browserType.launch: Executable doesn't exist at /ms-playwright/chromium\n",
+    stderr: "$ pnpm -r --if-present test\n",
+  });
+  await assert.rejects(
+    () => defaultVerify("/repo", async () => {
+      throw failure;
+    }),
+    /Executable doesn't exist[\s\S]*pnpm -r --if-present test/,
+  );
+});
+
+test("publish installs Playwright Chromium before synchronizing develop", async () => {
+  const yaml = await readFile(new URL("../../.github/workflows/release.yml", import.meta.url), "utf8");
+  assert.match(
+    yaml,
+    /playwright install chromium\s+node scripts\/release\/cli\.mjs sync-branches/,
+  );
 });

--- a/scripts/release/sync.test.mjs
+++ b/scripts/release/sync.test.mjs
@@ -159,3 +159,14 @@ test("recovery dispatch is not gated on the workflow ref being main", async () =
     /github\.event_name == 'pull_request' && github\.event\.pull_request\.merge_commit_sha \|\| 'main'/,
   );
 });
+
+test("recovery skips promotion when the GitHub release is already stable", async () => {
+  const yaml = await readFile(new URL("../../.github/workflows/release.yml", import.meta.url), "utf8");
+  assert.match(yaml, /gh release view "v\$VERSION" --json isPrerelease/);
+  assert.match(yaml, /already the stable release/);
+});
+
+test("recovery leaves an already published immutable image tag in place", async () => {
+  const yaml = await readFile(new URL("../../.github/workflows/release.yml", import.meta.url), "utf8");
+  assert.match(yaml, /already published; leaving the immutable digest in place/);
+});


### PR DESCRIPTION
## Summary
- 1.12.1 is published and `develop` is synced to the same merge commit as `main`.
- This lands the recovery fix on `develop` so the next release installs Playwright Chromium before branch-sync, can dispatch Release from a fixed workflow file, and no-ops promotion/GHCR when the version is already stable.

## Test plan
- [x] `node --test scripts/release/github.test.mjs scripts/release/sync.test.mjs`
- [x] Recovery Release run succeeded: https://github.com/jamezrin/lurkloot/actions/runs/33104003535
- [x] `origin/develop` == `origin/main` at the 1.12.1 merge