### PR TITLE
refactor(core): publish provider discovery snapshots

### DIFF
--- a/docs/scheduler-tick-baseline.md
+++ b/docs/scheduler-tick-baseline.md
@@ -47,7 +47,7 @@ Related scheduler entry paths and concurrency boundaries remain pinned by focuse
 - claim handoff: `backgroundController.test.ts` covers independent cross-platform handoffs, immediate post-claim heartbeats, and duplicate-handoff suppression;
 - discovery-signal overlap: `backgroundController.test.ts` proves bursts coalesce into one non-overlapping follow-up.
 
-The CLI interval baseline blocks one refresh across another elapsed interval. It proves provider work stays serialized by the controller lock, but every elapsed interval is queued and later runs. Changing that policy remains in #394; the planned implementation order remains #336 → #394 → #395 → #337.
+The CLI interval baseline blocks one refresh across another elapsed interval. Provider discovery is now single-flight per platform: elapsed intervals coalesce into at most one follow-up refresh instead of queuing every missed interval. Twitch and Kick own separate lanes, so either provider can publish while the other is blocked.
 
 ## Counting semantics
 
@@ -57,6 +57,7 @@ The CLI interval baseline blocks one refresh across another elapsed interval. It
 - `eventPublications` counts non-empty aggregate batches passed to the host reporter, not individual diagnostic or activity records.
 - Authentication health is saved before scheduler work so a later failure cannot erase the health observation. That makes two state saves per measured tick intentional.
 - `observedControllerMs` is parsed from the controller's emitted refresh, selection, and tick-completion diagnostics; assertions therefore verify the production timing instrumentation rather than only the fixture clock.
+- Snapshot candidate enumeration and validation are attributed to the controller's discovery duration. The legacy scheduler still performs its selection pass, but reads the committed normalized observations through an in-memory adapter view; #395 will make that selection lifecycle independently triggered and coalesced.
 - Real Twitch transport counts are pinned in `twitchCampaignDetailsReuse.test.ts`: the three-campaign cold refresh performs three `fetchJson` calls, while the following warm refresh adds only inventory and dashboard (five cumulative). `adapters.test.ts` pins a Kick refresh at two concurrent transport calls (campaigns and progress). The host matrix does not relabel adapter calls as HTTP requests.
 
 PR #450 / issue #339 merged before this baseline. Its Twitch campaign-details reuse is part of the starting behavior.

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -157,24 +157,24 @@ describe("CLI scheduler tick baseline", () => {
       reportBaseline(result);
 
       expect(result.counts).toEqual({
-        adapterOperations: 6,
+        adapterOperations: 8,
         campaignDiscovery: 2,
-        candidateListings: 0,
+        candidateListings: 2,
         channelChecks: 2,
         heartbeatAttempts: 1,
         heartbeatBlockedByDiscovery: 0,
         discoveryBlockedByHeartbeat: 0,
         // The non-once loop now performs one recovery pass for both providers
         // at startup before the first discovery completes.
-        adapterConstructions: 8,
+        adapterConstructions: 10,
         watcherReconciliations: 1,
       });
       expect(result.durationsMs).toEqual({
         discovery: 60,
-        selection: 20,
+        selection: 40,
         watcher: 5,
         persistence: 0,
-        total: 85,
+        total: 105,
       });
       expect(JSON.stringify(result)).not.toMatch(/credential|cookie|token|authorization|payload/i);
       expect(process.listeners("SIGINT")).toEqual(sigintListenersBefore);
@@ -201,7 +201,7 @@ describe("CLI scheduler tick baseline", () => {
         heartbeatAttempts: 0,
         heartbeatBlockedByDiscovery: 0,
         discoveryBlockedByHeartbeat: 0,
-        adapterConstructions: 2,
+        adapterConstructions: 3,
         watcherReconciliations: 0,
       },
       durationsMs: {
@@ -211,6 +211,7 @@ describe("CLI scheduler tick baseline", () => {
         persistence: 0,
         total: 30,
       },
+      outcomeCampaignId: undefined,
     });
   });
 
@@ -222,19 +223,19 @@ describe("CLI scheduler tick baseline", () => {
     reportBaseline(result);
 
     expect(result.counts).toMatchObject({
-      adapterOperations: 3,
+      adapterOperations: 4,
       campaignDiscovery: 1,
-      candidateListings: 0,
+      candidateListings: 1,
       channelChecks: 1,
-      adapterConstructions: 2,
+      adapterConstructions: 3,
       watcherReconciliations: 1,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
-      selection: 10,
+      selection: 20,
       watcher: 5,
       persistence: 0,
-      total: 45,
+      total: 55,
     });
   });
 
@@ -269,19 +270,19 @@ describe("CLI scheduler tick baseline", () => {
     expect(result.outcomeCampaignId).toBe(`${platform}-campaign`);
 
     expect(result.counts).toMatchObject({
-      adapterOperations: scenario === "higherPriorityUnavailable" ? 7 : 4,
+      adapterOperations: scenario === "higherPriorityUnavailable" ? 6 : 4,
       campaignDiscovery: 1,
       candidateListings: scenario === "higherPriorityUnavailable" ? 2 : 1,
-      channelChecks: scenario === "higherPriorityUnavailable" ? 3 : 1,
-      adapterConstructions: 2,
+      channelChecks: scenario === "higherPriorityUnavailable" ? 2 : 1,
+      adapterConstructions: 3,
       watcherReconciliations: 1,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
-      selection: scenario === "higherPriorityUnavailable" ? 50 : 20,
+      selection: scenario === "higherPriorityUnavailable" ? 40 : 20,
       watcher: 5,
       persistence: 0,
-      total: scenario === "higherPriorityUnavailable" ? 85 : 55,
+      total: scenario === "higherPriorityUnavailable" ? 75 : 55,
     });
   });
 
@@ -370,7 +371,7 @@ describe("runLoop disabled platform cleanup", () => {
 });
 
 describe("runLoop interval baseline", () => {
-  it("serializes provider work but queues each elapsed interval", async () => {
+  it("serializes provider discovery with at most one coalesced follow-up", async () => {
     vi.useFakeTimers();
     const pendingRefresh = deferred<DropCampaign[]>();
     let refreshCalls = 0;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "./staleCache": "./src/core/staleCache.ts",
     "./timestamps": "./src/core/timestamps.ts",
     "./heartbeatCadence": "./src/core/heartbeatCadence.ts",
+    "./discoverySnapshot": "./src/core/discoverySnapshot.ts",
     "./adapter": "./src/platforms/adapter.ts",
     "./twitch": "./src/platforms/twitch/index.ts",
     "./twitch/parser": "./src/platforms/twitch/parser.ts",

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -36,6 +36,12 @@ import {
   validTablessHeartbeatCadence,
 } from "../core/heartbeatCadence";
 import { mergePlatformState } from "./platformState";
+import {
+  collectDiscoverySnapshot,
+  adapterFromDiscoverySnapshot,
+  DiscoverySnapshotLane,
+  type DiscoverySnapshotState,
+} from "../core/discoverySnapshot";
 
 export const ALARM_NAME = "lurkloot.tick";
 export const TWITCH_ALARM_NAME = "lurkloot.tick.twitch";
@@ -718,11 +724,74 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   let integrityLifecycleOpen = true;
   let discoverySignalLifecycleOpen = true;
   let controllerShutdown = false;
+  const discoveryEvents: Record<Platform, EngineEvent[]> = { twitch: [], kick: [] };
+  const discoveryLanes: Record<Platform, DiscoverySnapshotLane> = {
+    twitch: createDiscoveryLane("twitch"),
+    kick: createDiscoveryLane("kick"),
+  };
   let installedTwitchIntegrity: TwitchIntegrity | undefined;
   let persistedIntegrityToken: string | undefined;
   // A missing rejectedToken means there was no usable bundle when the refresh
   // became due. Keeping the wrapper object distinguishes that from "not due."
   let twitchIntegrityRefreshDue: { rejectedToken?: string } | undefined;
+
+  function createDiscoveryLane(platform: Platform): DiscoverySnapshotLane {
+    return new DiscoverySnapshotLane(
+      platform,
+      async ({ signal }) => {
+        const [settings, state] = await withSettingsLock(() => withStateCommit(() =>
+          Promise.all([deps.loadSettings(), deps.loadState()])));
+        if (!settings.platform[platform].enabled) {
+          return {
+            campaigns: [],
+            complete: false,
+            failure: "Platform disabled",
+            metrics: { campaigns: 0, candidates: 0, cacheHits: 0, cacheMisses: 0, batchRequests: 0, singleFallbacks: 0 },
+          };
+        }
+        return withEventCollector(async (emit, events) => {
+          const adapter = createAdapter(platform, settings, emit, true);
+          try {
+            return await collectDiscoverySnapshot(adapter, state.sessions[platform], signal);
+          } finally {
+            discoveryEvents[platform].push(...events);
+          }
+        });
+      },
+      async (discoveryState) => queueDiscoveryAttempt(platform, discoveryState),
+    );
+  }
+
+  function queueDiscoveryAttempt(
+    platform: Platform,
+    discoveryState: Readonly<DiscoverySnapshotState>,
+  ): void {
+    const attempt = discoveryState.lastAttempt;
+    if (!attempt) return;
+    const snapshot = discoveryState.snapshot;
+    const metrics = attempt.metrics;
+    const duration = attempt.finishedAt - attempt.startedAt;
+    const age = snapshot ? Math.max(0, Date.now() - snapshot.observedAt) : 0;
+    const outcome = attempt.discarded
+      ? `discarded=${attempt.discarded}`
+      : attempt.complete
+        ? "complete"
+        : `incomplete (${attempt.failure ?? "unknown failure"})`;
+    discoveryEvents[platform].push({
+      category: "diagnostic",
+      platform,
+      level: attempt.complete ? "debug" : "warn",
+      message: `Discovery refresh finished in ${duration}ms (${outcome}, revision=${snapshot?.revision ?? 0}, age=${age}ms, coalesced=${attempt.coalesced}, campaigns=${metrics?.campaigns ?? 0}, candidates=${metrics?.candidates ?? 0}, cache hits=${metrics?.cacheHits ?? 0}, cache misses=${metrics?.cacheMisses ?? 0}, batch requests=${metrics?.batchRequests ?? 0}, single fallbacks=${metrics?.singleFallbacks ?? 0})`,
+    });
+    if (attempt.complete && snapshot) {
+      discoveryEvents[platform].push({
+        category: "diagnostic",
+        platform,
+        level: "debug",
+        message: `Campaign refresh finished in ${duration}ms (${snapshot.metrics.campaigns} ${snapshot.metrics.campaigns === 1 ? "campaign" : "campaigns"})`,
+      });
+    }
+  }
 
   // Prime the in-memory integrity token from storage whenever the background
   // script (re)evaluates, so a claim right after a service-worker wake can use
@@ -1422,6 +1491,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     afterLoad?: (settings: S) => void,
   ): Promise<S> {
     return withSettingsLock(async () => {
+      const patchKeys = Object.keys(patch);
+      const invalidatedPlatforms = patchKeys.every((key) => key === "platform") && patch.platform
+        ? PLATFORMS.filter((platform) => patch.platform?.[platform] !== undefined)
+        : PLATFORMS;
+      for (const platform of invalidatedPlatforms) discoveryLanes[platform].invalidate();
       if (!deps.applySettingsPatch) {
         throw new Error("applySettingsPatch dependency is required to mutate settings");
       }
@@ -1799,6 +1873,22 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }, {});
   }
 
+  async function refreshDiscovery(platforms: Platform[] = PLATFORMS): Promise<void> {
+    if (controllerShutdown) return;
+    const settings = await deps.loadSettings();
+    await Promise.all(platforms.map(async (platform) => {
+      if (!settings.platform[platform].enabled) {
+        discoveryLanes[platform].invalidate();
+        return;
+      }
+      await discoveryLanes[platform].requestAndWait();
+    }));
+  }
+
+  function discoverySnapshot(platform: Platform): Readonly<DiscoverySnapshotState> {
+    return discoveryLanes[platform].current();
+  }
+
   async function tickPlatform(
     platform: Platform,
     trigger: TickTrigger,
@@ -1898,6 +1988,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const schedulerPlatforms = requestedPlatforms.filter((platform) =>
       !excludedPlatforms.has(platform));
     if (schedulerPlatforms.length === 0) return claimedRewards;
+    const currentState = await withStateCommit(() => deps.loadState());
+    const discoveryPlatforms = schedulerPlatforms.filter((platform) =>
+      currentState.authHealth[platform].status === "healthy");
+    await refreshDiscovery(discoveryPlatforms);
+    signal.throwIfAborted();
     const platform = schedulerPlatforms[0];
     await withStateLock(() => withEventCollector(async (emit, events) => {
       signal.throwIfAborted();
@@ -1911,6 +2006,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       let publicationLeases: Array<readonly [Platform, HeartbeatPublicationLease]> = [];
       try {
         const adapters = createSelectedAdapters(settings, emit, schedulerPlatforms);
+        for (const discoveryPlatform of schedulerPlatforms) {
+          adapters[discoveryPlatform] = adapterFromDiscoverySnapshot(
+            adapters[discoveryPlatform],
+            discoveryLanes[discoveryPlatform].current().snapshot,
+            state.sessions[discoveryPlatform],
+          );
+        }
         // Observed here rather than returned by the scheduler: the controller
         // already sees every emitted event, and the post-claim handoff only
         // needs to know which platforms claimed.
@@ -1921,6 +2023,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           emit(event);
         };
         const eventsBeforeTick = events.length;
+        for (const discoveryPlatform of schedulerPlatforms) {
+          for (const event of discoveryEvents[discoveryPlatform].splice(0)) claimObservingEmit(event);
+        }
         const result = await runSchedulerTick(state, settings, adapters, {
           platforms: schedulerPlatforms,
           stopPageContextTabs: deps.stopPageContextTabs,
@@ -1928,6 +2033,14 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           emit: claimObservingEmit,
           signal,
           campaignEvaluationFingerprints,
+          discovery: Object.fromEntries(schedulerPlatforms.map((discoveryPlatform) => {
+            const discoveryState = discoveryLanes[discoveryPlatform].current();
+            return [discoveryPlatform, {
+              campaigns: discoveryState.snapshot?.campaigns.map(({ campaign }) => campaign)
+                ?? state.campaigns[discoveryPlatform],
+              complete: discoveryState.snapshot !== undefined,
+            }];
+          })),
         });
         signal.throwIfAborted();
         const lifecycleEvents = farmingLifecycleEvents(state, result.state);
@@ -2005,6 +2118,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function invalidateAuthHealth(platform: Platform): Promise<void> {
+    discoveryLanes[platform].invalidate();
     const releaseDiscoverySignalAuthRefresh = reserveDiscoverySignalAuthRefresh(platform);
     try {
       const generations = await beginAuthRefresh([platform]);
@@ -3074,6 +3188,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   function shutdown(): void {
     controllerShutdown = true;
+    for (const platform of PLATFORMS) discoveryLanes[platform].stop();
     discoverySignalLifecycleOpen = false;
     for (const platform of PLATFORMS) invalidateDiscoverySignalAdmission(platform);
     twitchSettingsTransitionGeneration += 1;
@@ -3090,6 +3205,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     discoverySignalLifecycleOpen = false;
     for (const platform of PLATFORMS) invalidateDiscoverySignalAdmission(platform);
     twitchSettingsTransitionGeneration += 1;
+    for (const platform of PLATFORMS) discoveryLanes[platform].invalidate();
     abortActiveTicks("Host reset");
     closeTwitchIntegrityLifecycle("Host reset");
     await stopDiscoverySignalControllersAndReport(PLATFORMS);
@@ -3868,6 +3984,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     invalidateAuthHealth,
     tick,
     tickAndHandOff,
+    refreshDiscovery,
+    discoverySnapshot,
     runWatchHeartbeat,
     runClaimHandoff,
     abortClaimHandoffs,

--- a/packages/core/src/core/discoverySnapshot.ts
+++ b/packages/core/src/core/discoverySnapshot.ts
@@ -1,0 +1,313 @@
+import type { ChannelCandidate, DropCampaign, Platform, WatchSession } from "@lurkloot/shared/models";
+import type { PlatformAdapter } from "../platforms/adapter";
+
+export type ChannelEligibility = true | false | "unknown";
+
+export interface DiscoveryCandidateObservation {
+  candidate: ChannelCandidate;
+  live: boolean;
+  categoryMatches: boolean;
+  eligible: ChannelEligibility;
+  observedAt: number;
+}
+
+export interface DiscoveryCampaignObservation {
+  campaign: DropCampaign;
+  candidates: DiscoveryCandidateObservation[];
+}
+
+export interface DiscoveryRefreshMetrics {
+  campaigns: number;
+  candidates: number;
+  cacheHits: number;
+  cacheMisses: number;
+  batchRequests: number;
+  singleFallbacks: number;
+}
+
+export interface DiscoverySnapshot {
+  platform: Platform;
+  revision: number;
+  observedAt: number;
+  campaigns: DiscoveryCampaignObservation[];
+  complete: true;
+  metrics: DiscoveryRefreshMetrics;
+}
+
+export interface DiscoveryAttempt {
+  startedAt: number;
+  finishedAt: number;
+  complete: boolean;
+  failure?: string;
+  discarded?: "stale_generation" | "stopped";
+  coalesced: number;
+  metrics?: DiscoveryRefreshMetrics;
+}
+
+export interface DiscoverySnapshotState {
+  snapshot?: DiscoverySnapshot;
+  lastAttempt?: DiscoveryAttempt;
+}
+
+export interface DiscoveryRefreshResult {
+  campaigns: DiscoveryCampaignObservation[];
+  complete: boolean;
+  failure?: string;
+  metrics: DiscoveryRefreshMetrics;
+}
+
+export interface DiscoveryRefreshContext {
+  generation: number;
+  signal: AbortSignal;
+}
+
+export type DiscoverySnapshotListener = (state: Readonly<DiscoverySnapshotState>) => void | Promise<void>;
+
+export async function collectDiscoverySnapshot(
+  adapter: Pick<PlatformAdapter, "platform" | "refreshCampaigns" | "listCandidateChannels" | "checkChannel" | "selectCandidateChannel">,
+  session: Parameters<PlatformAdapter["refreshCampaigns"]>[0],
+  signal: AbortSignal,
+  now: () => number = Date.now,
+): Promise<DiscoveryRefreshResult> {
+  const campaigns = await adapter.refreshCampaigns(session, { signal });
+  const observations: DiscoveryCampaignObservation[] = [];
+  let candidatesChecked = 0;
+  let cacheHits = 0;
+  let cacheMisses = 0;
+  let batchRequests = 0;
+  let singleFallbacks = 0;
+  for (const campaign of campaigns) {
+    signal.throwIfAborted();
+    const listedCandidates = await adapter.listCandidateChannels(campaign, { signal });
+    const candidates = session?.campaignId === campaign.id && session.channel
+      ? [...new Map(
+          [session.channel, ...listedCandidates]
+            .map((candidate) => [candidate.username.toLowerCase(), candidate] as const),
+        ).values()]
+      : listedCandidates;
+    const observed: DiscoveryCandidateObservation[] = [];
+    if (adapter.selectCandidateChannel) {
+      const selection = await adapter.selectCandidateChannel(candidates, campaign, { signal });
+      candidatesChecked += selection.checked;
+      cacheHits += selection.metrics?.cacheHits ?? 0;
+      cacheMisses += selection.metrics?.cacheMisses ?? 0;
+      batchRequests += selection.metrics?.batchRequests ?? 0;
+      singleFallbacks += selection.metrics?.singleFallbacks ?? 0;
+      observed.push(...(selection.observations ?? (selection.channel
+        ? [{ live: true, categoryMatches: true, candidate: selection.channel }]
+        : [])).map((check) => ({
+        candidate: check.candidate,
+        live: check.live,
+        categoryMatches: check.categoryMatches,
+        eligible: check.campaignMatches ?? "unknown" as const,
+        observedAt: now(),
+      })));
+    } else {
+      for (const candidate of candidates) {
+        signal.throwIfAborted();
+        const check = await adapter.checkChannel(candidate, { campaign, signal });
+        candidatesChecked += 1;
+        observed.push({
+          candidate: check.candidate,
+          live: check.live,
+          categoryMatches: check.categoryMatches,
+          eligible: check.campaignMatches ?? "unknown",
+          observedAt: now(),
+        });
+        if (check.live && check.categoryMatches && check.campaignMatches !== false) break;
+      }
+    }
+    observations.push({ campaign, candidates: observed });
+  }
+  return {
+    campaigns: observations,
+    complete: true,
+    metrics: {
+      campaigns: campaigns.length,
+      candidates: candidatesChecked,
+      cacheHits,
+      cacheMisses,
+      batchRequests,
+      singleFallbacks,
+    },
+  };
+}
+
+export function adapterFromDiscoverySnapshot(
+  adapter: PlatformAdapter,
+  snapshot: DiscoverySnapshot | undefined,
+  session?: WatchSession,
+): PlatformAdapter {
+  const campaigns = new Map((snapshot?.campaigns ?? []).map((observation) => [observation.campaign.id, observation]));
+  return new Proxy(adapter, {
+    get(target, property, receiver) {
+      if (property === "listCandidateChannels") {
+        return async (campaign: DropCampaign): Promise<ChannelCandidate[]> =>
+          campaigns.get(campaign.id)?.candidates.map(({ candidate }) => candidate) ?? [];
+      }
+      if (property === "selectCandidateChannel") return undefined;
+      if (property === "checkChannel") {
+        return async (candidate: ChannelCandidate, options?: { campaign?: DropCampaign }) => {
+          if (!options?.campaign) {
+            return { live: false, categoryMatches: false, candidate };
+          }
+          const observations = campaigns.get(options.campaign.id)?.candidates ?? [];
+          const observation = observations.find(({ candidate: observed }) =>
+            observed.username.toLowerCase() === candidate.username.toLowerCase());
+          if (!observation) {
+            const currentChannel = session?.channel;
+            if (session?.campaignId === options.campaign.id && currentChannel
+              && currentChannel.username.toLowerCase() === candidate.username.toLowerCase()) {
+              return { live: true, categoryMatches: true, candidate: currentChannel };
+            }
+            return { live: false, categoryMatches: false, candidate };
+          }
+          return {
+            live: observation.live,
+            categoryMatches: observation.categoryMatches,
+            campaignMatches: observation.eligible === "unknown" ? undefined : observation.eligible,
+            candidate: observation.candidate,
+          };
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+export class DiscoverySnapshotLane {
+  private state: DiscoverySnapshotState = {};
+  private generation = 0;
+  private revision = 0;
+  private running = false;
+  private pending = false;
+  private pendingCount = 0;
+  private stopped = false;
+  private abort?: AbortController;
+  private settled: Promise<void> = Promise.resolve();
+
+  constructor(
+    readonly platform: Platform,
+    private readonly refresh: (context: DiscoveryRefreshContext) => Promise<DiscoveryRefreshResult>,
+    private readonly onState?: DiscoverySnapshotListener,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  current(): Readonly<DiscoverySnapshotState> {
+    return this.state;
+  }
+
+  request(): void {
+    if (this.stopped) return;
+    if (this.running) {
+      this.pending = true;
+      this.pendingCount += 1;
+      return;
+    }
+    this.running = true;
+    const run = this.runLoop();
+    this.settled = run.then(() => undefined, () => undefined);
+  }
+
+  async requestAndWait(): Promise<void> {
+    this.request();
+    await this.settle();
+  }
+
+  invalidate(): void {
+    this.generation += 1;
+    this.pending = false;
+    this.pendingCount = 0;
+    this.abort?.abort();
+    this.state = {};
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.invalidate();
+  }
+
+  async settle(): Promise<void> {
+    await this.settled;
+  }
+
+  private async runLoop(): Promise<void> {
+    try {
+      do {
+        this.pending = false;
+        const coalesced = this.pendingCount;
+        this.pendingCount = 0;
+        await this.runOnce(coalesced);
+      } while (this.pending && !this.stopped);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async runOnce(coalesced: number): Promise<void> {
+    const generation = this.generation;
+    const startedAt = this.now();
+    const abort = new AbortController();
+    this.abort = abort;
+    try {
+      const result = await this.refresh({ generation, signal: abort.signal });
+      const finishedAt = this.now();
+      if (this.stopped || generation !== this.generation) {
+        this.state = {
+          ...this.state,
+          lastAttempt: {
+            startedAt,
+            finishedAt,
+            complete: false,
+            discarded: this.stopped ? "stopped" : "stale_generation",
+            coalesced,
+            metrics: result.metrics,
+          },
+        };
+      } else if (!result.complete) {
+        this.state = {
+          ...this.state,
+          lastAttempt: {
+            startedAt,
+            finishedAt,
+            complete: false,
+            failure: result.failure ?? "Discovery refresh was incomplete",
+            coalesced,
+            metrics: result.metrics,
+          },
+        };
+      } else {
+        this.state = {
+          snapshot: {
+            platform: this.platform,
+            revision: ++this.revision,
+            observedAt: finishedAt,
+            campaigns: result.campaigns,
+            complete: true,
+            metrics: result.metrics,
+          },
+          lastAttempt: { startedAt, finishedAt, complete: true, coalesced, metrics: result.metrics },
+        };
+      }
+    } catch (error) {
+      const finishedAt = this.now();
+      this.state = {
+        ...this.state,
+        lastAttempt: {
+          startedAt,
+          finishedAt,
+          complete: false,
+          failure: error instanceof Error ? error.message : String(error),
+          ...(this.stopped || generation !== this.generation
+            ? { discarded: this.stopped ? "stopped" as const : "stale_generation" as const }
+            : {}),
+          coalesced,
+        },
+      };
+    } finally {
+      if (this.abort === abort) this.abort = undefined;
+      await this.onState?.(this.state);
+    }
+  }
+}

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -567,6 +567,10 @@ export interface SchedulerTickOptions {
   // it in memory so unchanged minute ticks stay quiet, while a worker restart
   // naturally emits a fresh snapshot for the next exported diagnostic log.
   campaignEvaluationFingerprints?: Partial<Record<Platform, string>>;
+  discovery?: Partial<Record<Platform, {
+    campaigns: DropCampaign[];
+    complete: boolean;
+  }>>;
 }
 
 const CAMPAIGN_REJECTION_LABELS: Record<CampaignFarmingRejectionCode, string> = {
@@ -922,7 +926,11 @@ export async function runSchedulerTick(
 
       let campaigns: DropCampaign[];
       let discoveryFailed = false;
-      try {
+      const committedDiscovery = options.discovery?.[platform];
+      if (committedDiscovery) {
+        campaigns = preserveClaimedRewards(committedDiscovery.campaigns, state.campaigns[platform]);
+        discoveryFailed = !committedDiscovery.complete;
+      } else try {
         const refreshStartedAt = Date.now();
         campaigns = await adapter.refreshCampaigns(previous, { signal: options.signal });
         emitDiagnostic(

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -42,6 +42,13 @@ export interface AdapterOperationOptions {
 export interface CandidateChannelSelection {
   channel?: ChannelCandidate;
   checked: number;
+  observations?: ChannelCheck[];
+  metrics?: {
+    cacheHits: number;
+    cacheMisses: number;
+    batchRequests: number;
+    singleFallbacks: number;
+  };
 }
 
 // A gamification challenge that was just claimed. Account-level, so unlike

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -1524,7 +1524,18 @@ export class TwitchAdapter implements PlatformAdapter {
         "twitch",
       );
     };
-    for (const check of checks) {
+    const observations = (): ChannelCheck[] => checks.flatMap((check) => {
+      if (!check) return [];
+      return [{
+        ...check,
+        campaignMatches: campaign && check.candidate.channelId
+          && availabilityResult.matches.has(check.candidate.channelId)
+          ? availabilityResult.matches.get(check.candidate.channelId)
+          : check.campaignMatches,
+      }];
+    });
+    for (let index = 0; index < checks.length; index += 1) {
+      const check = checks[index];
       if (!check) continue;
       checked += 1;
       if (!check.live || !check.categoryMatches) continue;
@@ -1533,6 +1544,7 @@ export class TwitchAdapter implements PlatformAdapter {
       if (campaign && !check.candidate.channelId) {
         winnerFallbacks += 1;
         const confirmed = await this.checkChannel(check.candidate, { campaign, signal });
+        checks[index] = confirmed;
         if (!confirmed.live || !confirmed.categoryMatches || confirmed.campaignMatches === false) continue;
         selectedCandidate = confirmed.candidate;
         campaignMatches = confirmed.campaignMatches;
@@ -1546,6 +1558,13 @@ export class TwitchAdapter implements PlatformAdapter {
       reportSelectionFinished();
       return {
         checked: candidates.length,
+        observations: observations(),
+        metrics: {
+          cacheHits: availabilityResult.cacheHits,
+          cacheMisses: availabilityResult.cacheMisses,
+          batchRequests: Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT) + availabilityResult.batchRequests,
+          singleFallbacks: streamCheckResult.singleFallbacks + availabilityResult.singleFallbacks + winnerFallbacks,
+        },
         channel: {
           ...selectedCandidate,
           live: true,
@@ -1553,7 +1572,16 @@ export class TwitchAdapter implements PlatformAdapter {
       };
     }
     reportSelectionFinished();
-    return { checked: candidates.length };
+    return {
+      checked: candidates.length,
+      observations: observations(),
+      metrics: {
+        cacheHits: availabilityResult.cacheHits,
+        cacheMisses: availabilityResult.cacheMisses,
+        batchRequests: Math.ceil(streamCandidates.length / GQL_BATCH_OPERATION_LIMIT) + availabilityResult.batchRequests,
+        singleFallbacks: streamCheckResult.singleFallbacks + availabilityResult.singleFallbacks + winnerFallbacks,
+      },
+    };
   }
 
   private async batchCampaignAvailability(

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -4099,7 +4099,18 @@ describe("TwitchAdapter", () => {
       isAclMatch: true,
     }]);
 
-    expect(selection).toEqual({ checked: 1 });
+    expect(selection).toMatchObject({
+      checked: 1,
+      metrics: {
+        cacheHits: 0,
+        cacheMisses: 0,
+        batchRequests: 1,
+        singleFallbacks: 0,
+      },
+    });
+    expect(selection?.observations).toEqual([
+      expect.objectContaining({ live: false, categoryMatches: true }),
+    ]);
     expect(events).toContainEqual(expect.objectContaining({
       category: "diagnostic",
       message: expect.stringMatching(/^Twitch idle channel selection finished in \d+ms/),

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -2271,7 +2271,9 @@ describe("background controller", () => {
     detailsFail = true;
     await env.controller.tick();
 
-    expect(env.deps.createAdapter).toHaveBeenCalledTimes(6);
+    // Each platform tick now constructs one discovery adapter and one legacy
+    // selection adapter. #457 will reuse construction across the phases.
+    expect(env.deps.createAdapter).toHaveBeenCalledTimes(8);
     expect(env.state.campaigns.twitch.map((item) => item.id)).toEqual(["retained"]);
   });
 
@@ -4108,7 +4110,7 @@ describe("background controller", () => {
     }));
   });
 
-  it("reports material waits for same-platform scheduler work", async () => {
+  it("coalesces overlapping same-platform discovery instead of waiting on the scheduler lock", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-07-29T12:00:00.000Z"));
     const env = harness(farming(DEFAULT_SETTINGS));
@@ -4137,11 +4139,11 @@ describe("background controller", () => {
       expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
         category: "diagnostic",
         platform: "twitch",
-        globalTickId: 2,
-        platformTickId: 2,
-        message: "Tick #2 waited 75ms for Twitch platform work",
-        data: { waitMs: 75 },
+        message: expect.stringMatching(/^Discovery refresh finished in 0ms \(complete, revision=2, .*coalesced=1,/),
       }));
+      expect(allDiagnostics(env).some((event) =>
+        event.message.includes("waited") && event.message.includes("platform work"),
+      )).toBe(false);
     } finally {
       twitchDiscovery.resolve([]);
       await Promise.allSettled(secondTick ? [firstTick, secondTick] : [firstTick]);

--- a/packages/extension/tests/discoverySnapshot.test.ts
+++ b/packages/extension/tests/discoverySnapshot.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  adapterFromDiscoverySnapshot,
+  collectDiscoverySnapshot,
+  DiscoverySnapshotLane,
+  type DiscoveryRefreshMetrics,
+  type DiscoveryRefreshResult,
+} from "@lurkloot/core/discoverySnapshot";
+
+const metrics: DiscoveryRefreshMetrics = {
+  campaigns: 0,
+  candidates: 0,
+  cacheHits: 0,
+  cacheMisses: 0,
+  batchRequests: 0,
+  singleFallbacks: 0,
+};
+
+const complete = (): DiscoveryRefreshResult => ({ campaigns: [], complete: true, metrics });
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+describe("DiscoverySnapshotLane", () => {
+  it("runs one refresh and retains at most one coalesced pending refresh", async () => {
+    const first = deferred<DiscoveryRefreshResult>();
+    const second = deferred<DiscoveryRefreshResult>();
+    const refresh = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const lane = new DiscoverySnapshotLane("twitch", refresh);
+
+    lane.request();
+    lane.request();
+    lane.request();
+    expect(refresh).toHaveBeenCalledTimes(1);
+    first.resolve(complete());
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(2));
+    second.resolve(complete());
+    await lane.settle();
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(lane.current().snapshot?.revision).toBe(2);
+  });
+
+  it("lets provider lanes complete independently", async () => {
+    const twitchRefresh = deferred<DiscoveryRefreshResult>();
+    const twitch = new DiscoverySnapshotLane("twitch", () => twitchRefresh.promise);
+    const kick = new DiscoverySnapshotLane("kick", async () => complete());
+
+    twitch.request();
+    kick.request();
+    await kick.settle();
+    expect(kick.current().snapshot?.revision).toBe(1);
+    expect(twitch.current().snapshot).toBeUndefined();
+    twitchRefresh.resolve(complete());
+    await twitch.settle();
+  });
+
+  it("retains the last coherent snapshot after failed and incomplete attempts", async () => {
+    const refresh = vi.fn()
+      .mockResolvedValueOnce(complete())
+      .mockResolvedValueOnce({ campaigns: [], complete: false, failure: "partial", metrics })
+      .mockRejectedValueOnce(new Error("offline"));
+    const lane = new DiscoverySnapshotLane("kick", refresh);
+
+    lane.request();
+    await lane.settle();
+    const coherent = lane.current().snapshot;
+    lane.request();
+    await lane.settle();
+    expect(lane.current().snapshot).toBe(coherent);
+    expect(lane.current().lastAttempt?.failure).toBe("partial");
+    lane.request();
+    await lane.settle();
+    expect(lane.current().snapshot).toBe(coherent);
+    expect(lane.current().lastAttempt?.failure).toBe("offline");
+  });
+
+  it("discards an in-flight result after invalidation", async () => {
+    const refresh = deferred<DiscoveryRefreshResult>();
+    const lane = new DiscoverySnapshotLane("twitch", () => refresh.promise);
+
+    lane.request();
+    lane.invalidate();
+    refresh.resolve(complete());
+    await lane.settle();
+
+    expect(lane.current().snapshot).toBeUndefined();
+    expect(lane.current().lastAttempt?.discarded).toBe("stale_generation");
+  });
+
+  it("clears a previously committed snapshot when its generation is invalidated", async () => {
+    const lane = new DiscoverySnapshotLane("twitch", async () => complete());
+    lane.request();
+    await lane.settle();
+
+    lane.invalidate();
+
+    expect(lane.current().snapshot).toBeUndefined();
+    expect(lane.current().lastAttempt).toBeUndefined();
+    lane.request();
+    await lane.settle();
+    expect(lane.current().snapshot?.revision).toBe(2);
+  });
+});
+
+describe("collectDiscoverySnapshot", () => {
+  it("keeps Kick channel-specific eligibility unknown", async () => {
+    const campaign = {
+      id: "campaign",
+      platform: "kick" as const,
+      name: "Campaign",
+      status: "active" as const,
+      startsAt: new Date(0).toISOString(),
+      endsAt: new Date(1_000).toISOString(),
+      rewards: [],
+    };
+    const candidate = {
+      platform: "kick" as const,
+      username: "streamer",
+      displayName: "Streamer",
+      url: "https://kick.com/streamer",
+    };
+    const adapter = {
+      platform: "kick" as const,
+      refreshCampaigns: vi.fn(async () => [campaign]),
+      listCandidateChannels: vi.fn(async () => [candidate]),
+      checkChannel: vi.fn(async () => ({ live: true, categoryMatches: true, candidate })),
+      selectCandidateChannel: undefined,
+    };
+
+    const result = await collectDiscoverySnapshot(adapter, undefined, new AbortController().signal, () => 42);
+
+    expect(result.complete).toBe(true);
+    expect(result.campaigns[0]?.candidates[0]).toMatchObject({
+      live: true,
+      categoryMatches: true,
+      eligible: "unknown",
+      observedAt: 42,
+    });
+  });
+
+  it("preserves all provider candidate observations and tri-state eligibility", async () => {
+    const campaign = {
+      id: "campaign",
+      platform: "twitch" as const,
+      name: "Campaign",
+      status: "active" as const,
+      startsAt: new Date(0).toISOString(),
+      endsAt: new Date(1_000).toISOString(),
+      rewards: [],
+    };
+    const candidates = ["eligible", "rejected", "unknown"].map((username) => ({
+      platform: "twitch" as const,
+      username,
+      displayName: username,
+      url: `https://twitch.tv/${username}`,
+    }));
+    const adapter = {
+      platform: "twitch" as const,
+      refreshCampaigns: vi.fn(async () => [campaign]),
+      listCandidateChannels: vi.fn(async () => candidates),
+      checkChannel: vi.fn(),
+      selectCandidateChannel: vi.fn(async () => ({
+        channel: candidates[0],
+        checked: 3,
+        observations: candidates.map((candidate, index) => ({
+          live: true,
+          categoryMatches: true,
+          campaignMatches: index === 0 ? true : index === 1 ? false : undefined,
+          candidate,
+        })),
+      })),
+    };
+
+    const result = await collectDiscoverySnapshot(adapter, undefined, new AbortController().signal, () => 42);
+
+    expect(result.campaigns[0]?.candidates.map(({ candidate, eligible }) =>
+      [candidate.username, eligible])).toEqual([
+      ["eligible", true],
+      ["rejected", false],
+      ["unknown", "unknown"],
+    ]);
+  });
+});
+
+describe("adapterFromDiscoverySnapshot", () => {
+  it("does not perform inline provider discovery when no snapshot exists", async () => {
+    const candidate = {
+      platform: "kick" as const,
+      username: "streamer",
+      displayName: "Streamer",
+      url: "https://kick.com/streamer",
+    };
+    const campaign = {
+      id: "campaign",
+      platform: "kick" as const,
+      name: "Campaign",
+      status: "active" as const,
+      startsAt: new Date(0).toISOString(),
+      endsAt: new Date(1_000).toISOString(),
+      rewards: [],
+    };
+    const checkChannel = vi.fn();
+    const listCandidateChannels = vi.fn();
+    const adapter = adapterFromDiscoverySnapshot({
+      platform: "kick",
+      checkChannel,
+      listCandidateChannels,
+    } as never, undefined);
+
+    expect(await adapter.listCandidateChannels(campaign)).toEqual([]);
+    expect(await adapter.checkChannel(candidate, { campaign })).toMatchObject({
+      live: false,
+      categoryMatches: false,
+    });
+    expect(listCandidateChannels).not.toHaveBeenCalled();
+    expect(checkChannel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/tests/tickBaseline.test.ts
+++ b/packages/extension/tests/tickBaseline.test.ts
@@ -91,9 +91,9 @@ describe("extension scheduler tick baseline", () => {
     reportBaseline(result);
 
     expect(result.counts).toEqual({
-      adapterOperations: 3,
+      adapterOperations: 4,
       campaignDiscovery: 1,
-      candidateListings: 0,
+      candidateListings: 1,
       channelChecks: 1,
       heartbeatAttempts: 1,
       heartbeatBlockedByDiscovery: 0,
@@ -101,18 +101,18 @@ describe("extension scheduler tick baseline", () => {
       campaignsEvaluated: 0,
       candidatesEvaluated: 1,
       watcherReconciliations: 1,
-      adapterConstructions: 4,
-      settingsLoads: 4,
-      stateLoads: 6,
+      adapterConstructions: 5,
+      settingsLoads: 6,
+      stateLoads: 8,
       stateSaves: 3,
       eventPublications: 6,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
-      selection: 10,
+      selection: 20,
       watcher: 5,
       persistence: 15,
-      total: 60,
+      total: 70,
     });
     expect(JSON.stringify(result)).not.toMatch(/credential|cookie|token|authorization|payload/i);
   });
@@ -135,9 +135,9 @@ describe("extension scheduler tick baseline", () => {
         campaignsEvaluated: 0,
         candidatesEvaluated: 0,
         adapterOperations: 2,
-        adapterConstructions: 2,
-        settingsLoads: 3,
-        stateLoads: 3,
+        adapterConstructions: 3,
+        settingsLoads: 5,
+        stateLoads: 5,
         stateSaves: 2,
         eventPublications: 6,
         watcherReconciliations: 0,
@@ -164,24 +164,24 @@ describe("extension scheduler tick baseline", () => {
     reportBaseline(result);
 
     expect(result.counts).toMatchObject({
-      adapterOperations: 3,
+      adapterOperations: 4,
       campaignDiscovery: 1,
-      candidateListings: 0,
+      candidateListings: 1,
       channelChecks: 1,
       campaignsEvaluated: 0,
       candidatesEvaluated: 1,
-      adapterConstructions: 2,
-      settingsLoads: 3,
-      stateLoads: 3,
+      adapterConstructions: 3,
+      settingsLoads: 5,
+      stateLoads: 5,
       stateSaves: 2,
       watcherReconciliations: 1,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
-      selection: 10,
+      selection: 20,
       watcher: 5,
       persistence: 10,
-      total: 55,
+      total: 65,
     });
   });
 
@@ -200,24 +200,24 @@ describe("extension scheduler tick baseline", () => {
     expect(result.outcomeCampaignId).toBe(`${platform}-campaign`);
 
     expect(result.counts).toMatchObject({
-      adapterOperations: scenario === "higherPriorityUnavailable" ? 7 : 4,
+      adapterOperations: scenario === "higherPriorityUnavailable" ? 6 : 4,
       campaignDiscovery: 1,
       candidateListings: scenario === "higherPriorityUnavailable" ? 2 : 1,
-      channelChecks: scenario === "higherPriorityUnavailable" ? 3 : 1,
+      channelChecks: scenario === "higherPriorityUnavailable" ? 2 : 1,
       campaignsEvaluated: scenario === "higherPriorityUnavailable" ? 2 : 1,
       candidatesEvaluated: scenario === "higherPriorityUnavailable" ? 2 : 1,
-      adapterConstructions: 2,
-      settingsLoads: 3,
-      stateLoads: 3,
+      adapterConstructions: 3,
+      settingsLoads: 5,
+      stateLoads: 5,
       stateSaves: 2,
       watcherReconciliations: 1,
     });
     expect(result.durationsMs).toEqual({
       discovery: 30,
-      selection: scenario === "higherPriorityUnavailable" ? 50 : 20,
+      selection: scenario === "higherPriorityUnavailable" ? 40 : 20,
       watcher: 5,
       persistence: 10,
-      total: scenario === "higherPriorityUnavailable" ? 95 : 65,
+      total: scenario === "higherPriorityUnavailable" ? 85 : 65,
     });
   });
 
@@ -261,8 +261,8 @@ describe("extension scheduler tick baseline", () => {
       total: 515,
     });
     expect(result.observedControllerMs).toEqual({
-      discovery: 300,
-      selection: 200,
+      discovery: 500,
+      selection: 0,
       total: 515,
     });
   });


### PR DESCRIPTION
## Summary

- add revisioned, timestamped in-memory discovery snapshots with independent Twitch and Kick single-flight lanes
- retain the last coherent provider snapshot on transient failures while invalidating stale generations on settings, identity, and lifecycle changes
- normalize bounded candidate evidence, including Twitch tri-state campaign availability and Kick unknown eligibility, without persisting raw provider payloads
- route the existing scheduler selection pass through committed snapshot observations as a transitional boundary; #395 will own the independent event-driven selection lifecycle
- add aggregate discovery diagnostics and update extension/CLI concurrency baselines

## Testing

- `pnpm verify`
- independent code review completed with no blockers

Closes #394


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added background discovery snapshots to provide refreshed campaign and candidate availability data.
  - Discovery refreshes now run independently by platform and coalesce overlapping requests.
  - Scheduler results use committed discovery data when available, while preserving existing fallback behavior.
  - Added discovery status, eligibility, and refresh metrics to selection results.
- **Bug Fixes**
  - Improved handling of stale, invalidated, incomplete, and interrupted discovery refreshes.
  - Preserved coherent discovery results during settings, authentication, and host-reset changes.
- **Documentation**
  - Documented single-flight discovery behavior and interval coalescing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->