### PR TITLE
perf(twitch): reuse campaign details across scheduler ticks

### DIFF
--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -50,6 +50,19 @@ const GQL_BATCH_CONCURRENCY = 2;
 // enough to ride out an outage of many ticks, short enough that a campaign
 // Twitch quietly stopped serving does not linger for a whole session.
 const DISCOVERY_RETENTION_TTL_MS = 30 * 60_000;
+// How long a *successful* detail read may be reused instead of refetched. Far
+// shorter than the retention TTL above, which is an outage fallback: this is the
+// window in which a campaign the user is not watching cannot have changed in any
+// way this adapter would notice. Minutes watched and claim state for started
+// campaigns arrive from the Inventory payload every tick and are merged over
+// these details (mergeTwitchCampaignProgress), so what the cache holds back is
+// only the immutable half — name, images, reward tiers, allowed channels.
+const CAMPAIGN_DETAILS_FRESH_TTL_MS = 3 * 60_000;
+// Added on top of the base freshness, spread deterministically per campaign id.
+// Without it a cold start stamps every campaign with the same deadline and the
+// whole set re-expires on one tick, reproducing the full-batch refetch this is
+// meant to remove — just once every few minutes instead of every tick.
+const CAMPAIGN_DETAILS_FRESH_SPREAD_MS = 2 * 60_000;
 
 export interface TwitchAdapterOptions {
   // GQL Client-ID. Defaults to the web client. A headless runtime passes a
@@ -401,6 +414,16 @@ interface TwitchFollowedLiveData {
 
 interface CachedCampaignDetails {
   campaign: unknown;
+  // The dashboard's status for this campaign when the details were read. The
+  // dashboard is refetched every tick and is authoritative for status, so a
+  // campaign that has flipped (UPCOMING -> ACTIVE, #400) is refetched at once
+  // rather than waiting out its reuse window with a stale status. Undefined
+  // when no dashboard answered — see freshCampaignDetails.
+  dashboardStatus?: string;
+  // When this entry stops being reusable in place of a request. Lapsing only
+  // costs the campaign a refetch — it must never drop the entry, or #274's
+  // outage retention (expiresAt, far later) would be silently reduced to it.
+  freshUntil: number;
   expiresAt: number;
 }
 
@@ -439,6 +462,23 @@ export type ChannelAvailabilityLookup =
 export interface TwitchAvailabilityRequestIdentity {
   userId: string | undefined;
   generation: number;
+}
+
+// Deterministic per-campaign offset in [0, CAMPAIGN_DETAILS_FRESH_SPREAD_MS).
+// Deterministic rather than random so a campaign keeps its slot across ticks
+// and the same id always lands in the same place, which is what makes the
+// spread testable.
+function campaignDetailsFreshnessSpread(dropID: string): number {
+  // FNV-1a. A plain rolling sum reduced modulo a decimal constant collapses
+  // here: campaign ids share long prefixes and differ only in their last
+  // characters, which such a hash barely moves, so nearly every campaign lands
+  // in the same slot and the spread does nothing.
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < dropID.length; index += 1) {
+    hash ^= dropID.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return ((hash >>> 0) % CAMPAIGN_DETAILS_FRESH_SPREAD_MS);
 }
 
 export class TwitchDiscoveryState {
@@ -515,8 +555,12 @@ export class TwitchDiscoveryState {
     return this.retainedDashboard.campaignIds;
   }
 
-  rememberCampaignDetails(dropID: string, campaign: unknown): void {
+  rememberCampaignDetails(dropID: string, campaign: unknown, dashboardStatus?: string): void {
     const now = Date.now();
+    // A tick with no dashboard answer knows nothing about status; it must not
+    // erase what the last answering tick recorded, or the flip check below
+    // would go blind for a whole reuse window afterwards.
+    const status = dashboardStatus ?? this.campaignDetailsByDropId.get(dropID)?.dashboardStatus;
     let inspected = 0;
     for (const [cachedDropID, cached] of this.campaignDetailsByDropId) {
       if (inspected >= DISCOVERY_DETAIL_PRUNE_LIMIT) break;
@@ -525,12 +569,49 @@ export class TwitchDiscoveryState {
     }
     this.campaignDetailsByDropId.set(dropID, {
       campaign,
+      dashboardStatus: status,
+      freshUntil: now + CAMPAIGN_DETAILS_FRESH_TTL_MS + campaignDetailsFreshnessSpread(dropID),
       expiresAt: now + DISCOVERY_RETENTION_TTL_MS,
     });
   }
 
   forgetCampaignDetails(dropID: string): void {
     this.campaignDetailsByDropId.delete(dropID);
+  }
+
+  // Drops the entry's reuse window without dropping the entry: the next
+  // discovery refetches this campaign, while the payload stays available as
+  // outage retention until its normal expiry. Used when something outside
+  // discovery changed what a detail read would return — a claim, today.
+  expireCampaignDetailsFreshness(dropID: string): void {
+    const cached = this.campaignDetailsByDropId.get(dropID);
+    if (cached) cached.freshUntil = 0;
+  }
+
+  // The reuse path: details good enough to serve *instead of* a request, as
+  // opposed to retainedCampaignDetails below, which serves them only once a
+  // request has already failed. Deliberately does not delete on a lapsed
+  // freshness — only true expiry evicts.
+  // dashboardStatus is this tick's authoritative status for the campaign, or
+  // undefined when no dashboard answered — in which case there is nothing to
+  // compare against and reuse rides on the deadlines alone.
+  freshCampaignDetails(dropID: string, dashboardStatus?: string): unknown {
+    const cached = this.campaignDetailsByDropId.get(dropID);
+    if (!cached) return undefined;
+    const now = Date.now();
+    if (cached.expiresAt <= now) {
+      this.campaignDetailsByDropId.delete(dropID);
+      return undefined;
+    }
+    if (cached.freshUntil <= now) return undefined;
+    if (
+      dashboardStatus !== undefined
+      && cached.dashboardStatus !== undefined
+      && cached.dashboardStatus !== dashboardStatus
+    ) {
+      return undefined;
+    }
+    return cached.campaign;
   }
 
   retainedCampaignDetails(dropID: string): unknown {
@@ -863,6 +944,10 @@ export class TwitchAdapter implements PlatformAdapter {
 
   private async discoverCampaignSnapshot(
     { signal }: AdapterOperationOptions = {},
+    // The campaign being farmed right now, if any. Its details always come from
+    // a fresh request: it is the one campaign whose `self` block moves between
+    // ticks, and the one whose reward progress a stale read would visibly delay.
+    farmedCampaignId?: string,
   ): Promise<DropCampaign[]> {
     let [inventory, dashboardResult] = await Promise.all([
       this.fetchInventory({ signal }),
@@ -918,6 +1003,14 @@ export class TwitchAdapter implements PlatformAdapter {
         && (campaign.status === "ACTIVE" || campaign.status === "UPCOMING")
       )
       .map((campaign) => campaign.id as string);
+    // Only from a dashboard that actually answered: a retained id list carries
+    // no status, and treating "unknown" as a status would refetch everything.
+    const dashboardStatusById = new Map<string, string>();
+    if (dashboardResult.ok) {
+      for (const campaign of dashboardCampaigns) {
+        if (campaign.id && campaign.status) dashboardStatusById.set(campaign.id, campaign.status);
+      }
+    }
 
     // A failed dashboard parses to the same empty list as a dashboard with no
     // active drops, and the Inventory payload only carries campaigns the user
@@ -942,25 +1035,58 @@ export class TwitchAdapter implements PlatformAdapter {
       );
     }
 
+    // Campaigns whose details we already hold and that nothing can have changed
+    // since (see CAMPAIGN_DETAILS_FRESH_TTL_MS) cost no request this tick. The
+    // farmed campaign is never served from cache, and an unauthenticated pass
+    // has no identity to key reuse on, so it always refetches.
+    const cachedDetailsByDropId = new Map<string, unknown>();
+    const dropIdsToFetch: string[] = [];
+    for (const dropID of discoverableCampaignIds) {
+      const cached = authenticatedUserId && dropID !== farmedCampaignId
+        ? this.discoveryState.freshCampaignDetails(dropID, dashboardStatusById.get(dropID))
+        : undefined;
+      if (cached === undefined) dropIdsToFetch.push(dropID);
+      else cachedDetailsByDropId.set(dropID, cached);
+    }
+
     const detailsStartedAt = Date.now();
-    const detailFetch = await this.fetchCampaignDetails(discoverableCampaignIds, userLogin, signal);
-    const details = detailFetch.results;
+    const detailFetch = dropIdsToFetch.length > 0
+      ? await this.fetchCampaignDetails(dropIdsToFetch, userLogin, signal)
+      : { results: [], batchRequests: 0, singleFallbacks: 0 };
+    // Kept on an all-cache-hit tick too: a missing line would read as a dead
+    // code path exactly in the steady state this cache exists to produce.
     diagnostic(
       this.emit,
       "debug",
-      `Twitch campaign details finished in ${Date.now() - detailsStartedAt}ms (${discoverableCampaignIds.length} operations: ${detailFetch.batchRequests} batch requests, ${detailFetch.singleFallbacks} single fallbacks)`,
+      `Twitch campaign details finished in ${Date.now() - detailsStartedAt}ms (${discoverableCampaignIds.length} campaigns: ${dropIdsToFetch.length} fetched in ${detailFetch.batchRequests} batch requests, ${detailFetch.singleFallbacks} single fallbacks, ${cachedDetailsByDropId.size} served from cache)`,
       "twitch",
     );
     signal?.throwIfAborted();
-    for (const result of details) {
+    for (const result of detailFetch.results) {
       if (result.status === "rejected" && authHealthFromError(result.reason)) throw result.reason;
     }
+    // Keyed by drop id rather than read positionally: only a subset of the
+    // dashboard's campaigns is fetched, so results[i] no longer lines up with
+    // discoverableCampaignIds[i], and getting that wrong would file one
+    // campaign's payload under another's id with nothing to catch it.
+    const fetchedByDropId = new Map<string, PromiseSettledResult<TwitchGqlResponse<TwitchCampaignDetailsData>>>();
+    detailFetch.results.forEach((result, index) => {
+      const dropID = dropIdsToFetch[index];
+      if (dropID !== undefined) fetchedByDropId.set(dropID, result);
+    });
     // A campaign the user has not started is only ever described by its detail
     // request, so dropping a rejection loses the campaign entirely. Serve the
     // last details we saw for it instead, and never lose the failure silently.
+    // Iterated in dashboard order so reuse cannot reorder the snapshot.
     const detailedCampaigns: unknown[] = [];
-    details.forEach((result, index) => {
-      const dropID = discoverableCampaignIds[index];
+    discoverableCampaignIds.forEach((dropID) => {
+      const cached = cachedDetailsByDropId.get(dropID);
+      if (cached !== undefined) {
+        detailedCampaigns.push(cached);
+        return;
+      }
+      const result = fetchedByDropId.get(dropID);
+      if (!result) return;
       if (result.status === "fulfilled") {
         const data = result.value.data;
         const campaign = data?.dropCampaign ?? data?.user?.dropCampaign;
@@ -980,7 +1106,9 @@ export class TwitchAdapter implements PlatformAdapter {
           }
           return;
         }
-        if (authenticatedUserId) this.discoveryState.rememberCampaignDetails(dropID, campaign);
+        if (authenticatedUserId) {
+          this.discoveryState.rememberCampaignDetails(dropID, campaign, dashboardStatusById.get(dropID));
+        }
         detailedCampaigns.push(campaign);
         return;
       }
@@ -1021,7 +1149,7 @@ export class TwitchAdapter implements PlatformAdapter {
     session?: WatchSession,
     options: AdapterOperationOptions = {},
   ): Promise<DropCampaign[]> {
-    const campaigns = await this.discoverCampaignSnapshot(options);
+    const campaigns = await this.discoverCampaignSnapshot(options, session?.campaignId);
     if (!session?.channel || session.status !== "watching") return campaigns;
     return this.mergeCurrentSessionProgress(campaigns, session.channel, options.signal);
   }
@@ -1927,8 +2055,17 @@ export class TwitchAdapter implements PlatformAdapter {
     // fast path when a token is already captured.
     await this.ensureIntegrity({ signal });
 
+    // A successful claim changes what a detail read returns for this campaign
+    // (`self { isClaimed dropInstanceID }`), so its reuse window ends here even
+    // though nothing about discovery has run yet. Freshness only: the payload
+    // stays available as outage retention until its normal expiry.
+    const invalidateOnClaim = (claimed: boolean): boolean => {
+      if (claimed && campaign.id) this.discoveryState.expireCampaignDetailsFreshness(campaign.id);
+      return claimed;
+    };
+
     try {
-      return await this.runClaim(reward, signal);
+      return invalidateOnClaim(await this.runClaim(reward, signal));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // Only integrity rejections are worth a refresh + retry; everything else
@@ -1940,7 +2077,7 @@ export class TwitchAdapter implements PlatformAdapter {
       // propagates.
       const rejectedToken = sentIntegrityToken(error);
       const retry = await refreshIntegrityForRetry(this.ensureIntegrity, rejectedToken, signal);
-      if (retry.refreshed) return await this.runClaim(reward, signal, retry.integrity);
+      if (retry.refreshed) return invalidateOnClaim(await this.runClaim(reward, signal, retry.integrity));
       throw new Error(`Twitch rejected the claim for ${reward.name} (${message}). Keep a logged-in twitch.tv tab open so the extension can capture a valid integrity token, then retry.`);
     }
   }

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -555,7 +555,18 @@ export class TwitchDiscoveryState {
     return this.retainedDashboard.campaignIds;
   }
 
-  rememberCampaignDetails(dropID: string, campaign: unknown, dashboardStatus?: string): void {
+  rememberCampaignDetails(
+    dropID: string,
+    campaign: unknown,
+    dashboardStatus: string | undefined,
+    requestIdentity: TwitchAvailabilityRequestIdentity,
+  ): boolean {
+    if (
+      requestIdentity.userId !== this.authenticatedUserId
+      || requestIdentity.generation !== this.availabilityGeneration
+    ) {
+      return false;
+    }
     const now = Date.now();
     // A tick with no dashboard answer knows nothing about status; it must not
     // erase what the last answering tick recorded, or the flip check below
@@ -573,10 +584,20 @@ export class TwitchDiscoveryState {
       freshUntil: now + CAMPAIGN_DETAILS_FRESH_TTL_MS + campaignDetailsFreshnessSpread(dropID),
       expiresAt: now + DISCOVERY_RETENTION_TTL_MS,
     });
+    return true;
   }
 
-  forgetCampaignDetails(dropID: string): void {
-    this.campaignDetailsByDropId.delete(dropID);
+  forgetCampaignDetails(
+    dropID: string,
+    requestIdentity: TwitchAvailabilityRequestIdentity,
+  ): boolean {
+    if (
+      requestIdentity.userId !== this.authenticatedUserId
+      || requestIdentity.generation !== this.availabilityGeneration
+    ) {
+      return false;
+    }
+    return this.campaignDetailsByDropId.delete(dropID);
   }
 
   // Drops the entry's reuse window without dropping the entry: the next
@@ -997,6 +1018,11 @@ export class TwitchAdapter implements PlatformAdapter {
       diagnostic(this.emit, "debug", "Twitch authenticated identity changed; discovery caches cleared", "twitch");
     }
     const userLogin = authenticatedUserId ?? dashboard.data?.currentUser?.login ?? "";
+    // Captured after installing this response's identity and replayed when the
+    // asynchronous detail requests settle. A request from an older identity
+    // may still finish after a later tick clears the cache; it must answer its
+    // own caller without repopulating shared state for the new identity.
+    const detailsRequestIdentity = this.discoveryState.availabilityRequestIdentity();
     const freshCampaignIds = dashboardCampaigns
       .filter((campaign) =>
         campaign.id
@@ -1102,12 +1128,17 @@ export class TwitchAdapter implements PlatformAdapter {
             ),
           );
           if (authenticatedUserId && campaignWasAuthoritativelyMissing) {
-            this.discoveryState.forgetCampaignDetails(dropID);
+            this.discoveryState.forgetCampaignDetails(dropID, detailsRequestIdentity);
           }
           return;
         }
         if (authenticatedUserId) {
-          this.discoveryState.rememberCampaignDetails(dropID, campaign, dashboardStatusById.get(dropID));
+          this.discoveryState.rememberCampaignDetails(
+            dropID,
+            campaign,
+            dashboardStatusById.get(dropID),
+            detailsRequestIdentity,
+          );
         }
         detailedCampaigns.push(campaign);
         return;

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2044,9 +2044,19 @@ describe("TwitchAdapter", () => {
         campaignDetailsByDropId: Map<string, unknown>;
       }).campaignDetailsByDropId;
 
-      discoveryState.rememberCampaignDetails("expired", { id: "expired" });
+      discoveryState.rememberCampaignDetails(
+        "expired",
+        { id: "expired" },
+        undefined,
+        discoveryState.availabilityRequestIdentity(),
+      );
       vi.setSystemTime("2026-07-26T12:31:00.000Z");
-      discoveryState.rememberCampaignDetails("fresh", { id: "fresh" });
+      discoveryState.rememberCampaignDetails(
+        "fresh",
+        { id: "fresh" },
+        undefined,
+        discoveryState.availabilityRequestIdentity(),
+      );
 
       expect([...details.keys()]).toEqual(["fresh"]);
     } finally {

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -1641,7 +1641,7 @@ describe("TwitchAdapter", () => {
     expect(emit).toHaveBeenCalledWith(expect.objectContaining({
       category: "diagnostic",
       platform: "twitch",
-      message: expect.stringMatching(/^Twitch campaign details finished in \d+ms \(41 operations: 3 batch requests, 0 single fallbacks\)$/),
+      message: expect.stringMatching(/^Twitch campaign details finished in \d+ms \(41 campaigns: 41 fetched in 3 batch requests, 0 single fallbacks, 0 served from cache\)$/),
     }));
   });
 
@@ -1723,13 +1723,22 @@ describe("TwitchAdapter", () => {
     const discoveryState = new TwitchDiscoveryState();
     const firstAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
 
-    expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
-    failing = "b";
-    const secondAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
-    const campaigns = await secondAdapter.refreshCampaigns();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-31T12:00:00.000Z");
+      expect((await firstAdapter.refreshCampaigns()).map((campaign) => campaign.id)).toEqual(["a", "b"]);
+      failing = "b";
+      // Past the detail reuse window, so "b" is actually re-requested and can
+      // fail; retention is what has to carry it, not the reuse cache.
+      vi.setSystemTime("2026-08-31T12:10:00.000Z");
+      const secondAdapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState }, (event) => events.push(event));
+      const campaigns = await secondAdapter.refreshCampaigns();
 
-    expect(campaigns.map((campaign) => campaign.id)).toEqual(["a", "b"]);
-    expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("b"))).toBe(true);
+      expect(campaigns.map((campaign) => campaign.id)).toEqual(["a", "b"]);
+      expect(events.some((event) => event.category === "diagnostic" && event.level === "warn" && event.message.includes("b"))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("omits a campaign whose details request fails before it was ever seen, but records it", async () => {
@@ -2004,15 +2013,26 @@ describe("TwitchAdapter", () => {
     });
     const discoveryState = new TwitchDiscoveryState();
 
-    expect((await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
-      .map((campaign) => campaign.id)).toEqual(["campaign"]);
-    detailResponse = "missing";
-    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
-      .resolves.toEqual([]);
-    detailResponse = "failure";
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-31T12:00:00.000Z");
+      expect((await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+        .map((campaign) => campaign.id)).toEqual(["campaign"]);
+      detailResponse = "missing";
+      // Each later refresh is stepped past the detail reuse window so it issues
+      // a real request: reuse must not stand in for the authoritative "no such
+      // campaign" answer this test is about.
+      vi.setSystemTime("2026-08-31T12:10:00.000Z");
+      await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+        .resolves.toEqual([]);
+      detailResponse = "failure";
 
-    await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
-      .resolves.toEqual([]);
+      vi.setSystemTime("2026-08-31T12:20:00.000Z");
+      await expect(twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns())
+        .resolves.toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("prunes expired retained campaign details during a later write", () => {

--- a/packages/extension/tests/twitchCampaignDetailsReuse.test.ts
+++ b/packages/extension/tests/twitchCampaignDetailsReuse.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PageFetcher } from "@lurkloot/core/adapter";
+import { TwitchDiscoveryState } from "@lurkloot/core/twitch";
+import type { EngineEvent } from "@lurkloot/shared/events";
+import type { DropCampaign, DropReward, WatchSession } from "@lurkloot/shared/models";
+import { twitchAdapter } from "./helpers/adapters";
+
+// #339: campaign details were refetched for every dashboard-listed campaign on
+// every tick. They are now reused for a short, per-campaign-spread window, so
+// what these tests pin down is exactly when a request must still happen.
+
+const REUSE_WINDOW_MS = 5 * 60_000 + 1;
+
+function dashboard(campaigns: readonly { id: string; status?: string }[]): unknown {
+  return {
+    data: {
+      currentUser: {
+        id: "user-id",
+        login: "viewer",
+        dropCampaigns: campaigns.map(({ id, status }) => ({
+          id,
+          status: status ?? "ACTIVE",
+          self: { isAccountConnected: true },
+        })),
+      },
+    },
+  };
+}
+
+function details(dropID: string): unknown {
+  return {
+    data: {
+      dropCampaign: {
+        id: dropID,
+        name: `Campaign ${dropID}`,
+        game: { id: "game", slug: "game-slug", displayName: "Game" },
+        timeBasedDrops: [{
+          id: `${dropID}-drop`,
+          requiredMinutesWatched: 60,
+          benefitEdges: [{ benefit: { id: "benefit", name: "Reward" } }],
+        }],
+      },
+    },
+  };
+}
+
+const EMPTY_INVENTORY = {
+  data: { currentUser: { id: "user-id", inventory: { dropCampaignsInProgress: [] } } },
+};
+
+// Records which campaigns each refresh actually asked Twitch about, which is
+// the whole measurement #339 is after.
+function detailRecordingFetcher(
+  listedCampaigns: () => readonly { id: string; status?: string }[],
+): { fetcher: PageFetcher; requested: string[]; claims: number } {
+  const requested: string[] = [];
+  const state = { claims: 0 };
+  const handle = (body: Record<string, unknown>): unknown => {
+    const op = body.operationName;
+    if (op === "Inventory") return EMPTY_INVENTORY;
+    if (op === "ViewerDropsDashboard") return dashboard(listedCampaigns());
+    if (op === "DropCampaignDetails") {
+      const dropID = String((body.variables as { dropID?: string }).dropID);
+      requested.push(dropID);
+      return details(dropID);
+    }
+    if (op === "DropsPage_ClaimDropRewards") {
+      state.claims += 1;
+      return { data: { claimDropRewards: { status: "ELIGIBLE_FOR_ALL" } } };
+    }
+    throw new Error(`Unexpected operation ${String(op)}`);
+  };
+  const fetcher: PageFetcher = {
+    fetchJson: vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as
+        | Record<string, unknown>
+        | Record<string, unknown>[];
+      return Array.isArray(body) ? body.map(handle) : handle(body);
+    }) as PageFetcher["fetchJson"],
+  };
+  return { fetcher, requested, get claims() { return state.claims; } };
+}
+
+describe("twitch campaign details reuse (#339)", () => {
+  it("serves a steady-state tick from cache instead of refetching every campaign", async () => {
+    const listed = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const { fetcher, requested } = detailRecordingFetcher(() => listed);
+    const discoveryState = new TwitchDiscoveryState();
+    const events: EngineEvent[] = [];
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-31T12:00:00.000Z");
+      const first = await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+      expect(requested).toEqual(["a", "b", "c"]);
+
+      vi.setSystemTime("2026-08-31T12:01:00.000Z");
+      const second = await twitchAdapter(
+        fetcher,
+        undefined,
+        undefined,
+        { discoveryState },
+        (event) => events.push(event),
+      ).refreshCampaigns();
+
+      expect(requested).toEqual(["a", "b", "c"]);
+      expect(second.map((campaign) => campaign.id)).toEqual(first.map((campaign) => campaign.id));
+      expect(events.some((event) =>
+        event.category === "diagnostic"
+        && /^Twitch campaign details finished in \d+ms \(3 campaigns: 0 fetched in 0 batch requests, 0 single fallbacks, 3 served from cache\)$/.test(event.message))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fetches a campaign the dashboard lists for the first time on the tick it appears", async () => {
+    let listed: { id: string }[] = [{ id: "a" }, { id: "b" }];
+    const { fetcher, requested } = detailRecordingFetcher(() => listed);
+    const discoveryState = new TwitchDiscoveryState();
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-31T12:00:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+      requested.length = 0;
+
+      listed = [{ id: "a" }, { id: "b" }, { id: "new" }];
+      vi.setSystemTime("2026-08-31T12:01:00.000Z");
+      const campaigns = await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+
+      expect(requested).toEqual(["new"]);
+      // Reuse must not reorder the snapshot: it stays in dashboard order.
+      expect(campaigns.map((campaign) => campaign.id)).toEqual(["a", "b", "new"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("always refetches the campaign being farmed", async () => {
+    const listed = [{ id: "a" }, { id: "farmed" }];
+    const { fetcher, requested } = detailRecordingFetcher(() => listed);
+    const discoveryState = new TwitchDiscoveryState();
+    // No channel, so discovery returns without the watched-session progress
+    // merge; only the reuse decision is under test here.
+    const session: WatchSession = { platform: "twitch", campaignId: "farmed", status: "starting", offlineChecks: 0 };
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-31T12:00:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(session);
+      requested.length = 0;
+
+      vi.setSystemTime("2026-08-31T12:01:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns(session);
+
+      expect(requested).toEqual(["farmed"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refetches a campaign whose dashboard status changed inside the reuse window", async () => {
+    let listed: { id: string; status?: string }[] = [{ id: "a" }, { id: "starting", status: "UPCOMING" }];
+    const { fetcher, requested } = detailRecordingFetcher(() => listed);
+    const discoveryState = new TwitchDiscoveryState();
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-31T12:00:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+      requested.length = 0;
+
+      listed = [{ id: "a" }, { id: "starting", status: "ACTIVE" }];
+      vi.setSystemTime("2026-08-31T12:01:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+
+      expect(requested).toEqual(["starting"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ends a campaign's reuse window when one of its rewards is claimed", async () => {
+    const listed = [{ id: "a" }, { id: "claimed" }];
+    const { fetcher, requested } = detailRecordingFetcher(() => listed);
+    const discoveryState = new TwitchDiscoveryState();
+    const adapter = twitchAdapter(fetcher, undefined, undefined, { discoveryState });
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-31T12:00:00.000Z");
+      await adapter.refreshCampaigns();
+      requested.length = 0;
+
+      const campaign = { id: "claimed", name: "Campaign claimed" } as DropCampaign;
+      const reward = { id: "claimed-drop", name: "Reward", claimId: "instance-1" } as DropReward;
+      expect(await adapter.claimReward(campaign, reward)).toBe(true);
+
+      vi.setSystemTime("2026-08-31T12:01:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+
+      expect(requested).toEqual(["claimed"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spreads reuse deadlines so a cold batch does not all re-expire on one tick", async () => {
+    const listed = Array.from({ length: 40 }, (_, index) => ({ id: `campaign-${index}` }));
+    const { fetcher, requested } = detailRecordingFetcher(() => listed);
+    const discoveryState = new TwitchDiscoveryState();
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-31T12:00:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+      requested.length = 0;
+
+      // Past the base freshness but inside the spread: some campaigns are due,
+      // most are not. A single shared deadline would refetch all 40 here.
+      vi.setSystemTime("2026-08-31T12:04:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+
+      expect(requested.length).toBeGreaterThan(0);
+      expect(requested.length).toBeLessThan(listed.length);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refetches after a service-worker restart discards the in-memory cache", async () => {
+    const listed = [{ id: "a" }, { id: "b" }];
+    const { fetcher, requested } = detailRecordingFetcher(() => listed);
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime("2026-08-31T12:00:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState: new TwitchDiscoveryState() }).refreshCampaigns();
+      requested.length = 0;
+
+      vi.setSystemTime("2026-08-31T12:01:00.000Z");
+      await twitchAdapter(fetcher, undefined, undefined, { discoveryState: new TwitchDiscoveryState() }).refreshCampaigns();
+
+      expect(requested).toEqual(["a", "b"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  describe("TwitchDiscoveryState", () => {
+    it("keeps outage retention alive after the reuse window lapses", () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        vi.setSystemTime("2026-08-31T12:00:00.000Z");
+        const discoveryState = new TwitchDiscoveryState();
+        discoveryState.rememberCampaignDetails("a", { id: "a" });
+
+        vi.setSystemTime(new Date("2026-08-31T12:00:00.000Z").getTime() + REUSE_WINDOW_MS);
+        // #274's failure fallback outlives reuse by design: a lapsed reuse
+        // window costs a request, it must never drop the payload.
+        expect(discoveryState.freshCampaignDetails("a")).toBeUndefined();
+        expect(discoveryState.retainedCampaignDetails("a")).toEqual({ id: "a" });
+
+        vi.setSystemTime("2026-08-31T12:31:00.000Z");
+        expect(discoveryState.retainedCampaignDetails("a")).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("drops reusable details when the authenticated identity changes", () => {
+      const discoveryState = new TwitchDiscoveryState();
+      discoveryState.setAuthenticatedUser("user-a");
+      discoveryState.rememberCampaignDetails("a", { id: "a" });
+      expect(discoveryState.freshCampaignDetails("a")).toEqual({ id: "a" });
+
+      discoveryState.setAuthenticatedUser("user-b");
+
+      expect(discoveryState.freshCampaignDetails("a")).toBeUndefined();
+      expect(discoveryState.retainedCampaignDetails("a")).toBeUndefined();
+    });
+
+    it("keeps the last known dashboard status when a tick has no dashboard answer", () => {
+      const discoveryState = new TwitchDiscoveryState();
+      discoveryState.rememberCampaignDetails("a", { id: "a" }, "UPCOMING");
+      discoveryState.rememberCampaignDetails("a", { id: "a" }, undefined);
+
+      // Still comparable against a later dashboard answer, so the flip is not
+      // lost just because one tick could not reach the dashboard.
+      expect(discoveryState.freshCampaignDetails("a", "ACTIVE")).toBeUndefined();
+      expect(discoveryState.freshCampaignDetails("a", "UPCOMING")).toEqual({ id: "a" });
+    });
+  });
+});

--- a/packages/extension/tests/twitchCampaignDetailsReuse.test.ts
+++ b/packages/extension/tests/twitchCampaignDetailsReuse.test.ts
@@ -11,6 +11,14 @@ import { twitchAdapter } from "./helpers/adapters";
 
 const REUSE_WINDOW_MS = 5 * 60_000 + 1;
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 function dashboard(campaigns: readonly { id: string; status?: string }[]): unknown {
   return {
     data: {
@@ -247,13 +255,111 @@ describe("twitch campaign details reuse (#339)", () => {
     }
   });
 
+  it("does not let an old identity refresh overwrite the current identity's details cache", async () => {
+    let activeUser = { id: "user-a-id", login: "user-a" };
+    const oldDetails = deferred<unknown>();
+    const oldDetailsStarted = deferred<void>();
+    let userBDetailRequests = 0;
+    const fetcher: PageFetcher = {
+      fetchJson: vi.fn(async (_url: string, init?: RequestInit) => {
+        const request = JSON.parse(String(init?.body)) as
+          | Record<string, unknown>
+          | Record<string, unknown>[];
+        const respond = async (body: Record<string, unknown>): Promise<unknown> => {
+          if (body.operationName === "Inventory") {
+            return {
+              data: {
+                currentUser: {
+                  id: activeUser.id,
+                  inventory: { dropCampaignsInProgress: [] },
+                },
+              },
+            };
+          }
+          if (body.operationName === "ViewerDropsDashboard") {
+            return {
+              data: {
+                currentUser: {
+                  ...activeUser,
+                  dropCampaigns: [{
+                    id: "campaign",
+                    status: "ACTIVE",
+                    self: { isAccountConnected: true },
+                  }],
+                },
+              },
+            };
+          }
+          if (body.operationName === "DropCampaignDetails") {
+            const login = String((body.variables as { channelLogin?: string }).channelLogin);
+            if (login === "user-a-id") {
+              oldDetailsStarted.resolve();
+              return oldDetails.promise;
+            }
+            userBDetailRequests += 1;
+            return {
+              data: {
+                dropCampaign: {
+                  ...(details("campaign") as { data: { dropCampaign: Record<string, unknown> } }).data.dropCampaign,
+                  name: "Campaign from user B",
+                },
+              },
+            };
+          }
+          throw new Error(`Unexpected operation ${String(body.operationName)}`);
+        };
+        return Array.isArray(request)
+          ? Promise.all(request.map(respond))
+          : respond(request);
+      }) as PageFetcher["fetchJson"],
+    };
+    const discoveryState = new TwitchDiscoveryState();
+
+    const oldRefresh = twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
+    await oldDetailsStarted.promise;
+
+    activeUser = { id: "user-b-id", login: "user-b" };
+    const currentRefresh = await twitchAdapter(
+      fetcher,
+      undefined,
+      undefined,
+      { discoveryState },
+    ).refreshCampaigns();
+    expect(currentRefresh[0]?.name).toBe("Campaign from user B");
+
+    oldDetails.resolve({
+      data: {
+        dropCampaign: {
+          ...(details("campaign") as { data: { dropCampaign: Record<string, unknown> } }).data.dropCampaign,
+          name: "Campaign from user A",
+        },
+      },
+    });
+    await oldRefresh;
+
+    const nextCurrentRefresh = await twitchAdapter(
+      fetcher,
+      undefined,
+      undefined,
+      { discoveryState },
+    ).refreshCampaigns();
+
+    expect(userBDetailRequests).toBe(1);
+    expect(nextCurrentRefresh[0]?.name).toBe("Campaign from user B");
+  });
+
   describe("TwitchDiscoveryState", () => {
     it("keeps outage retention alive after the reuse window lapses", () => {
       vi.useFakeTimers({ toFake: ["Date"] });
       try {
         vi.setSystemTime("2026-08-31T12:00:00.000Z");
         const discoveryState = new TwitchDiscoveryState();
-        discoveryState.rememberCampaignDetails("a", { id: "a" });
+        discoveryState.rememberCampaignDetails(
+          "a",
+          { id: "a" },
+          undefined,
+          discoveryState.availabilityRequestIdentity(),
+        );
 
         vi.setSystemTime(new Date("2026-08-31T12:00:00.000Z").getTime() + REUSE_WINDOW_MS);
         // #274's failure fallback outlives reuse by design: a lapsed reuse
@@ -271,7 +377,12 @@ describe("twitch campaign details reuse (#339)", () => {
     it("drops reusable details when the authenticated identity changes", () => {
       const discoveryState = new TwitchDiscoveryState();
       discoveryState.setAuthenticatedUser("user-a");
-      discoveryState.rememberCampaignDetails("a", { id: "a" });
+      discoveryState.rememberCampaignDetails(
+        "a",
+        { id: "a" },
+        undefined,
+        discoveryState.availabilityRequestIdentity(),
+      );
       expect(discoveryState.freshCampaignDetails("a")).toEqual({ id: "a" });
 
       discoveryState.setAuthenticatedUser("user-b");
@@ -280,10 +391,31 @@ describe("twitch campaign details reuse (#339)", () => {
       expect(discoveryState.retainedCampaignDetails("a")).toBeUndefined();
     });
 
+    it("does not let an old identity response delete the current identity's details", () => {
+      const discoveryState = new TwitchDiscoveryState();
+      discoveryState.setAuthenticatedUser("user-a");
+      const oldRequestIdentity = discoveryState.availabilityRequestIdentity();
+
+      discoveryState.setAuthenticatedUser("user-b");
+      discoveryState.rememberCampaignDetails(
+        "campaign",
+        { id: "campaign", owner: "user-b" },
+        "ACTIVE",
+        discoveryState.availabilityRequestIdentity(),
+      );
+
+      expect(discoveryState.forgetCampaignDetails("campaign", oldRequestIdentity)).toBe(false);
+      expect(discoveryState.retainedCampaignDetails("campaign")).toEqual({
+        id: "campaign",
+        owner: "user-b",
+      });
+    });
+
     it("keeps the last known dashboard status when a tick has no dashboard answer", () => {
       const discoveryState = new TwitchDiscoveryState();
-      discoveryState.rememberCampaignDetails("a", { id: "a" }, "UPCOMING");
-      discoveryState.rememberCampaignDetails("a", { id: "a" }, undefined);
+      const requestIdentity = discoveryState.availabilityRequestIdentity();
+      discoveryState.rememberCampaignDetails("a", { id: "a" }, "UPCOMING", requestIdentity);
+      discoveryState.rememberCampaignDetails("a", { id: "a" }, undefined, requestIdentity);
 
       // Still comparable against a later dashboard answer, so the flip is not
       // lost just because one tick could not reach the dashboard.


### PR DESCRIPTION
## Summary

Restarts #339 along the lines of the review that closed #342: a read-through cache **entirely in memory, inside `TwitchDiscoveryState`**. No `SchedulerState` field, no `models.ts` change, no `defaults.ts` validator, no storage migration, no Twitch payload knowledge outside `packages/core/src/platforms/twitch/`.

`discoverCampaignSnapshot()` called `fetchCampaignDetails()` for every dashboard-listed ACTIVE/UPCOMING campaign on every tick, while `retainedCampaignDetails()` was consulted only in the rejected-result branch. Details are now reused for a short window and a request is spent only on what can actually have changed.

## What earns a request

- the campaign being farmed (`session.campaignId`, threaded through `refreshCampaigns`) — its `self { currentMinutesWatched isClaimed dropInstanceID }` moves every tick;
- any campaign the dashboard lists for the first time;
- any campaign whose **dashboard status changed** inside the window — this is what keeps the #400 `UPCOMING -> ACTIVE` case immediate;
- any campaign whose reward was just claimed (`claimReward` ends that campaign's reuse window);
- anything past its reuse window: three minutes plus a deterministic per-campaign spread of up to two more, so a cold batch does not re-expire on a single tick.

## Retention is untouched

`CachedCampaignDetails` now carries two deadlines. `freshUntil` gates reuse; `expiresAt` is #274's unchanged thirty-minute outage retention. A lapsed `freshUntil` **never** drops the entry — it only costs the campaign a request — so a transient failure still cannot blank campaigns the user has not started. `expireCampaignDetailsFreshness()` (the claim hook) ends reuse without dropping the payload.

## Index correspondence

`details[i] <-> discoverableCampaignIds[i]` no longer holds once a subset is fetched, so results are collected into a `Map<dropID, PromiseSettledResult>` and the snapshot is assembled by iterating the dashboard's id list. That removes the class of bug where one campaign's payload gets filed under another's id, and keeps the output in dashboard order.

## Diagnostics

The `campaign details finished in …` line still fires on an all-cache-hit tick — its absence would read as a dead code path in exactly the steady state this targets — and now reads:

```
Twitch campaign details finished in 4ms (41 campaigns: 2 fetched in 1 batch requests, 0 single fallbacks, 39 served from cache)
```

Aggregate only; no per-campaign records.

## Notes on two acceptance criteria

- **"a relevant settings change invalidates the affected entries"** — no hook added, because nothing found one to hang off: the details query is `user(login: $channelLogin) { dropCampaign(id: $dropID) }` and settings drive downstream filtering, not the payload or its parsing. Adding an invalidation path for a payload settings cannot affect would be the same layering creep the #342 review rejected.
- **service-worker restart** — a restarted worker builds a fresh `TwitchDiscoveryState` and refetches on its next tick, which is the pre-existing behaviour. Covered by a test rather than made to survive, per the #342 review.

No savings figure is quoted here: the ~1.7–2.0 s/tick number in #339 comes from the pre-`twitch-inventory-v2` sample flagged in #358 and should be restated from a fresh capture.

## Testing

- New `packages/extension/tests/twitchCampaignDetailsReuse.test.ts` — steady-state reuse (and its diagnostic), new campaign on the tick it appears, farmed campaign always refetched, dashboard status flip, claim invalidation, deterministic spread, service-worker restart, retention outliving the reuse window, identity change, and dashboard-outage status handling.
- Three existing `adapters.test.ts` cases now step past the reuse window so their second refresh still issues a real request; assertions unchanged apart from the reworded diagnostic.
- `pnpm verify` — CLI 156, extension 1654, site 3, script tests, all workspace typechecks, and both browser builds.

Part of #361 / #382.

Closes #339

https://claude.ai/code/session_01EhmxNsKjNXXmzLvPRtFTDt