### PR TITLE
feat(popup): allow typing a sort rank

### DIFF
--- a/docs/superpowers/plans/2026-08-27-rank-input.md
+++ b/docs/superpowers/plans/2026-08-27-rank-input.md
@@ -1,0 +1,455 @@
+# Click-to-Edit Sort Rank Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users type a 1-based sort rank on Drops, Idle Watchlist, and settings category rows instead of only dragging.
+
+**Architecture:** A pure `commitRank` helper plus a shared `RankInput` in `primitives.tsx` replace the static rank span. Callers still persist through existing `arrayMove` + `onReorder` / `onChange`. Drops search keeps a non-editable number.
+
+**Tech Stack:** TypeScript, React 19, `@dnd-kit/helpers` `arrayMove`, Vitest + linkedom in `packages/extension/tests/`
+
+**Spec:** `docs/superpowers/specs/2026-08-27-rank-input-design.md`
+
+## Global Constraints
+
+- Display is 1-based (`index + 1`); `commitRank` / `onMove` use 0-based indexes.
+- Successful commit is insert-and-shift via `arrayMove`, not a swap.
+- Empty, `0`, negatives, and non-whole-numbers cancel; `n > count` clamps to `count`; same rank is a no-op (no settings write).
+- Enter or blur commits; Escape cancels without moving.
+- Use `inputMode="numeric"` text input, never `type="number"`.
+- English `aria-label` `Set rank of {name}`; no new locale catalog keys.
+- Drops search stays view-only: static number, no rank button/input.
+- No new settings keys, scheduler changes, or overlay/column-grow UI.
+- Follow strict TypeScript, ES modules, two-space indentation, double quotes, and semicolons.
+
+## File structure
+
+- `packages/popup-ui/src/primitives.tsx` — `commitRank`, `RankInput`, and `CompactRow` using `RankInput`.
+- `packages/popup-ui/src/drops.tsx` — campaign rail uses `RankInput`; search omits `onMove`.
+- `packages/popup-ui/src/idleWatchlist.tsx` — pass rank props into `CompactRow`.
+- `packages/popup-ui/src/settingsPlatform.tsx` — pass rank props into `CompactRow`.
+- `packages/extension/tests/rankInput.test.ts` — pure `commitRank` cases.
+- `packages/extension/tests/dropsView.test.tsx` — click/type/blur reorder + search stays static.
+
+---
+
+### Task 1: `commitRank` helper
+
+**Files:**
+- Create: `packages/extension/tests/rankInput.test.ts`
+- Modify: `packages/popup-ui/src/primitives.tsx` (insert after `moveById`, around line 21)
+
+**Interfaces:**
+- Consumes: none.
+- Produces: `export type CommitRankResult = { action: "cancel" } | { action: "move"; toIndex: number }` and `export function commitRank(raw: string, currentIndex: number, count: number): CommitRankResult`. `toIndex` is 0-based.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/extension/tests/rankInput.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { commitRank } from "../../popup-ui/src/primitives";
+
+describe("commitRank", () => {
+  it("cancels empty, zero, and non-whole numbers", () => {
+    for (const raw of ["", "  ", "0", "-1", "abc", "3.5", "3abc"]) {
+      expect(commitRank(raw, 2, 12), raw).toEqual({ action: "cancel" });
+    }
+  });
+
+  it("clamps a too-large rank to the last index", () => {
+    expect(commitRank("99", 0, 12)).toEqual({ action: "move", toIndex: 11 });
+  });
+
+  it("accepts leading zeros as the integer they parse to", () => {
+    expect(commitRank("03", 0, 12)).toEqual({ action: "move", toIndex: 2 });
+  });
+
+  it("moves to the typed 1-based position", () => {
+    expect(commitRank("3", 0, 12)).toEqual({ action: "move", toIndex: 2 });
+  });
+
+  it("cancels when the typed rank is already the current position", () => {
+    expect(commitRank("3", 2, 12)).toEqual({ action: "cancel" });
+    expect(commitRank("99", 0, 1)).toEqual({ action: "cancel" });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/rankInput.test.ts`
+
+Expected: FAIL because `commitRank` is not exported.
+
+- [ ] **Step 3: Implement `commitRank`**
+
+In `packages/popup-ui/src/primitives.tsx`, immediately after `moveById`:
+
+```ts
+export type CommitRankResult =
+  | { action: "cancel" }
+  | { action: "move"; toIndex: number };
+
+export function commitRank(raw: string, currentIndex: number, count: number): CommitRankResult {
+  const trimmed = raw.trim();
+  if (count < 1 || !/^\d+$/.test(trimmed)) return { action: "cancel" };
+  const n = Number(trimmed);
+  if (n < 1) return { action: "cancel" };
+  const toIndex = Math.min(n, count) - 1;
+  if (toIndex === currentIndex) return { action: "cancel" };
+  return { action: "move", toIndex };
+}
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/rankInput.test.ts`
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/extension/tests/rankInput.test.ts packages/popup-ui/src/primitives.tsx
+git commit -m "feat(popup): add commitRank helper"
+```
+
+---
+
+### Task 2: `RankInput` and `CompactRow`
+
+**Files:**
+- Modify: `packages/popup-ui/src/primitives.tsx` (`DragHandle` ends ~line 109; `CompactRow` ~158–211)
+- Modify: `packages/popup-ui/src/idleWatchlist.tsx` (`SortableIdleWatchlist`, ~96–105)
+- Modify: `packages/popup-ui/src/settingsPlatform.tsx` (`SortableCategoryRow`, ~315–321)
+
+**Interfaces:**
+- Consumes: `commitRank` from Task 1.
+- Produces: `export function RankInput(props: { index: number; count: number; label: string; onMove?: (toIndex: number) => void; size: "row" | "rail" }): React.ReactElement`. `CompactRow` requires `rankLabel: string`, `rankCount: number`, and `onRankMove(toIndex: number): void` in addition to existing props.
+
+- [ ] **Step 1: Add `RankInput` after `DragHandle`**
+
+```tsx
+export function RankInput({ index, count, label, onMove, size }: { index: number; count: number; label: string; onMove?: (toIndex: number) => void; size: "row" | "rail" }) {
+  const [editing, setEditing] = React.useState(false);
+  const [value, setValue] = React.useState(String(index + 1));
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const skipBlur = React.useRef(false);
+  const textClass = size === "rail"
+    ? "w-full min-w-0 text-center text-[10px] font-bold tabular leading-none"
+    : "w-4 text-center text-[11px] font-bold tabular";
+  const color: React.CSSProperties = { color: "var(--accent-text)" };
+
+  React.useEffect(() => {
+    if (editing) inputRef.current?.select();
+  }, [editing]);
+
+  if (!onMove) {
+    return <span className={textClass} style={color}>{index + 1}</span>;
+  }
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        aria-label={`Set rank of ${label}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          setValue(String(index + 1));
+          setEditing(true);
+        }}
+        onPointerDown={(event) => event.stopPropagation()}
+        className={cn(textClass, "rounded-sm outline-none hover:text-zinc-700 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:hover:text-zinc-200")}
+        style={color}
+      >
+        {index + 1}
+      </button>
+    );
+  }
+
+  function close(commit: boolean): void {
+    skipBlur.current = !commit;
+    setEditing(false);
+    if (!commit) return;
+    const result = commitRank(value, index, count);
+    if (result.action === "move") onMove(result.toIndex);
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      autoFocus
+      inputMode="numeric"
+      aria-label={`Set rank of ${label}`}
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onBlur={() => {
+        if (skipBlur.current) {
+          skipBlur.current = false;
+          return;
+        }
+        close(true);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          close(false);
+        } else if (event.key === "Enter") {
+          event.preventDefault();
+          event.currentTarget.blur();
+        }
+      }}
+      onClick={(event) => event.stopPropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
+      className={cn(textClass, "bg-transparent p-0 outline-none focus:ring-1 focus:ring-[var(--accent-ring)]")}
+      style={color}
+    />
+  );
+}
+```
+
+`onMove` is narrowed by the `if (!onMove)` return above, so `close(true)` can call it directly.
+
+- [ ] **Step 2: Point `CompactRow` at `RankInput`**
+
+Replace the rank `<span>` (`index + 1`) with:
+
+```tsx
+<RankInput index={index} count={rankCount} label={rankLabel} onMove={onRankMove} size="row" />
+```
+
+Add `rankLabel: string`, `rankCount: number`, and `onRankMove(toIndex: number): void` to the `CompactRow` props type and destructuring.
+
+- [ ] **Step 3: Wire Idle Watchlist and settings categories**
+
+In `idleWatchlist.tsx`, import `arrayMove` from `@dnd-kit/helpers`. Pass list length and move through `SortableIdleWatchlist`:
+
+```tsx
+{streamers.map((streamer, index) => (
+  <SortableIdleWatchlist
+    key={streamer.id}
+    streamer={streamer}
+    index={index}
+    count={streamers.length}
+    platform={platform}
+    onRemove={() => removeChannel(streamer.id)}
+    onMove={(toIndex) => void onChange(arrayMove(streamers, index, toIndex))}
+  />
+))}
+```
+
+Extend `SortableIdleWatchlist` with `count` and `onMove`, and pass them into `CompactRow` as `rankCount={count}`, `rankLabel={streamer.name}`, `onRankMove={onMove}`.
+
+In `settingsPlatform.tsx`, import `arrayMove` from `@dnd-kit/helpers`. Update the category map:
+
+```tsx
+{categories.map((category, index) => (
+  <SortableCategoryRow
+    key={category.id}
+    category={category}
+    index={index}
+    count={categories.length}
+    accent={accentFor(index)}
+    onRemove={() => void onChange(categories.filter((entry) => entry.id !== category.id))}
+    onMove={(toIndex) => void onChange(arrayMove(categories, index, toIndex))}
+  />
+))}
+```
+
+Extend `SortableCategoryRow` the same way and pass `rankLabel={category.name}`, `rankCount={count}`, `onRankMove={onMove}` into `CompactRow`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm --filter @lurkloot/popup-ui typecheck`
+
+Expected: PASS. `CompactRow` call sites all supply the new props. Drops is not using `CompactRow`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/popup-ui/src/primitives.tsx packages/popup-ui/src/idleWatchlist.tsx packages/popup-ui/src/settingsPlatform.tsx
+git commit -m "feat(popup): add inline RankInput to compact rows"
+```
+
+---
+
+### Task 3: Campaign rail and Drops search
+
+**Files:**
+- Modify: `packages/popup-ui/src/drops.tsx` (`endDrag` ~108; search cards ~153–157; `SortableCampaign` ~176–185; campaign rail span ~223–225)
+- Test: `packages/extension/tests/dropsView.test.tsx`
+
+**Interfaces:**
+- Consumes: `RankInput` from Task 2; `arrayMove` from `@dnd-kit/helpers`.
+- Produces: `CampaignCard` optional `rankCount?: number` and `onRankMove?: (toIndex: number) => void`. Search cards omit `onRankMove` so `RankInput` renders a span.
+
+- [ ] **Step 1: Write the failing DropsPanel tests**
+
+In `packages/extension/tests/dropsView.test.tsx`, add a helper next to `setSearchQuery` that drives a controlled input, then add this describe:
+
+```tsx
+function setInputValue(input: HTMLInputElement, value: string): void {
+  input.value = value;
+  const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+  const props = propsKey
+    ? (input as unknown as Record<string, { onChange?(event: { target: HTMLInputElement; currentTarget: HTMLInputElement }): void; onBlur?(): void }>)[propsKey]
+    : undefined;
+  props?.onChange?.({ target: input, currentTarget: input });
+}
+
+describe("campaign rank input", () => {
+  it("reorders via the typed rank on blur", () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const onReorder = vi.fn();
+    const adapter = { openLink: vi.fn() } as unknown as PopupAdapter;
+    const campaigns = [
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "first", name: "First campaign" }, 0, idleSession, false),
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "second", name: "Second campaign" }, 1, idleSession, false),
+    ];
+    const container = document.getElementById("app")!;
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <I18nContext.Provider value={{ t: (key) => ({ search: "Search" })[key] ?? key, dir: "ltr", locale: "en" }}>
+          <PopupRuntimeContext.Provider value={{ adapter, preview: false }}>
+            <DropsPanel
+              campaigns={campaigns}
+              gameMap={{}}
+              refreshing={false}
+              onRefreshCampaign={() => undefined}
+              onReorder={onReorder}
+              onToggleExclude={() => undefined}
+            />
+          </PopupRuntimeContext.Provider>
+        </I18nContext.Provider>,
+      );
+    });
+
+    const rank = [...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Set rank of Second campaign");
+    expect(rank).not.toBeNull();
+    act(() => rank?.click());
+    const input = container.querySelector<HTMLInputElement>("input[inputmode='numeric']")!;
+    expect(input).not.toBeNull();
+    act(() => {
+      setInputValue(input, "1");
+      input.blur();
+    });
+
+    expect(onReorder).toHaveBeenCalledOnce();
+    expect(onReorder.mock.calls[0]?.[0].map((campaign: { id: string }) => campaign.id)).toEqual(["second", "first"]);
+  });
+
+  it("does not expose a rank editor while searching", () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.getElementById("app")!;
+    const campaigns = [
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "first", name: "First campaign" }, 0, idleSession, false),
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "second", name: "Second campaign" }, 1, idleSession, false),
+    ];
+
+    act(() => {
+      root = createRoot(container);
+      renderDropsPanel(campaigns);
+    });
+
+    act(() => container.querySelector<HTMLButtonElement>("button[aria-label='Search']")?.click());
+    const input = container.querySelector<HTMLInputElement>("input[type='search']")!;
+    act(() => setSearchQuery(input, "Second"));
+
+    expect([...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Set rank of Second campaign")).toBeUndefined();
+    expect(container.querySelector("input[inputmode='numeric']")).toBeNull();
+    expect(container.querySelector<HTMLElement>("article .w-7 span")?.textContent).toBe("2");
+  });
+});
+```
+
+The existing test `"keeps the original priority number in filtered results"` already asserts `article .w-7 span` text `"2"`. Keep that test; the search path must still render a span.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/dropsView.test.tsx`
+
+Expected: FAIL — no `Set rank of Second campaign` button.
+
+- [ ] **Step 3: Wire `RankInput` into the campaign rail**
+
+Import `arrayMove` from `@dnd-kit/helpers` and `RankInput` from `./primitives`.
+
+In `DropsPanel`, add:
+
+```ts
+function moveCampaign(fromIndex: number, toIndex: number): void {
+  void onReorder(arrayMove(campaigns, fromIndex, toIndex));
+}
+```
+
+Pass `rankCount={campaigns.length}` and `onRankMove={(toIndex) => moveCampaign(index, toIndex)}` only through `SortableCampaign` (the non-search list). Do **not** pass `onRankMove` on the search `CampaignCard` map.
+
+Extend `SortableCampaign` and `CampaignCard` with optional `rankCount?: number` and `onRankMove?: (toIndex: number) => void`. `SortableCampaign` forwards both onto `CampaignCard`.
+
+Replace the rail number span with:
+
+```tsx
+<RankInput index={index} count={rankCount ?? 0} label={campaign.title} onMove={onRankMove} size="rail" />
+```
+
+Keep the decorative `GripVertical` fallback when `dragHandle` is missing (search). The rank stays a span in that case because `onMove` is undefined.
+
+- [ ] **Step 4: Run the Drops tests and make sure they pass**
+
+Run: `pnpm --filter @lurkloot/extension test -- tests/dropsView.test.tsx tests/rankInput.test.ts`
+
+Expected: PASS, including `"keeps the original priority number in filtered results"`.
+
+If blur does not fire React's `onBlur` under linkedom, call the `__reactProps$` `onBlur` the same way `setInputValue` calls `onChange`.
+
+- [ ] **Step 5: Typecheck and commit**
+
+Run: `pnpm --filter @lurkloot/popup-ui typecheck && pnpm --filter @lurkloot/extension typecheck`
+
+```bash
+git add packages/popup-ui/src/drops.tsx packages/extension/tests/dropsView.test.tsx
+git commit -m "feat(popup): type a campaign sort rank"
+```
+
+---
+
+### Task 4: Verification
+
+**Files:** none new.
+
+- [ ] **Step 1: Run the extension test suite**
+
+Run: `pnpm --filter @lurkloot/extension test`
+
+Expected: PASS.
+
+- [ ] **Step 2: Manual check (if a popup host is available)**
+
+On Drops, Idle Watchlist, and settings categories: click a rank, type a new 1-based position, blur, confirm insert-and-shift. Escape cancels. Open campaign search and confirm the number is not editable. Drag still works on the grip.
+
+- [ ] **Step 3: Final commit only if verification left uncommitted fixes**
+
+Do not create an empty commit. If Step 2 required code changes, commit those with a focused `fix(popup): ...` message.

--- a/docs/superpowers/plans/2026-08-30-drops-rail-rank-alignment.md
+++ b/docs/superpowers/plans/2026-08-30-drops-rail-rank-alignment.md
@@ -1,0 +1,104 @@
+# Drops Rail Rank Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Drops campaign rank a 16px-wide caption of the grip, centered in the existing 28px rail.
+
+**Architecture:** Wrap grip + `RankInput` in a `w-4` column inside the unchanged `w-7` rail. Change `RankInput` `size="rail"` from `w-full` to `w-4` with flex centering. CompactRow `size="row"` stays as it is.
+
+**Tech Stack:** TypeScript, React, Tailwind utilities, Vitest + linkedom in `packages/extension/tests/`
+
+**Spec:** `docs/superpowers/specs/2026-08-30-drops-rail-rank-alignment-design.md`
+
+## Global Constraints
+
+- Rail stays `w-7`; inner unit is `w-4`; do not grow either.
+- `RankInput` rail is not `w-full`; display, edit, and search span share the `w-4` box.
+- CompactRow / `size="row"` unchanged; do not change `DragHandle` globally.
+- Click-to-edit, Escape, search view-only, and `stopPropagation` stay as in `docs/superpowers/specs/2026-08-27-rank-input-design.md`.
+- Follow strict TypeScript, ES modules, two-space indentation, double quotes, and semicolons.
+
+## File structure
+
+- `packages/popup-ui/src/primitives.tsx` — `RankInput` `size="rail"` classes.
+- `packages/popup-ui/src/drops.tsx` — inner `w-4` stack in the campaign rail.
+- `packages/extension/tests/dropsView.test.tsx` — assert rail rank is `w-4` and not `w-full`.
+
+---
+
+### Task 1: Shared-width Drops rail stack
+
+**Files:**
+- Modify: `packages/popup-ui/src/primitives.tsx` (`RankInput` `textClass` for `size === "rail"`)
+- Modify: `packages/popup-ui/src/drops.tsx` (campaign rail around the `w-7` div)
+- Test: `packages/extension/tests/dropsView.test.tsx`
+
+**Interfaces:**
+- Consumes: existing `RankInput({ index, count, label, onMove, size: "rail" })`.
+- Produces: rail rank control whose `className` includes `w-4` and does not include `w-full`.
+
+- [ ] **Step 1: Write the failing assertions**
+
+In `packages/extension/tests/dropsView.test.tsx`, in `"moves a campaign when the rank is typed and committed"`, after `expect(rank).toBeDefined();` add:
+
+```ts
+    expect(rank?.className).toContain("w-4");
+    expect(rank?.className).not.toContain("w-full");
+```
+
+In `"keeps the rank static while campaign search is open"`, after the existing span text assertion, add:
+
+```ts
+    const rankSpan = container.querySelector<HTMLElement>("article .w-7 span");
+    expect(rankSpan?.className).toContain("w-4");
+    expect(rankSpan?.className).not.toContain("w-full");
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/dropsView.test.tsx`
+
+Expected: FAIL — rank button/span still use `w-full min-w-0`.
+
+- [ ] **Step 3: Change `RankInput` rail classes**
+
+In `packages/popup-ui/src/primitives.tsx`, replace the rail branch of `textClass`:
+
+```ts
+  const textClass = size === "rail"
+    ? "flex w-4 items-center justify-center text-center text-[10px] font-bold tabular leading-none"
+    : "w-4 text-center text-[11px] font-bold tabular";
+```
+
+- [ ] **Step 4: Wrap the Drops rail contents in a `w-4` unit**
+
+In `packages/popup-ui/src/drops.tsx`, replace the rail block with:
+
+```tsx
+        <div className="flex w-7 shrink-0 items-center justify-center border-r border-zinc-100 bg-zinc-50/60 dark:border-zinc-800 dark:bg-zinc-800/40">
+          <div className="flex w-4 flex-col items-center gap-0.5">
+            {dragHandle ?? <GripVertical size={14} className="text-zinc-300 dark:text-zinc-600" />}
+            <RankInput index={index} count={rankCount ?? 0} label={campaign.title} onMove={onRankMove} size="rail" />
+          </div>
+        </div>
+```
+
+Update the comment above it to say the grip and rank share a 16px column centered in the rail.
+
+- [ ] **Step 5: Run the tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension exec vitest run tests/dropsView.test.tsx tests/rankInput.test.ts
+pnpm --filter @lurkloot/popup-ui typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/popup-ui/src/primitives.tsx packages/popup-ui/src/drops.tsx packages/extension/tests/dropsView.test.tsx
+git commit -m "fix(popup): align drops rank under the grip"
+```

--- a/docs/superpowers/specs/2026-08-27-rank-input-design.md
+++ b/docs/superpowers/specs/2026-08-27-rank-input-design.md
@@ -1,0 +1,71 @@
+# Click-to-Edit Sort Rank
+
+## Context
+
+Drops, Idle Watchlist, and the settings category list are ordered by drag-and-drop. Each row already shows a 1-based rank next to the grip (`index + 1`). Reordering a long list means scrolling and dragging; campaign search disables drag entirely. [Issue #432](https://github.com/jamezrin/lurkloot/issues/432) asks for typing a new rank instead.
+
+This is a popup-only interaction. Persistence stays on the existing reorder callbacks.
+
+## Goal
+
+Clicking the displayed rank turns it into a small numeric field. Committing moves that item to the typed 1-based position and shifts neighbors (insert, not swap), the same `arrayMove` path drag already uses.
+
+## Scope
+
+In:
+
+- Drops campaign cards (the number under the grip in the drag rail)
+- Idle Watchlist rows (`CompactRow`)
+- Settings category rows (`CompactRow`)
+
+Out:
+
+- Rank editing while Drops search is open (filtered cards keep a static number, matching drag)
+- New settings keys, scheduler changes, or locale catalog entries
+
+## Architecture
+
+A shared `RankInput` primitive lives in `packages/popup-ui/src/primitives.tsx` beside `DragHandle`. It replaces the static `index + 1` span in `CompactRow` and in the campaign drag rail in `drops.tsx`. The field stays in that existing slot (no overlay, no column grow). `CompactRow` gains the item label, list length, and an `onMove(toIndex)` callback so watchlist and category rows can share the control.
+
+A pure helper `commitRank(raw, currentIndex, count)` returns either cancel or a 0-based `toIndex`. Callers apply `arrayMove` and the existing `onReorder` / `onChange` callbacks:
+
+- Drops → `onReorder` → `campaignPriorities` via `prioritiesFromOrder`
+- Idle Watchlist → `onChange(streamers)`
+- Categories → `onChange(categories)`
+
+No new storage shape.
+
+## Interaction
+
+Display state is a button showing the 1-based rank. Click (or Enter/Space when focused) opens a centered text input with `inputMode="numeric"` — not `type="number"`, so there are no spinners. The current value is selected so typing replaces it.
+
+- Enter or blur runs `commitRank` and closes the field
+- Escape restores the original rank and closes without moving
+
+The campaign rank sits in the left rail, outside the card's expand toggle and off the grip, so editing must not expand the card or start a drag.
+
+## Commit rules
+
+`commitRank` trims the raw string. The remainder must be a whole number (`/^\d+$/`); leading zeros are allowed (`03` → 3). Then:
+
+| Input | Result |
+| --- | --- |
+| empty, `0`, negatives, or not a whole number (`abc`, `3.5`, `3abc`) | cancel |
+| `n > count` | clamp to `count` |
+| `n` in `1…count` | `toIndex = n - 1` |
+| `toIndex === currentIndex` | cancel (no settings write, no tick) |
+
+A cancelled commit leaves the list unchanged. A successful commit is insert-and-shift via `arrayMove`, not a swap.
+
+## Accessibility
+
+Follow `DragHandle`: an English `aria-label` of the form `Set rank of {name}`. No new locale keys. The control is keyboard-reachable; Tab lands on the button, Enter/Space open edit.
+
+## Testing
+
+Vitest in `packages/extension/tests/`, same as other popup-ui coverage.
+
+1. Pure `commitRank` cases for cancel, clamp-to-end, a real move, and same-rank no-op.
+2. One focused `DropsPanel` test: click rank, type, blur, assert `onReorder` received `arrayMove` order. While search is open, the rank is not a button or input.
+
+`CompactRow` shares `RankInput`, so watchlist and settings do not need a duplicated click path. Scheduler and settings-schema tests are out of scope.

--- a/docs/superpowers/specs/2026-08-30-drops-rail-rank-alignment-design.md
+++ b/docs/superpowers/specs/2026-08-30-drops-rail-rank-alignment-design.md
@@ -1,0 +1,46 @@
+# Drops Rail Rank Alignment
+
+## Context
+
+Click-to-edit rank shipped in [PR #443](https://github.com/jamezrin/lurkloot/pull/443) against [issue #432](https://github.com/jamezrin/lurkloot/issues/432). The Drops campaign number sits under the grip in a 28px (`w-7`) rail. After the static `<span>` became a `w-full` `RankInput` button, the 1-based rank looks left of the grip’s axis — Geist tabular “1” is left-heavy in its slot, and full-rail `text-center` treats the digit as rail text instead of a caption of the handle.
+
+Idle Watchlist and settings `CompactRow` ranks (beside the grip) are out of scope.
+
+Follows `docs/superpowers/specs/2026-08-27-rank-input-design.md`. Interaction, commit rules, and accessibility do not change.
+
+## Goal
+
+The Drops rail rank and grip share one 16px-wide stack, centered in the existing rail, so the number reads as a caption of the handle.
+
+## Scope
+
+In:
+
+- Drops campaign drag rail (`packages/popup-ui/src/drops.tsx`)
+- `RankInput` `size="rail"` box in `packages/popup-ui/src/primitives.tsx`
+
+Out:
+
+- Idle Watchlist and settings `CompactRow` (`size="row"`)
+- Growing the rail, overlay/badge treatments, locale keys, scheduler, or commit-rule changes
+
+## Layout
+
+The rail stays `w-7` with the same border and background. Inside it, a `w-4` column (`flex flex-col items-center gap-0.5`) holds:
+
+1. The grip (`DragHandle`, or the 14px `GripVertical` overlay fallback)
+2. `RankInput` `size="rail"`
+
+The rail itself is `flex items-center justify-center` so that unit is centered. `gap-0.5` lives on the inner unit, not on the rail.
+
+`RankInput` rail classes are `w-4` plus flex centering (`flex items-center justify-center text-center text-[10px] font-bold tabular leading-none`). They are not `w-full`. Display, edit input, and the search-mode static span all use that same box.
+
+Two-digit ranks may clip. Do not grow the rail or the unit.
+
+## Interaction
+
+Unchanged from the rank-input spec: click/Enter/Space edit, Enter/blur commit, Escape cancel, `stopPropagation` so the card does not expand and drag does not start. Drops search still omits `onMove`. The edit field stays in the 16px slot (no overlay).
+
+## Testing
+
+Existing `DropsPanel` rank click/type/blur tests must still pass. Add one assertion that the Drops rank control’s class list includes `w-4` and does not include `w-full`, covering display and search-mode span.

--- a/packages/extension/tests/dropsView.test.tsx
+++ b/packages/extension/tests/dropsView.test.tsx
@@ -176,6 +176,33 @@ function setInputValue(input: HTMLInputElement, value: string): void {
   props?.onChange?.({ target: input, currentTarget: input });
 }
 
+function findNumericRankInput(container: Element): HTMLInputElement | undefined {
+  // linkedom keeps React's camelCase inputMode attribute rather than lowercasing it.
+  return [...container.querySelectorAll<HTMLInputElement>("input")].find((el) =>
+    el.getAttribute("inputmode") === "numeric" || el.getAttribute("inputMode") === "numeric"
+  );
+}
+
+function blurRankInput(input: HTMLInputElement): void {
+  // Re-read props after the controlled value commit; the pre-change onBlur
+  // closure still sees the old rank and would cancel the move.
+  const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+  const props = propsKey
+    ? (input as unknown as Record<string, { onBlur?(): void }>)[propsKey]
+    : undefined;
+  props?.onBlur?.();
+}
+
+function keyDownRankInput(input: HTMLInputElement, key: string): void {
+  const propsKey = Object.keys(input).find((keyName) => keyName.startsWith("__reactProps$"));
+  const props = propsKey
+    ? (input as unknown as Record<string, {
+      onKeyDown?(event: { key: string; preventDefault(): void; stopPropagation(): void }): void;
+    }>)[propsKey]
+    : undefined;
+  props?.onKeyDown?.({ key, preventDefault() {}, stopPropagation() {} });
+}
+
 describe("campaign rank input", () => {
   it("reorders via the typed rank on blur", () => {
     const { document, window } = parseHTML("<div id=app></div>");
@@ -217,24 +244,80 @@ describe("campaign rank input", () => {
     });
 
     const rank = [...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Set rank of Second campaign");
-    expect(rank).not.toBeNull();
+    expect(rank).toBeDefined();
     act(() => rank?.click());
-    // linkedom keeps React's camelCase inputMode attribute rather than lowercasing it.
-    const input = [...container.querySelectorAll<HTMLInputElement>("input")].find((el) =>
-      el.getAttribute("inputmode") === "numeric" || el.getAttribute("inputMode") === "numeric"
-    )!;
-    expect(input).not.toBeNull();
+    const input = findNumericRankInput(container);
+    expect(input).toBeDefined();
     act(() => {
-      setInputValue(input, "1");
+      setInputValue(input!, "1");
     });
     act(() => {
-      // Re-read props after the controlled value commit; the pre-change onBlur
-      // closure still sees the old rank and would cancel the move.
-      const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
-      const props = propsKey
-        ? (input as unknown as Record<string, { onBlur?(): void }>)[propsKey]
-        : undefined;
-      props?.onBlur?.();
+      blurRankInput(input!);
+    });
+
+    expect(onReorder).toHaveBeenCalledOnce();
+    expect(onReorder.mock.calls[0]?.[0].map((campaign: { id: string }) => campaign.id)).toEqual(["second", "first"]);
+  });
+
+  it("allows commit after Escape cancels a prior edit on the same row", () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    Object.defineProperty(window.HTMLInputElement.prototype, "select", { configurable: true, value: () => undefined });
+    const onReorder = vi.fn();
+    const adapter = { openLink: vi.fn() } as unknown as PopupAdapter;
+    const campaigns = [
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "first", name: "First campaign" }, 0, idleSession, false),
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "second", name: "Second campaign" }, 1, idleSession, false),
+    ];
+    const container = document.getElementById("app")!;
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <I18nContext.Provider value={{ t: (key) => ({ search: "Search" })[key] ?? key, dir: "ltr", locale: "en" }}>
+          <PopupRuntimeContext.Provider value={{ adapter, preview: false }}>
+            <DropsPanel
+              campaigns={campaigns}
+              gameMap={{}}
+              refreshing={false}
+              onRefreshCampaign={() => undefined}
+              onReorder={onReorder}
+              onToggleExclude={() => undefined}
+            />
+          </PopupRuntimeContext.Provider>
+        </I18nContext.Provider>,
+      );
+    });
+
+    const openRank = () => {
+      const rank = [...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Set rank of Second campaign");
+      expect(rank).toBeDefined();
+      act(() => rank?.click());
+      return findNumericRankInput(container);
+    };
+
+    const inputAfterOpen = openRank();
+    expect(inputAfterOpen).toBeDefined();
+    act(() => {
+      keyDownRankInput(inputAfterOpen!, "Escape");
+    });
+    expect(onReorder).not.toHaveBeenCalled();
+
+    const input = openRank();
+    expect(input).toBeDefined();
+    act(() => {
+      setInputValue(input!, "1");
+    });
+    act(() => {
+      blurRankInput(input!);
     });
 
     expect(onReorder).toHaveBeenCalledOnce();
@@ -268,7 +351,7 @@ describe("campaign rank input", () => {
     act(() => setSearchQuery(input, "Second"));
 
     expect([...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Set rank of Second campaign")).toBeUndefined();
-    expect(container.querySelector("input[inputmode='numeric']")).toBeNull();
+    expect(findNumericRankInput(container)).toBeUndefined();
     expect(container.querySelector<HTMLElement>("article .w-7 span")?.textContent).toBe("2");
   });
 });

--- a/packages/extension/tests/dropsView.test.tsx
+++ b/packages/extension/tests/dropsView.test.tsx
@@ -167,6 +167,112 @@ function setSearchQuery(input: HTMLInputElement, value: string): void {
   props?.onChange?.({ target: input, currentTarget: input });
 }
 
+function setInputValue(input: HTMLInputElement, value: string): void {
+  input.value = value;
+  const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+  const props = propsKey
+    ? (input as unknown as Record<string, { onChange?(event: { target: HTMLInputElement; currentTarget: HTMLInputElement }): void; onBlur?(): void }>)[propsKey]
+    : undefined;
+  props?.onChange?.({ target: input, currentTarget: input });
+}
+
+describe("campaign rank input", () => {
+  it("reorders via the typed rank on blur", () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    // linkedom's HTMLInputElement has no select(); RankInput calls it on edit.
+    Object.defineProperty(window.HTMLInputElement.prototype, "select", { configurable: true, value: () => undefined });
+    const onReorder = vi.fn();
+    const adapter = { openLink: vi.fn() } as unknown as PopupAdapter;
+    const campaigns = [
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "first", name: "First campaign" }, 0, idleSession, false),
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "second", name: "Second campaign" }, 1, idleSession, false),
+    ];
+    const container = document.getElementById("app")!;
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <I18nContext.Provider value={{ t: (key) => ({ search: "Search" })[key] ?? key, dir: "ltr", locale: "en" }}>
+          <PopupRuntimeContext.Provider value={{ adapter, preview: false }}>
+            <DropsPanel
+              campaigns={campaigns}
+              gameMap={{}}
+              refreshing={false}
+              onRefreshCampaign={() => undefined}
+              onReorder={onReorder}
+              onToggleExclude={() => undefined}
+            />
+          </PopupRuntimeContext.Provider>
+        </I18nContext.Provider>,
+      );
+    });
+
+    const rank = [...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Set rank of Second campaign");
+    expect(rank).not.toBeNull();
+    act(() => rank?.click());
+    // linkedom keeps React's camelCase inputMode attribute rather than lowercasing it.
+    const input = [...container.querySelectorAll<HTMLInputElement>("input")].find((el) =>
+      el.getAttribute("inputmode") === "numeric" || el.getAttribute("inputMode") === "numeric"
+    )!;
+    expect(input).not.toBeNull();
+    act(() => {
+      setInputValue(input, "1");
+    });
+    act(() => {
+      // Re-read props after the controlled value commit; the pre-change onBlur
+      // closure still sees the old rank and would cancel the move.
+      const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+      const props = propsKey
+        ? (input as unknown as Record<string, { onBlur?(): void }>)[propsKey]
+        : undefined;
+      props?.onBlur?.();
+    });
+
+    expect(onReorder).toHaveBeenCalledOnce();
+    expect(onReorder.mock.calls[0]?.[0].map((campaign: { id: string }) => campaign.id)).toEqual(["second", "first"]);
+  });
+
+  it("does not expose a rank editor while searching", () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.getElementById("app")!;
+    const campaigns = [
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "first", name: "First campaign" }, 0, idleSession, false),
+      campaignViewFromCampaign({ ...sourceCampaign(), id: "second", name: "Second campaign" }, 1, idleSession, false),
+    ];
+
+    act(() => {
+      root = createRoot(container);
+      renderDropsPanel(campaigns);
+    });
+
+    act(() => container.querySelector<HTMLButtonElement>("button[aria-label='Search']")?.click());
+    const input = container.querySelector<HTMLInputElement>("input[type='search']")!;
+    act(() => setSearchQuery(input, "Second"));
+
+    expect([...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Set rank of Second campaign")).toBeUndefined();
+    expect(container.querySelector("input[inputmode='numeric']")).toBeNull();
+    expect(container.querySelector<HTMLElement>("article .w-7 span")?.textContent).toBe("2");
+  });
+});
+
 describe("initial drops expansion", () => {
   it("expands nothing when no campaign is farming", () => {
     const campaigns = [

--- a/packages/extension/tests/dropsView.test.tsx
+++ b/packages/extension/tests/dropsView.test.tsx
@@ -245,6 +245,8 @@ describe("campaign rank input", () => {
 
     const rank = [...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Set rank of Second campaign");
     expect(rank).toBeDefined();
+    expect(rank?.className).toContain("w-4");
+    expect(rank?.className).not.toContain("w-full");
     act(() => rank?.click());
     const input = findNumericRankInput(container);
     expect(input).toBeDefined();
@@ -352,7 +354,10 @@ describe("campaign rank input", () => {
 
     expect([...container.querySelectorAll("button")].find((button) => button.getAttribute("aria-label") === "Set rank of Second campaign")).toBeUndefined();
     expect(findNumericRankInput(container)).toBeUndefined();
-    expect(container.querySelector<HTMLElement>("article .w-7 span")?.textContent).toBe("2");
+    const rankSpan = container.querySelector<HTMLElement>("article .w-7 span");
+    expect(rankSpan?.textContent).toBe("2");
+    expect(rankSpan?.className).toContain("w-4");
+    expect(rankSpan?.className).not.toContain("w-full");
   });
 });
 

--- a/packages/extension/tests/rankInput.test.ts
+++ b/packages/extension/tests/rankInput.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { commitRank } from "../../popup-ui/src/primitives";
+
+describe("commitRank", () => {
+  it("cancels empty, zero, and non-whole numbers", () => {
+    for (const raw of ["", "  ", "0", "-1", "abc", "3.5", "3abc"]) {
+      expect(commitRank(raw, 2, 12), raw).toEqual({ action: "cancel" });
+    }
+  });
+
+  it("clamps a too-large rank to the last index", () => {
+    expect(commitRank("99", 0, 12)).toEqual({ action: "move", toIndex: 11 });
+  });
+
+  it("accepts leading zeros as the integer they parse to", () => {
+    expect(commitRank("03", 0, 12)).toEqual({ action: "move", toIndex: 2 });
+  });
+
+  it("moves to the typed 1-based position", () => {
+    expect(commitRank("3", 0, 12)).toEqual({ action: "move", toIndex: 2 });
+  });
+
+  it("cancels when the typed rank is already the current position", () => {
+    expect(commitRank("3", 2, 12)).toEqual({ action: "cancel" });
+    expect(commitRank("99", 0, 1)).toEqual({ action: "cancel" });
+  });
+});

--- a/packages/extension/tests/sortableDragEnd.test.ts
+++ b/packages/extension/tests/sortableDragEnd.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { reorderFromDragEnd, type SortableDragEndEvent } from "../../popup-ui/src/primitives";
+
+function dragEnd(
+  source: { id: string; initialIndex: number; index: number },
+  targetId: string,
+  canceled = false,
+): SortableDragEndEvent {
+  return {
+    canceled,
+    operation: { source, target: { id: targetId } },
+  } as unknown as SortableDragEndEvent;
+}
+
+describe("reorderFromDragEnd", () => {
+  // @dnd-kit/react keeps the pointer over the dragged row after it has already
+  // projected that row into the new slot, so source.id === target.id at drop.
+  // Matching source/target ids is a no-op if we only look at those ids, which
+  // is why ranks stayed stale and the order reverted on popup reopen.
+  it("commits a sortable drop even when the pointer is still over the dragged item", () => {
+    const list = [{ id: "xqc" }, { id: "xlibano" }, { id: "m2cg" }, { id: "poionako" }];
+    const next = reorderFromDragEnd(
+      list,
+      dragEnd({ id: "poionako", initialIndex: 3, index: 0 }, "poionako"),
+    );
+    expect(next.map((item) => item.id)).toEqual(["poionako", "xqc", "xlibano", "m2cg"]);
+  });
+
+  it("does not reorder a canceled drag", () => {
+    const list = [{ id: "a" }, { id: "b" }];
+    const next = reorderFromDragEnd(
+      list,
+      dragEnd({ id: "b", initialIndex: 1, index: 0 }, "b", true),
+    );
+    expect(next).toBe(list);
+  });
+});

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -222,12 +222,14 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
   return (
     <article className={cn("overflow-hidden rounded-2xl border bg-white transition-shadow dark:bg-zinc-900", emphasized ? "border-[var(--accent-ring)]" : "border-zinc-200 dark:border-zinc-800", isOverlay ? "shadow-2xl shadow-black/25" : "shadow-sm", dimmed && "opacity-40")} style={emphasized && !isOverlay ? { boxShadow: "0 10px 30px -18px var(--accent-glow)" } : undefined}>
       <div className="relative flex items-stretch">
-        {/* Drag rail doubles as the priority column: the grip keeps reorder
-            discoverable, the number underneath is the campaign's rank — the same
-            handle+index grammar CompactRow uses for watchlist rows. */}
-        <div className="flex w-7 shrink-0 flex-col items-center justify-center gap-0.5 border-r border-zinc-100 bg-zinc-50/60 dark:border-zinc-800 dark:bg-zinc-800/40">
-          {dragHandle ?? <GripVertical size={14} className="text-zinc-300 dark:text-zinc-600" />}
-          <RankInput index={index} count={rankCount ?? 0} label={campaign.title} onMove={onRankMove} size="rail" />
+        {/* Drag rail doubles as the priority column: grip and rank share a
+            16px column centered in the rail so the number is a caption of the
+            handle, not full-rail text. */}
+        <div className="flex w-7 shrink-0 items-center justify-center border-r border-zinc-100 bg-zinc-50/60 dark:border-zinc-800 dark:bg-zinc-800/40">
+          <div className="flex w-4 flex-col items-center gap-0.5">
+            {dragHandle ?? <GripVertical size={14} className="text-zinc-300 dark:text-zinc-600" />}
+            <RankInput index={index} count={rankCount ?? 0} label={campaign.title} onMove={onRankMove} size="rail" />
+          </div>
         </div>
         {/* Full-area toggle behind the content so the page-link anchor can live next
             to the title without nesting an <a> inside a <button>. */}

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { arrayMove } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { AnimatePresence, motion } from "motion/react";
@@ -35,6 +36,7 @@ import {
   MetaStat,
   Pill,
   ProgressBar,
+  RankInput,
   SearchBox,
   SectionHeader,
   cn,
@@ -112,6 +114,10 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollaps
     void onReorder(moveById(campaigns, String(source.id), String(target.id)));
   }
 
+  function moveCampaign(fromIndex: number, toIndex: number): void {
+    void onReorder(arrayMove(campaigns, fromIndex, toIndex));
+  }
+
   return (
     <section className="space-y-1.5">
       {/* The list owns its own heading: name, count and the search that filters
@@ -161,7 +167,7 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollaps
               <DragDropProvider onDragEnd={endDrag}>
                 <div ref={listRef} className="space-y-1">
                   {campaigns.map((campaign, index) => (
-                    <SortableCampaign key={campaign.id} campaign={campaign} index={index} farmingIndex={farmingIndex} anyFarming={anyFarming} game={gameMap[campaign.gameId] ?? fallbackGame(campaign, index, t)} expanded={Boolean(expandedIds[campaign.id])} refreshing={refreshing} onToggle={() => setExpandedIds((current) => ({ ...current, [campaign.id]: !current[campaign.id] }))} onRefreshCampaign={onRefreshCampaign} onToggleExclude={onToggleExclude} />
+                    <SortableCampaign key={campaign.id} campaign={campaign} index={index} farmingIndex={farmingIndex} anyFarming={anyFarming} game={gameMap[campaign.gameId] ?? fallbackGame(campaign, index, t)} expanded={Boolean(expandedIds[campaign.id])} refreshing={refreshing} onToggle={() => setExpandedIds((current) => ({ ...current, [campaign.id]: !current[campaign.id] }))} onRefreshCampaign={onRefreshCampaign} onToggleExclude={onToggleExclude} rankCount={campaigns.length} onRankMove={(toIndex) => moveCampaign(index, toIndex)} />
                   ))}
                 </div>
               </DragDropProvider>
@@ -173,7 +179,7 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollaps
   );
 }
 
-function SortableCampaign(props: { campaign: CampaignView; index: number; farmingIndex: number; anyFarming: boolean; game: GameItem; expanded: boolean; refreshing: boolean; onToggle(): void; onRefreshCampaign(id: string): void | Promise<void>; onToggleExclude(id: string): void | Promise<void> }) {
+function SortableCampaign(props: { campaign: CampaignView; index: number; farmingIndex: number; anyFarming: boolean; game: GameItem; expanded: boolean; refreshing: boolean; onToggle(): void; onRefreshCampaign(id: string): void | Promise<void>; onToggleExclude(id: string): void | Promise<void>; rankCount?: number; onRankMove?: (toIndex: number) => void }) {
   // The new dnd-kit animates the real element, so there is no DragOverlay copy
   // and no transform/transition to apply by hand.
   const { ref, handleRef, isDragging } = useSortable({ id: props.campaign.id, index: props.index });
@@ -184,7 +190,7 @@ function SortableCampaign(props: { campaign: CampaignView; index: number; farmin
   );
 }
 
-function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expanded, refreshing, onToggle, onRefreshCampaign, onToggleExclude, dragHandle, isOverlay = false, dimmed = false }: { campaign: CampaignView; index: number; farmingIndex: number; anyFarming: boolean; game: GameItem; expanded: boolean; refreshing: boolean; onToggle(): void; onRefreshCampaign(id: string): void | Promise<void>; onToggleExclude?(id: string): void | Promise<void>; dragHandle?: React.ReactNode; isOverlay?: boolean; dimmed?: boolean }) {
+function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expanded, refreshing, onToggle, onRefreshCampaign, onToggleExclude, dragHandle, isOverlay = false, dimmed = false, rankCount, onRankMove }: { campaign: CampaignView; index: number; farmingIndex: number; anyFarming: boolean; game: GameItem; expanded: boolean; refreshing: boolean; onToggle(): void; onRefreshCampaign(id: string): void | Promise<void>; onToggleExclude?(id: string): void | Promise<void>; dragHandle?: React.ReactNode; isOverlay?: boolean; dimmed?: boolean; rankCount?: number; onRankMove?: (toIndex: number) => void }) {
   const t = useT();
   const runtime = React.useContext(PopupRuntimeContext);
   // Where the pointer went down on the meta row, so drag-scrolling an
@@ -222,7 +228,7 @@ function CampaignCard({ campaign, index, farmingIndex, anyFarming, game, expande
             handle+index grammar CompactRow uses for watchlist rows. */}
         <div className="flex w-7 shrink-0 flex-col items-center justify-center gap-0.5 border-r border-zinc-100 bg-zinc-50/60 dark:border-zinc-800 dark:bg-zinc-800/40">
           {dragHandle ?? <GripVertical size={14} className="text-zinc-300 dark:text-zinc-600" />}
-          <span className="text-[10px] font-bold tabular leading-none" style={{ color: "var(--accent-text)" }}>{index + 1}</span>
+          <RankInput index={index} count={rankCount ?? 0} label={campaign.title} onMove={onRankMove} size="rail" />
         </div>
         {/* Full-area toggle behind the content so the page-link anchor can live next
             to the title without nesting an <a> inside a <button>. */}

--- a/packages/popup-ui/src/drops.tsx
+++ b/packages/popup-ui/src/drops.tsx
@@ -40,7 +40,7 @@ import {
   SearchBox,
   SectionHeader,
   cn,
-  moveById,
+  reorderFromDragEnd,
   preventNativeDrag,
   type SortableDragEndEvent,
 } from "./primitives";
@@ -108,10 +108,9 @@ export function DropsPanel({ campaigns, gameMap, focus, refreshing, startCollaps
   const anyFarming = campaigns.some((campaign) => Boolean(campaign.farmingChannel));
 
   function endDrag(event: SortableDragEndEvent): void {
-    if (event.canceled) return;
-    const { source, target } = event.operation;
-    if (!source || !target) return;
-    void onReorder(moveById(campaigns, String(source.id), String(target.id)));
+    const next = reorderFromDragEnd(campaigns, event);
+    if (next === campaigns) return;
+    void onReorder(next);
   }
 
   function moveCampaign(fromIndex: number, toIndex: number): void {

--- a/packages/popup-ui/src/idleWatchlist.tsx
+++ b/packages/popup-ui/src/idleWatchlist.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
+import { arrayMove } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { Eye, Play, Plus } from "lucide-react";
@@ -75,7 +76,17 @@ export function IdleWatchlistPanel({ platform, streamers, expanded, adding, onEx
               {streamers.length === 0 ? <EmptyPanel>{t("noIdleWatchlist")}</EmptyPanel> : (
                 <DragDropProvider onDragEnd={endDrag}>
                   <div className="space-y-1.5">
-                    {streamers.map((streamer, index) => <SortableIdleWatchlist key={streamer.id} streamer={streamer} index={index} platform={platform} onRemove={() => removeChannel(streamer.id)} />)}
+                    {streamers.map((streamer, index) => (
+                      <SortableIdleWatchlist
+                        key={streamer.id}
+                        streamer={streamer}
+                        index={index}
+                        count={streamers.length}
+                        platform={platform}
+                        onRemove={() => removeChannel(streamer.id)}
+                        onMove={(toIndex) => void onChange(arrayMove(streamers, index, toIndex))}
+                      />
+                    ))}
                   </div>
                 </DragDropProvider>
               )}
@@ -93,14 +104,14 @@ export function IdleWatchlistPanel({ platform, streamers, expanded, adding, onEx
   );
 }
 
-function SortableIdleWatchlist({ streamer, index, platform, onRemove }: { streamer: StreamerItem; index: number; platform: Platform; onRemove(): void }) {
+function SortableIdleWatchlist({ streamer, index, count, platform, onRemove, onMove }: { streamer: StreamerItem; index: number; count: number; platform: Platform; onRemove(): void; onMove(toIndex: number): void }) {
   // The new dnd-kit animates the real element, so there is no DragOverlay copy
   // and no transform/transition to apply by hand.
   const { ref, handleRef, isDragging } = useSortable({ id: streamer.id, index });
   const status = <IdleWatchlistStatus streamer={streamer} />;
   return (
     <div ref={ref} onDragStart={preventNativeDrag}>
-      <CompactRow index={index} avatar={streamer.name.slice(0, 2).toUpperCase()} avatarStyle={{ backgroundColor: "var(--accent-soft)", color: "var(--accent-text)" }} title={streamer.name} titleHref={channelUrl(platform, streamer.id)} subtitle={streamer.subtitle} dimmed={isDragging} dragHandle={<DragHandle handleRef={handleRef} label={`Reorder ${streamer.name}`} />} trailing={<span className="flex shrink-0 items-center gap-1.5">{status}<RemoveRowButton label={`Remove ${streamer.name}`} onClick={onRemove} /></span>} />
+      <CompactRow index={index} rankCount={count} rankLabel={streamer.name} onRankMove={onMove} avatar={streamer.name.slice(0, 2).toUpperCase()} avatarStyle={{ backgroundColor: "var(--accent-soft)", color: "var(--accent-text)" }} title={streamer.name} titleHref={channelUrl(platform, streamer.id)} subtitle={streamer.subtitle} dimmed={isDragging} dragHandle={<DragHandle handleRef={handleRef} label={`Reorder ${streamer.name}`} />} trailing={<span className="flex shrink-0 items-center gap-1.5">{status}<RemoveRowButton label={`Remove ${streamer.name}`} onClick={onRemove} /></span>} />
     </div>
   );
 }

--- a/packages/popup-ui/src/idleWatchlist.tsx
+++ b/packages/popup-ui/src/idleWatchlist.tsx
@@ -17,7 +17,7 @@ import {
   Pill,
   RemoveRowButton,
   SectionHeader,
-  moveById,
+  reorderFromDragEnd,
   preventNativeDrag,
   type SortableDragEndEvent,
 } from "./primitives";
@@ -30,10 +30,9 @@ export function IdleWatchlistPanel({ platform, streamers, expanded, adding, onEx
   const [value, setValue] = useState("");
 
   function endDrag(event: SortableDragEndEvent): void {
-    if (event.canceled) return;
-    const { source, target } = event.operation;
-    if (!source || !target) return;
-    void onChange(moveById(streamers, String(source.id), String(target.id)));
+    const next = reorderFromDragEnd(streamers, event);
+    if (next === streamers) return;
+    void onChange(next);
   }
 
   function addChannel(): void {

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -20,6 +20,20 @@ export function moveById<T extends { id: string }>(list: T[], activeId: string, 
   return arrayMove(list, oldIndex, newIndex);
 }
 
+export type CommitRankResult =
+  | { action: "cancel" }
+  | { action: "move"; toIndex: number };
+
+export function commitRank(raw: string, currentIndex: number, count: number): CommitRankResult {
+  const trimmed = raw.trim();
+  if (count < 1 || !/^\d+$/.test(trimmed)) return { action: "cancel" };
+  const n = Number(trimmed);
+  if (n < 1) return { action: "cancel" };
+  const toIndex = Math.min(n, count) - 1;
+  if (toIndex === currentIndex) return { action: "cancel" };
+  return { action: "move", toIndex };
+}
+
 // `compact` only trims the vertical padding — the icon offset and left padding
 // classes stay put because styles.css mirrors those exact class names for RTL.
 export function SearchBox({ value, onChange, placeholder, autoFocus = false, compact = false }: { value: string; onChange(value: string): void; placeholder: string; autoFocus?: boolean; compact?: boolean }) {

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -122,6 +122,87 @@ export function DragHandle({ handleRef, label }: { handleRef(element: Element | 
   );
 }
 
+export function RankInput({ index, count, label, onMove, size }: { index: number; count: number; label: string; onMove?: (toIndex: number) => void; size: "row" | "rail" }) {
+  const [editing, setEditing] = React.useState(false);
+  const [value, setValue] = React.useState(String(index + 1));
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const skipBlur = React.useRef(false);
+  const textClass = size === "rail"
+    ? "w-full min-w-0 text-center text-[10px] font-bold tabular leading-none"
+    : "w-4 text-center text-[11px] font-bold tabular";
+  const color: React.CSSProperties = { color: "var(--accent-text)" };
+
+  React.useEffect(() => {
+    if (editing) inputRef.current?.select();
+  }, [editing]);
+
+  if (!onMove) {
+    return <span className={textClass} style={color}>{index + 1}</span>;
+  }
+
+  // Local binding so nested `close` keeps the narrowed non-optional type.
+  const move = onMove;
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        aria-label={`Set rank of ${label}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          setValue(String(index + 1));
+          setEditing(true);
+        }}
+        onPointerDown={(event) => event.stopPropagation()}
+        className={cn(textClass, "rounded-sm outline-none hover:text-zinc-700 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] dark:hover:text-zinc-200")}
+        style={color}
+      >
+        {index + 1}
+      </button>
+    );
+  }
+
+  function close(commit: boolean): void {
+    skipBlur.current = !commit;
+    setEditing(false);
+    if (!commit) return;
+    const result = commitRank(value, index, count);
+    if (result.action === "move") move(result.toIndex);
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      autoFocus
+      inputMode="numeric"
+      aria-label={`Set rank of ${label}`}
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onBlur={() => {
+        if (skipBlur.current) {
+          skipBlur.current = false;
+          return;
+        }
+        close(true);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          close(false);
+        } else if (event.key === "Enter") {
+          event.preventDefault();
+          event.currentTarget.blur();
+        }
+      }}
+      onClick={(event) => event.stopPropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
+      className={cn(textClass, "bg-transparent p-0 outline-none focus:ring-1 focus:ring-[var(--accent-ring)]")}
+      style={color}
+    />
+  );
+}
+
 /** Collapsible group heading, used to fold the Idle Watchlist under the drops
  * list instead of hiding it behind a tab. `action` is a sibling of the toggle,
  * not a child: the section's own actions belong on its heading, and a button
@@ -174,6 +255,9 @@ export function CompactRow({
   avatarImageUrl,
   avatarStyle,
   index,
+  rankLabel,
+  rankCount,
+  onRankMove,
   title,
   titleHref,
   subtitle,
@@ -186,6 +270,9 @@ export function CompactRow({
   avatarImageUrl?: string;
   avatarStyle: React.CSSProperties;
   index: number;
+  rankLabel: string;
+  rankCount: number;
+  onRankMove(toIndex: number): void;
   title: string;
   titleHref?: string;
   subtitle?: string;
@@ -197,7 +284,7 @@ export function CompactRow({
   return (
     <div className={cn("flex items-center gap-2 rounded-xl border bg-white px-2 py-2 dark:bg-zinc-900", isOverlay ? "border-transparent shadow-2xl shadow-black/25" : "border-zinc-200 shadow-sm dark:border-zinc-800", dimmed && "opacity-40")}>
       {dragHandle}
-      <span className="w-4 text-center text-[11px] font-bold tabular" style={{ color: "var(--accent-text)" }}>{index + 1}</span>
+      <RankInput index={index} count={rankCount} label={rankLabel} onMove={onRankMove} size="row" />
       <span
         className={cn(
           "flex h-8 w-8 shrink-0 items-center justify-center text-[11px] font-bold",

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -133,7 +133,9 @@ export function RankInput({ index, count, label, onMove, size }: { index: number
   const color: React.CSSProperties = { color: "var(--accent-text)" };
 
   React.useEffect(() => {
-    if (editing) inputRef.current?.select();
+    if (!editing) return;
+    skipBlur.current = false;
+    inputRef.current?.select();
   }, [editing]);
 
   if (!onMove) {

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { arrayMove } from "@dnd-kit/helpers";
+import { move } from "@dnd-kit/helpers";
 import type { DragDropProvider } from "@dnd-kit/react";
 import { motion } from "motion/react";
 import { ChevronRight, GripVertical, Search, X, type LucideIcon } from "lucide-react";
@@ -12,12 +12,13 @@ export function cn(...classes: Array<string | false | null | undefined>): string
  * rather than pinning a hand-written shape. */
 export type SortableDragEndEvent = Parameters<NonNullable<React.ComponentProps<typeof DragDropProvider>["onDragEnd"]>>[0];
 
-export function moveById<T extends { id: string }>(list: T[], activeId: string, overId: string): T[] {
-  if (activeId === overId) return list;
-  const oldIndex = list.findIndex((item) => item.id === activeId);
-  const newIndex = list.findIndex((item) => item.id === overId);
-  if (oldIndex === -1 || newIndex === -1) return list;
-  return arrayMove(list, oldIndex, newIndex);
+/** @dnd-kit/react projects the dragged row into its new slot before drop, so
+ * the pointer is often still over that same row (`source.id === target.id`).
+ * Matching ids is a no-op if we only look at source/target ids; `move()` uses
+ * the sortable's projected `source.index` instead. */
+export function reorderFromDragEnd<T extends { id: string }>(list: T[], event: SortableDragEndEvent): T[] {
+  if (event.canceled) return list;
+  return move(list, event);
 }
 
 export type CommitRankResult =

--- a/packages/popup-ui/src/primitives.tsx
+++ b/packages/popup-ui/src/primitives.tsx
@@ -129,7 +129,7 @@ export function RankInput({ index, count, label, onMove, size }: { index: number
   const inputRef = React.useRef<HTMLInputElement>(null);
   const skipBlur = React.useRef(false);
   const textClass = size === "rail"
-    ? "w-full min-w-0 text-center text-[10px] font-bold tabular leading-none"
+    ? "flex w-4 items-center justify-center text-center text-[10px] font-bold tabular leading-none"
     : "w-4 text-center text-[11px] font-bold tabular";
   const color: React.CSSProperties = { color: "var(--accent-text)" };
 

--- a/packages/popup-ui/src/settingsPlatform.tsx
+++ b/packages/popup-ui/src/settingsPlatform.tsx
@@ -14,7 +14,7 @@ import {
   Pill,
   RemoveRowButton,
   Toggle,
-  moveById,
+  reorderFromDragEnd,
   preventNativeDrag,
   type SortableDragEndEvent,
 } from "./primitives";
@@ -145,10 +145,9 @@ function CategoryFilterEditor({ platform, categories, suggestions, onChange, onS
   }
 
   function endDrag(event: SortableDragEndEvent): void {
-    if (event.canceled) return;
-    const { source, target } = event.operation;
-    if (!source || !target) return;
-    void onChange(moveById(categories, String(source.id), String(target.id)));
+    const next = reorderFromDragEnd(categories, event);
+    if (next === categories) return;
+    void onChange(next);
   }
 
   const accentFor = (index: number): string => GAME_ACCENTS[index % GAME_ACCENTS.length];

--- a/packages/popup-ui/src/settingsPlatform.tsx
+++ b/packages/popup-ui/src/settingsPlatform.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { arrayMove } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { AlertTriangle, Plus, Search } from "lucide-react";
@@ -166,7 +167,19 @@ function CategoryFilterEditor({ platform, categories, suggestions, onChange, onS
         </div>
       ) : (
         <DragDropProvider onDragEnd={endDrag}>
-          <div className="space-y-1.5">{categories.map((category, index) => <SortableCategoryRow key={category.id} category={category} index={index} accent={accentFor(index)} onRemove={() => void onChange(categories.filter((entry) => entry.id !== category.id))} />)}</div>
+          <div className="space-y-1.5">
+            {categories.map((category, index) => (
+              <SortableCategoryRow
+                key={category.id}
+                category={category}
+                index={index}
+                count={categories.length}
+                accent={accentFor(index)}
+                onRemove={() => void onChange(categories.filter((entry) => entry.id !== category.id))}
+                onMove={(toIndex) => void onChange(arrayMove(categories, index, toIndex))}
+              />
+            ))}
+          </div>
         </DragDropProvider>
       )}
 
@@ -312,11 +325,11 @@ function CategoryPickerGroup({ label, items, onSelect }: {
   );
 }
 
-function SortableCategoryRow({ category, index, accent, onRemove }: { category: CategorySelection; index: number; accent: string; onRemove(): void }) {
+function SortableCategoryRow({ category, index, count, accent, onRemove, onMove }: { category: CategorySelection; index: number; count: number; accent: string; onRemove(): void; onMove(toIndex: number): void }) {
   const { ref, handleRef, isDragging } = useSortable({ id: category.id, index });
   return (
     <div ref={ref} onDragStart={preventNativeDrag}>
-      <CompactRow index={index} avatar={initials(category.name)} avatarImageUrl={category.imageUrl} avatarStyle={{ backgroundColor: accent, color: "#fff" }} title={category.name} dimmed={isDragging} dragHandle={<DragHandle handleRef={handleRef} label={`Reorder ${category.name}`} />} trailing={<RemoveRowButton label={`Remove ${category.name}`} onClick={onRemove} />} />
+      <CompactRow index={index} rankCount={count} rankLabel={category.name} onRankMove={onMove} avatar={initials(category.name)} avatarImageUrl={category.imageUrl} avatarStyle={{ backgroundColor: accent, color: "#fff" }} title={category.name} dimmed={isDragging} dragHandle={<DragHandle handleRef={handleRef} label={`Reorder ${category.name}`} />} trailing={<RemoveRowButton label={`Remove ${category.name}`} onClick={onRemove} />} />
     </div>
   );
 }

--- a/packages/site/src/changelog.json
+++ b/packages/site/src/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "1.12.2",
+    "changes": [
+      {
+        "kind": "new",
+        "text": "You can now click the sort number next to a drag handle and type a new position. This works on Drops campaigns, Idle Watchlist rows, and Settings categories. The item moves to that rank and the others shift, the same as dragging. While Drops search is open, the number stays view-only, matching drag."
+      },
+      {
+        "kind": "fixed",
+        "text": "Fixed a dragged row sometimes snapping back to its old place after you closed the popup. The list looked reordered on screen, but the saved order — including which campaign Lurkloot farms — did not change. Drops, Idle Watchlist, and category lists now keep the order you dropped."
+      }
+    ]
+  },
+  {
     "version": "1.12.1",
     "changes": [
       {


### PR DESCRIPTION
## Why

Reordering Drops, Idle Watchlist, or settings categories currently means scrolling and dragging. [#432](https://github.com/jamezrin/lurkloot/issues/432) asks to type a new 1-based rank instead.

Clicking the existing rank turns it into a small numeric field. Enter or blur insert-and-shifts via the same `arrayMove` path as drag; Escape cancels. Campaign search stays view-only (same as drag). No new settings keys.

This also fixes a pre-existing `@dnd-kit/react` drop bug: after a drag, the pointer is still over the moved row (`source.id === target.id`), so the old `moveById` helper no-op'd. Ranks stayed stale, the order reverted on popup close, and farming did not switch. Drag-end now uses the library `move()` projected index on Drops, Idle Watchlist, and settings categories.

## Testing

- [x] Drops: click a rank, type a new position, blur — item moves and neighbors shift
- [x] Drops: Escape then type again on the same row — the second commit applies
- [x] Drops search: rank stays a static number (not a button/input)
- [x] Idle Watchlist and settings category list: same click-to-type behavior
- [x] Grip drag reorders, ranks update, order persists, and a live channel dragged above the current one takes over

Closes #432