### PR TITLE
ci(release): move the develop sync off the release critical path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,9 +146,6 @@ jobs:
           RELEASE_SYNC_APP_ID: ${{ secrets.RELEASE_SYNC_APP_ID }}
           RELEASE_SYNC_APP_PRIVATE_KEY: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
         run: node scripts/release/cli.mjs app-token
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 11.26.0
       - uses: actions/download-artifact@v8
         with:
           pattern: stable-docker-${{ github.run_id }}-${{ github.run_attempt }}-oci-*
@@ -240,6 +237,40 @@ jobs:
           directory: site-artifact
           api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Report stable publication
+        run: >-
+          gh pr comment "$RELEASE_PR"
+          --body "Released v$VERSION. Chrome Web Store review was requested with automatic publication: https://chrome.google.com/webstore/devconsole/5fdc4582-d1e8-4714-819e-d4bdcee7da79/aobaackpofkghaejdnnmpmeaiaoibhdn"
+
+  # Synchronization is deliberately outside publish. It verifies the merged `develop` tree, which is
+  # not the tree being released, so a develop-side failure must not be able to wedge a release that
+  # has already shipped: this leaves a completed release plus one retryable job, instead of a rerun
+  # that repeats the entire publication before failing in the same place. Its own checkout is clean,
+  # so nothing has to be restored before switching branches.
+  sync:
+    needs: [resolve, publish]
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.26.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - id: sync-token
+        name: Mint the dedicated synchronization credential
+        env:
+          RELEASE_SYNC_APP_ID: ${{ secrets.RELEASE_SYNC_APP_ID }}
+          RELEASE_SYNC_APP_PRIVATE_KEY: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
+        run: node scripts/release/cli.mjs app-token
       - name: Merge main directly into develop with the dedicated App
         env:
           SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}
@@ -249,17 +280,9 @@ jobs:
           export GIT_CONFIG_COUNT=1
           export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
           export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth"
-          # Publication dirties the workspace before this runs: the site deploy installs wrangler on
-          # demand, which rewrites package.json. Synchronization switches branches, so it aborts on a
-          # dirty tree. Everything is already published by now, so tracked edits are discarded.
-          git restore --staged --worktree -- .
           # Playwright browsers live in the runner cache, not the worktree, so they survive the
           # branch switch inside sync-branches. Candidate and PR verify jobs already install
-          # Chromium; this publish checkout may be an older release SHA whose defaultVerify does not.
+          # Chromium; this checkout may be an older release SHA whose defaultVerify does not.
           pnpm install --frozen-lockfile
           pnpm --filter @lurkloot/extension exec playwright install chromium
           node scripts/release/cli.mjs sync-branches --remote origin
-      - name: Report stable publication
-        run: >-
-          gh pr comment "$RELEASE_PR"
-          --body "Released v$VERSION. Chrome Web Store review was requested with automatic publication: https://chrome.google.com/webstore/devconsole/5fdc4582-d1e8-4714-819e-d4bdcee7da79/aobaackpofkghaejdnnmpmeaiaoibhdn"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,9 @@ whose diff is only the version bump. Candidate artifacts refresh on every push t
 and on every release-branch push.
 
 Merge the generated release PR with a merge commit; **Release** starts automatically, publishes the
-GitHub release, GHCR aliases, Chrome Web Store submission and production site after one approval,
-then merges `main` directly into `develop` with the dedicated sync App. A hotfix is the same flow
+GitHub release, GHCR aliases, Chrome Web Store submission and production site after approval, then a
+separate `sync` job — approved on `production` in its own right — merges `main` directly into
+`develop` with the dedicated sync App. A hotfix is the same flow
 with `release/patch` on a PR branched from `main`. Use manual **Release** dispatch only for idempotent
 recovery. Do not create or move tags by hand.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,8 +2,8 @@
 
 Label a pull request into `main`, inspect the candidate, and merge that pull request normally. A
 generated release pull request carrying the version bump then opens against `main`; merging it starts
-publication automatically, pausing once for approval on the `production` environment. Do not create
-or move tags by hand.
+publication automatically, pausing for approval on the `production` environment. Do not create or
+move tags by hand.
 
 ## Before you start: write the changelog
 
@@ -36,10 +36,15 @@ empty entry. That intentionally permits build-only releases, but produces an emp
    generated pull request's diff is only the version bump and changelog date.
 6. Review and merge the generated `release/X.Y.Z` pull request with a **merge commit**. Squash and
    rebase are blocked on `main`; the original `develop` commit SHAs remain in `main` history.
-7. Release runs from the merged `main` commit. Approve its single `production` job. It promotes the
-   `vX.Y.Z` prerelease to the latest release, publishing the extension artifacts it already carries
-   rather than rebuilding them, then publishes GHCR, Chrome Web Store, and the production site, and
-   merges `main` directly into `develop` with the dedicated synchronization App.
+7. Release runs from the merged `main` commit. Approve its `production` publication job. It promotes
+   the `vX.Y.Z` prerelease to the latest release, publishing the extension artifacts it already
+   carries rather than rebuilding them, then publishes GHCR, Chrome Web Store, and the production
+   site.
+8. A separate `sync` job then merges `main` directly into `develop` with the dedicated
+   synchronization App, after verifying the merged tree. It is also gated on `production`, so it
+   asks for a second approval. That separation is deliberate: it verifies a tree that is not the one
+   being released, and a failure there must leave a completed release plus one retryable job rather
+   than wedge publication.
 
 `workflow_dispatch` remains on **Release** only for idempotent recovery. A successful release does
 not require a manual dispatch.
@@ -121,7 +126,8 @@ Stable publication operates on the exact merged commit and is idempotent:
   after review approval.
 - The production site deploys to `https://lurkloot.jamezrin.com`.
 - The owned mutable candidate release and tag are removed after the stable release exists.
-- `main` is merged directly into `develop` after local `pnpm verify` succeeds.
+- `main` is merged directly into `develop` after local `pnpm verify` succeeds, in the separate
+  `sync` job. The release is complete before it runs; nothing it does can unpublish anything.
 
 Firefox Add-ons publication remains manual. Upload the Firefox and source ZIPs from the GitHub
 release to AMO.
@@ -147,7 +153,7 @@ There are exactly two environments:
 | Environment | Approval | Credentials and purpose |
 | --- | --- | --- |
 | `preview` | none | `CRX_PRIVATE_KEY`; candidate signing, candidate GHCR, preview site |
-| `production` | `jamezrin` | CWS credentials and sync App credentials; all stable publication |
+| `production` | `jamezrin` | CWS credentials and sync App credentials; stable publication and the `develop` synchronization, approved separately |
 
 Repository secrets used from both channels remain `CLOUDFLARE_API_TOKEN` and
 `CLOUDFLARE_ACCOUNT_ID`. Variables are `CWS_PUBLISHER_ID` and `CWS_EXTENSION_ID`.
@@ -217,6 +223,8 @@ The repository default workflow token remains read-only.
 - Stable failure after merge: fix the external/configuration problem and manually dispatch
   **Release** on `main`. Matching completed steps are no-ops.
 - Existing stable tag at another SHA: stop and prepare a new version. Never move it.
+- Sync failure, including a `develop` tree that no longer passes `pnpm verify`: the release itself
+  is complete. Fix `develop`, then rerun the failed `sync` job alone; publication is not repeated.
 - Sync conflict: merge `main` into `develop` locally, run `pnpm verify`, and push with the dedicated
   App credential; alternatively use a one-off reviewed synchronization PR. Do not disable branch
   protection.

--- a/scripts/release/sync.test.mjs
+++ b/scripts/release/sync.test.mjs
@@ -143,7 +143,7 @@ test("defaultVerify includes command stdout when verification fails", async () =
   );
 });
 
-test("publish installs Playwright Chromium before synchronizing develop", async () => {
+test("the sync job installs Playwright Chromium before synchronizing develop", async () => {
   const yaml = await readFile(new URL("../../.github/workflows/release.yml", import.meta.url), "utf8");
   assert.match(
     yaml,


### PR DESCRIPTION
Item 2 of #472.

## Summary

`sync-branches` ran `pnpm verify` on the merged `develop` tree as the final step of the approved `publish` job. Release completion was therefore coupled to `develop`'s health at publication time, on a tree that is not the one being released: if `develop` had advanced with something that fails verify, the release wedged at its last step, and each rerun repeated the entire publish before failing in the same place.

- Synchronization is now its own `sync` job, needing `publish`. A develop-side failure leaves a completed release plus one retryable job.
- Its checkout is clean, so the blanket `git restore --staged --worktree -- .` is gone rather than narrowed. That line was correct today but silently discarded anything else an earlier step left behind; a fresh checkout removes the need entirely (the "while in there" note on the issue).
- `publish` keeps its fail-fast `sync-token` step, so missing App configuration still fails before anything is published. The `sync` job mints its own token.
- `pnpm` setup moved out of `publish`, which no longer runs pnpm at all.

## The one judgment call — say the word and I'll flip it

**The `sync` job needs the App credentials, which live on `production`, so it requests a second approval.** Environment protection is evaluated per job; there is no way to split the job and keep exactly one approval while the credentials stay on the protected environment. I picked the option that preserves both the credential boundary and the pre-push verification, and updated `RELEASING.md` / `AGENTS.md` accordingly — the cost is one extra click per release.

The alternatives, if you would rather keep the single approval:

1. Move `RELEASE_SYNC_APP_ID` / `RELEASE_SYNC_APP_PRIVATE_KEY` to repository secrets. The `sync` job then needs no environment: one approval, one retryable job — but the sync credential leaves the protected boundary. One-line change here.
2. Keep sync inside `publish` and drop `defaultVerify` from the pre-push path. One approval, fully decoupled — but nothing verifies `develop` before the push, and `pr-validation.yml` is PR-only, so a broken tree is not caught until the next PR (which is strict-up-to-date gated, so it does get caught, later and by someone else).

## Testing

Workflow and docs only; `sync.mjs` is unchanged, so its unit tests still cover the behavior as-is. `release.yml` re-parses and the job graph is `resolve → docker/site-build → publish → sync`.

https://claude.ai/code/session_01ASCiGmqtAcEfdebkmh1qEf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Release publishing and post-release synchronization are now handled as separate, independently approved stages.
  - Post-release synchronization merges the released changes into the development branch after verification.
  - Recovery guidance now includes steps for handling synchronization failures.

- **Documentation**
  - Updated release procedures and contributor guidance to reflect the revised publishing and synchronization workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->