### PR TITLE
refactor(core): select from discovery snapshots

### DIFF
--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -166,7 +166,9 @@ describe("CLI scheduler tick baseline", () => {
         discoveryBlockedByHeartbeat: 0,
         // The non-once loop now performs one recovery pass for both providers
         // at startup before the first discovery completes.
-        adapterConstructions: 10,
+        // A heartbeat health transition invalidates the in-flight selection;
+        // the shared controller reconstructs once to restore the prior context.
+        adapterConstructions: 11,
         watcherReconciliations: 1,
       });
       expect(result.durationsMs).toEqual({
@@ -215,7 +217,7 @@ describe("CLI scheduler tick baseline", () => {
     });
   });
 
-  it.each(["twitch", "kick"] as const)("matches retained %s core work with the extension host", async (platform) => {
+  it.each(["twitch", "kick"] as const)("uses the shared snapshot-driven %s selection lifecycle", async (platform) => {
     vi.useFakeTimers();
     vi.setSystemTime("2026-09-01T20:00:00.000Z");
 
@@ -223,6 +225,8 @@ describe("CLI scheduler tick baseline", () => {
     reportBaseline(result);
 
     expect(result.counts).toMatchObject({
+      // Candidate listing and validation happen once while building the
+      // committed discovery snapshot. Core selection adds no provider calls.
       adapterOperations: 4,
       campaignDiscovery: 1,
       candidateListings: 1,
@@ -230,6 +234,7 @@ describe("CLI scheduler tick baseline", () => {
       adapterConstructions: 3,
       watcherReconciliations: 1,
     });
+    expect(result.outcomeCampaignId).toBe(`${platform}-campaign`);
     expect(result.durationsMs).toEqual({
       discovery: 30,
       selection: 20,

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -5,7 +5,7 @@ import type { SettingsPatch } from "@lurkloot/shared/settings";
 import { isFarmingActive } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
 import { isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
-import { isPlaybackTelemetryHealthy, MANUAL_WATCH_TTL_MS, runSchedulerTick, type StopPageContextTabs } from "../core/scheduler";
+import { isPlaybackTelemetryHealthy, MANUAL_WATCH_TTL_MS, runSchedulerTick, selectWatchTargetFromSnapshot, type SnapshotSelectionResult, type StopPageContextTabs } from "../core/scheduler";
 import { isTimestampStale } from "../core/timestamps";
 import {
   currentManagedPageContextTabs,
@@ -40,6 +40,7 @@ import {
   collectDiscoverySnapshot,
   adapterFromDiscoverySnapshot,
   DiscoverySnapshotLane,
+  type DiscoverySnapshot,
   type DiscoverySnapshotState,
 } from "../core/discoverySnapshot";
 
@@ -326,6 +327,7 @@ export interface BackgroundControllerDeps<S extends EngineSettings = EngineSetti
   // Omitted in headless/test runs, where the scheduler forgets contexts from
   // state only (see runSchedulerTick / StopPageContextTabs).
   stopPageContextTabs?: StopPageContextTabs;
+  selectWatchTarget?: typeof selectWatchTargetFromSnapshot;
   // Delay used by the bounded post-claim handoff. Injected so tests can drive
   // the loop deterministically instead of racing real timers. Resolves early
   // (without throwing) when the signal aborts, so callers check `signal.aborted`
@@ -729,6 +731,27 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     twitch: createDiscoveryLane("twitch"),
     kick: createDiscoveryLane("kick"),
   };
+  interface SelectionInput {
+    platform: Platform;
+    trigger: TickTrigger;
+    snapshot: DiscoverySnapshot;
+    settings: S;
+    state: SchedulerState;
+    key: string;
+    force: boolean;
+    signal: AbortSignal;
+    generation: number;
+  }
+  interface CommittedSelection {
+    key: string;
+    snapshotRevision: number;
+    generation: number;
+    result: SnapshotSelectionResult;
+  }
+  const selectionCache: Partial<Record<Platform, CommittedSelection>> = {};
+  const selectionRuns: Partial<Record<Platform, Promise<CommittedSelection>>> = {};
+  const pendingSelections: Partial<Record<Platform, SelectionInput>> = {};
+  const selectionGeneration: Record<Platform, number> = { twitch: 0, kick: 0 };
   let installedTwitchIntegrity: TwitchIntegrity | undefined;
   let persistedIntegrityToken: string | undefined;
   // A missing rejectedToken means there was no usable bundle when the refresh
@@ -744,6 +767,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         if (!settings.platform[platform].enabled) {
           return {
             campaigns: [],
+            idleCandidates: [],
+            followedChannels: [],
             complete: false,
             failure: "Platform disabled",
             metrics: { campaigns: 0, candidates: 0, cacheHits: 0, cacheMisses: 0, batchRequests: 0, singleFallbacks: 0 },
@@ -752,7 +777,24 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         return withEventCollector(async (emit, events) => {
           const adapter = createAdapter(platform, settings, emit, true);
           try {
-            return await collectDiscoverySnapshot(adapter, state.sessions[platform], signal);
+            return await collectDiscoverySnapshot(
+              adapter,
+              state.sessions[platform],
+              signal,
+              Date.now,
+              settings.preferKnownChannels,
+              settings.platform[platform].idleWatchlistChannels
+                .map((username) => username.trim().toLowerCase())
+                .filter(Boolean)
+                .map((username) => ({
+                  platform,
+                  username,
+                  displayName: username,
+                  url: platform === "twitch"
+                    ? `https://www.twitch.tv/${username}`
+                    : `https://kick.com/${username}`,
+                })),
+            );
           } finally {
             discoveryEvents[platform].push(...events);
           }
@@ -1225,16 +1267,20 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     platform: Platform,
     state: SchedulerState,
     events: readonly EngineEvent[] = [],
-  ): Promise<void> {
-    await persistPlatformState(platform, state);
+    isCurrent?: () => boolean,
+  ): Promise<boolean> {
+    const persisted = await persistPlatformState(platform, state, isCurrent);
+    if (!persisted) return false;
     await reportBestEffort(events);
+    return true;
   }
 
   async function persistPlatformState(
     platform: Platform,
     state: SchedulerState,
-  ): Promise<void> {
-    await withStateCommit(async () => {
+    isCurrent?: () => boolean,
+  ): Promise<boolean> {
+    return withStateCommit(async () => {
       // The registry can change while storage I/O is in flight (for example a
       // page-context fallback reported by the heartbeat watcher). Retry the
       // short merge when its revision moved, so the last write is a compare-
@@ -1276,8 +1322,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
               },
             }
           : stateForMerge;
+        if (isCurrent?.() === false) return false;
         await saveOperationalStateDirect(mergePlatformState(latest, mergeSource, platform));
-        if (currentManagedPageContextTabsRevision() === pageContextRevision) return;
+        if (currentManagedPageContextTabsRevision() === pageContextRevision) return true;
       }
     });
   }
@@ -1495,7 +1542,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       const invalidatedPlatforms = patchKeys.every((key) => key === "platform") && patch.platform
         ? PLATFORMS.filter((platform) => patch.platform?.[platform] !== undefined)
         : PLATFORMS;
-      for (const platform of invalidatedPlatforms) discoveryLanes[platform].invalidate();
+      for (const platform of invalidatedPlatforms) {
+        discoveryLanes[platform].invalidate();
+        invalidateSelection(platform);
+      }
       if (!deps.applySettingsPatch) {
         throw new Error("applySettingsPatch dependency is required to mutate settings");
       }
@@ -1879,6 +1929,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     await Promise.all(platforms.map(async (platform) => {
       if (!settings.platform[platform].enabled) {
         discoveryLanes[platform].invalidate();
+        invalidateSelection(platform);
         return;
       }
       await discoveryLanes[platform].requestAndWait();
@@ -1887,6 +1938,162 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   function discoverySnapshot(platform: Platform): Readonly<DiscoverySnapshotState> {
     return discoveryLanes[platform].current();
+  }
+
+  function selectionKey(platform: Platform, snapshot: DiscoverySnapshot, settings: S, state: SchedulerState): string {
+    const session = state.sessions[platform];
+    return JSON.stringify({
+      discovery: {
+        campaigns: snapshot.campaigns.map(({ campaign, candidates }) => ({
+          campaign,
+          candidates: candidates.map(({ observedAt: _observedAt, ...candidate }) => candidate),
+        })),
+        idleCandidates: snapshot.idleCandidates.map(({ observedAt: _observedAt, ...candidate }) => candidate),
+        followedChannels: snapshot.followedChannels,
+      },
+      persistedCampaigns: state.campaigns[platform],
+      settings,
+      target: {
+        status: session.status,
+        channel: session.channel,
+        campaignId: session.campaignId,
+        rewardId: session.rewardId,
+        watchMode: session.watchMode,
+        offlineChecks: session.offlineChecks,
+        playbackHealthy: session.playback ? isPlaybackTelemetryHealthy(session.playback) : undefined,
+        playbackChecks: session.playbackChecks,
+        heartbeatChecks: session.heartbeatChecks,
+        lastHeartbeatOk: session.lastHeartbeatOk,
+        noProgressChecks: session.noProgressChecks,
+        lastWatchedMinutes: session.lastWatchedMinutes,
+      },
+    });
+  }
+
+  function selectionIsForced(trigger: TickTrigger): boolean {
+    return trigger === "manual_tick" || trigger === "claim_handoff" || trigger === "startup";
+  }
+
+  function invalidateSelection(platform: Platform): void {
+    selectionGeneration[platform] += 1;
+    delete selectionCache[platform];
+    delete pendingSelections[platform];
+  }
+
+  async function evaluateSelection(input: SelectionInput): Promise<CommittedSelection> {
+    const startedAt = Date.now();
+    const result = await (deps.selectWatchTarget ?? selectWatchTargetFromSnapshot)({
+      snapshot: input.snapshot,
+      previous: input.state.sessions[input.platform],
+      previousCampaigns: input.state.campaigns[input.platform],
+      settings: input.settings,
+      signal: input.signal,
+    });
+    discoveryEvents[input.platform].push({
+      category: "diagnostic",
+      platform: input.platform,
+      level: "debug",
+      message: `Snapshot selection finished in ${Date.now() - startedAt}ms (trigger=${input.trigger}, revision=${input.snapshot.revision}, age=${Math.max(0, Date.now() - input.snapshot.observedAt)}ms, material=${selectionCache[input.platform]?.key !== input.key}, campaigns=${result.campaignsChecked}, candidates=${result.candidatesChecked}, outcome=${result.decision.action}, retention=${result.retention.reasonCode})`,
+    });
+    return { key: input.key, snapshotRevision: input.snapshot.revision, generation: input.generation, result };
+  }
+
+  async function prepareSelection(input: SelectionInput): Promise<CommittedSelection> {
+    const cached = selectionCache[input.platform];
+    if (!input.force && cached?.key === input.key && cached.generation === input.generation) {
+      discoveryEvents[input.platform].push({
+        category: "diagnostic",
+        platform: input.platform,
+        level: "debug",
+        message: `Snapshot selection skipped (trigger=${input.trigger}, revision=${input.snapshot.revision}, age=${Math.max(0, Date.now() - input.snapshot.observedAt)}ms, material=false)`,
+      });
+      const reused = {
+        ...cached,
+        snapshotRevision: input.snapshot.revision,
+        generation: input.generation,
+      };
+      selectionCache[input.platform] = reused;
+      return reused;
+    }
+    const running = selectionRuns[input.platform];
+    if (running) {
+      pendingSelections[input.platform] = input;
+      return running;
+    }
+    const run = (async () => {
+      let current = input;
+      while (true) {
+        const evaluated = await evaluateSelection(current);
+        const pending = pendingSelections[current.platform];
+        delete pendingSelections[current.platform];
+        if (!pending) {
+          if (current.generation === selectionGeneration[current.platform]) {
+            selectionCache[current.platform] = evaluated;
+          } else {
+            discoveryEvents[current.platform].push({
+              category: "diagnostic",
+              platform: current.platform,
+              level: "debug",
+              message: `Snapshot selection discarded stale lifecycle work (trigger=${current.trigger}, revision=${current.snapshot.revision})`,
+            });
+          }
+          return evaluated;
+        }
+        discoveryEvents[current.platform].push({
+          category: "diagnostic",
+          platform: current.platform,
+          level: "debug",
+          message: `Snapshot selection discarded stale work (trigger=${current.trigger}, revision=${current.snapshot.revision})`,
+        });
+        current = pending;
+      }
+    })();
+    selectionRuns[input.platform] = run;
+    try {
+      return await run;
+    } finally {
+      if (selectionRuns[input.platform] === run) delete selectionRuns[input.platform];
+    }
+  }
+
+  function selectionAlreadyCommitted(
+    prepared: CommittedSelection,
+    snapshot: DiscoverySnapshot,
+    state: SchedulerState,
+    platform: Platform,
+  ): SnapshotSelectionResult | undefined {
+    if (prepared.snapshotRevision !== snapshot.revision) return undefined;
+    if (prepared.generation !== selectionGeneration[platform]) return undefined;
+    const session = state.sessions[platform];
+    const decision = prepared.result.decision;
+    const action = session.status === "watching"
+      ? session.campaignId ? "watch" : "fallback"
+      : "idle";
+    if (action !== decision.action
+      || session.campaignId !== decision.campaign?.id
+      || session.rewardId !== decision.reward?.id
+      || session.channel?.url !== decision.channel?.url) return undefined;
+    return {
+      ...prepared.result,
+      decision: {
+        ...decision,
+        reason: "Keeping already committed snapshot selection",
+        reasonCode: "keeping_current_watch",
+      },
+      retention: {
+        keep: true,
+        offlineChecks: session.offlineChecks,
+        playbackChecks: session.playbackChecks ?? 0,
+        noProgressChecks: session.noProgressChecks,
+        lastWatchedMinutes: session.lastWatchedMinutes,
+        channel: session.channel,
+        reason: "Keeping already committed snapshot selection",
+        reasonCode: "keeping_current_watch",
+      },
+      campaignsChecked: 0,
+      candidatesChecked: 0,
+      fastPath: true,
+    };
   }
 
   async function tickPlatform(
@@ -1908,7 +2115,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       tickContext,
     );
     try {
-      const claimed = await runTick(tickContext, [platform], abort.signal);
+      const claimed = await runTick(tickContext, [platform], abort.signal, trigger);
       return [platform, claimed[platform] ?? []];
     } catch (error) {
       if (abort.signal.aborted) return [platform, []];
@@ -1930,6 +2137,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     tickContext: TickDiagnosticContext,
     platforms: Platform[] | undefined,
     signal: AbortSignal,
+    trigger: TickTrigger,
   ): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
     const settings = await deps.loadSettings();
@@ -1993,6 +2201,24 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       currentState.authHealth[platform].status === "healthy");
     await refreshDiscovery(discoveryPlatforms);
     signal.throwIfAborted();
+    const preparedSelections: Partial<Record<Platform, CommittedSelection>> = {};
+    await Promise.all(discoveryPlatforms.map(async (selectionPlatform) => {
+      const snapshot = discoveryLanes[selectionPlatform].current().snapshot;
+      if (!snapshot) return;
+      const input: SelectionInput = {
+        platform: selectionPlatform,
+        trigger,
+        snapshot,
+        settings,
+        state: currentState,
+        key: selectionKey(selectionPlatform, snapshot, settings, currentState),
+        force: selectionIsForced(trigger),
+        signal,
+        generation: selectionGeneration[selectionPlatform],
+      };
+      preparedSelections[selectionPlatform] = await prepareSelection(input);
+    }));
+    signal.throwIfAborted();
     const platform = schedulerPlatforms[0];
     await withStateLock(() => withEventCollector(async (emit, events) => {
       signal.throwIfAborted();
@@ -2013,6 +2239,62 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
             state.sessions[discoveryPlatform],
           );
         }
+        const selections: Partial<Record<Platform, SnapshotSelectionResult>> = {};
+        for (const selectionPlatform of schedulerPlatforms) {
+          const snapshot = discoveryLanes[selectionPlatform].current().snapshot;
+          if (!snapshot) continue;
+          const key = selectionKey(selectionPlatform, snapshot, settings, state);
+          let prepared = preparedSelections[selectionPlatform];
+          if (!prepared || prepared.key !== key || prepared.snapshotRevision !== snapshot.revision) {
+            const committed = prepared
+              ? selectionAlreadyCommitted(prepared, snapshot, state, selectionPlatform)
+              : undefined;
+            if (committed) {
+              selections[selectionPlatform] = committed;
+              continue;
+            }
+            if (prepared) {
+              discoveryEvents[selectionPlatform].push({
+                category: "diagnostic",
+                platform: selectionPlatform,
+                level: "debug",
+                message: `Snapshot selection discarded before commit (trigger=${trigger}, revision=${prepared.snapshotRevision})`,
+              });
+            }
+            prepared = await prepareSelection({
+              platform: selectionPlatform,
+              trigger,
+              snapshot,
+              settings,
+              state,
+              key,
+              force: false,
+              signal,
+              generation: selectionGeneration[selectionPlatform],
+            });
+          }
+          preparedSelections[selectionPlatform] = prepared;
+          if (prepared.generation !== selectionGeneration[selectionPlatform]) {
+            discoveryEvents[selectionPlatform].push({
+              category: "diagnostic",
+              platform: selectionPlatform,
+              level: "debug",
+              message: `Snapshot selection discarded before commit after lifecycle change (trigger=${trigger}, revision=${prepared.snapshotRevision})`,
+            });
+            continue;
+          }
+          selections[selectionPlatform] = prepared.result;
+        }
+        const selectionsAreCurrent = (): boolean => schedulerPlatforms.every((selectionPlatform) => {
+          const prepared = preparedSelections[selectionPlatform];
+          const snapshot = discoveryLanes[selectionPlatform].current().snapshot;
+          return !prepared || (prepared.generation === selectionGeneration[selectionPlatform]
+            && prepared.snapshotRevision === snapshot?.revision);
+        });
+        const staleSelection = new Error("Snapshot selection lifecycle changed before publication");
+        const assertSelectionsCurrent = (): void => {
+          if (!selectionsAreCurrent()) throw staleSelection;
+        };
         // Observed here rather than returned by the scheduler: the controller
         // already sees every emitted event, and the post-claim handoff only
         // needs to know which platforms claimed.
@@ -2033,6 +2315,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           emit: claimObservingEmit,
           signal,
           campaignEvaluationFingerprints,
+          selections,
+          selectionIsCurrent: Object.fromEntries(schedulerPlatforms.map((selectionPlatform) => {
+            const prepared = preparedSelections[selectionPlatform];
+            return [selectionPlatform, () => prepared?.generation === selectionGeneration[selectionPlatform]];
+          })),
           discovery: Object.fromEntries(schedulerPlatforms.map((discoveryPlatform) => {
             const discoveryState = discoveryLanes[discoveryPlatform].current();
             return [discoveryPlatform, {
@@ -2043,12 +2330,15 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           })),
         });
         signal.throwIfAborted();
+        assertSelectionsCurrent();
         const lifecycleEvents = farmingLifecycleEvents(state, result.state);
         for (const event of lifecycleEvents) emit(event);
         await emitNotifications(settings, state, result.state, result.events);
         signal.throwIfAborted();
+        assertSelectionsCurrent();
         await applyAdFocusForState(result.state, emit, schedulerPlatforms);
         signal.throwIfAborted();
+        assertSelectionsCurrent();
         publicationLeases = await reconcileTablessWatchers(
           result.state,
           settings,
@@ -2057,8 +2347,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           schedulerPlatforms,
         );
         signal.throwIfAborted();
+        assertSelectionsCurrent();
         await reconcileDiscoverySignalControllers(result.state, settings, adapters, emit, schedulerPlatforms);
         signal.throwIfAborted();
+        assertSelectionsCurrent();
         nextState = result.state;
         if (settings.criticalFailurePromptEnabled) {
           // Page-context tabs are created deep inside tabs.ts, which has no access
@@ -2084,6 +2376,19 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         clearOperationalEvents(events);
         try {
           if (signal.aborted) return;
+          if (error instanceof Error && error.message === "Snapshot selection lifecycle changed before publication") {
+            await applyAdFocusForState(state, emit, schedulerPlatforms);
+            publicationLeases.push(...await reconcileTablessWatchers(
+              state,
+              settings,
+              createSelectedAdapters(settings, emit, schedulerPlatforms),
+              emit,
+              schedulerPlatforms,
+            ));
+            emit({ category: "diagnostic", level: "debug", platform, message: error.message });
+            await reportBestEffort(correlateTickDiagnostics(events, tickContext));
+            return;
+          }
           const detail = error instanceof Error ? error.message : "Scheduler tick failed";
           emit({ category: "activity", code: "interruption", level: "error", platform, data: { reason: "platform_error", detail } });
           emit({ category: "diagnostic", level: "error", platform, message: detail });
@@ -2095,7 +2400,18 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         return;
       }
       try {
-        await persistPlatformAndReport(platform, nextState, correlateTickDiagnostics(events, tickContext));
+        const persisted = await persistPlatformAndReport(
+          platform,
+          nextState,
+          correlateTickDiagnostics(events, tickContext),
+          () => schedulerPlatforms.every((selectionPlatform) => {
+            const prepared = preparedSelections[selectionPlatform];
+            const snapshot = discoveryLanes[selectionPlatform].current().snapshot;
+            return !prepared || (prepared.generation === selectionGeneration[selectionPlatform]
+              && prepared.snapshotRevision === snapshot?.revision);
+          }),
+        );
+        if (!persisted) return;
         waitingClaimRewardIds[platform].clear();
         for (const rewardId of nextWaitingClaimRewardIds[platform]) {
           waitingClaimRewardIds[platform].add(rewardId);
@@ -2119,6 +2435,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   async function invalidateAuthHealth(platform: Platform): Promise<void> {
     discoveryLanes[platform].invalidate();
+    invalidateSelection(platform);
     const releaseDiscoverySignalAuthRefresh = reserveDiscoverySignalAuthRefresh(platform);
     try {
       const generations = await beginAuthRefresh([platform]);
@@ -3043,6 +3360,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           },
           managedPageContextTabs,
         });
+        if (current.lastHeartbeatOk !== ok || previousChecks !== heartbeatChecks) {
+          invalidateSelection(platform);
+        }
         committedSession = nextSession;
         return { stale: false, fallback };
       });
@@ -3188,7 +3508,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   function shutdown(): void {
     controllerShutdown = true;
-    for (const platform of PLATFORMS) discoveryLanes[platform].stop();
+    for (const platform of PLATFORMS) {
+      discoveryLanes[platform].stop();
+      invalidateSelection(platform);
+    }
     discoverySignalLifecycleOpen = false;
     for (const platform of PLATFORMS) invalidateDiscoverySignalAdmission(platform);
     twitchSettingsTransitionGeneration += 1;
@@ -3205,7 +3528,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     discoverySignalLifecycleOpen = false;
     for (const platform of PLATFORMS) invalidateDiscoverySignalAdmission(platform);
     twitchSettingsTransitionGeneration += 1;
-    for (const platform of PLATFORMS) discoveryLanes[platform].invalidate();
+    for (const platform of PLATFORMS) {
+      discoveryLanes[platform].invalidate();
+      invalidateSelection(platform);
+    }
     abortActiveTicks("Host reset");
     closeTwitchIntegrityLifecycle("Host reset");
     await stopDiscoverySignalControllersAndReport(PLATFORMS);
@@ -3550,6 +3876,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       for (const event of playbackDiagnostics) emit(event);
 
       await persistPlatformState(message.platform, nextState);
+      if ((previous ? isPlaybackTelemetryHealthy(previous) : undefined)
+        !== isPlaybackTelemetryHealthy(telemetry)) {
+        invalidateSelection(message.platform);
+      }
       try {
         if (deps.applyAdFocus && session.status === "watching" && session.tabId === senderTabId) {
           await deps.applyAdFocus(message.platform, session.tabId, Boolean(message.telemetry.adActive), emit);

--- a/packages/core/src/core/discoverySnapshot.ts
+++ b/packages/core/src/core/discoverySnapshot.ts
@@ -30,6 +30,8 @@ export interface DiscoverySnapshot {
   revision: number;
   observedAt: number;
   campaigns: DiscoveryCampaignObservation[];
+  idleCandidates: DiscoveryCandidateObservation[];
+  followedChannels: string[];
   complete: true;
   metrics: DiscoveryRefreshMetrics;
 }
@@ -51,6 +53,8 @@ export interface DiscoverySnapshotState {
 
 export interface DiscoveryRefreshResult {
   campaigns: DiscoveryCampaignObservation[];
+  idleCandidates: DiscoveryCandidateObservation[];
+  followedChannels: string[];
   complete: boolean;
   failure?: string;
   metrics: DiscoveryRefreshMetrics;
@@ -64,12 +68,19 @@ export interface DiscoveryRefreshContext {
 export type DiscoverySnapshotListener = (state: Readonly<DiscoverySnapshotState>) => void | Promise<void>;
 
 export async function collectDiscoverySnapshot(
-  adapter: Pick<PlatformAdapter, "platform" | "refreshCampaigns" | "listCandidateChannels" | "checkChannel" | "selectCandidateChannel">,
+  adapter: Pick<PlatformAdapter, "platform" | "refreshCampaigns" | "listCandidateChannels" | "checkChannel" | "selectCandidateChannel" | "listFollowedChannels">,
   session: Parameters<PlatformAdapter["refreshCampaigns"]>[0],
   signal: AbortSignal,
   now: () => number = Date.now,
+  includeFollowedChannels = true,
+  idleCandidates: ChannelCandidate[] = [],
 ): Promise<DiscoveryRefreshResult> {
-  const campaigns = await adapter.refreshCampaigns(session, { signal });
+  const [campaigns, followedChannels] = await Promise.all([
+    adapter.refreshCampaigns(session, { signal }),
+    includeFollowedChannels
+      ? adapter.listFollowedChannels?.({ signal }) ?? Promise.resolve([])
+      : Promise.resolve([]),
+  ]);
   const observations: DiscoveryCampaignObservation[] = [];
   let candidatesChecked = 0;
   let cacheHits = 0;
@@ -119,8 +130,41 @@ export async function collectDiscoverySnapshot(
     }
     observations.push({ campaign, candidates: observed });
   }
+  const observedIdleCandidates: DiscoveryCandidateObservation[] = [];
+  if (adapter.selectCandidateChannel) {
+    const selection = await adapter.selectCandidateChannel(idleCandidates, undefined, { signal });
+    candidatesChecked += selection.checked;
+    cacheHits += selection.metrics?.cacheHits ?? 0;
+    cacheMisses += selection.metrics?.cacheMisses ?? 0;
+    batchRequests += selection.metrics?.batchRequests ?? 0;
+    singleFallbacks += selection.metrics?.singleFallbacks ?? 0;
+    observedIdleCandidates.push(...(selection.observations ?? (selection.channel
+      ? [{ live: true, categoryMatches: true, candidate: selection.channel }]
+      : [])).map((check) => ({
+      candidate: check.candidate,
+      live: check.live,
+      categoryMatches: check.categoryMatches,
+      eligible: "unknown" as const,
+      observedAt: now(),
+    })));
+  } else {
+    for (const candidate of idleCandidates) {
+      signal.throwIfAborted();
+      const check = await adapter.checkChannel(candidate, { signal });
+      candidatesChecked += 1;
+      observedIdleCandidates.push({
+        candidate: check.candidate,
+        live: check.live,
+        categoryMatches: check.categoryMatches,
+        eligible: "unknown",
+        observedAt: now(),
+      });
+    }
+  }
   return {
     campaigns: observations,
+    idleCandidates: observedIdleCandidates,
+    followedChannels,
     complete: true,
     metrics: {
       campaigns: campaigns.length,
@@ -146,17 +190,19 @@ export function adapterFromDiscoverySnapshot(
           campaigns.get(campaign.id)?.candidates.map(({ candidate }) => candidate) ?? [];
       }
       if (property === "selectCandidateChannel") return undefined;
+      if (property === "listFollowedChannels") {
+        return async (): Promise<string[]> => [...(snapshot?.followedChannels ?? [])];
+      }
       if (property === "checkChannel") {
         return async (candidate: ChannelCandidate, options?: { campaign?: DropCampaign }) => {
-          if (!options?.campaign) {
-            return { live: false, categoryMatches: false, candidate };
-          }
-          const observations = campaigns.get(options.campaign.id)?.candidates ?? [];
+          const observations = options?.campaign
+            ? campaigns.get(options.campaign.id)?.candidates ?? []
+            : snapshot?.idleCandidates ?? [];
           const observation = observations.find(({ candidate: observed }) =>
             observed.username.toLowerCase() === candidate.username.toLowerCase());
           if (!observation) {
             const currentChannel = session?.channel;
-            if (session?.campaignId === options.campaign.id && currentChannel
+            if (options?.campaign && session?.campaignId === options.campaign.id && currentChannel
               && currentChannel.username.toLowerCase() === candidate.username.toLowerCase()) {
               return { live: true, categoryMatches: true, candidate: currentChannel };
             }
@@ -174,6 +220,40 @@ export function adapterFromDiscoverySnapshot(
       return typeof value === "function" ? value.bind(target) : value;
     },
   });
+}
+
+export function selectionAdapterFromDiscoverySnapshot(
+  snapshot: DiscoverySnapshot,
+  session?: WatchSession,
+): Pick<PlatformAdapter, "listCandidateChannels" | "selectCandidateChannel" | "checkChannel" | "listFollowedChannels"> {
+  const campaigns = new Map(snapshot.campaigns.map((observation) => [observation.campaign.id, observation]));
+  return {
+    listCandidateChannels: async (campaign) =>
+      campaigns.get(campaign.id)?.candidates.map(({ candidate }) => candidate) ?? [],
+    selectCandidateChannel: undefined,
+    listFollowedChannels: async () => [...snapshot.followedChannels],
+    checkChannel: async (candidate, options) => {
+      const observations = options?.campaign
+        ? campaigns.get(options.campaign.id)?.candidates ?? []
+        : snapshot.idleCandidates;
+      const observation = observations.find(({ candidate: observed }) =>
+        observed.username.toLowerCase() === candidate.username.toLowerCase());
+      if (!observation) {
+        const currentChannel = session?.channel;
+        if (options?.campaign && session?.campaignId === options.campaign.id && currentChannel
+          && currentChannel.username.toLowerCase() === candidate.username.toLowerCase()) {
+          return { live: true, categoryMatches: true, candidate: currentChannel };
+        }
+        return { live: false, categoryMatches: false, candidate };
+      }
+      return {
+        live: observation.live,
+        categoryMatches: observation.categoryMatches,
+        campaignMatches: observation.eligible === "unknown" ? undefined : observation.eligible,
+        candidate: observation.candidate,
+      };
+    },
+  };
 }
 
 export class DiscoverySnapshotLane {
@@ -284,6 +364,8 @@ export class DiscoverySnapshotLane {
             revision: ++this.revision,
             observedAt: finishedAt,
             campaigns: result.campaigns,
+            idleCandidates: result.idleCandidates,
+            followedChannels: result.followedChannels,
             complete: true,
             metrics: result.metrics,
           },

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -32,6 +32,7 @@ import type { CriticalHealthObservation } from "./criticalHealth";
 import { isManagedTabBreakerOpen, observeCriticalHealth, recordManagedTabOpen } from "./criticalHealth";
 import { isTimestampStale, PLAYBACK_TELEMETRY_MAX_AGE_MS } from "./timestamps";
 import { heartbeatContextKey, validTablessHeartbeatCadence } from "./heartbeatCadence";
+import { selectionAdapterFromDiscoverySnapshot, type DiscoverySnapshot } from "./discoverySnapshot";
 
 const PLATFORMS: Platform[] = ["twitch", "kick"];
 const MAX_PLATFORM_BACKOFF_MINUTES = 30;
@@ -542,6 +543,143 @@ function retainTablessHeartbeat(previous: WatchSession, next: WatchSession): Wat
   return next;
 }
 
+export interface WatchRetention {
+  keep: boolean;
+  offlineChecks: number;
+  playbackChecks: number;
+  noProgressChecks?: number;
+  lastWatchedMinutes?: number;
+  reason: string;
+  reasonCode: WatchReasonCode;
+  channel?: ChannelCandidate;
+}
+
+export interface SnapshotSelectionResult {
+  decision: WatchDecision;
+  retention: WatchRetention;
+  campaignsChecked: number;
+  candidatesChecked: number;
+  fastPath: boolean;
+}
+
+/** Pure provider-I/O-free selection when paired with a committed snapshot adapter. */
+async function selectWatchTarget(
+  platform: Platform,
+  previous: WatchSession,
+  campaigns: DropCampaign[],
+  settings: EngineSettings,
+  adapter: Pick<PlatformAdapter, "listCandidateChannels" | "selectCandidateChannel" | "checkChannel" | "listFollowedChannels">,
+  signal?: AbortSignal,
+): Promise<SnapshotSelectionResult> {
+  const currentWatch = await evaluatePreferredCurrentWatch(previous, campaigns, settings, adapter, signal);
+  let decision: WatchDecision;
+  let retention: WatchRetention;
+  let campaignsChecked = 0;
+  let candidatesChecked = 0;
+  if (currentWatch?.keep.keep) {
+    decision = currentWatch.decision;
+    retention = currentWatch.keep;
+    candidatesChecked = 1;
+  } else {
+    const stalled = currentWatch?.keep.reasonCode === "no_progress" && previous.channel
+      ? new Set([previous.channel.username.toLowerCase()])
+      : undefined;
+    decision = await chooseCampaignDecision(
+      platform,
+      campaigns,
+      settings,
+      adapter,
+      signal,
+      (metrics) => {
+        campaignsChecked = metrics.campaignsChecked;
+        candidatesChecked = metrics.candidatesChecked;
+      },
+      stalled,
+    );
+    retention = currentWatch?.keep
+      ?? await shouldKeepWatching(previous, decision, campaigns, settings, adapter, signal);
+  }
+  if (retention.keep && previous.channel) {
+    decision = {
+      platform,
+      action: previous.campaignId ? "watch" : "fallback",
+      campaign: campaigns.find((campaign) => campaign.id === previous.campaignId),
+      reward: campaigns
+        .find((campaign) => campaign.id === previous.campaignId)
+        ?.rewards.find((reward) => reward.id === previous.rewardId),
+      channel: retention.channel ?? previous.channel,
+      reason: retention.reason,
+      reasonCode: retention.reasonCode,
+    };
+  } else if (previous.status === "watching" && previous.channel && retention.reason !== "No existing watch session") {
+    decision = { ...decision, reason: retention.reason, reasonCode: retention.reasonCode };
+  }
+  return { decision, retention, campaignsChecked, candidatesChecked, fastPath: currentWatch?.keep.keep === true };
+}
+
+export interface SnapshotSelectionInput {
+  snapshot: DiscoverySnapshot;
+  previous: WatchSession;
+  previousCampaigns: DropCampaign[];
+  settings: EngineSettings;
+  signal?: AbortSignal;
+}
+
+export async function selectWatchTargetFromSnapshot({
+  snapshot,
+  previous,
+  previousCampaigns,
+  settings,
+  signal,
+}: SnapshotSelectionInput): Promise<SnapshotSelectionResult> {
+  const campaigns = preserveClaimedRewards(
+    snapshot.campaigns.map(({ campaign }) => campaign),
+    previousCampaigns,
+  );
+  return selectWatchTarget(
+    snapshot.platform,
+    previous,
+    campaigns,
+    settings,
+    selectionAdapterFromDiscoverySnapshot(snapshot, previous),
+    signal,
+  );
+}
+
+function retainHealthyWatchOnAmbiguousDiscovery(
+  previous: WatchSession,
+  campaigns: DropCampaign[],
+): SnapshotSelectionResult | undefined {
+  if (previous.status !== "watching" || !previous.channel || !isSessionHealthy(previous)) return undefined;
+  const campaign = campaigns.find((candidate) => candidate.id === previous.campaignId);
+  const reward = campaign?.rewards.find((candidate) => candidate.id === previous.rewardId);
+  const decision: WatchDecision = {
+    platform: previous.platform,
+    action: previous.campaignId ? "watch" : "fallback",
+    campaign,
+    reward,
+    channel: previous.channel,
+    reason: "Keeping healthy current watch while discovery is incomplete",
+    reasonCode: "keeping_current_watch",
+  };
+  return {
+    decision,
+    retention: {
+      keep: true,
+      offlineChecks: previous.offlineChecks,
+      playbackChecks: previous.playbackChecks ?? 0,
+      noProgressChecks: previous.noProgressChecks,
+      lastWatchedMinutes: previous.lastWatchedMinutes,
+      channel: previous.channel,
+      reason: decision.reason,
+      reasonCode: decision.reasonCode,
+    },
+    campaignsChecked: 0,
+    candidatesChecked: 0,
+    fastPath: true,
+  };
+}
+
 export interface SchedulerTickResult {
   state: SchedulerState;
   decisions: WatchDecision[];
@@ -571,6 +709,8 @@ export interface SchedulerTickOptions {
     campaigns: DropCampaign[];
     complete: boolean;
   }>>;
+  selections?: Partial<Record<Platform, SnapshotSelectionResult>>;
+  selectionIsCurrent?: Partial<Record<Platform, () => boolean>>;
 }
 
 const CAMPAIGN_REJECTION_LABELS: Record<CampaignFarmingRejectionCode, string> = {
@@ -1069,51 +1209,29 @@ export async function runSchedulerTick(
       }
 
       const selectionStartedAt = Date.now();
-      const currentWatch = await evaluatePreferredCurrentWatch(
-        previous,
-        campaigns,
-        settings,
-        adapter,
-        options.signal,
-      );
-      let decision: WatchDecision;
-      let shouldKeep: Awaited<ReturnType<typeof shouldKeepWatching>>;
-      if (currentWatch?.keep.keep) {
-        decision = currentWatch.decision;
-        shouldKeep = currentWatch.keep;
+      const selection = options.selections?.[platform]
+        ?? (discoveryFailed ? retainHealthyWatchOnAmbiguousDiscovery(previous, campaigns) : undefined)
+        ?? await selectWatchTarget(platform, previous, campaigns, settings, adapter, options.signal);
+      let { decision } = selection;
+      const shouldKeep = selection.retention;
+      if (options.selectionIsCurrent?.[platform]?.() === false) {
+        emitDiagnostic(emit, platform, "debug", "Snapshot selection discarded after target health changed");
+        continue;
+      }
+      if (selection.fastPath) {
         emitDiagnostic(
           emit,
           platform,
           "debug",
-          `Campaign selection fast path retained current watch in ${Date.now() - selectionStartedAt}ms (1 candidate checked)`,
+          `Campaign selection fast path retained current watch in ${Date.now() - selectionStartedAt}ms (${countLabel(selection.candidatesChecked, "candidate")} checked)`,
         );
       } else {
-        let selectionMetrics = { campaignsChecked: 0, candidatesChecked: 0 };
-        // Reselecting the channel that just stalled would reset its counter and
-        // loop forever, so this tick passes over it when anything else can run
-        // the campaign (#400).
-        const stalled = currentWatch?.keep.reasonCode === "no_progress" && previous.channel
-          ? new Set([previous.channel.username.toLowerCase()])
-          : undefined;
-        decision = await chooseCampaignDecision(
-          platform,
-          campaigns,
-          settings,
-          adapter,
-          options.signal,
-          (metrics) => {
-            selectionMetrics = metrics;
-          },
-          stalled,
-        );
         emitDiagnostic(
           emit,
           platform,
           "debug",
-          `Campaign selection finished in ${Date.now() - selectionStartedAt}ms (${countLabel(selectionMetrics.campaignsChecked, "campaign")} checked, ${countLabel(selectionMetrics.candidatesChecked, "candidate")} checked)`,
+          `Campaign selection finished in ${Date.now() - selectionStartedAt}ms (${countLabel(selection.campaignsChecked, "campaign")} checked, ${countLabel(selection.candidatesChecked, "candidate")} checked)`,
         );
-        shouldKeep = currentWatch?.keep
-          ?? await shouldKeepWatching(previous, decision, campaigns, settings, adapter, options.signal);
       }
       // The single site where a stop reason is decided for an existing watch, so
       // the precondition-break arm is set here rather than at every consumer.
@@ -1128,26 +1246,6 @@ export async function runSchedulerTick(
           `Switching watch target (${shouldKeep.reason}); ${previous.watchMode === "tabless" ? "heartbeat" : "playback"} ${isSessionHealthy(previous) ? "healthy" : "unhealthy"}`,
         );
       }
-      if (shouldKeep.keep && previous.channel) {
-        decision = {
-          platform,
-          action: previous.campaignId ? "watch" : "fallback",
-          campaign: campaigns.find((campaign) => campaign.id === previous.campaignId),
-          reward: campaigns
-            .find((campaign) => campaign.id === previous.campaignId)
-            ?.rewards.find((reward) => reward.id === previous.rewardId),
-          channel: shouldKeep.channel ?? previous.channel,
-          reason: shouldKeep.reason,
-          reasonCode: shouldKeep.reasonCode,
-        };
-      } else if (previous.status === "watching" && previous.channel && shouldKeep.reason !== "No existing watch session") {
-        decision = {
-          ...decision,
-          reason: shouldKeep.reason,
-          reasonCode: shouldKeep.reasonCode,
-        };
-      }
-
       const decisionChanged = previous.campaignId !== decision.campaign?.id
         || previous.rewardId !== decision.reward?.id
         || previous.channel?.url !== decision.channel?.url
@@ -1235,6 +1333,19 @@ export async function runSchedulerTick(
             previous,
             { ...watchTabOptions, signal: options.signal },
           );
+          if (options.selectionIsCurrent?.[platform]?.() === false) {
+            if (prepared.managedByExtension && prepared.tabId !== previousManagedTabId) {
+              await adapter.stopWatchTab?.({
+                ...previous,
+                status: "watching",
+                channel: decision.channel,
+                tabId: prepared.tabId,
+                tabManagedByExtension: true,
+              }, { signal: options.signal });
+            }
+            emitDiagnostic(emit, platform, "debug", "Snapshot selection discarded after target health changed");
+            continue;
+          }
           // Only a genuinely NEW extension-managed tab counts as churn evidence.
           // Reusing the tab we already track happens on every ordinary tick, and
           // counting it would trip the breaker during completely normal farming.
@@ -1450,7 +1561,7 @@ async function claimReadyRewards(
   return { campaigns: updated, events };
 }
 
-function preserveClaimedRewards(
+export function preserveClaimedRewards(
   campaigns: DropCampaign[],
   previousCampaigns: readonly DropCampaign[],
 ): DropCampaign[] {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -5,6 +5,7 @@ import {
   KICK_ALARM_NAME,
   TWITCH_ALARM_NAME,
   TWITCH_INTEGRITY_ALARM_NAME,
+  type BackgroundControllerDeps,
   type CredentialAvailability,
 } from "@lurkloot/core/controller";
 import { resolveCompatibility } from "@lurkloot/core";
@@ -19,7 +20,7 @@ import { createKickFetcher, KickClaimState } from "@lurkloot/core/kick";
 import { TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import { kickAdapter, twitchAdapter } from "./helpers/adapters";
 import type { TablessWatchController } from "@lurkloot/core/tablessWatch";
-import type { StopPageContextTabs } from "@lurkloot/core/scheduler";
+import { selectWatchTargetFromSnapshot, type StopPageContextTabs } from "@lurkloot/core/scheduler";
 import {
   cancelTwitchIntegrityAcquisition,
   currentManagedPageContextTabs,
@@ -241,6 +242,7 @@ function harness(
       request?: TwitchIntegrityRequest,
     ) => Promise<boolean>;
     cancelTwitchIntegrityAcquisition?: (reason?: unknown) => void;
+    selectWatchTarget?: BackgroundControllerDeps<ExtensionSettings>["selectWatchTarget"];
   } = {},
 ) {
   let currentSettings = settings;
@@ -291,6 +293,7 @@ function harness(
     })),
     reportEvents: vi.fn(overrides.reportEvents ?? reportEvents),
     stopPageContextTabs: vi.fn(overrides.stopPageContextTabs ?? forgetManagedPageContextTabs),
+    ...(overrides.selectWatchTarget ? { selectWatchTarget: vi.fn(overrides.selectWatchTarget) } : {}),
     wait: overrides.wait,
     ...(overrides.checkCredentialAvailability
       ? { checkCredentialAvailability: vi.fn(overrides.checkCredentialAvailability) }
@@ -2271,10 +2274,29 @@ describe("background controller", () => {
     detailsFail = true;
     await env.controller.tick();
 
-    // Each platform tick now constructs one discovery adapter and one legacy
-    // selection adapter. #457 will reuse construction across the phases.
+    // Snapshot selection is provider-free, so it adds no adapter construction
+    // beyond the discovery and scheduler phases introduced by #394.
     expect(env.deps.createAdapter).toHaveBeenCalledTimes(8);
     expect(env.state.campaigns.twitch.map((item) => item.id)).toEqual(["retained"]);
+  });
+
+  it("skips redundant target evaluation when a new discovery revision is materially unchanged", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, tablessMode: true }));
+    env.twitch.supportsTabless = true;
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([{
+      ...campaign("twitch"),
+      rewards: [{ ...reward("in_progress"), isWatchBased: false }],
+    }]);
+
+    await env.controller.tick(["twitch"]);
+    await env.controller.tick(["twitch"]);
+    await env.controller.tick(["twitch"]);
+    await env.controller.tick(["twitch"]);
+
+    expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringMatching(/^Snapshot selection skipped \(trigger=unknown, revision=\d+, age=\d+ms, material=false\)$/),
+    }));
   });
 
   it("starts enabled auth probes concurrently and persists each before scheduler work", async () => {
@@ -6218,6 +6240,88 @@ describe("background controller", () => {
     }
 
     expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
+  });
+
+  it("completes a due heartbeat while snapshot selection is blocked", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-09-02T12:00:00.000Z"));
+    const selectionStarted = deferred<void>();
+    const allowSelection = deferred<void>();
+    let blockSelection = false;
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      tablessMode: true,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: false, idleWatchlistChannels: [] },
+      },
+    }, {
+      selectWatchTarget: async (...args) => {
+        if (blockSelection) {
+          selectionStarted.resolve();
+          await allowSelection.promise;
+        }
+        return selectWatchTargetFromSnapshot(...args);
+      },
+    });
+    const watcher = fakeTablessWatcher(async () => ({ ok: true, live: true }));
+    env.twitch.supportsTabless = true;
+    env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
+    await env.controller.tick(["twitch"]);
+    advanceToNextHeartbeatDue();
+    watcher.tick.mockClear();
+
+    blockSelection = true;
+    const selection = env.controller.tick(["twitch"], "manual_tick");
+    await selectionStarted.promise;
+    const heartbeat = env.controller.runWatchHeartbeat();
+    try {
+      await drainMicrotasks();
+      expect(watcher.tick).toHaveBeenCalledOnce();
+      await heartbeat;
+    } finally {
+      allowSelection.resolve();
+      await selection;
+    }
+    expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
+    expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringContaining("Snapshot selection discarded stale lifecycle work"),
+    }));
+  });
+
+  it("coalesces concurrent snapshot selection requests to one pending evaluation", async () => {
+    const selectionStarted = deferred<void>();
+    const allowSelection = deferred<void>();
+    let blockSelection = false;
+    const env = harness(farming(DEFAULT_SETTINGS), {
+      selectWatchTarget: async (...args) => {
+        if (blockSelection) {
+          selectionStarted.resolve();
+          await allowSelection.promise;
+        }
+        return selectWatchTargetFromSnapshot(...args);
+      },
+    });
+    await env.controller.tick(["twitch"]);
+    const selectWatchTarget = env.deps.selectWatchTarget!;
+    selectWatchTarget.mockClear();
+
+    blockSelection = true;
+    const first = env.controller.tick(["twitch"], "manual_tick");
+    await selectionStarted.promise;
+    const second = env.controller.tick(["twitch"], "manual_tick");
+    const third = env.controller.tick(["twitch"], "manual_tick");
+    await vi.waitFor(() => expect(vi.mocked(env.twitch.refreshCampaigns).mock.calls.length).toBeGreaterThanOrEqual(3));
+    allowSelection.resolve();
+    await Promise.all([first, second, third]);
+
+    expect(selectWatchTarget).toHaveBeenCalledTimes(2);
+    expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringContaining("Snapshot selection discarded stale work"),
+    }));
   });
 
   it("completes a due initial heartbeat while discovery-signal start is blocked after publication", async () => {

--- a/packages/extension/tests/discoverySnapshot.test.ts
+++ b/packages/extension/tests/discoverySnapshot.test.ts
@@ -16,7 +16,7 @@ const metrics: DiscoveryRefreshMetrics = {
   singleFallbacks: 0,
 };
 
-const complete = (): DiscoveryRefreshResult => ({ campaigns: [], complete: true, metrics });
+const complete = (): DiscoveryRefreshResult => ({ campaigns: [], idleCandidates: [], followedChannels: [], complete: true, metrics });
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -63,7 +63,7 @@ describe("DiscoverySnapshotLane", () => {
   it("retains the last coherent snapshot after failed and incomplete attempts", async () => {
     const refresh = vi.fn()
       .mockResolvedValueOnce(complete())
-      .mockResolvedValueOnce({ campaigns: [], complete: false, failure: "partial", metrics })
+      .mockResolvedValueOnce({ campaigns: [], idleCandidates: [], followedChannels: [], complete: false, failure: "partial", metrics })
       .mockRejectedValueOnce(new Error("offline"));
     const lane = new DiscoverySnapshotLane("kick", refresh);
 
@@ -109,6 +109,46 @@ describe("DiscoverySnapshotLane", () => {
 });
 
 describe("collectDiscoverySnapshot", () => {
+  it("captures followed-channel preference evidence inside discovery", async () => {
+    const listFollowedChannels = vi.fn(async () => ["friend"]);
+    const adapter = {
+      platform: "twitch" as const,
+      refreshCampaigns: vi.fn(async () => []),
+      listCandidateChannels: vi.fn(),
+      checkChannel: vi.fn(),
+      selectCandidateChannel: undefined,
+      listFollowedChannels,
+    };
+
+    const result = await collectDiscoverySnapshot(adapter, undefined, new AbortController().signal);
+
+    expect(result.followedChannels).toEqual(["friend"]);
+    expect(listFollowedChannels).toHaveBeenCalledOnce();
+  });
+
+  it("skips followed-channel discovery when preference is disabled", async () => {
+    const listFollowedChannels = vi.fn(async () => ["friend"]);
+    const adapter = {
+      platform: "twitch" as const,
+      refreshCampaigns: vi.fn(async () => []),
+      listCandidateChannels: vi.fn(),
+      checkChannel: vi.fn(),
+      selectCandidateChannel: undefined,
+      listFollowedChannels,
+    };
+
+    const result = await collectDiscoverySnapshot(
+      adapter,
+      undefined,
+      new AbortController().signal,
+      Date.now,
+      false,
+    );
+
+    expect(result.followedChannels).toEqual([]);
+    expect(listFollowedChannels).not.toHaveBeenCalled();
+  });
+
   it("keeps Kick channel-specific eligibility unknown", async () => {
     const campaign = {
       id: "campaign",

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChannelCandidate, DropCampaign, DropReward, ExtensionSettings, KickPlatformSettings, Platform, SchedulerState, TwitchPlatformSettings } from "@lurkloot/shared/models";
 import { DEFAULT_SETTINGS } from "@lurkloot/shared/settings";
 import { NO_CATEGORY_ID } from "@lurkloot/shared/categories";
-import { chooseCampaignDecision, runSchedulerTick, sortCampaigns } from "@lurkloot/core/scheduler";
+import { chooseCampaignDecision, runSchedulerTick, selectWatchTargetFromSnapshot, sortCampaigns } from "@lurkloot/core/scheduler";
 import type { PlatformAdapter } from "@lurkloot/core/adapter";
 import { forgetManagedPageContextTabs, managedTabBreakerOpen, syncManagedTabBreakers } from "@lurkloot/core/tabs";
 import { SafeFetchError } from "@lurkloot/core/fetchError";
@@ -69,6 +69,92 @@ const HEALTHY_AUTH: SchedulerState["authHealth"] = {
 };
 
 describe("scheduler campaign selection", () => {
+  it("selects from a named committed snapshot without provider discovery I/O", async () => {
+    const selectedCampaign = campaign("snapshot-campaign");
+    const selectedChannel = channel("snapshot-channel");
+    const result = await selectWatchTargetFromSnapshot({
+      snapshot: {
+        platform: "twitch",
+        revision: 7,
+        observedAt: Date.now(),
+        complete: true,
+        idleCandidates: [],
+        followedChannels: ["snapshot-channel"],
+        metrics: { campaigns: 1, candidates: 1, cacheHits: 0, cacheMisses: 0, batchRequests: 0, singleFallbacks: 0 },
+        campaigns: [{
+          campaign: selectedCampaign,
+          candidates: [{ candidate: selectedChannel, live: true, categoryMatches: true, eligible: true, observedAt: Date.now() }],
+        }],
+      },
+      previous: { platform: "twitch", status: "idle", offlineChecks: 0, playbackChecks: 0, errorChecks: 0 },
+      previousCampaigns: [],
+      settings: settings(),
+    });
+
+    expect(result.decision).toMatchObject({ action: "watch", campaign: { id: "snapshot-campaign" }, channel: { username: "snapshot-channel" } });
+  });
+
+  it("selects an idle-watchlist fallback only from committed snapshot observations", async () => {
+    const idleChannel = channel("snapshot-idle");
+    const result = await selectWatchTargetFromSnapshot({
+      snapshot: {
+        platform: "twitch",
+        revision: 9,
+        observedAt: Date.now(),
+        complete: true,
+        campaigns: [],
+        idleCandidates: [{ candidate: idleChannel, live: true, categoryMatches: true, eligible: true, observedAt: Date.now() }],
+        followedChannels: [],
+        metrics: { campaigns: 0, candidates: 1, cacheHits: 0, cacheMisses: 1, batchRequests: 1, singleFallbacks: 0 },
+      },
+      previous: { platform: "twitch", status: "idle", offlineChecks: 0, playbackChecks: 0, errorChecks: 0 },
+      previousCampaigns: [],
+      settings: {
+        ...settings(),
+        platform: {
+          ...settings().platform,
+          twitch: { ...settings().platform.twitch, idleWatchlistChannels: [idleChannel.username] },
+        },
+      },
+    });
+
+    expect(result.decision).toMatchObject({ action: "fallback", channel: { username: "snapshot-idle" } });
+  });
+
+  it("rejects a current candidate with fresh explicit provider-negative evidence", async () => {
+    const selectedCampaign = campaign("negative-campaign");
+    const selectedChannel = channel("negative-channel");
+    const result = await selectWatchTargetFromSnapshot({
+      snapshot: {
+        platform: "twitch",
+        revision: 8,
+        observedAt: Date.now(),
+        complete: true,
+        idleCandidates: [],
+        followedChannels: [],
+        metrics: { campaigns: 1, candidates: 1, cacheHits: 0, cacheMisses: 1, batchRequests: 1, singleFallbacks: 0 },
+        campaigns: [{
+          campaign: selectedCampaign,
+          candidates: [{ candidate: selectedChannel, live: true, categoryMatches: true, eligible: false, observedAt: Date.now() }],
+        }],
+      },
+      previous: {
+        platform: "twitch",
+        status: "watching",
+        channel: selectedChannel,
+        campaignId: selectedCampaign.id,
+        rewardId: selectedCampaign.rewards[0]?.id,
+        offlineChecks: 0,
+        playbackChecks: 0,
+      },
+      previousCampaigns: [selectedCampaign],
+      settings: settings(),
+    });
+
+    expect(result.retention).toMatchObject({ keep: false, reasonCode: "campaign_ineligible" });
+    expect(result.decision.action).toBe("idle");
+  });
+
   it("skips an infeasible in-progress reward for a feasible locked reward", async () => {
     vi.useFakeTimers();
     vi.setSystemTime("2026-07-19T12:00:00.000Z");
@@ -1046,6 +1132,57 @@ describe("scheduler tick", () => {
     },
     campaigns: { twitch: [], kick: [] },
   };
+
+  it("retains a healthy current watch when committed discovery is incomplete", async () => {
+    const activeCampaign = campaign("current");
+    const activeChannel = channel("current");
+    const twitch = adapter("twitch", [], []);
+    twitch.checkChannel = vi.fn(async () => { throw new Error("selection must not validate through the provider"); });
+    const current: SchedulerState = {
+      ...baseState,
+      campaigns: { ...baseState.campaigns, twitch: [activeCampaign] },
+      sessions: {
+        ...baseState.sessions,
+        twitch: {
+          platform: "twitch",
+          status: "watching",
+          channel: activeChannel,
+          campaignId: activeCampaign.id,
+          rewardId: activeCampaign.rewards[0]?.id,
+          offlineChecks: 0,
+          playbackChecks: 0,
+          watchMode: "tab",
+          tabId: 42,
+          playback: {
+            platform: "twitch",
+            checkedAt: new Date().toISOString(),
+            videoCount: 1,
+            playingVideoCount: 1,
+            mutedVideoCount: 1,
+            unmutedVideoCount: 0,
+            blockedPlaybackCount: 0,
+            documentHidden: true,
+          },
+        },
+      },
+    };
+
+    const result = await runSchedulerTick(current, settings({ autoClaim: false }), {
+      twitch,
+      kick: adapter("kick", [], []),
+    }, {
+      platforms: ["twitch"],
+      discovery: { twitch: { campaigns: [activeCampaign], complete: false } },
+    });
+
+    expect(result.state.sessions.twitch).toMatchObject({
+      status: "watching",
+      campaignId: activeCampaign.id,
+      rewardId: activeCampaign.rewards[0]?.id,
+      channel: { username: "current" },
+    });
+    expect(twitch.checkChannel).not.toHaveBeenCalled();
+  });
 
   function realtimeCampaigns(): [DropCampaign, DropCampaign] {
     const ordinary = campaign("ordinary", {


### PR DESCRIPTION
## Summary

- move Twitch and Kick target selection onto named, committed discovery snapshot revisions
- collect campaign, followed-channel, and Idle Watchlist evidence during discovery so selection performs no provider I/O
- coalesce concurrent selection requests, skip materially unchanged evaluations, and re-evaluate forced/manual/claim lifecycle triggers
- retain healthy watches on ambiguous or incomplete evidence while rejecting fresh explicit-negative observations
- guard settings, auth, snapshot, and target-health generations through final watch-context publication and persistence
- keep heartbeat transport independent from blocked discovery/selection work and emit aggregate selection diagnostics
- exercise the shared lifecycle deterministically in both extension and CLI hosts

## Testing

- `pnpm verify`
- 181 CLI tests
- 1,761 extension tests
- Chromium and Firefox production builds

Closes #395

Depends on #481.
