### PR TITLE
perf(core): baseline scheduler ticks across hosts and providers

### DIFF
--- a/docs/scheduler-tick-baseline.md
+++ b/docs/scheduler-tick-baseline.md
@@ -1,0 +1,33 @@
+# Scheduler tick baseline
+
+Issue #452 is measured with credential-free, deterministic controller fixtures. The fixtures use normalized campaign and channel models; they contain no cookies, tokens, authorization headers, or raw authenticated provider payloads.
+
+Run the focused extension and CLI matrices from the repository root:
+
+```bash
+LURKLOOT_TICK_BASELINE=1 pnpm --filter @lurkloot/extension exec vitest run tests/tickBaseline.test.ts --reporter=dot
+LURKLOOT_TICK_BASELINE=1 pnpm --filter @lurkloot/cli exec vitest run tests/run.test.ts --reporter=dot
+```
+
+Each `TICK_BASELINE` line is JSON containing the host, provider, scenario, aggregate work counts, and controlled-clock durations. Normal test runs do not print these records.
+
+The controlled clock assigns fixed costs to observable boundaries:
+
+- discovery request: 30 ms, or 300 ms in the slow-response scenario;
+- candidate listing and channel validation: 10 ms each, or 100 ms each in the slow-response scenario;
+- watcher preparation: 5 ms;
+- each persisted state commit: 5 ms.
+
+These values are not production latency claims. They prove that phase attribution and total duration remain deterministic when work counts change. Environment-specific before/after tables and live limitations belong in issue #452 so the repository does not preserve stale timing snapshots.
+
+The matrix covers idle, stable retained watch, target switch, unavailable candidate, failed discovery, and slow discovery/selection for Twitch and Kick in both hosts. Existing controller tests separately block Twitch work and prove Kick completes independently. Timer/heartbeat isolation and trigger coalescing remain ordered work in #336, #394, and #395.
+
+## Counting semantics
+
+- `providerRequests` includes the authentication probe and adapter discovery/selection calls.
+- `watcherReconciliations` counts observable watcher preparation, not a no-op traversal of the controller's watcher map.
+- `eventPublications` counts non-empty aggregate batches passed to the host reporter, not individual diagnostic or activity records.
+- CLI state loads include the post-tick read used to report subscription waits; extension has no equivalent wrapper read.
+- Authentication health is saved before scheduler work so a later failure cannot erase the health observation. That makes two state saves per measured tick intentional.
+
+PR #450 / issue #339 merged before this baseline. Its Twitch campaign-details reuse is part of the starting behavior.

--- a/docs/scheduler-tick-baseline.md
+++ b/docs/scheduler-tick-baseline.md
@@ -7,6 +7,8 @@ Run the focused extension and CLI matrices from the repository root:
 ```bash
 LURKLOOT_TICK_BASELINE=1 pnpm --filter @lurkloot/extension exec vitest run tests/tickBaseline.test.ts --reporter=dot
 LURKLOOT_TICK_BASELINE=1 pnpm --filter @lurkloot/cli exec vitest run tests/run.test.ts --reporter=dot
+pnpm --filter @lurkloot/extension exec vitest run tests/twitchCampaignDetailsReuse.test.ts --reporter=dot
+pnpm --filter @lurkloot/extension exec vitest run tests/adapters.test.ts --reporter=dot
 ```
 
 Each `TICK_BASELINE` line is JSON containing the host, provider, scenario, aggregate work counts, and controlled-clock durations. Normal test runs do not print these records.
@@ -16,18 +18,29 @@ The controlled clock assigns fixed costs to observable boundaries:
 - discovery request: 30 ms, or 300 ms in the slow-response scenario;
 - candidate listing and channel validation: 10 ms each, or 100 ms each in the slow-response scenario;
 - watcher preparation: 5 ms;
-- each persisted state commit: 5 ms.
+- each extension persisted state commit: 5 ms. CLI persistence is intentionally not assigned a synthetic duration because the production run loop no longer exposes test-only hooks.
 
 These values are not production latency claims. They prove that phase attribution and total duration remain deterministic when work counts change. Environment-specific before/after tables and live limitations belong in issue #452 so the repository does not preserve stale timing snapshots.
 
-The matrix covers idle, stable retained watch, target switch, unavailable candidate, failed discovery, and slow discovery/selection for Twitch and Kick in both hosts. Existing controller tests separately block Twitch work and prove Kick completes independently. Timer/heartbeat isolation and trigger coalescing remain ordered work in #336, #394, and #395.
+The four-cell matrix covers idle, stable retained watch, real target switch, a higher-priority target that is unavailable followed by retention of the current watch, failed discovery, and slow discovery/selection for Twitch and Kick in both hosts.
+
+Related scheduler entry paths and concurrency boundaries remain pinned by focused deterministic tests rather than duplicated inside every matrix cell:
+
+- extension alarm dispatch: `backgroundEntrypoint.test.ts` asserts Twitch and Kick alarm names dispatch targeted `alarm` ticks;
+- manual/settings overlap: `backgroundController.test.ts` covers a pending manual claim while the sibling scheduler completes, settings patches during active work, and non-overlapping settings reconciliation;
+- heartbeat isolation: `backgroundController.test.ts` blocks Twitch heartbeat work and proves Kick heartbeat and persistence complete independently;
+- claim handoff: `backgroundController.test.ts` covers independent cross-platform handoffs, immediate post-claim heartbeats, and duplicate-handoff suppression;
+- discovery-signal overlap: `backgroundController.test.ts` proves bursts coalesce into one non-overlapping follow-up.
+
+The CLI interval baseline blocks one refresh across another elapsed interval. It proves provider work stays serialized by the controller lock, but every elapsed interval is queued and later runs. Changing that policy remains in #394; the planned implementation order remains #336 → #394 → #395 → #337.
 
 ## Counting semantics
 
-- `providerRequests` includes the authentication probe and adapter discovery/selection calls.
+- `adapterOperations` counts calls across the normalized `PlatformAdapter` boundary, including the authentication probe and discovery/selection operations. It deliberately does not claim to count HTTP requests: an adapter operation may issue zero, one, or several transport requests. Provider transport request counts belong in focused adapter tests.
 - `watcherReconciliations` counts observable watcher preparation, not a no-op traversal of the controller's watcher map.
 - `eventPublications` counts non-empty aggregate batches passed to the host reporter, not individual diagnostic or activity records.
-- CLI state loads include the post-tick read used to report subscription waits; extension has no equivalent wrapper read.
 - Authentication health is saved before scheduler work so a later failure cannot erase the health observation. That makes two state saves per measured tick intentional.
+- `observedControllerMs` is parsed from the controller's emitted refresh, selection, and tick-completion diagnostics; assertions therefore verify the production timing instrumentation rather than only the fixture clock.
+- Real Twitch transport counts are pinned in `twitchCampaignDetailsReuse.test.ts`: the three-campaign cold refresh performs three `fetchJson` calls, while the following warm refresh adds only inventory and dashboard (five cumulative). `adapters.test.ts` pins a Kick refresh at two concurrent transport calls (campaigns and progress). The host matrix does not relabel adapter calls as HTTP requests.
 
 PR #450 / issue #339 merged before this baseline. Its Twitch campaign-details reuse is part of the starting behavior.

--- a/docs/superpowers/plans/2026-09-01-scheduler-tick-baseline.md
+++ b/docs/superpowers/plans/2026-09-01-scheduler-tick-baseline.md
@@ -1,0 +1,344 @@
+# Scheduler Tick Baseline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish deterministic scheduler tick measurements for extension/Twitch, extension/Kick, CLI/Twitch, and CLI/Kick, then remove only redundant work proven by those measurements.
+
+**Architecture:** A credential-free test harness drives the real shared controller with host-specific wrappers and provider-specific counting adapters. Controlled work delays produce deterministic phase timing, while aggregate counters expose requests, discovery, selection, watcher reconciliation, persistence, publication, and adapter construction. Baseline evidence gates small optimizations; architectural findings are filed as focused v1.13.0 issues instead of bypassing #336 → #394 → #395 → #337.
+
+**Tech Stack:** TypeScript, Vitest fake timers, `@lurkloot/core`, WXT alarm adapters, Node timer adapters, pnpm, GitHub CLI.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-scheduler-tick-baseline-design.md`
+
+## Global Constraints
+
+- Start from `origin/develop` including merged PR #450 / closed issue #339.
+- Cover extension/Twitch, extension/Kick, CLI/Twitch, and CLI/Kick.
+- Record no credentials, cookies, tokens, or raw authenticated provider payloads.
+- Use deterministic work/request counts and controlled-clock timing; use no flaky real-time thresholds.
+- Keep provider behavior behind `PlatformAdapter`; do not force Kick to emulate Twitch availability evidence.
+- Preserve the planned sequence #336 → #394 → #395 → #337.
+- Add no browser permissions and persist no raw provider payloads.
+- Keep environment-specific measured tables in issue #452 rather than committing stale result snapshots.
+- `pnpm verify` must pass before completion.
+
+---
+
+### Task 1: Build the credential-free measurement vocabulary
+
+**Files:**
+- Create: `packages/extension/tests/helpers/tickBaseline.ts`
+- Create: `packages/extension/tests/tickBaseline.test.ts`
+
+**Interfaces:**
+- Produces: `TickBaselineCounts`, a flat aggregate count record.
+- Produces: `ControlledTickClock.advance(phase, milliseconds): Promise<void>` and `ControlledTickClock.duration(phase): number`.
+- Produces: `createCountingAdapter(platform, scenario, recorder): PlatformAdapter`.
+- Consumes: normalized `DropCampaign`, `ChannelCandidate`, `PlatformAdapter`, and controller dependency contracts only.
+
+- [ ] **Step 1: Write the failing vocabulary test**
+
+Define the intended public shapes in the test before the helper exists:
+
+```ts
+it("records aggregate work without credential or payload fields", async () => {
+  const recorder = createTickBaselineRecorder();
+  recorder.count("providerRequests");
+  await recorder.clock.advance("discovery", 40);
+
+  expect(recorder.snapshot()).toEqual({
+    counts: expect.objectContaining({ providerRequests: 1 }),
+    durationsMs: expect.objectContaining({ discovery: 40 }),
+  });
+  expect(JSON.stringify(recorder.snapshot())).not.toMatch(
+    /credential|cookie|token|authorization|payload/i,
+  );
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm --filter @lurkloot/extension test -- tickBaseline.test.ts`
+
+Expected: FAIL because `createTickBaselineRecorder` and its types do not exist.
+
+- [ ] **Step 3: Implement the minimal recorder and controlled clock**
+
+Use fixed keys so reports remain comparable:
+
+```ts
+export interface TickBaselineCounts {
+  providerRequests: number;
+  campaignDiscovery: number;
+  candidateListings: number;
+  channelChecks: number;
+  campaignsEvaluated: number;
+  candidatesEvaluated: number;
+  watcherReconciliations: number;
+  heartbeats: number;
+  adapterConstructions: number;
+  settingsLoads: number;
+  stateLoads: number;
+  stateSaves: number;
+  eventPublications: number;
+}
+
+export type TickPhase = "discovery" | "selection" | "watcher" | "persistence" | "total";
+```
+
+The fake clock increments an internal millisecond value and calls `vi.setSystemTime()`; it performs no real sleep.
+
+- [ ] **Step 4: Add counting adapters built from normalized domain objects**
+
+Implement Twitch and Kick variants whose methods increment counts and return minimal campaigns/candidates. Scenario inputs select `idle`, `stable`, `refresh`, `retained`, `switch`, `higherPriorityUnavailable`, `slow`, or `failed`. Do not include headers, cookies, tokens, raw JSON response bodies, or provider GraphQL/REST payload shapes.
+
+- [ ] **Step 5: Run the focused test and verify GREEN**
+
+Run: `pnpm --filter @lurkloot/extension test -- tickBaseline.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the measurement vocabulary**
+
+```bash
+git add packages/extension/tests/helpers/tickBaseline.ts packages/extension/tests/tickBaseline.test.ts
+git commit -m "test(core): add scheduler tick measurement harness"
+```
+
+### Task 2: Establish the extension/Twitch and extension/Kick baselines
+
+**Files:**
+- Modify: `packages/extension/tests/helpers/tickBaseline.ts`
+- Modify: `packages/extension/tests/tickBaseline.test.ts`
+- Modify: `packages/core/src/core/scheduler.ts`
+
+**Interfaces:**
+- Produces: `runExtensionBaselineCell(platform, scenario): Promise<TickBaselineResult>`.
+- Consumes: `createBackgroundController()`, `createBackgroundAlarmListener()`, named per-platform alarms, and `runSchedulerTick()` metrics.
+- Extends: scheduler metrics callback with aggregate watcher/persistence phase boundaries only if those values cannot be measured at the controller dependency boundary.
+
+- [ ] **Step 1: Write failing four-scenario extension matrix tests**
+
+Use `it.each(["twitch", "kick"] as const)` for idle, stable retained target, target switch, and failed response. Assert exact work counts and phase durations from one alarm-driven tick. Add separate tests for discovery refresh and unavailable higher-priority candidate because their expected provider calls differ.
+
+- [ ] **Step 2: Verify RED against the unmeasured controller path**
+
+Run: `pnpm --filter @lurkloot/extension test -- tickBaseline.test.ts`
+
+Expected: FAIL because no extension cell runner maps alarms, storage, events, adapters, and scheduler metrics into one result.
+
+- [ ] **Step 3: Implement the extension host runner**
+
+Construct the real controller with counting dependencies, trigger exactly one `TWITCH_ALARM_NAME` or `KICK_ALARM_NAME`, await controller background settlement, and snapshot counts. Increment `stateLoads`, `stateSaves`, `settingsLoads`, `eventPublications`, and `adapterConstructions` in dependency wrappers rather than production code.
+
+- [ ] **Step 4: Add controlled phase boundaries**
+
+Reuse the existing discovery and selection diagnostic boundaries. Advance the fake clock inside adapter methods and persistence callbacks so the emitted aggregate durations equal declared costs. If watcher reconciliation has no observable boundary, add a narrow optional scheduler metrics callback rather than a production global counter.
+
+- [ ] **Step 5: Add overlap and provider-independence characterization**
+
+Block Twitch discovery with a deferred promise, trigger Kick, and assert Kick reaches persistence before Twitch resolves. Trigger two alarms for one platform while its first tick is blocked and assert the measured number of active and pending ticks, documenting current behavior without implementing #394.
+
+- [ ] **Step 6: Verify extension matrix GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/extension test -- tickBaseline.test.ts backgroundEntrypoint.test.ts scheduler.test.ts
+pnpm typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit the extension baseline**
+
+```bash
+git add packages/extension/tests/helpers/tickBaseline.ts packages/extension/tests/tickBaseline.test.ts packages/core/src/core/scheduler.ts
+git commit -m "test(extension): baseline scheduler tick work"
+```
+
+### Task 3: Establish CLI/Twitch and CLI/Kick host-equivalence baselines
+
+**Files:**
+- Create: `packages/cli/tests/helpers/tickBaseline.ts`
+- Modify: `packages/cli/src/runtime/run.ts`
+- Modify: `packages/cli/tests/run.test.ts`
+- Modify: `packages/extension/tests/tickBaseline.test.ts`
+
+**Interfaces:**
+- Produces: a test-only `RunLoopHooks` contract for observing a completed tick and injecting a scheduler driver.
+- Produces: `runCliBaselineCell(platform, scenario): Promise<TickBaselineResult>`.
+- Consumes: the same counting adapter behavior and `TickBaselineResult` shape used by extension tests.
+
+- [ ] **Step 1: Write a failing CLI one-shot measurement test**
+
+Run a single-platform CLI configuration through `runLoop({ once: true })` and assert exact adapter construction, state load/save, publication, discovery, selection, and provider request counts.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm --filter @lurkloot/cli test -- run.test.ts`
+
+Expected: FAIL because the run loop exposes neither its completed-tick observation nor deterministic host-driver injection.
+
+- [ ] **Step 3: Add narrow optional test hooks to the CLI run loop**
+
+Add an optional dependency object rather than importing Vitest or test helpers into production:
+
+```ts
+export interface RunLoopHooks {
+  onTickCompleted?: () => void | Promise<void>;
+  setInterval?: typeof globalThis.setInterval;
+  clearInterval?: typeof globalThis.clearInterval;
+}
+```
+
+Default every hook to the existing production behavior. Call `onTickCompleted` after `tickAndHandOff()` and subscription-wait reconciliation complete.
+
+- [ ] **Step 4: Implement the CLI baseline runner**
+
+Use a temporary state file containing normalized `SchedulerState`, a silent logger, counting transport adapters, and fake timers. Enable only the measured platform so the result describes one matrix cell.
+
+- [ ] **Step 5: Assert host equivalence and unavoidable wrapper differences**
+
+For equivalent normalized scenarios, compare discovery, selection, watcher, and provider request counts between CLI and extension. Assert CLI-specific state-file reads separately and require a comment explaining each count that differs by host.
+
+- [ ] **Step 6: Characterize timer overlap deterministically**
+
+Inject the timer hooks, block the first tick, advance the fake clock through another interval, and assert the exact number of controller tick requests. This records whether the CLI currently overlaps or queues timer-driven work without implementing #336 or #394.
+
+- [ ] **Step 7: Verify CLI and cross-host matrix GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lurkloot/cli test -- run.test.ts
+pnpm --filter @lurkloot/extension test -- tickBaseline.test.ts
+pnpm typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit the CLI baseline**
+
+```bash
+git add packages/cli/tests/helpers/tickBaseline.ts packages/cli/src/runtime/run.ts packages/cli/tests/run.test.ts packages/extension/tests/tickBaseline.test.ts
+git commit -m "test(cli): baseline scheduler tick work"
+```
+
+### Task 4: Audit and implement bounded redundant-work reductions
+
+**Files:**
+- Modify: `packages/extension/tests/tickBaseline.test.ts`
+- Modify: `packages/cli/tests/run.test.ts`
+- Modify only when justified: `packages/core/src/background/controller.ts`
+- Modify only when justified: `packages/core/src/core/scheduler.ts`
+- Modify only when justified: `packages/cli/src/runtime/run.ts`
+- Modify only when justified: `packages/extension/entrypoints/background.ts`
+
+**Interfaces:**
+- Consumes: exact before counts from Tasks 2 and 3.
+- Produces: reduced count assertions for behavior-preserving work eliminated in this branch.
+- Excludes: independent heartbeat ownership, discovery snapshots, snapshot-driven selection, and negative-search policy.
+
+- [ ] **Step 1: Produce the before table from deterministic test output**
+
+Run the matrix with `LURKLOOT_TICK_BASELINE=1` so tests print JSON results only when explicitly requested. Save the command output in the working notes used to compose issue #452; do not commit generated measurements.
+
+- [ ] **Step 2: Audit each counted boundary**
+
+For every matrix cell, trace nonzero adapter constructions, settings/state loads, state saves, event publications, discovery calls, candidate listings, channel checks, watcher reconciliations, and host timer triggers to a source line. Classify each as required, safely removable now, or owned by #336/#394/#395/#337.
+
+- [ ] **Step 3: Write one failing count assertion per safely removable operation**
+
+Change only the expected count for the selected operation and verify the test fails with the old count. The assertion name must identify the eliminated work, for example `does not reload CLI state after a tick when the completed state is already available` or `does not publish an empty unchanged batch`.
+
+- [ ] **Step 4: Implement the minimal reduction**
+
+Change the narrowest host or shared-core boundary that eliminates the counted operation. Preserve state transition events, auth-health persistence, claim handoff behavior, and per-platform concurrency. Do not add a cache or concurrency model whose invalidation belongs in a later sequence issue.
+
+- [ ] **Step 5: Verify each reduction before starting the next**
+
+Run the single failing test until GREEN, then run the complete `tickBaseline.test.ts`, `run.test.ts`, `backgroundController.test.ts`, and `scheduler.test.ts` set. Reprint the opted-in baseline and confirm only intended counts changed.
+
+- [ ] **Step 6: Commit each independently reviewable reduction**
+
+Use a Conventional Commit subject naming the actual removed work, such as:
+
+```bash
+git commit -m "perf(cli): reuse completed scheduler state"
+```
+
+Do not create an empty optimization commit if the audit finds no safe reduction outside the planned sequence.
+
+### Task 5: File focused findings and update the performance trackers
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-09-01-scheduler-tick-baseline.md` only if implementation discoveries require correcting this plan.
+
+**Interfaces:**
+- Produces: focused GitHub issues assigned to milestone `v1.13.0` for material unbundled findings.
+- Produces: a findings comment on #452 and status correction on #361.
+- Consumes: deterministic before/after results and source-backed audit classifications.
+
+- [ ] **Step 1: Draft each material follow-up locally**
+
+Each draft must contain observed counts, affected matrix cells, source locations, desired behavior, deterministic acceptance tests, relationship to #361/#452, and why it is not bundled. Explicitly state its ordering dependency relative to #336, #394, #395, and #337.
+
+- [ ] **Step 2: Create only non-duplicate v1.13.0 issues**
+
+Search open and closed issues by the finding's source symbol and behavior. Create an issue only when no existing issue owns it, add milestone `v1.13.0`, and link #361 and #452. Never create separate host issues for shared-core work.
+
+- [ ] **Step 3: Update #361 bookkeeping**
+
+Edit or comment on #361 to mark #339 / PR #450 complete and link any newly created focused issues. Preserve the published execution order exactly.
+
+- [ ] **Step 4: Post the #452 findings report**
+
+Include the baseline commit, four-cell before/after tables, scenario limitations, controlled-clock phase durations, request/work counts, bundled reductions, remaining unavoidable work, linked follow-ups, and the statement that no credentials or raw authenticated payloads were recorded.
+
+- [ ] **Step 5: Verify issue links and milestone assignments**
+
+Read #361, #452, and each created issue back through `gh issue view`; confirm links, milestone `v1.13.0`, scope, and sequence language.
+
+### Task 6: Final verification and handoff
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-09-01-scheduler-tick-baseline-design.md` only if the implemented public behavior differs from the approved design.
+
+**Interfaces:**
+- Consumes: all implementation commits and GitHub findings.
+- Produces: verified branch ready for review.
+
+- [ ] **Step 1: Run formatting and diff safety checks**
+
+Run:
+
+```bash
+git diff --check origin/develop...HEAD
+git status --short
+```
+
+Expected: no whitespace errors and only intentional tracked changes.
+
+- [ ] **Step 2: Run the full repository verification**
+
+Run: `pnpm verify`
+
+Expected: script tests, all workspace typechecks, CLI tests, extension tests, site build/tests, and Chromium/Firefox builds pass.
+
+- [ ] **Step 3: Re-run the opted-in baseline report**
+
+Run the documented `LURKLOOT_TICK_BASELINE=1` commands for extension and CLI. Compare output with the #452 comment and correct any transcription mismatch.
+
+- [ ] **Step 4: Review repository and GitHub scope**
+
+Confirm no credentials, raw payloads, new browser permissions, or implementation from #336/#394/#395/#337 entered the diff. Confirm #452 and #361 link every material deferred finding.
+
+- [ ] **Step 5: Commit final documentation corrections if needed**
+
+```bash
+git add docs/superpowers/specs/2026-09-01-scheduler-tick-baseline-design.md docs/superpowers/plans/2026-09-01-scheduler-tick-baseline.md
+git commit -m "docs(core): finalize scheduler tick baseline"
+```
+
+Skip this commit when neither document changed.

--- a/docs/superpowers/plans/2026-09-01-scheduler-tick-baseline.md
+++ b/docs/superpowers/plans/2026-09-01-scheduler-tick-baseline.md
@@ -43,11 +43,11 @@ Define the intended public shapes in the test before the helper exists:
 ```ts
 it("records aggregate work without credential or payload fields", async () => {
   const recorder = createTickBaselineRecorder();
-  recorder.count("providerRequests");
+  recorder.count("adapterOperations");
   await recorder.clock.advance("discovery", 40);
 
   expect(recorder.snapshot()).toEqual({
-    counts: expect.objectContaining({ providerRequests: 1 }),
+    counts: expect.objectContaining({ adapterOperations: 1 }),
     durationsMs: expect.objectContaining({ discovery: 40 }),
   });
   expect(JSON.stringify(recorder.snapshot())).not.toMatch(
@@ -68,14 +68,13 @@ Use fixed keys so reports remain comparable:
 
 ```ts
 export interface TickBaselineCounts {
-  providerRequests: number;
+  adapterOperations: number;
   campaignDiscovery: number;
   candidateListings: number;
   channelChecks: number;
   campaignsEvaluated: number;
   candidatesEvaluated: number;
   watcherReconciliations: number;
-  heartbeats: number;
   adapterConstructions: number;
   settingsLoads: number;
   stateLoads: number;
@@ -166,33 +165,22 @@ git commit -m "test(extension): baseline scheduler tick work"
 - Modify: `packages/extension/tests/tickBaseline.test.ts`
 
 **Interfaces:**
-- Produces: a test-only `RunLoopHooks` contract for observing a completed tick and injecting a scheduler driver.
 - Produces: `runCliBaselineCell(platform, scenario): Promise<TickBaselineResult>`.
 - Consumes: the same counting adapter behavior and `TickBaselineResult` shape used by extension tests.
 
 - [ ] **Step 1: Write a failing CLI one-shot measurement test**
 
-Run a single-platform CLI configuration through `runLoop({ once: true })` and assert exact adapter construction, state load/save, publication, discovery, selection, and provider request counts.
+Run a single-platform CLI configuration through `runLoop({ once: true })` and assert exact adapter construction, discovery, selection, and normalized adapter-operation counts.
 
 - [ ] **Step 2: Verify RED**
 
 Run: `pnpm --filter @lurkloot/cli test -- run.test.ts`
 
-Expected: FAIL because the run loop exposes neither its completed-tick observation nor deterministic host-driver injection.
+Expected: FAIL because the CLI baseline runner does not exist.
 
-- [ ] **Step 3: Add narrow optional test hooks to the CLI run loop**
+- [ ] **Step 3: Keep the production run-loop API unchanged**
 
-Add an optional dependency object rather than importing Vitest or test helpers into production:
-
-```ts
-export interface RunLoopHooks {
-  onTickCompleted?: () => void | Promise<void>;
-  setInterval?: typeof globalThis.setInterval;
-  clearInterval?: typeof globalThis.clearInterval;
-}
-```
-
-Default every hook to the existing production behavior. Call `onTickCompleted` after `tickAndHandOff()` and subscription-wait reconciliation complete.
+Measure normalized controller work through counting transport adapters and use Vitest's controlled clock for the real interval driver. Do not add test-only callbacks to `RunOptions`.
 
 - [ ] **Step 4: Implement the CLI baseline runner**
 
@@ -200,11 +188,11 @@ Use a temporary state file containing normalized `SchedulerState`, a silent logg
 
 - [ ] **Step 5: Assert host equivalence and unavoidable wrapper differences**
 
-For equivalent normalized scenarios, compare discovery, selection, watcher, and provider request counts between CLI and extension. Assert CLI-specific state-file reads separately and require a comment explaining each count that differs by host.
+For equivalent normalized scenarios, compare discovery, selection, watcher, and adapter-operation counts between CLI and extension. Keep real HTTP request counts in focused adapter tests.
 
 - [ ] **Step 6: Characterize timer overlap deterministically**
 
-Inject the timer hooks, block the first tick, advance the fake clock through another interval, and assert the exact number of controller tick requests. This records whether the CLI currently overlaps or queues timer-driven work without implementing #336 or #394.
+Block a refresh, advance the fake clock through another interval, and assert that provider work remains serialized while each elapsed interval queues a later tick. This records current behavior without implementing #336 or #394.
 
 - [ ] **Step 7: Verify CLI and cross-host matrix GREEN**
 

--- a/docs/superpowers/specs/2026-09-01-scheduler-tick-baseline-design.md
+++ b/docs/superpowers/specs/2026-09-01-scheduler-tick-baseline-design.md
@@ -1,0 +1,98 @@
+# Scheduler Tick Baseline Design
+
+## Purpose
+
+Establish a reproducible, credential-free scheduler tick baseline for the complete supported runtime matrix: extension/Twitch, extension/Kick, CLI/Twitch, and CLI/Kick. Use that evidence to remove only redundant work that can be safely eliminated without pre-empting the planned architecture sequence #336 → #394 → #395 → #337.
+
+PR #450 merged into `develop` as commit `a5e22d74` and closed #339. Its Twitch campaign-details read-through cache is therefore part of this baseline, not a proposed optimization or a historical comparison point.
+
+## Measurement boundary
+
+The baseline exercises the real shared background controller and scheduler path with deterministic host and provider doubles. It does not use live credentials, captured cookies, raw authenticated responses, or payload recordings.
+
+Each cell varies two dimensions:
+
+- host behavior: extension-style alarm/storage integration or CLI-style timer/file-storage integration;
+- provider behavior: Twitch or Kick adapter capabilities and request shapes.
+
+All cells share the same normalized scenarios where meaningful:
+
+- idle with no eligible campaign;
+- stable active watch with unchanged campaign data;
+- discovery refresh;
+- retained target without a switch;
+- target switch or claim handoff;
+- unavailable higher-priority candidate;
+- slow or failed provider response;
+- overlapping timer, manual, or settings triggers.
+
+If a provider cannot represent a scenario, the report records the capability limitation instead of fabricating equivalent evidence. In particular, Kick is not given Twitch-specific channel availability semantics.
+
+## Reproducible harness
+
+Add focused test utilities under the existing test packages rather than a production benchmark subsystem. The harness wraps synthetic adapters, storage callbacks, event publication, watchers, and host drivers with counters. A fake clock advances only at declared work boundaries, making phase and total duration assertions deterministic.
+
+The measurement record contains aggregate numeric data only:
+
+- provider request count;
+- campaign discovery calls;
+- candidate listing and channel validation calls;
+- campaigns and candidates evaluated during selection;
+- watcher reconciliation and heartbeat calls;
+- adapter construction count;
+- state and settings load count;
+- state save count;
+- event publication count;
+- controlled-clock durations for discovery, selection, watcher reconciliation, persistence, and the total tick.
+
+The harness must not model or retain credential fields. Synthetic responses use the smallest normalized domain objects required by the scheduler rather than raw provider payloads.
+
+## Host equivalence
+
+Extension and CLI fixtures drive the same `createBackgroundController()` and `runSchedulerTick()` implementation. Their wrappers differ only where the real hosts differ: alarm versus timer triggering and storage/event adapters. Assertions compare core work counts for equivalent scenarios and separately account for unavoidable host wrapper work.
+
+The CLI wrapper must not be reduced to a renamed extension fixture. It exercises the CLI run-loop boundary sufficiently to detect duplicated timer ticks, extra state reads, or host-specific adapter reconstruction. The extension wrapper similarly covers named per-platform alarms and publication behavior.
+
+## Provider independence and controlled timing
+
+Blocked-promise tests prove Twitch and Kick ticks can make progress independently. Fake timers prove overlapping triggers do not create unbounded queued work and expose the current coalescing behavior without relying on wall-clock thresholds.
+
+The baseline records current behavior even where it does not yet meet the final #452 criteria. Heartbeat isolation belongs to #336, discovery snapshots to #394, snapshot-driven selection to #395, and Twitch negative-search backoff to #337. Baseline tests may characterize those gaps, but this change must not implement their architecture early.
+
+## Evidence-backed reductions
+
+After recording the initial four-cell counts, audit:
+
+- duplicated extension alarms or CLI timers;
+- repeated state/settings loads and unconditional saves;
+- adapter reconstruction;
+- unchanged-state event publication;
+- repeated provider discovery, candidate enumeration, channel validation, parsing, or liveness work.
+
+A reduction may be bundled only when it is small, shared where appropriate, behavior-preserving, and directly supported by a failing count assertion. Every production change follows test-driven development: establish the before count, write the expected reduced count, observe the failure, then make the minimal change.
+
+Material work with its own cache policy, invalidation model, concurrency boundary, or provider semantics becomes a focused v1.13.0 GitHub issue linked to #361 and #452. Such issues must preserve the sequence #336 → #394 → #395 → #337 and must not duplicate those scopes.
+
+## Reporting
+
+Repository artifacts contain the deterministic harness, assertions, and instructions for reproducing counts. Environment-specific before/after results live in issue #452 so measured snapshots do not become stale committed fixtures.
+
+The final #452 update includes:
+
+- PR #450/#339 merge status and baseline commit;
+- a before/after table for all four cells and supported scenarios;
+- controlled-clock phase timing and work/request counts;
+- reductions implemented in this branch;
+- remaining unavoidable work and rationale;
+- provider/account limitations for any unavailable live observation;
+- focused v1.13.0 issues created or linked;
+- confirmation that no credentials or raw authenticated payloads were recorded;
+- verification results.
+
+#361 may be updated to mark #339 complete and link newly justified work. No sequence item is reordered.
+
+## Verification
+
+Focused tests cover the harness itself, count regressions, host equivalence, provider independence, controlled timing, and any bundled reduction. The completed branch must pass `pnpm verify`.
+
+The acceptance boundary is deterministic evidence, not a claimed universal wall-clock speedup. Live authenticated diagnostics may corroborate a finding, but are optional and must remain aggregate, ephemeral, and credential-free.

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -20,6 +20,12 @@ export interface RunOptions {
   // transiently unavailable one. Stays independent of any browser cookie
   // observation — it reads only the CLI's file/env credential store.
   checkCredentialAvailability?: (platform: Platform) => Promise<CredentialAvailability>;
+  hooks?: {
+    onStateLoad?(): void;
+    onStateSave?(): void;
+    onEventsPublished?(): void;
+    onTickCompleted?(): void | Promise<void>;
+  };
 }
 
 // Headless farming loop. Reuses the engine's background controller — the same
@@ -32,15 +38,28 @@ export async function runLoop(options: RunOptions): Promise<void> {
   // The shared engine works on the EngineSettings contract; expand the CLI's
   // schema once, pinning the headless invariants (always running, always tabless).
   const engineSettings = toEngineSettings(settings);
+  const enabledPlatforms = (["twitch", "kick"] as const).filter((platform) =>
+    engineSettings.platform[platform].enabled);
   const seenSubscriptionWaits = new Set<string>();
+  const loadRuntimeState = async (): Promise<SchedulerState> => {
+    options.hooks?.onStateLoad?.();
+    return await loadState(statePath);
+  };
+  const saveRuntimeState = async (state: SchedulerState): Promise<void> => {
+    options.hooks?.onStateSave?.();
+    await saveState(statePath, state);
+  };
 
   const controller = createBackgroundController({
     loadSettings: async () => engineSettings,
     // Settings come from the config file; the run loop never mutates them.
     saveSettings: async () => {},
-    loadState: () => loadState(statePath),
-    saveState: (state: SchedulerState) => saveState(statePath, state),
-    reportEvents: (events) => reportCliEvents(events, logger),
+    loadState: loadRuntimeState,
+    saveState: saveRuntimeState,
+    reportEvents: (events) => {
+      if (events.length > 0) options.hooks?.onEventsPublished?.();
+      return reportCliEvents(events, logger);
+    },
     // The CLI drives its own interval below, so alarm scheduling is a no-op.
     createAlarm: async () => {},
     createAdapter: (platform, emit, currentSettings) => transport.createAdapter(platform, emit, currentSettings),
@@ -51,8 +70,8 @@ export async function runLoop(options: RunOptions): Promise<void> {
 
   const tickOnce = async () => {
     try {
-      await controller.tickAndHandOff();
-      const state = await loadState(statePath);
+      await controller.tickAndHandOff(enabledPlatforms);
+      const state = await loadRuntimeState();
       const waits = subscriptionWaitKeys([...state.campaigns.twitch, ...state.campaigns.kick]);
       for (const key of seenSubscriptionWaits) {
         if (!waits.has(key)) seenSubscriptionWaits.delete(key);
@@ -62,6 +81,7 @@ export async function runLoop(options: RunOptions): Promise<void> {
         seenSubscriptionWaits.add(key);
         logger.info(message, key.slice(0, key.indexOf(":")) as Platform);
       }
+      await options.hooks?.onTickCompleted?.();
     } catch (error) {
       logger.error(error instanceof Error ? error.message : String(error), "tick");
     }

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -20,12 +20,22 @@ export interface RunOptions {
   // transiently unavailable one. Stays independent of any browser cookie
   // observation — it reads only the CLI's file/env credential store.
   checkCredentialAvailability?: (platform: Platform) => Promise<CredentialAvailability>;
-  hooks?: {
-    onStateLoad?(): void;
-    onStateSave?(): void;
-    onEventsPublished?(): void;
-    onTickCompleted?(): void | Promise<void>;
-  };
+}
+
+function disabledPlatformsNeedingCleanup(
+  state: SchedulerState,
+  settings: ReturnType<typeof toEngineSettings>,
+): Platform[] {
+  return (["twitch", "kick"] as const).filter((platform) => {
+    if (settings.platform[platform].enabled) return false;
+    const session = state.sessions[platform];
+    return state.campaigns[platform].length > 0
+      || session.channel !== undefined
+      || session.campaignId !== undefined
+      || session.rewardId !== undefined
+      || session.watchMode !== undefined
+      || state.managedWatchTabs?.[platform] !== undefined;
+  });
 }
 
 // Headless farming loop. Reuses the engine's background controller — the same
@@ -41,14 +51,8 @@ export async function runLoop(options: RunOptions): Promise<void> {
   const enabledPlatforms = (["twitch", "kick"] as const).filter((platform) =>
     engineSettings.platform[platform].enabled);
   const seenSubscriptionWaits = new Set<string>();
-  const loadRuntimeState = async (): Promise<SchedulerState> => {
-    options.hooks?.onStateLoad?.();
-    return await loadState(statePath);
-  };
-  const saveRuntimeState = async (state: SchedulerState): Promise<void> => {
-    options.hooks?.onStateSave?.();
-    await saveState(statePath, state);
-  };
+  const loadRuntimeState = async (): Promise<SchedulerState> => loadState(statePath);
+  const saveRuntimeState = async (state: SchedulerState): Promise<void> => saveState(statePath, state);
 
   const controller = createBackgroundController({
     loadSettings: async () => engineSettings,
@@ -56,10 +60,7 @@ export async function runLoop(options: RunOptions): Promise<void> {
     saveSettings: async () => {},
     loadState: loadRuntimeState,
     saveState: saveRuntimeState,
-    reportEvents: (events) => {
-      if (events.length > 0) options.hooks?.onEventsPublished?.();
-      return reportCliEvents(events, logger);
-    },
+    reportEvents: (events) => reportCliEvents(events, logger),
     // The CLI drives its own interval below, so alarm scheduling is a no-op.
     createAlarm: async () => {},
     createAdapter: (platform, emit, currentSettings) => transport.createAdapter(platform, emit, currentSettings),
@@ -71,7 +72,12 @@ export async function runLoop(options: RunOptions): Promise<void> {
   const tickOnce = async () => {
     try {
       await controller.tickAndHandOff(enabledPlatforms);
-      const state = await loadRuntimeState();
+      let state = await loadRuntimeState();
+      const staleDisabledPlatforms = disabledPlatformsNeedingCleanup(state, engineSettings);
+      if (staleDisabledPlatforms.length > 0) {
+        await controller.tickAndHandOff(staleDisabledPlatforms);
+        state = await loadRuntimeState();
+      }
       const waits = subscriptionWaitKeys([...state.campaigns.twitch, ...state.campaigns.kick]);
       for (const key of seenSubscriptionWaits) {
         if (!waits.has(key)) seenSubscriptionWaits.delete(key);
@@ -81,7 +87,6 @@ export async function runLoop(options: RunOptions): Promise<void> {
         seenSubscriptionWaits.add(key);
         logger.info(message, key.slice(0, key.indexOf(":")) as Platform);
       }
-      await options.hooks?.onTickCompleted?.();
     } catch (error) {
       logger.error(error instanceof Error ? error.message : String(error), "tick");
     }

--- a/packages/cli/tests/helpers/tickBaseline.ts
+++ b/packages/cli/tests/helpers/tickBaseline.ts
@@ -8,20 +8,18 @@ import type { EventEmitter } from "@lurkloot/shared/events";
 import { DEFAULT_CLI_SETTINGS, type CliSettings } from "../../src/settings";
 import type { Logger } from "../../src/logger";
 import { runLoop } from "../../src/runtime/run";
-import { saveState } from "../../src/storage";
+import { loadState, saveState } from "../../src/storage";
 import type { TransportHandle } from "../../src/transport";
 
 type Scenario = "idle" | "stable" | "switch" | "higherPriorityUnavailable" | "slow" | "failed";
 
 interface Counts {
-  providerRequests: number;
+  // PlatformAdapter calls, not raw HTTP request counts.
+  adapterOperations: number;
   campaignDiscovery: number;
   candidateListings: number;
   channelChecks: number;
   adapterConstructions: number;
-  stateLoads: number;
-  stateSaves: number;
-  eventPublications: number;
   watcherReconciliations: number;
 }
 
@@ -61,6 +59,10 @@ function countingAdapter(
       status: "in_progress",
     }],
   };
+  const urgentCampaign: DropCampaign = {
+    ...campaign,
+    id: `${platform}-urgent`,
+  };
   const candidate: ChannelCandidate = {
     platform,
     username: `${platform}-creator`,
@@ -68,7 +70,7 @@ function countingAdapter(
       ? "https://www.twitch.tv/twitch-creator"
       : "https://kick.com/kick-creator",
   };
-  const request = (): void => { counts.providerRequests += 1; };
+  const request = (): void => { counts.adapterOperations += 1; };
   return {
     platform,
     checkAuthHealth: async () => {
@@ -80,20 +82,25 @@ function countingAdapter(
       request();
       advance("discovery", scenario === "slow" ? 300 : 30);
       if (scenario === "failed") throw new Error(`${platform} synthetic discovery failure`);
-      return scenario === "idle" ? [] : [campaign];
+      return scenario === "idle"
+        ? []
+        : scenario === "higherPriorityUnavailable" ? [campaign, urgentCampaign] : [campaign];
     },
-    listCandidateChannels: async () => {
+    listCandidateChannels: async (selectedCampaign) => {
       counts.candidateListings += 1;
       request();
       advance("selection", scenario === "slow" ? 100 : 10);
-      return [candidate];
+      return [{
+        ...candidate,
+        username: selectedCampaign.id.endsWith("urgent") ? `${platform}-urgent-creator` : candidate.username,
+      }];
     },
     checkChannel: async (checkedCandidate) => {
       counts.channelChecks += 1;
       request();
       advance("selection", scenario === "slow" ? 100 : 10);
       return {
-        live: scenario !== "higherPriorityUnavailable",
+        live: scenario !== "higherPriorityUnavailable" || !checkedCandidate.username.includes("urgent"),
         categoryMatches: true,
         candidate: checkedCandidate,
       };
@@ -114,14 +121,11 @@ export async function runCliBaselineCell(
   scenario: Scenario,
 ) {
   const counts: Counts = {
-    providerRequests: 0,
+    adapterOperations: 0,
     campaignDiscovery: 0,
     candidateListings: 0,
     channelChecks: 0,
     adapterConstructions: 0,
-    stateLoads: 0,
-    stateSaves: 0,
-    eventPublications: 0,
     watcherReconciliations: 0,
   };
   const durationsMs: Durations = {
@@ -146,6 +150,9 @@ export async function runCliBaselineCell(
       twitch: { ...DEFAULT_CLI_SETTINGS.platform.twitch, enabled: platform === "twitch" },
       kick: { ...DEFAULT_CLI_SETTINGS.platform.kick, enabled: platform === "kick" },
     },
+    campaignPriorities: scenario === "higherPriorityUnavailable"
+      ? { [`${platform}-urgent`]: 10 }
+      : {},
   };
   const buildOne = (selectedPlatform: Platform, _emit: EventEmitter, engineSettings: EngineSettings) => {
     counts.adapterConstructions += 1;
@@ -168,7 +175,7 @@ export async function runCliBaselineCell(
   };
 
   const statePath = join(directory, `${platform}-${scenario}.json`);
-  if (scenario === "stable") {
+  if (scenario === "stable" || scenario === "switch" || scenario === "higherPriorityUnavailable") {
     const candidate: ChannelCandidate = {
       platform,
       username: `${platform}-creator`,
@@ -176,7 +183,9 @@ export async function runCliBaselineCell(
         ? "https://www.twitch.tv/twitch-creator"
         : "https://kick.com/kick-creator",
     };
-    const current = countingCampaign(platform);
+    const current = scenario === "switch"
+      ? countingCampaign(platform, "old-campaign", "old-reward")
+      : countingCampaign(platform);
     await saveState(statePath, {
       ...structuredClone(DEFAULT_STATE),
       campaigns: { ...DEFAULT_STATE.campaigns, [platform]: [current] },
@@ -202,27 +211,27 @@ export async function runCliBaselineCell(
     transport,
     logger: silentLogger,
     once: true,
-    hooks: {
-      onStateLoad: () => { counts.stateLoads += 1; },
-      onStateSave: () => {
-        counts.stateSaves += 1;
-        advance("persistence", 5);
-      },
-      onEventsPublished: () => { counts.eventPublications += 1; },
-    },
   });
+  const finalState = await loadState(statePath);
 
-  return { host: "cli" as const, platform, scenario, counts, durationsMs };
+  return {
+    host: "cli" as const,
+    platform,
+    scenario,
+    counts,
+    durationsMs,
+    outcomeCampaignId: finalState.sessions[platform].campaignId,
+  };
 }
 
-function countingCampaign(platform: Platform): DropCampaign {
+function countingCampaign(platform: Platform, campaignSuffix = "campaign", rewardSuffix = "reward"): DropCampaign {
   return {
-    id: `${platform}-campaign`,
+    id: `${platform}-${campaignSuffix}`,
     platform,
     name: `${platform} campaign`,
     status: "active",
     rewards: [{
-      id: `${platform}-reward`,
+      id: `${platform}-${rewardSuffix}`,
       name: `${platform} reward`,
       requiredMinutes: 60,
       watchedMinutes: 10,

--- a/packages/cli/tests/helpers/tickBaseline.ts
+++ b/packages/cli/tests/helpers/tickBaseline.ts
@@ -1,0 +1,226 @@
+import { join } from "node:path";
+import { vi } from "vitest";
+import { resolveCompatibility } from "@lurkloot/core";
+import { DEFAULT_STATE } from "@lurkloot/core/defaults";
+import type { PlatformAdapter } from "@lurkloot/core/adapter";
+import type { ChannelCandidate, DropCampaign, EngineSettings, Platform } from "@lurkloot/shared/models";
+import type { EventEmitter } from "@lurkloot/shared/events";
+import { DEFAULT_CLI_SETTINGS, type CliSettings } from "../../src/settings";
+import type { Logger } from "../../src/logger";
+import { runLoop } from "../../src/runtime/run";
+import { saveState } from "../../src/storage";
+import type { TransportHandle } from "../../src/transport";
+
+type Scenario = "idle" | "stable" | "switch" | "higherPriorityUnavailable" | "slow" | "failed";
+
+interface Counts {
+  providerRequests: number;
+  campaignDiscovery: number;
+  candidateListings: number;
+  channelChecks: number;
+  adapterConstructions: number;
+  stateLoads: number;
+  stateSaves: number;
+  eventPublications: number;
+}
+
+interface Durations {
+  discovery: number;
+  selection: number;
+  watcher: number;
+  persistence: number;
+  total: number;
+}
+
+const silentLogger: Logger = {
+  level: "error",
+  log: () => undefined,
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+function countingAdapter(
+  platform: Platform,
+  scenario: Scenario,
+  counts: Counts,
+  advance: (phase: "discovery" | "selection", milliseconds: number) => void,
+): PlatformAdapter {
+  const campaign: DropCampaign = {
+    id: `${platform}-campaign`,
+    platform,
+    name: `${platform} campaign`,
+    status: "active",
+    rewards: [{
+      id: `${platform}-reward`,
+      name: `${platform} reward`,
+      requiredMinutes: 60,
+      watchedMinutes: 10,
+      status: "in_progress",
+    }],
+  };
+  const candidate: ChannelCandidate = {
+    platform,
+    username: `${platform}-creator`,
+    url: platform === "twitch"
+      ? "https://www.twitch.tv/twitch-creator"
+      : "https://kick.com/kick-creator",
+  };
+  const request = (): void => { counts.providerRequests += 1; };
+  return {
+    platform,
+    checkAuthHealth: async () => {
+      request();
+      return { status: "healthy" };
+    },
+    refreshCampaigns: async () => {
+      counts.campaignDiscovery += 1;
+      request();
+      advance("discovery", scenario === "slow" ? 300 : 30);
+      if (scenario === "failed") throw new Error(`${platform} synthetic discovery failure`);
+      return scenario === "idle" ? [] : [campaign];
+    },
+    listCandidateChannels: async () => {
+      counts.candidateListings += 1;
+      request();
+      advance("selection", scenario === "slow" ? 100 : 10);
+      return [candidate];
+    },
+    checkChannel: async (checkedCandidate) => {
+      counts.channelChecks += 1;
+      request();
+      advance("selection", scenario === "slow" ? 100 : 10);
+      return {
+        live: scenario !== "higherPriorityUnavailable",
+        categoryMatches: true,
+        candidate: checkedCandidate,
+      };
+    },
+    claimReward: async () => false,
+    prepareWatchTab: async () => ({ tabId: platform === "twitch" ? 10 : 20, managedByExtension: false }),
+    stopWatchTab: async () => undefined,
+  };
+}
+
+export async function runCliBaselineCell(
+  directory: string,
+  platform: Platform,
+  scenario: Scenario,
+) {
+  const counts: Counts = {
+    providerRequests: 0,
+    campaignDiscovery: 0,
+    candidateListings: 0,
+    channelChecks: 0,
+    adapterConstructions: 0,
+    stateLoads: 0,
+    stateSaves: 0,
+    eventPublications: 0,
+  };
+  const durationsMs: Durations = {
+    discovery: 0,
+    selection: 0,
+    watcher: 0,
+    persistence: 0,
+    total: 0,
+  };
+  const advance = (phase: "discovery" | "selection" | "persistence", milliseconds: number): void => {
+    durationsMs[phase] += milliseconds;
+    durationsMs.total += milliseconds;
+    vi.setSystemTime(Date.now() + milliseconds);
+  };
+  const adapters = {
+    twitch: countingAdapter("twitch", platform === "twitch" ? scenario : "idle", counts, advance),
+    kick: countingAdapter("kick", platform === "kick" ? scenario : "idle", counts, advance),
+  } satisfies Record<Platform, PlatformAdapter>;
+  const settings: CliSettings = {
+    ...DEFAULT_CLI_SETTINGS,
+    platform: {
+      twitch: { ...DEFAULT_CLI_SETTINGS.platform.twitch, enabled: platform === "twitch" },
+      kick: { ...DEFAULT_CLI_SETTINGS.platform.kick, enabled: platform === "kick" },
+    },
+  };
+  const buildOne = (selectedPlatform: Platform, _emit: EventEmitter, engineSettings: EngineSettings) => {
+    counts.adapterConstructions += 1;
+    return {
+      adapter: adapters[selectedPlatform],
+      ...resolveCompatibility(engineSettings.compatibility, { host: "cli", twitchIdentity: "web" }),
+    };
+  };
+  const transport: TransportHandle = {
+    adapters,
+    createAdapter: buildOne,
+    createAdapters: (_emit, engineSettings) => {
+      counts.adapterConstructions += 2;
+      return {
+        adapters,
+        ...resolveCompatibility(engineSettings.compatibility, { host: "cli", twitchIdentity: "web" }),
+      };
+    },
+    dispose: async () => undefined,
+  };
+
+  const statePath = join(directory, `${platform}-${scenario}.json`);
+  if (scenario === "stable") {
+    const candidate: ChannelCandidate = {
+      platform,
+      username: `${platform}-creator`,
+      url: platform === "twitch"
+        ? "https://www.twitch.tv/twitch-creator"
+        : "https://kick.com/kick-creator",
+    };
+    const current = countingCampaign(platform);
+    await saveState(statePath, {
+      ...structuredClone(DEFAULT_STATE),
+      campaigns: { ...DEFAULT_STATE.campaigns, [platform]: [current] },
+      sessions: {
+        ...DEFAULT_STATE.sessions,
+        [platform]: {
+          platform,
+          status: "watching",
+          offlineChecks: 0,
+          channel: candidate,
+          campaignId: current.id,
+          rewardId: current.rewards[0].id,
+          watchMode: "tab",
+          startedAt: new Date().toISOString(),
+        },
+      },
+    });
+  }
+
+  await runLoop({
+    settings,
+    statePath,
+    transport,
+    logger: silentLogger,
+    once: true,
+    hooks: {
+      onStateLoad: () => { counts.stateLoads += 1; },
+      onStateSave: () => {
+        counts.stateSaves += 1;
+        advance("persistence", 5);
+      },
+      onEventsPublished: () => { counts.eventPublications += 1; },
+    },
+  });
+
+  return { host: "cli" as const, platform, scenario, counts, durationsMs };
+}
+
+function countingCampaign(platform: Platform): DropCampaign {
+  return {
+    id: `${platform}-campaign`,
+    platform,
+    name: `${platform} campaign`,
+    status: "active",
+    rewards: [{
+      id: `${platform}-reward`,
+      name: `${platform} reward`,
+      requiredMinutes: 60,
+      watchedMinutes: 10,
+      status: "in_progress",
+    }],
+  };
+}

--- a/packages/cli/tests/helpers/tickBaseline.ts
+++ b/packages/cli/tests/helpers/tickBaseline.ts
@@ -22,6 +22,7 @@ interface Counts {
   stateLoads: number;
   stateSaves: number;
   eventPublications: number;
+  watcherReconciliations: number;
 }
 
 interface Durations {
@@ -45,7 +46,7 @@ function countingAdapter(
   platform: Platform,
   scenario: Scenario,
   counts: Counts,
-  advance: (phase: "discovery" | "selection", milliseconds: number) => void,
+  advance: (phase: "discovery" | "selection" | "watcher", milliseconds: number) => void,
 ): PlatformAdapter {
   const campaign: DropCampaign = {
     id: `${platform}-campaign`,
@@ -98,7 +99,11 @@ function countingAdapter(
       };
     },
     claimReward: async () => false,
-    prepareWatchTab: async () => ({ tabId: platform === "twitch" ? 10 : 20, managedByExtension: false }),
+    prepareWatchTab: async () => {
+      counts.watcherReconciliations += 1;
+      advance("watcher", 5);
+      return { tabId: platform === "twitch" ? 10 : 20, managedByExtension: false };
+    },
     stopWatchTab: async () => undefined,
   };
 }
@@ -117,6 +122,7 @@ export async function runCliBaselineCell(
     stateLoads: 0,
     stateSaves: 0,
     eventPublications: 0,
+    watcherReconciliations: 0,
   };
   const durationsMs: Durations = {
     discovery: 0,
@@ -125,7 +131,7 @@ export async function runCliBaselineCell(
     persistence: 0,
     total: 0,
   };
-  const advance = (phase: "discovery" | "selection" | "persistence", milliseconds: number): void => {
+  const advance = (phase: "discovery" | "selection" | "watcher" | "persistence", milliseconds: number): void => {
     durationsMs[phase] += milliseconds;
     durationsMs.total += milliseconds;
     vi.setSystemTime(Date.now() + milliseconds);

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,6 +11,7 @@ import type { TransportHandle } from "../src/transport";
 import { DEFAULT_CLI_SETTINGS } from "../src/settings";
 import { runLoop } from "../src/runtime/run";
 import { createLogger } from "../src/logger";
+import { runCliBaselineCell } from "./helpers/tickBaseline";
 
 // A benign adapter whose only interesting behaviour is checkAuthHealth. Every
 // data method returns an empty result so an unhealthy (suspended) tick never
@@ -66,7 +67,10 @@ async function readAuthHealth(statePath: string): Promise<SchedulerState["authHe
 
 let dir: string;
 beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), "lurkloot-run-")); });
-afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+afterEach(async () => {
+  vi.useRealTimers();
+  await rm(dir, { recursive: true, force: true });
+});
 
 async function runOnce(health: Record<Platform, PlatformAuthHealth>, availability: (platform: Platform) => CredentialAvailability): Promise<string> {
   const statePath = join(dir, "state.json");
@@ -115,5 +119,127 @@ describe("runLoop authentication health reporting", () => {
     );
     const authHealth = await readAuthHealth(statePath);
     expect(authHealth.kick).toMatchObject({ status: "unavailable", reasonCode: "credential_lookup_failed" });
+  });
+});
+
+describe("CLI scheduler tick baseline", () => {
+  it.each(["twitch", "kick"] as const)("measures an idle %s one-shot tick", async (platform) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+    const result = await runCliBaselineCell(dir, platform, "idle");
+
+    expect(result).toEqual({
+      host: "cli",
+      platform,
+      scenario: "idle",
+      counts: {
+        providerRequests: 2,
+        campaignDiscovery: 1,
+        candidateListings: 0,
+        channelChecks: 0,
+        adapterConstructions: 2,
+        stateLoads: 4,
+        stateSaves: 2,
+        eventPublications: 6,
+      },
+      durationsMs: {
+        discovery: 30,
+        selection: 0,
+        watcher: 0,
+        persistence: 10,
+        total: 40,
+      },
+    });
+  });
+
+  it.each(["twitch", "kick"] as const)("matches retained %s core work with the extension host", async (platform) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+
+    const result = await runCliBaselineCell(dir, platform, "stable");
+
+    expect(result.counts).toMatchObject({
+      providerRequests: 3,
+      campaignDiscovery: 1,
+      candidateListings: 0,
+      channelChecks: 1,
+      adapterConstructions: 2,
+      stateLoads: 4,
+      stateSaves: 2,
+    });
+    expect(result.durationsMs).toEqual({
+      discovery: 30,
+      selection: 10,
+      watcher: 0,
+      persistence: 10,
+      total: 50,
+    });
+  });
+
+  it.each(["twitch", "kick"] as const)("attributes slow %s work with the same controlled clock", async (platform) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+
+    const result = await runCliBaselineCell(dir, platform, "slow");
+
+    expect(result.durationsMs).toEqual({
+      discovery: 300,
+      selection: 200,
+      watcher: 0,
+      persistence: 10,
+      total: 510,
+    });
+  });
+
+  it.each([
+    ["twitch", "switch"],
+    ["kick", "switch"],
+    ["twitch", "higherPriorityUnavailable"],
+    ["kick", "higherPriorityUnavailable"],
+  ] as const)("measures %s/%s selection work", async (platform, scenario) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+
+    const result = await runCliBaselineCell(dir, platform, scenario);
+
+    expect(result.counts).toMatchObject({
+      providerRequests: 4,
+      campaignDiscovery: 1,
+      candidateListings: 1,
+      channelChecks: 1,
+      adapterConstructions: 2,
+      stateLoads: 4,
+      stateSaves: 2,
+    });
+    expect(result.durationsMs).toEqual({
+      discovery: 30,
+      selection: 20,
+      watcher: 0,
+      persistence: 10,
+      total: 60,
+    });
+  });
+
+  it.each(["twitch", "kick"] as const)("measures a failed %s response", async (platform) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+
+    const result = await runCliBaselineCell(dir, platform, "failed");
+
+    expect(result.counts).toMatchObject({
+      providerRequests: 2,
+      campaignDiscovery: 1,
+      candidateListings: 0,
+      channelChecks: 0,
+      stateLoads: 4,
+      stateSaves: 2,
+    });
+    expect(result.durationsMs).toEqual({
+      discovery: 30,
+      selection: 0,
+      watcher: 0,
+      persistence: 10,
+      total: 40,
+    });
   });
 });

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CredentialAvailability } from "@lurkloot/core/controller";
+import { resolveCompatibility } from "@lurkloot/core";
 import type { ChannelCandidate, ChannelCheck, DropCampaign, EngineSettings, Platform, PlatformAuthHealth, SchedulerState } from "@lurkloot/shared/models";
 import type { PlatformAdapter, PreparedWatchTab } from "@lurkloot/core/adapter";
 import type { EventEmitter } from "@lurkloot/shared/events";
@@ -12,6 +13,8 @@ import { DEFAULT_CLI_SETTINGS } from "../src/settings";
 import { runLoop } from "../src/runtime/run";
 import { createLogger } from "../src/logger";
 import { runCliBaselineCell } from "./helpers/tickBaseline";
+import { DEFAULT_STATE } from "@lurkloot/core/defaults";
+import { saveState } from "../src/storage";
 
 function reportBaseline(result: unknown): void {
   if (process.env.LURKLOOT_TICK_BASELINE === "1") {
@@ -65,6 +68,12 @@ async function fakeTransport(health: Record<Platform, PlatformAuthHealth>): Prom
 }
 
 const HEALTHY: PlatformAuthHealth = { status: "healthy", message: { key: "authHealthy" } };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => { resolve = resolvePromise; });
+  return { promise, resolve };
+}
 
 async function readAuthHealth(statePath: string): Promise<SchedulerState["authHealth"]> {
   const state = JSON.parse(await readFile(statePath, "utf8")) as SchedulerState;
@@ -140,22 +149,19 @@ describe("CLI scheduler tick baseline", () => {
       platform,
       scenario: "idle",
       counts: {
-        providerRequests: 2,
+        adapterOperations: 2,
         campaignDiscovery: 1,
         candidateListings: 0,
         channelChecks: 0,
         adapterConstructions: 2,
-        stateLoads: 4,
-        stateSaves: 2,
-        eventPublications: 6,
         watcherReconciliations: 0,
       },
       durationsMs: {
         discovery: 30,
         selection: 0,
         watcher: 0,
-        persistence: 10,
-        total: 40,
+        persistence: 0,
+        total: 30,
       },
     });
   });
@@ -168,21 +174,19 @@ describe("CLI scheduler tick baseline", () => {
     reportBaseline(result);
 
     expect(result.counts).toMatchObject({
-      providerRequests: 3,
+      adapterOperations: 3,
       campaignDiscovery: 1,
       candidateListings: 0,
       channelChecks: 1,
       adapterConstructions: 2,
-      stateLoads: 4,
-      stateSaves: 2,
       watcherReconciliations: 1,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
       selection: 10,
       watcher: 5,
-      persistence: 10,
-      total: 55,
+      persistence: 0,
+      total: 45,
     });
   });
 
@@ -197,8 +201,8 @@ describe("CLI scheduler tick baseline", () => {
       discovery: 300,
       selection: 200,
       watcher: 5,
-      persistence: 10,
-      total: 515,
+      persistence: 0,
+      total: 505,
     });
   });
 
@@ -214,22 +218,22 @@ describe("CLI scheduler tick baseline", () => {
     const result = await runCliBaselineCell(dir, platform, scenario);
     reportBaseline(result);
 
+    expect(result.outcomeCampaignId).toBe(`${platform}-campaign`);
+
     expect(result.counts).toMatchObject({
-      providerRequests: 4,
+      adapterOperations: scenario === "higherPriorityUnavailable" ? 7 : 4,
       campaignDiscovery: 1,
-      candidateListings: 1,
-      channelChecks: 1,
+      candidateListings: scenario === "higherPriorityUnavailable" ? 2 : 1,
+      channelChecks: scenario === "higherPriorityUnavailable" ? 3 : 1,
       adapterConstructions: 2,
-      stateLoads: 4,
-      stateSaves: 2,
-      watcherReconciliations: scenario === "switch" ? 1 : 0,
+      watcherReconciliations: 1,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
-      selection: 20,
-      watcher: scenario === "switch" ? 5 : 0,
-      persistence: 10,
-      total: scenario === "switch" ? 65 : 60,
+      selection: scenario === "higherPriorityUnavailable" ? 50 : 20,
+      watcher: 5,
+      persistence: 0,
+      total: scenario === "higherPriorityUnavailable" ? 85 : 55,
     });
   });
 
@@ -241,19 +245,131 @@ describe("CLI scheduler tick baseline", () => {
     reportBaseline(result);
 
     expect(result.counts).toMatchObject({
-      providerRequests: 2,
+      adapterOperations: 2,
       campaignDiscovery: 1,
       candidateListings: 0,
       channelChecks: 0,
-      stateLoads: 4,
-      stateSaves: 2,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
       selection: 0,
       watcher: 0,
-      persistence: 10,
-      total: 40,
+      persistence: 0,
+      total: 30,
     });
+  });
+});
+
+describe("runLoop disabled platform cleanup", () => {
+  it("clears a persisted watch when its platform was disabled between runs", async () => {
+    const statePath = join(dir, "state.json");
+    await saveState(statePath, {
+      ...structuredClone(DEFAULT_STATE),
+      campaigns: {
+        ...DEFAULT_STATE.campaigns,
+        kick: [{
+          id: "stale-kick-campaign",
+          platform: "kick",
+          name: "Stale Kick campaign",
+          status: "active",
+          rewards: [{
+            id: "stale-kick-reward",
+            name: "Stale reward",
+            requiredMinutes: 60,
+            watchedMinutes: 10,
+            status: "in_progress",
+          }],
+        }],
+      },
+      sessions: {
+        ...DEFAULT_STATE.sessions,
+        kick: {
+          platform: "kick",
+          status: "watching",
+          offlineChecks: 0,
+          campaignId: "stale-kick-campaign",
+          rewardId: "stale-kick-reward",
+          channel: { platform: "kick", username: "stale", url: "https://kick.com/stale" },
+          watchMode: "tabless",
+        },
+      },
+    });
+    const settings = {
+      ...DEFAULT_CLI_SETTINGS,
+      platform: {
+        twitch: { ...DEFAULT_CLI_SETTINGS.platform.twitch, enabled: true },
+        kick: { ...DEFAULT_CLI_SETTINGS.platform.kick, enabled: false },
+      },
+    };
+
+    await runLoop({
+      settings,
+      statePath,
+      transport: await fakeTransport({ twitch: HEALTHY, kick: HEALTHY }),
+      logger: createLogger("error"),
+      once: true,
+      checkCredentialAvailability: async () => ({ status: "available" }),
+    });
+
+    const state = JSON.parse(await readFile(statePath, "utf8")) as SchedulerState;
+    expect(state.campaigns.kick).toEqual([]);
+    expect(state.sessions.kick).toMatchObject({
+      status: "paused",
+      reasonCode: "platform_disabled",
+    });
+    expect(state.sessions.kick.channel).toBeUndefined();
+  });
+});
+
+describe("runLoop interval baseline", () => {
+  it("serializes provider work but queues each elapsed interval", async () => {
+    vi.useFakeTimers();
+    const pendingRefresh = deferred<DropCampaign[]>();
+    let refreshCalls = 0;
+    const twitch = fakeAdapter("twitch", HEALTHY);
+    twitch.refreshCampaigns = vi.fn(async () => {
+      refreshCalls += 1;
+      return refreshCalls === 1 ? [] : pendingRefresh.promise;
+    });
+    const kick = fakeAdapter("kick", HEALTHY);
+    const transport: TransportHandle = {
+      adapters: { twitch, kick },
+      createAdapter: (platform) => ({
+        adapter: platform === "twitch" ? twitch : kick,
+        ...resolveCompatibility(DEFAULT_CLI_SETTINGS.compatibility, { host: "cli", twitchIdentity: "web" }),
+      }),
+      createAdapters: () => ({
+        adapters: { twitch, kick },
+        ...resolveCompatibility(DEFAULT_CLI_SETTINGS.compatibility, { host: "cli", twitchIdentity: "web" }),
+      }),
+      dispose: vi.fn(async () => undefined),
+    };
+    const settings = {
+      ...DEFAULT_CLI_SETTINGS,
+      pollIntervalMinutes: 1,
+      platform: {
+        twitch: { ...DEFAULT_CLI_SETTINGS.platform.twitch, enabled: true },
+        kick: { ...DEFAULT_CLI_SETTINGS.platform.kick, enabled: false },
+      },
+    };
+
+    const running = runLoop({
+      settings,
+      statePath: join(dir, "interval-state.json"),
+      transport,
+      logger: createLogger("error"),
+      checkCredentialAvailability: async () => ({ status: "available" }),
+    });
+    await vi.waitFor(() => expect(refreshCalls).toBe(1));
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.waitFor(() => expect(refreshCalls).toBe(2));
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(refreshCalls).toBe(2);
+
+    pendingRefresh.resolve([]);
+    await vi.waitFor(() => expect(refreshCalls).toBe(3));
+    process.emit("SIGTERM");
+    await running;
   });
 });

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -13,6 +13,12 @@ import { runLoop } from "../src/runtime/run";
 import { createLogger } from "../src/logger";
 import { runCliBaselineCell } from "./helpers/tickBaseline";
 
+function reportBaseline(result: unknown): void {
+  if (process.env.LURKLOOT_TICK_BASELINE === "1") {
+    console.log(`TICK_BASELINE ${JSON.stringify(result)}`);
+  }
+}
+
 // A benign adapter whose only interesting behaviour is checkAuthHealth. Every
 // data method returns an empty result so an unhealthy (suspended) tick never
 // throws while we assert on the persisted auth health.
@@ -127,6 +133,7 @@ describe("CLI scheduler tick baseline", () => {
     vi.useFakeTimers();
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
     const result = await runCliBaselineCell(dir, platform, "idle");
+    reportBaseline(result);
 
     expect(result).toEqual({
       host: "cli",
@@ -141,6 +148,7 @@ describe("CLI scheduler tick baseline", () => {
         stateLoads: 4,
         stateSaves: 2,
         eventPublications: 6,
+        watcherReconciliations: 0,
       },
       durationsMs: {
         discovery: 30,
@@ -157,6 +165,7 @@ describe("CLI scheduler tick baseline", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
     const result = await runCliBaselineCell(dir, platform, "stable");
+    reportBaseline(result);
 
     expect(result.counts).toMatchObject({
       providerRequests: 3,
@@ -166,13 +175,14 @@ describe("CLI scheduler tick baseline", () => {
       adapterConstructions: 2,
       stateLoads: 4,
       stateSaves: 2,
+      watcherReconciliations: 1,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
       selection: 10,
-      watcher: 0,
+      watcher: 5,
       persistence: 10,
-      total: 50,
+      total: 55,
     });
   });
 
@@ -181,13 +191,14 @@ describe("CLI scheduler tick baseline", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
     const result = await runCliBaselineCell(dir, platform, "slow");
+    reportBaseline(result);
 
     expect(result.durationsMs).toEqual({
       discovery: 300,
       selection: 200,
-      watcher: 0,
+      watcher: 5,
       persistence: 10,
-      total: 510,
+      total: 515,
     });
   });
 
@@ -201,6 +212,7 @@ describe("CLI scheduler tick baseline", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
     const result = await runCliBaselineCell(dir, platform, scenario);
+    reportBaseline(result);
 
     expect(result.counts).toMatchObject({
       providerRequests: 4,
@@ -210,13 +222,14 @@ describe("CLI scheduler tick baseline", () => {
       adapterConstructions: 2,
       stateLoads: 4,
       stateSaves: 2,
+      watcherReconciliations: scenario === "switch" ? 1 : 0,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
       selection: 20,
-      watcher: 0,
+      watcher: scenario === "switch" ? 5 : 0,
       persistence: 10,
-      total: 60,
+      total: scenario === "switch" ? 65 : 60,
     });
   });
 
@@ -225,6 +238,7 @@ describe("CLI scheduler tick baseline", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
     const result = await runCliBaselineCell(dir, platform, "failed");
+    reportBaseline(result);
 
     expect(result.counts).toMatchObject({
       providerRequests: 2,

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -811,6 +811,7 @@ export async function runSchedulerTick(
         // platform-scoped stop. Both reason codes remain meaningful.
         const automationOff = !isFarmingActive(settings);
         await adapter.stopWatchTab?.(previous, { signal: options.signal });
+        nextState.campaigns[platform] = [];
         nextState.sessions[platform] = {
           ...previous,
           status: "paused",

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -99,7 +99,7 @@ describe("KickAdapter", () => {
   it("starts Kick campaign and progress requests concurrently", async () => {
     let campaignStarted = false;
     let progressStarted = false;
-    const adapter = kickAdapter(jsonFetcher(async (url) => {
+    const fetcher = jsonFetcher(async (url) => {
       if (url.endsWith("/drops/campaigns")) {
         campaignStarted = true;
         await vi.waitFor(() => expect(progressStarted).toBe(true));
@@ -125,11 +125,13 @@ describe("KickAdapter", () => {
         };
       }
       throw new Error(`Unexpected URL ${url}`);
-    }));
+    });
+    const adapter = kickAdapter(fetcher);
 
     const campaigns = await adapter.refreshCampaigns();
 
     expect(campaigns[0]?.rewards[0]?.watchedMinutes).toBe(30);
+    expect(fetcher.fetchJson).toHaveBeenCalledTimes(2);
   });
 
   it("keeps Kick campaigns when concurrent progress refresh fails", async () => {

--- a/packages/extension/tests/helpers/tickBaseline.ts
+++ b/packages/extension/tests/helpers/tickBaseline.ts
@@ -1,0 +1,151 @@
+import { vi } from "vitest";
+import type { PlatformAdapter } from "@lurkloot/core/adapter";
+import type { ChannelCandidate, DropCampaign, Platform } from "@lurkloot/shared/models";
+
+export interface TickBaselineCounts {
+  providerRequests: number;
+  campaignDiscovery: number;
+  candidateListings: number;
+  channelChecks: number;
+  campaignsEvaluated: number;
+  candidatesEvaluated: number;
+  watcherReconciliations: number;
+  heartbeats: number;
+  adapterConstructions: number;
+  settingsLoads: number;
+  stateLoads: number;
+  stateSaves: number;
+  eventPublications: number;
+}
+
+export type TickPhase = "discovery" | "selection" | "watcher" | "persistence" | "total";
+
+export interface TickBaselineResult {
+  counts: TickBaselineCounts;
+  durationsMs: Record<TickPhase, number>;
+}
+
+export type TickBaselineScenario =
+  | "idle"
+  | "stable"
+  | "refresh"
+  | "retained"
+  | "switch"
+  | "higherPriorityUnavailable"
+  | "slow"
+  | "failed";
+
+export type TickBaselineRecorder = ReturnType<typeof createTickBaselineRecorder>;
+
+const countKeys = [
+  "providerRequests",
+  "campaignDiscovery",
+  "candidateListings",
+  "channelChecks",
+  "campaignsEvaluated",
+  "candidatesEvaluated",
+  "watcherReconciliations",
+  "heartbeats",
+  "adapterConstructions",
+  "settingsLoads",
+  "stateLoads",
+  "stateSaves",
+  "eventPublications",
+] as const satisfies readonly (keyof TickBaselineCounts)[];
+
+export function createTickBaselineRecorder() {
+  const counts = Object.fromEntries(countKeys.map((key) => [key, 0])) as unknown as TickBaselineCounts;
+  const durationsMs: Record<TickPhase, number> = {
+    discovery: 0,
+    selection: 0,
+    watcher: 0,
+    persistence: 0,
+    total: 0,
+  };
+
+  return {
+    count(key: keyof TickBaselineCounts, amount = 1): void {
+      counts[key] += amount;
+    },
+    clock: {
+      async advance(phase: Exclude<TickPhase, "total">, milliseconds: number): Promise<void> {
+        durationsMs[phase] += milliseconds;
+        durationsMs.total += milliseconds;
+        vi.setSystemTime(Date.now() + milliseconds);
+        await Promise.resolve();
+      },
+      duration(phase: TickPhase): number {
+        return durationsMs[phase];
+      },
+    },
+    snapshot(): TickBaselineResult {
+      return {
+        counts: { ...counts },
+        durationsMs: { ...durationsMs },
+      };
+    },
+  };
+}
+
+export function createCountingAdapter(
+  platform: Platform,
+  scenario: TickBaselineScenario,
+  recorder: TickBaselineRecorder,
+): PlatformAdapter {
+  const campaign: DropCampaign = {
+    id: `${platform}-campaign`,
+    platform,
+    name: `${platform} campaign`,
+    status: "active",
+    rewards: [{
+      id: `${platform}-reward`,
+      name: `${platform} reward`,
+      requiredMinutes: 60,
+      watchedMinutes: 10,
+      status: "in_progress",
+    }],
+  };
+  const candidate: ChannelCandidate = {
+    platform,
+    username: `${platform}-creator`,
+    displayName: `${platform} creator`,
+    url: platform === "twitch"
+      ? "https://www.twitch.tv/twitch-creator"
+      : "https://kick.com/kick-creator",
+  };
+  const request = async (phase: "discovery" | "selection", milliseconds: number): Promise<void> => {
+    recorder.count("providerRequests");
+    await recorder.clock.advance(phase, scenario === "slow" ? milliseconds * 10 : milliseconds);
+  };
+
+  return {
+    platform,
+    checkAuthHealth: async () => ({ status: "healthy" }),
+    refreshCampaigns: async () => {
+      recorder.count("campaignDiscovery");
+      await request("discovery", 30);
+      if (scenario === "failed") throw new Error(`${platform} synthetic discovery failure`);
+      return scenario === "idle" ? [] : [campaign];
+    },
+    listCandidateChannels: async () => {
+      recorder.count("candidateListings");
+      await request("selection", 10);
+      return [candidate];
+    },
+    checkChannel: async (checkedCandidate) => {
+      recorder.count("channelChecks");
+      await request("selection", 10);
+      return {
+        live: scenario !== "higherPriorityUnavailable",
+        categoryMatches: true,
+        candidate: checkedCandidate,
+      };
+    },
+    claimReward: async () => false,
+    prepareWatchTab: async () => ({
+      tabId: platform === "twitch" ? 10 : 20,
+      managedByExtension: true,
+    }),
+    stopWatchTab: async () => undefined,
+  };
+}

--- a/packages/extension/tests/helpers/tickBaseline.ts
+++ b/packages/extension/tests/helpers/tickBaseline.ts
@@ -137,10 +137,14 @@ export function createCountingAdapter(
       };
     },
     claimReward: async () => false,
-    prepareWatchTab: async () => ({
-      tabId: platform === "twitch" ? 10 : 20,
-      managedByExtension: true,
-    }),
+    prepareWatchTab: async () => {
+      recorder.count("watcherReconciliations");
+      await recorder.clock.advance("watcher", 5);
+      return {
+        tabId: platform === "twitch" ? 10 : 20,
+        managedByExtension: true,
+      };
+    },
     stopWatchTab: async () => undefined,
   };
 }

--- a/packages/extension/tests/helpers/tickBaseline.ts
+++ b/packages/extension/tests/helpers/tickBaseline.ts
@@ -8,14 +8,15 @@ import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
 import { DEFAULT_STATE } from "../../src/core/storage";
 
 export interface TickBaselineCounts {
-  providerRequests: number;
+  // Calls across the PlatformAdapter boundary. These are not transport request
+  // counts: one adapter operation may issue zero, one, or several HTTP requests.
+  adapterOperations: number;
   campaignDiscovery: number;
   candidateListings: number;
   channelChecks: number;
   campaignsEvaluated: number;
   candidatesEvaluated: number;
   watcherReconciliations: number;
-  heartbeats: number;
   adapterConstructions: number;
   settingsLoads: number;
   stateLoads: number;
@@ -28,12 +29,14 @@ export type TickPhase = "discovery" | "selection" | "watcher" | "persistence" | 
 export interface TickBaselineResult {
   counts: TickBaselineCounts;
   durationsMs: Record<TickPhase, number>;
+  observedControllerMs?: Partial<Record<"discovery" | "selection" | "total", number>>;
 }
 
 export interface HostTickBaselineResult extends TickBaselineResult {
   host: "extension" | "cli";
   platform: Platform;
   scenario: TickBaselineScenario;
+  outcomeCampaignId?: string;
 }
 
 export type TickBaselineScenario =
@@ -49,14 +52,13 @@ export type TickBaselineScenario =
 export type TickBaselineRecorder = ReturnType<typeof createTickBaselineRecorder>;
 
 const countKeys = [
-  "providerRequests",
+  "adapterOperations",
   "campaignDiscovery",
   "candidateListings",
   "channelChecks",
   "campaignsEvaluated",
   "candidatesEvaluated",
   "watcherReconciliations",
-  "heartbeats",
   "adapterConstructions",
   "settingsLoads",
   "stateLoads",
@@ -104,34 +106,40 @@ export function createCountingAdapter(
   recorder: TickBaselineRecorder,
 ): PlatformAdapter {
   const campaign = baselineCampaign(platform);
+  const urgentCampaign = baselineCampaign(platform, "urgent");
   const candidate = baselineCandidate(platform);
   const request = async (phase: "discovery" | "selection", milliseconds: number): Promise<void> => {
-    recorder.count("providerRequests");
+    recorder.count("adapterOperations");
     await recorder.clock.advance(phase, scenario === "slow" ? milliseconds * 10 : milliseconds);
   };
 
   return {
     platform,
     checkAuthHealth: async () => {
-      recorder.count("providerRequests");
+      recorder.count("adapterOperations");
       return { status: "healthy" };
     },
     refreshCampaigns: async () => {
       recorder.count("campaignDiscovery");
       await request("discovery", 30);
       if (scenario === "failed") throw new Error(`${platform} synthetic discovery failure`);
-      return scenario === "idle" ? [] : [campaign];
+      return scenario === "idle"
+        ? []
+        : scenario === "higherPriorityUnavailable" ? [campaign, urgentCampaign] : [campaign];
     },
-    listCandidateChannels: async () => {
+    listCandidateChannels: async (selectedCampaign) => {
       recorder.count("candidateListings");
       await request("selection", 10);
-      return [candidate];
+      return [{
+        ...candidate,
+        username: selectedCampaign.id.endsWith("urgent") ? `${platform}-urgent-creator` : candidate.username,
+      }];
     },
     checkChannel: async (checkedCandidate) => {
       recorder.count("channelChecks");
       await request("selection", 10);
       return {
-        live: scenario !== "higherPriorityUnavailable",
+        live: scenario !== "higherPriorityUnavailable" || !checkedCandidate.username.includes("urgent"),
         categoryMatches: true,
         candidate: checkedCandidate,
       };
@@ -149,9 +157,9 @@ export function createCountingAdapter(
   };
 }
 
-function baselineCampaign(platform: Platform): DropCampaign {
+function baselineCampaign(platform: Platform, suffix = "campaign"): DropCampaign {
   return {
-    id: `${platform}-campaign`,
+    id: `${platform}-${suffix}`,
     platform,
     name: `${platform} campaign`,
     status: "active",
@@ -191,9 +199,12 @@ export async function runExtensionBaselineCell(
       twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: platform === "twitch" },
       kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: platform === "kick" },
     },
+    campaignPriorities: scenario === "higherPriorityUnavailable"
+      ? { [`${platform}-urgent`]: 10 }
+      : {},
   };
   let state: SchedulerState = structuredClone(DEFAULT_STATE);
-  if (scenario === "stable" || scenario === "retained" || scenario === "switch") {
+  if (scenario === "stable" || scenario === "retained" || scenario === "switch" || scenario === "higherPriorityUnavailable") {
     const currentIds = scenario === "switch"
       ? { campaign: `${platform}-old-campaign`, reward: `${platform}-old-reward` }
       : { campaign: `${platform}-campaign`, reward: `${platform}-reward` };
@@ -251,11 +262,18 @@ export async function runExtensionBaselineCell(
     host: "extension",
     twitchIdentity: "web",
   });
+  const observedControllerMs: Partial<Record<"discovery" | "selection" | "total", number>> = {};
   const reportEvents = async (events: readonly EngineEvent[]): Promise<void> => {
     if (events.length === 0) return;
     recorder.count("eventPublications");
     for (const event of events) {
       if (event.category !== "diagnostic") continue;
+      const refreshDuration = event.message.match(/^Campaign refresh finished in (\d+)ms/);
+      if (refreshDuration) observedControllerMs.discovery = Number(refreshDuration[1]);
+      const selectionDuration = event.message.match(/^Campaign selection(?: fast path retained current watch)? finished in (\d+)ms/);
+      if (selectionDuration) observedControllerMs.selection = Number(selectionDuration[1]);
+      const totalDuration = event.message.match(/^Tick #\d+ finished after (\d+)ms/);
+      if (totalDuration) observedControllerMs.total = Number(totalDuration[1]);
       const selection = event.message.match(/\((\d+) campaigns? checked, (\d+) candidates? checked\)/);
       if (selection) {
         recorder.count("campaignsEvaluated", Number(selection[1]));
@@ -302,5 +320,7 @@ export async function runExtensionBaselineCell(
     platform,
     scenario,
     ...recorder.snapshot(),
+    observedControllerMs,
+    outcomeCampaignId: state.sessions[platform].campaignId,
   };
 }

--- a/packages/extension/tests/helpers/tickBaseline.ts
+++ b/packages/extension/tests/helpers/tickBaseline.ts
@@ -1,6 +1,11 @@
 import { vi } from "vitest";
 import type { PlatformAdapter } from "@lurkloot/core/adapter";
-import type { ChannelCandidate, DropCampaign, Platform } from "@lurkloot/shared/models";
+import { createBackgroundController } from "@lurkloot/core/controller";
+import { resolveCompatibility } from "@lurkloot/core";
+import type { EngineEvent, EventEmitter } from "@lurkloot/shared/events";
+import type { ChannelCandidate, DropCampaign, ExtensionSettings, Platform, SchedulerState } from "@lurkloot/shared/models";
+import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
+import { DEFAULT_STATE } from "../../src/core/storage";
 
 export interface TickBaselineCounts {
   providerRequests: number;
@@ -23,6 +28,12 @@ export type TickPhase = "discovery" | "selection" | "watcher" | "persistence" | 
 export interface TickBaselineResult {
   counts: TickBaselineCounts;
   durationsMs: Record<TickPhase, number>;
+}
+
+export interface HostTickBaselineResult extends TickBaselineResult {
+  host: "extension" | "cli";
+  platform: Platform;
+  scenario: TickBaselineScenario;
 }
 
 export type TickBaselineScenario =
@@ -92,27 +103,8 @@ export function createCountingAdapter(
   scenario: TickBaselineScenario,
   recorder: TickBaselineRecorder,
 ): PlatformAdapter {
-  const campaign: DropCampaign = {
-    id: `${platform}-campaign`,
-    platform,
-    name: `${platform} campaign`,
-    status: "active",
-    rewards: [{
-      id: `${platform}-reward`,
-      name: `${platform} reward`,
-      requiredMinutes: 60,
-      watchedMinutes: 10,
-      status: "in_progress",
-    }],
-  };
-  const candidate: ChannelCandidate = {
-    platform,
-    username: `${platform}-creator`,
-    displayName: `${platform} creator`,
-    url: platform === "twitch"
-      ? "https://www.twitch.tv/twitch-creator"
-      : "https://kick.com/kick-creator",
-  };
+  const campaign = baselineCampaign(platform);
+  const candidate = baselineCandidate(platform);
   const request = async (phase: "discovery" | "selection", milliseconds: number): Promise<void> => {
     recorder.count("providerRequests");
     await recorder.clock.advance(phase, scenario === "slow" ? milliseconds * 10 : milliseconds);
@@ -120,7 +112,10 @@ export function createCountingAdapter(
 
   return {
     platform,
-    checkAuthHealth: async () => ({ status: "healthy" }),
+    checkAuthHealth: async () => {
+      recorder.count("providerRequests");
+      return { status: "healthy" };
+    },
     refreshCampaigns: async () => {
       recorder.count("campaignDiscovery");
       await request("discovery", 30);
@@ -147,5 +142,161 @@ export function createCountingAdapter(
       managedByExtension: true,
     }),
     stopWatchTab: async () => undefined,
+  };
+}
+
+function baselineCampaign(platform: Platform): DropCampaign {
+  return {
+    id: `${platform}-campaign`,
+    platform,
+    name: `${platform} campaign`,
+    status: "active",
+    rewards: [{
+      id: `${platform}-reward`,
+      name: `${platform} reward`,
+      requiredMinutes: 60,
+      watchedMinutes: 10,
+      status: "in_progress",
+    }],
+  };
+}
+
+function baselineCandidate(platform: Platform): ChannelCandidate {
+  return {
+    platform,
+    username: `${platform}-creator`,
+    displayName: `${platform} creator`,
+    url: platform === "twitch"
+      ? "https://www.twitch.tv/twitch-creator"
+      : "https://kick.com/kick-creator",
+  };
+}
+
+export async function runExtensionBaselineCell(
+  platform: Platform,
+  scenario: TickBaselineScenario,
+): Promise<HostTickBaselineResult> {
+  const recorder = createTickBaselineRecorder();
+  const adapters = {
+    twitch: createCountingAdapter("twitch", platform === "twitch" ? scenario : "idle", recorder),
+    kick: createCountingAdapter("kick", platform === "kick" ? scenario : "idle", recorder),
+  } satisfies Record<Platform, PlatformAdapter>;
+  const settings: ExtensionSettings = {
+    ...DEFAULT_SETTINGS,
+    platform: {
+      twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: platform === "twitch" },
+      kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: platform === "kick" },
+    },
+  };
+  let state: SchedulerState = structuredClone(DEFAULT_STATE);
+  if (scenario === "stable" || scenario === "retained" || scenario === "switch") {
+    const currentIds = scenario === "switch"
+      ? { campaign: `${platform}-old-campaign`, reward: `${platform}-old-reward` }
+      : { campaign: `${platform}-campaign`, reward: `${platform}-reward` };
+    const candidate = scenario === "switch"
+      ? {
+          ...baselineCandidate(platform),
+          username: `${platform}-old-creator`,
+          url: platform === "twitch"
+            ? "https://www.twitch.tv/twitch-old-creator"
+            : "https://kick.com/kick-old-creator",
+        }
+      : baselineCandidate(platform);
+    const tabId = platform === "twitch" ? 10 : 20;
+    const retainedCampaign = scenario === "switch"
+      ? {
+          ...baselineCampaign(platform),
+          id: currentIds.campaign,
+          rewards: [{
+            ...baselineCampaign(platform).rewards[0],
+            id: currentIds.reward,
+          }],
+        }
+      : baselineCampaign(platform);
+    state = {
+      ...state,
+      campaigns: { ...state.campaigns, [platform]: [retainedCampaign] },
+      sessions: {
+        ...state.sessions,
+        [platform]: {
+          platform,
+          status: "watching",
+          offlineChecks: 0,
+          channel: candidate,
+          campaignId: currentIds.campaign,
+          rewardId: currentIds.reward,
+          tabId,
+          tabManagedByExtension: true,
+          watchMode: "tab",
+          startedAt: new Date().toISOString(),
+          watchTabOpenedAt: new Date().toISOString(),
+        },
+      },
+      managedWatchTabs: {
+        ...state.managedWatchTabs,
+        [platform]: {
+          platform,
+          tabId,
+          channelUrl: candidate.url,
+          ownedByExtension: true,
+        },
+      },
+    };
+  }
+  const compatibility = resolveCompatibility(settings.compatibility, {
+    host: "extension",
+    twitchIdentity: "web",
+  });
+  const reportEvents = async (events: readonly EngineEvent[]): Promise<void> => {
+    if (events.length === 0) return;
+    recorder.count("eventPublications");
+    for (const event of events) {
+      if (event.category !== "diagnostic") continue;
+      const selection = event.message.match(/\((\d+) campaigns? checked, (\d+) candidates? checked\)/);
+      if (selection) {
+        recorder.count("campaignsEvaluated", Number(selection[1]));
+        recorder.count("candidatesEvaluated", Number(selection[2]));
+      }
+      if (/fast path retained current watch/.test(event.message)) {
+        recorder.count("candidatesEvaluated");
+      }
+    }
+  };
+  const resolutionFor = (selectedPlatform: Platform) => {
+    recorder.count("adapterConstructions");
+    return { adapter: adapters[selectedPlatform], ...compatibility };
+  };
+  const controller = createBackgroundController<ExtensionSettings>({
+    loadSettings: async () => {
+      recorder.count("settingsLoads");
+      return settings;
+    },
+    saveSettings: async () => undefined,
+    loadState: async () => {
+      recorder.count("stateLoads");
+      return state;
+    },
+    saveState: async (next) => {
+      recorder.count("stateSaves");
+      await recorder.clock.advance("persistence", 5);
+      state = next;
+    },
+    reportEvents,
+    createAlarm: async () => undefined,
+    ensureTwitchIntegrity: async () => true,
+    createNotification: async () => undefined,
+    createAdapter: (selectedPlatform) => resolutionFor(selectedPlatform),
+    createAdapters: (_emit: EventEmitter) => {
+      recorder.count("adapterConstructions", 2);
+      return { adapters, ...compatibility };
+    },
+  });
+
+  await controller.tickAndHandOff([platform], "alarm");
+  return {
+    host: "extension",
+    platform,
+    scenario,
+    ...recorder.snapshot(),
   };
 }

--- a/packages/extension/tests/tickBaseline.test.ts
+++ b/packages/extension/tests/tickBaseline.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createCountingAdapter, createTickBaselineRecorder } from "./helpers/tickBaseline";
+import {
+  createCountingAdapter,
+  createTickBaselineRecorder,
+  runExtensionBaselineCell,
+} from "./helpers/tickBaseline";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -63,6 +67,141 @@ describe("scheduler tick baseline recorder", () => {
         channelChecks: 1,
       },
       durationsMs: { discovery: 30, selection: 20, total: 50 },
+    });
+  });
+});
+
+describe("extension scheduler tick baseline", () => {
+  it.each(["twitch", "kick"] as const)("measures an idle %s alarm tick", async (platform) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+
+    const result = await runExtensionBaselineCell(platform, "idle");
+
+    expect(result).toMatchObject({
+      host: "extension",
+      platform,
+      scenario: "idle",
+      counts: {
+        campaignDiscovery: 1,
+        candidateListings: 0,
+        channelChecks: 0,
+        campaignsEvaluated: 0,
+        candidatesEvaluated: 0,
+        providerRequests: 2,
+        adapterConstructions: 2,
+        settingsLoads: 3,
+        stateLoads: 3,
+        stateSaves: 2,
+        eventPublications: 6,
+        watcherReconciliations: 0,
+        heartbeats: 0,
+      },
+      durationsMs: {
+        discovery: 30,
+        selection: 0,
+        watcher: 0,
+        persistence: 10,
+        total: 40,
+      },
+    });
+  });
+
+  it.each(["twitch", "kick"] as const)("measures a stable retained %s watch", async (platform) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+
+    const result = await runExtensionBaselineCell(platform, "stable");
+
+    expect(result.counts).toMatchObject({
+      providerRequests: 3,
+      campaignDiscovery: 1,
+      candidateListings: 0,
+      channelChecks: 1,
+      campaignsEvaluated: 0,
+      candidatesEvaluated: 1,
+      adapterConstructions: 2,
+      settingsLoads: 3,
+      stateLoads: 3,
+      stateSaves: 2,
+    });
+    expect(result.durationsMs).toEqual({
+      discovery: 30,
+      selection: 10,
+      watcher: 0,
+      persistence: 10,
+      total: 50,
+    });
+  });
+
+  it.each([
+    ["twitch", "switch"],
+    ["kick", "switch"],
+    ["twitch", "higherPriorityUnavailable"],
+    ["kick", "higherPriorityUnavailable"],
+  ] as const)("measures %s/%s selection work", async (platform, scenario) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+
+    const result = await runExtensionBaselineCell(platform, scenario);
+
+    expect(result.counts).toMatchObject({
+      providerRequests: 4,
+      campaignDiscovery: 1,
+      candidateListings: 1,
+      channelChecks: 1,
+      campaignsEvaluated: 1,
+      candidatesEvaluated: 1,
+      adapterConstructions: 2,
+      settingsLoads: 3,
+      stateLoads: 3,
+      stateSaves: 2,
+    });
+    expect(result.durationsMs).toEqual({
+      discovery: 30,
+      selection: 20,
+      watcher: 0,
+      persistence: 10,
+      total: 60,
+    });
+  });
+
+  it.each(["twitch", "kick"] as const)("measures a failed %s provider response", async (platform) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+
+    const result = await runExtensionBaselineCell(platform, "failed");
+
+    expect(result.counts).toMatchObject({
+      providerRequests: 2,
+      campaignDiscovery: 1,
+      candidateListings: 0,
+      channelChecks: 0,
+      campaignsEvaluated: 0,
+      candidatesEvaluated: 0,
+      stateSaves: 2,
+    });
+    expect(result.durationsMs).toEqual({
+      discovery: 30,
+      selection: 0,
+      watcher: 0,
+      persistence: 10,
+      total: 40,
+    });
+  });
+
+  it.each(["twitch", "kick"] as const)("attributes controlled slow %s work to its phases", async (platform) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+
+    const result = await runExtensionBaselineCell(platform, "slow");
+
+    expect(result.durationsMs).toEqual({
+      discovery: 300,
+      selection: 200,
+      watcher: 0,
+      persistence: 10,
+      total: 510,
     });
   });
 });

--- a/packages/extension/tests/tickBaseline.test.ts
+++ b/packages/extension/tests/tickBaseline.test.ts
@@ -5,6 +5,12 @@ import {
   runExtensionBaselineCell,
 } from "./helpers/tickBaseline";
 
+function reportBaseline(result: unknown): void {
+  if (process.env.LURKLOOT_TICK_BASELINE === "1") {
+    console.log(`TICK_BASELINE ${JSON.stringify(result)}`);
+  }
+}
+
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -77,6 +83,7 @@ describe("extension scheduler tick baseline", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
     const result = await runExtensionBaselineCell(platform, "idle");
+    reportBaseline(result);
 
     expect(result).toMatchObject({
       host: "extension",
@@ -112,6 +119,7 @@ describe("extension scheduler tick baseline", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
     const result = await runExtensionBaselineCell(platform, "stable");
+    reportBaseline(result);
 
     expect(result.counts).toMatchObject({
       providerRequests: 3,
@@ -124,13 +132,14 @@ describe("extension scheduler tick baseline", () => {
       settingsLoads: 3,
       stateLoads: 3,
       stateSaves: 2,
+      watcherReconciliations: 1,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
       selection: 10,
-      watcher: 0,
+      watcher: 5,
       persistence: 10,
-      total: 50,
+      total: 55,
     });
   });
 
@@ -144,6 +153,7 @@ describe("extension scheduler tick baseline", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
     const result = await runExtensionBaselineCell(platform, scenario);
+    reportBaseline(result);
 
     expect(result.counts).toMatchObject({
       providerRequests: 4,
@@ -156,13 +166,14 @@ describe("extension scheduler tick baseline", () => {
       settingsLoads: 3,
       stateLoads: 3,
       stateSaves: 2,
+      watcherReconciliations: scenario === "switch" ? 1 : 0,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
       selection: 20,
-      watcher: 0,
+      watcher: scenario === "switch" ? 5 : 0,
       persistence: 10,
-      total: 60,
+      total: scenario === "switch" ? 65 : 60,
     });
   });
 
@@ -171,6 +182,7 @@ describe("extension scheduler tick baseline", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
     const result = await runExtensionBaselineCell(platform, "failed");
+    reportBaseline(result);
 
     expect(result.counts).toMatchObject({
       providerRequests: 2,
@@ -195,13 +207,14 @@ describe("extension scheduler tick baseline", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
     const result = await runExtensionBaselineCell(platform, "slow");
+    reportBaseline(result);
 
     expect(result.durationsMs).toEqual({
       discovery: 300,
       selection: 200,
-      watcher: 0,
+      watcher: 5,
       persistence: 10,
-      total: 510,
+      total: 515,
     });
   });
 });

--- a/packages/extension/tests/tickBaseline.test.ts
+++ b/packages/extension/tests/tickBaseline.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCountingAdapter, createTickBaselineRecorder } from "./helpers/tickBaseline";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("scheduler tick baseline recorder", () => {
+  it("records aggregate work without credential or payload fields", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+    const recorder = createTickBaselineRecorder();
+
+    recorder.count("providerRequests");
+    await recorder.clock.advance("discovery", 40);
+
+    expect(recorder.snapshot()).toEqual({
+      counts: {
+        providerRequests: 1,
+        campaignDiscovery: 0,
+        candidateListings: 0,
+        channelChecks: 0,
+        campaignsEvaluated: 0,
+        candidatesEvaluated: 0,
+        watcherReconciliations: 0,
+        heartbeats: 0,
+        adapterConstructions: 0,
+        settingsLoads: 0,
+        stateLoads: 0,
+        stateSaves: 0,
+        eventPublications: 0,
+      },
+      durationsMs: {
+        discovery: 40,
+        selection: 0,
+        watcher: 0,
+        persistence: 0,
+        total: 40,
+      },
+    });
+    expect(JSON.stringify(recorder.snapshot())).not.toMatch(
+      /credential|cookie|token|authorization|payload/i,
+    );
+  });
+
+  it.each(["twitch", "kick"] as const)("counts normalized %s provider work", async (platform) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-01T20:00:00.000Z");
+    const recorder = createTickBaselineRecorder();
+    const adapter = createCountingAdapter(platform, "refresh", recorder);
+
+    const campaigns = await adapter.refreshCampaigns();
+    const candidates = await adapter.listCandidateChannels(campaigns[0]);
+    const checked = await adapter.checkChannel(candidates[0]);
+
+    expect(campaigns).toHaveLength(1);
+    expect(checked).toMatchObject({ live: true, categoryMatches: true });
+    expect(recorder.snapshot()).toMatchObject({
+      counts: {
+        providerRequests: 3,
+        campaignDiscovery: 1,
+        candidateListings: 1,
+        channelChecks: 1,
+      },
+      durationsMs: { discovery: 30, selection: 20, total: 50 },
+    });
+  });
+});

--- a/packages/extension/tests/tickBaseline.test.ts
+++ b/packages/extension/tests/tickBaseline.test.ts
@@ -21,19 +21,18 @@ describe("scheduler tick baseline recorder", () => {
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
     const recorder = createTickBaselineRecorder();
 
-    recorder.count("providerRequests");
+    recorder.count("adapterOperations");
     await recorder.clock.advance("discovery", 40);
 
     expect(recorder.snapshot()).toEqual({
       counts: {
-        providerRequests: 1,
+        adapterOperations: 1,
         campaignDiscovery: 0,
         candidateListings: 0,
         channelChecks: 0,
         campaignsEvaluated: 0,
         candidatesEvaluated: 0,
         watcherReconciliations: 0,
-        heartbeats: 0,
         adapterConstructions: 0,
         settingsLoads: 0,
         stateLoads: 0,
@@ -67,7 +66,7 @@ describe("scheduler tick baseline recorder", () => {
     expect(checked).toMatchObject({ live: true, categoryMatches: true });
     expect(recorder.snapshot()).toMatchObject({
       counts: {
-        providerRequests: 3,
+        adapterOperations: 3,
         campaignDiscovery: 1,
         candidateListings: 1,
         channelChecks: 1,
@@ -95,20 +94,23 @@ describe("extension scheduler tick baseline", () => {
         channelChecks: 0,
         campaignsEvaluated: 0,
         candidatesEvaluated: 0,
-        providerRequests: 2,
+        adapterOperations: 2,
         adapterConstructions: 2,
         settingsLoads: 3,
         stateLoads: 3,
         stateSaves: 2,
         eventPublications: 6,
         watcherReconciliations: 0,
-        heartbeats: 0,
       },
       durationsMs: {
         discovery: 30,
         selection: 0,
         watcher: 0,
         persistence: 10,
+        total: 40,
+      },
+      observedControllerMs: {
+        discovery: 30,
         total: 40,
       },
     });
@@ -122,7 +124,7 @@ describe("extension scheduler tick baseline", () => {
     reportBaseline(result);
 
     expect(result.counts).toMatchObject({
-      providerRequests: 3,
+      adapterOperations: 3,
       campaignDiscovery: 1,
       candidateListings: 0,
       channelChecks: 1,
@@ -155,25 +157,27 @@ describe("extension scheduler tick baseline", () => {
     const result = await runExtensionBaselineCell(platform, scenario);
     reportBaseline(result);
 
+    expect(result.outcomeCampaignId).toBe(`${platform}-campaign`);
+
     expect(result.counts).toMatchObject({
-      providerRequests: 4,
+      adapterOperations: scenario === "higherPriorityUnavailable" ? 7 : 4,
       campaignDiscovery: 1,
-      candidateListings: 1,
-      channelChecks: 1,
-      campaignsEvaluated: 1,
-      candidatesEvaluated: 1,
+      candidateListings: scenario === "higherPriorityUnavailable" ? 2 : 1,
+      channelChecks: scenario === "higherPriorityUnavailable" ? 3 : 1,
+      campaignsEvaluated: scenario === "higherPriorityUnavailable" ? 2 : 1,
+      candidatesEvaluated: scenario === "higherPriorityUnavailable" ? 2 : 1,
       adapterConstructions: 2,
       settingsLoads: 3,
       stateLoads: 3,
       stateSaves: 2,
-      watcherReconciliations: scenario === "switch" ? 1 : 0,
+      watcherReconciliations: 1,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
-      selection: 20,
-      watcher: scenario === "switch" ? 5 : 0,
+      selection: scenario === "higherPriorityUnavailable" ? 50 : 20,
+      watcher: 5,
       persistence: 10,
-      total: scenario === "switch" ? 65 : 60,
+      total: scenario === "higherPriorityUnavailable" ? 95 : 65,
     });
   });
 
@@ -185,7 +189,7 @@ describe("extension scheduler tick baseline", () => {
     reportBaseline(result);
 
     expect(result.counts).toMatchObject({
-      providerRequests: 2,
+      adapterOperations: 2,
       campaignDiscovery: 1,
       candidateListings: 0,
       channelChecks: 0,
@@ -214,6 +218,11 @@ describe("extension scheduler tick baseline", () => {
       selection: 200,
       watcher: 5,
       persistence: 10,
+      total: 515,
+    });
+    expect(result.observedControllerMs).toEqual({
+      discovery: 300,
+      selection: 200,
       total: 515,
     });
   });

--- a/packages/extension/tests/twitchCampaignDetailsReuse.test.ts
+++ b/packages/extension/tests/twitchCampaignDetailsReuse.test.ts
@@ -101,6 +101,7 @@ describe("twitch campaign details reuse (#339)", () => {
       vi.setSystemTime("2026-08-31T12:00:00.000Z");
       const first = await twitchAdapter(fetcher, undefined, undefined, { discoveryState }).refreshCampaigns();
       expect(requested).toEqual(["a", "b", "c"]);
+      expect(fetcher.fetchJson).toHaveBeenCalledTimes(3);
 
       vi.setSystemTime("2026-08-31T12:01:00.000Z");
       const second = await twitchAdapter(
@@ -112,6 +113,9 @@ describe("twitch campaign details reuse (#339)", () => {
       ).refreshCampaigns();
 
       expect(requested).toEqual(["a", "b", "c"]);
+      // The warm tick performs only inventory + dashboard transport requests;
+      // campaign details are served from the state shared by rebuilt adapters.
+      expect(fetcher.fetchJson).toHaveBeenCalledTimes(5);
       expect(second.map((campaign) => campaign.id)).toEqual(first.map((campaign) => campaign.id));
       expect(events.some((event) =>
         event.category === "diagnostic"


### PR DESCRIPTION
## Summary

- adds a credential-free deterministic scheduler baseline for extension/Twitch, extension/Kick, CLI/Twitch, and CLI/Kick
- distinguishes normalized adapter operations from real provider transport requests, with exact Twitch and Kick transport assertions in focused adapter tests
- covers idle, retained target, real switch, unavailable higher-priority target, failed provider, slow provider, emitted controller timing, and CLI interval queuing
- skips clean disabled CLI providers while cleaning any stale campaigns/watch state left by a configuration change
- documents alarm, manual/settings, heartbeat, claim-handoff, and discovery-signal concurrency evidence without changing #336 → #394 → #395 → #337

PR #450 / issue #339 was merged before this branch and is included in the starting baseline.

## Audit follow-ups

- #457 tracks adapter reuse after the planned scheduler sequence
- #458 tracks the CLI-only post-tick state reload after #395
- #361 is updated without changing #336 → #394 → #395 → #337

## Testing

- `pnpm verify`
  - CLI: 170 tests
  - extension: 1,671 tests
  - script tests and all workspace typechecks
  - site tests/build
  - Chromium and Firefox production builds
- focused opt-in JSON baseline runs for both hosts

No credentials, cookies, tokens, authorization headers, or raw authenticated provider payloads are present in the fixtures or reports.

Part of #361.
Implements the baseline phase of #452; #452 remains open as the final performance gate.
