### PR TITLE
docs(release): cover the abandoned release and correct two claims

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -142,6 +142,20 @@ jobs:
         env:
           VERSION: ${{ steps.policy.outputs.version }}
         run: node scripts/release/cli.mjs prepare-workspace --version "$VERSION" --date "$(date -u +%F)"
+      # `main` already carrying the bump means the release merged but was never approved, and the
+      # cut has nothing to open a pull request from. Say so here rather than failing later inside
+      # `gh pr create` with "no commits between main and release/X.Y.Z".
+      - name: Detect a release that is already bumped on main
+        env:
+          VERSION: ${{ steps.policy.outputs.version }}
+          TRIGGER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git add package.json packages/*/package.json packages/site/src/changelog.json
+          git diff --cached --quiet || exit 0
+          gh pr comment "$TRIGGER" --body "\`main\` already carries the version bump for \`$VERSION\`, so there is no release pull request to cut. This is the abandoned-release case: the release pull request merged but its \`production\` approval was never given. Dispatch **Release** manually to finish publishing \`$VERSION\`; do not re-apply a release label."
+          echo "main already carries $VERSION; dispatch Release to finish publication" >&2
+          exit 1
       - id: open
         name: Push the release branch and open its pull request
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,10 +69,11 @@ Candidate pointers are deliberately mutable:
 Every push to a labelled head rebuilds and refreshes those targets, as does every generated
 release-branch push, so the candidate always describes the commit that would be released rather
 than whichever commit was current when the label went on. Ownership metadata binds
-the candidate release to its pull request. An exact-SHA tag left behind by interrupted initial
-creation is recovered; a tag at any other SHA is rejected. Automation never modifies a stable
-release through the candidate path: promotion clears the prerelease flag, and every later candidate
-build against that tag fails.
+the candidate release to its pull request. While the candidate release object still exists, its tag
+is moved to the commit being built — that is what makes the candidate mutable. A tag left behind
+with no release object is recovered only when it points at the exact commit being published; at any
+other commit it is rejected. Automation never modifies a stable release through the candidate path:
+promotion clears the prerelease flag, and every later candidate build against that tag fails.
 
 The candidate and the stable release are the same object. `vX.Y.Z` is created during candidacy at the
 release branch head and is never moved; merging the release pull request flips it from prerelease to
@@ -216,12 +217,17 @@ The repository default workflow token remains read-only.
 - Candidate failure: re-run the failed workflow or push the corrected release branch.
 - Stable failure after merge: fix the external/configuration problem and manually dispatch
   **Release** on `main`. Matching completed steps are no-ops.
+- Release merged but never approved, then re-cut: dispatch **Release**, do not re-apply a release
+  label. `main` already carries the bump, so preparation has an empty commit and no pull request to
+  open; it detects that and comments with this instruction. The tag is fine — a still-prerelease tag
+  is moved rather than rejected — and a dispatch resolves the merged release commit and publishes
+  from it.
 - Existing stable tag at another SHA: stop and prepare a new version. Never move it.
 - Sync conflict: merge `main` into `develop` locally, run `pnpm verify`, and push with the dedicated
   App credential; alternatively use a one-off reviewed synchronization PR. Do not disable branch
   protection.
-- Missing App configuration: publication reports the completed stable steps and fails at sync. Add
-  the two production secrets and rerun Release.
+- Missing App configuration: the credential check is the first step of publication, so the job
+  fails before anything is published. Add the two production secrets and rerun Release.
 
 The Chrome Web Store intentionally trails the GitHub release while Google reviews the submission.
 There is no polling, cancellation, or rollback workflow.


### PR DESCRIPTION
Items 4 and 5 of #472.

## Summary

**Item 4 — abandoned release.** The state "release pull request merged, `production` approval never given, release then re-cut" had no entry in the recovery matrix, and it is the one state preparation cannot work around: the tag is fine (`reconcilePrerelease` moves a still-prerelease tag rather than rejecting it), but `main` already carries the bump, so `prepare-workspace` produces an empty commit and `gh pr create` has no diff to open. The actual escape is a manual **Release** dispatch, which resolves the merged release commit correctly.

- `RELEASING.md` gains the entry: release merged but never approved → dispatch **Release**, do not re-label.
- `prepare-release.yml`'s `cut` job detects the empty bump before pushing and comments that instruction on the triggering pull request, instead of failing later inside `gh pr create` with "no commits between main and release/X.Y.Z".

**Item 5 — two statements that no longer matched the code.**

- "An exact-SHA tag left behind by interrupted initial creation is recovered; a tag at any other SHA is rejected." The rejection at `scripts/release/github.mjs:135` only fires when the *release object* is missing. While the prerelease exists, `reconcilePrerelease` moves the ref — the intended mutable-candidate behavior. Reworded to describe both paths.
- The Recovery section claimed missing App configuration "reports the completed stable steps and fails at sync". `sync-token` is the first step of `publish`, so it fails before anything is published. The implementation is better than the doc; the doc now says so.

## Testing

Docs plus one workflow step; no JS changed, so no unit tests (and per repo convention nothing asserts on workflow YAML). `prepare-release.yml` re-parses and the new step's condition was checked by hand: `git diff --cached --quiet` exits non-zero when there *is* a bump, which short-circuits to the normal path.

Note: overlaps `RELEASING.md`'s Recovery section with #478, which adds a sync-failure bullet nearby. Whichever lands second may need a trivial rebase.

https://claude.ai/code/session_01ASCiGmqtAcEfdebkmh1qEf