### PR TITLE
ci(release): attest build provenance and pin third-party actions

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v6
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       with:
         version: 11.26.0
     - uses: actions/setup-node@v7

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -27,6 +27,8 @@ on:
     outputs:
       image_tag:
         value: ${{ jobs.publish.outputs.image_tag }}
+      image_digest:
+        value: ${{ jobs.publish.outputs.image_digest }}
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/lurkloot-cli
@@ -61,9 +63,9 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: node scripts/release/cli.mjs prepare-workspace --version "$VERSION" --date "$(date -u +%F)"
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: packages/cli/Dockerfile
@@ -101,6 +103,7 @@ jobs:
       packages: write
     outputs:
       image_tag: ${{ steps.publish.outputs.image_tag }}
+      image_digest: ${{ steps.publish.outputs.image_digest }}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -110,7 +113,7 @@ jobs:
       - name: Verify OCI artifacts
         working-directory: images
         run: sha256sum -c image-amd64.tar.sha256 && sha256sum -c image-arm64.tar.sha256
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -131,3 +134,7 @@ jobs:
           docker buildx imagetools create --tag "$IMAGE_NAME:$IMAGE_TAG" \
             "$IMAGE_NAME:$IMAGE_TAG-amd64" "$IMAGE_NAME:$IMAGE_TAG-arm64"
           echo "image_tag=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          # The manifest digest is what provenance is attested against, and what stable publication
+          # later promotes. The tag is mutable; this is not.
+          digest=$(docker buildx imagetools inspect "$IMAGE_NAME:$IMAGE_TAG" --format '{{.Manifest.Digest}}')
+          echo "image_digest=$digest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           ref: ${{ inputs.trusted_ref }}
           persist-credentials: false
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.26.0
       - uses: actions/setup-node@v7
@@ -70,7 +70,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.26.0
       - uses: actions/setup-node@v7

--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.26.0
       - uses: actions/setup-node@v7
@@ -106,6 +106,41 @@ jobs:
       image_tag: candidate-${{ inputs.version }}
       artifact_prefix: candidate-docker-${{ inputs.version }}
       push: true
+
+  # Provenance is emitted where the bits are produced, not where they are promoted: the stable
+  # release retags this exact image digest and republishes these exact asset bytes, so one
+  # attestation covers both the candidate and the release. Keeping it out of build-extension.yml
+  # and build-docker.yml matters — those are also called by pr-validation.yml, and a reusable
+  # workflow's permission ceiling is validated in the caller even when the job is skipped, which
+  # would force `id-token: write` onto pull-request validation.
+  attest:
+    needs: [extension, docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: candidate-extension-${{ inputs.version }}
+          path: release-assets
+      - name: Attest the signed extension artifacts
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: release-assets/lurkloot-*
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attest the candidate image
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/lurkloot-cli
+          subject-digest: ${{ needs.docker.outputs.image_digest }}
+          push-to-registry: true
 
   publish:
     needs: [verify, extension, docker]
@@ -194,7 +229,7 @@ jobs:
 
   gate:
     if: always()
-    needs: [verify, extension, docker, publish, site, status]
+    needs: [verify, extension, docker, attest, publish, site, status]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -215,12 +250,13 @@ jobs:
           VERIFY: ${{ needs.verify.result }}
           EXTENSION: ${{ needs.extension.result }}
           DOCKER: ${{ needs.docker.result }}
+          ATTEST: ${{ needs.attest.result }}
           PUBLISH: ${{ needs.publish.result }}
           SITE: ${{ needs.site.result }}
           STATUS: ${{ needs.status.result }}
         run: |
           state=success
-          for result in "$VERIFY" "$EXTENSION" "$DOCKER" "$PUBLISH" "$SITE" "$STATUS"; do
+          for result in "$VERIFY" "$EXTENSION" "$DOCKER" "$ATTEST" "$PUBLISH" "$SITE" "$STATUS"; do
             test "$result" = success || state=failure
           done
           node scripts/release/cli.mjs candidate-checks \

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.26.0
       - uses: actions/setup-node@v7

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -78,6 +78,10 @@ jobs:
       packages: write
       pull-requests: write
       statuses: write
+      # The candidate's attest job emits build provenance; a reusable workflow's permission
+      # ceiling is validated against the caller.
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build-release-candidate.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
@@ -176,6 +180,10 @@ jobs:
       packages: write
       pull-requests: write
       statuses: write
+      # The candidate's attest job emits build provenance; a reusable workflow's permission
+      # ceiling is validated against the caller.
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build-release-candidate.yml
     with:
       ref: ${{ needs.cut.outputs.release_sha }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -82,6 +82,10 @@ jobs:
       packages: write
       pull-requests: write
       statuses: write
+      # The candidate's attest job emits build provenance; a reusable workflow's permission
+      # ceiling is validated against the caller.
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build-release-candidate.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           RELEASE_SYNC_APP_ID: ${{ secrets.RELEASE_SYNC_APP_ID }}
           RELEASE_SYNC_APP_PRIVATE_KEY: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
         run: node scripts/release/cli.mjs app-token
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.26.0
       - uses: actions/download-artifact@v8
@@ -185,7 +185,7 @@ jobs:
           else
             echo "v$VERSION is already the stable release"
           fi
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -117,6 +117,10 @@ Stable publication operates on the exact merged commit and is idempotent:
 - Docker architectures are exported as checksummed OCI archives before approval. GHCR receives
   `X.Y.Z`, `X.Y`, `X`, and `latest` only inside the approved production job; an existing `X.Y.Z`
   digest is never replaced.
+- Build provenance is attested during candidacy, for the signed extension assets and for the CLI
+  image digest, and stable publication ships those same bytes. Verify a downloaded asset with
+  `gh attestation verify <file> --repo jamezrin/lurkloot`, and the image with
+  `gh attestation verify oci://ghcr.io/jamezrin/lurkloot-cli:X.Y.Z --repo jamezrin/lurkloot`.
 - Chrome Web Store receives the Chrome ZIP with `DEFAULT_PUBLISH`; Google publishes it automatically
   after review approval.
 - The production site deploys to `https://lurkloot.jamezrin.com`.
@@ -209,6 +213,10 @@ only then removes the conflicting classic protections. It refuses to run without
 - only the Lurkloot Release Sync App as an always-allowed bypass actor.
 
 The repository default workflow token remains read-only.
+
+Third-party actions (`pnpm/*`, `docker/*`, `cloudflare/*`) are pinned to a commit SHA with the
+version in a trailing comment. GitHub-owned `actions/*` stay tag-pinned. Renovate updates the pinned
+SHAs; do not replace one with a floating tag.
 
 ## Recovery
 


### PR DESCRIPTION
Item 3 of #472.

## Summary

Two independent hardening gaps: nothing in the pipeline attested what it built, and third-party actions were tag-pinned — including `pnpm/action-setup` in the `build` job whose output later gets signed.

**Provenance.** A new `attest` job in `build-release-candidate.yml` emits `actions/attest-build-provenance` for the signed extension assets and for the candidate image digest (`push-to-registry: true`). It is part of the `gate` aggregate, so a missing attestation fails the candidate.

It deliberately does *not* live in `build-extension.yml` / `build-docker.yml`: `pr-validation.yml` calls both, and — as the existing comment at `pr-validation.yml:42` records — a reusable workflow's permission ceiling is validated in the caller even when the job is skipped. Declaring `id-token: write` there would force it onto pull-request validation, including fork PRs. Emitting from the candidate workflow keeps that permission on trusted release paths only; `prepare-release.yml` and `release-candidate.yml` grant the ceiling.

Provenance is emitted where the bits are produced, not where they are promoted. Stable publication republishes the same asset bytes and (with #475) retags the same image digest, so one attestation covers candidate and release.

**Pins.** `pnpm/*` and `docker/*` are pinned to commit SHAs with the version in a trailing comment, matching the existing `cloudflare/wrangler-action` style. GitHub-owned `actions/*` stay tag-pinned. Renovate keeps pinned digests current and automerges those updates.

## Deliberately not in this PR

Verifying provenance at publication time (`gh attestation verify` on the recovered release assets, replacing the trust placed in the unsigned `SHA256SUMS`) can only be enforced once a candidate built by *this* code has produced attestations. Enforcing it in the same change would wedge the first release that runs it. Worth a follow-up once one release cycle has passed.

## Testing

Workflow YAML only, so no unit tests per the repo convention. All workflow and composite-action files re-parse; action SHAs were resolved via the GitHub API (annotated tags dereferenced to their commits).

https://claude.ai/code/session_01ASCiGmqtAcEfdebkmh1qEf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved build reliability by pinning third-party automation components to specific versions.
  - Added provenance attestations for release candidate artifacts and container images.
  - Exposed container image digests for easier verification.

- **Documentation**
  - Documented how to verify build provenance and the policy for pinned automation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->