### PR TITLE
perf(cli): reuse committed tick state

### DIFF
--- a/docs/scheduler-tick-baseline.md
+++ b/docs/scheduler-tick-baseline.md
@@ -60,4 +60,39 @@ The CLI interval baseline blocks one refresh across another elapsed interval. Pr
 - Snapshot candidate enumeration and validation are attributed to the controller's discovery duration. The legacy scheduler still performs its selection pass, but reads the committed normalized observations through an in-memory adapter view; #395 will make that selection lifecycle independently triggered and coalesced.
 - Real Twitch transport counts are pinned in `twitchCampaignDetailsReuse.test.ts`: the three-campaign cold refresh performs three `fetchJson` calls, while the following warm refresh adds only inventory and dashboard (five cumulative). `adapters.test.ts` pins a Kick refresh at two concurrent transport calls (campaigns and progress). The host matrix does not relabel adapter calls as HTTP requests.
 
+## v1.13.0 final gate
+
+The final deterministic gate was recorded from the stacked v1.13.0 implementation after #336, #394, #395, #337, #457, and #458. Twitch and Kick have identical normalized counts in both hosts for each single-provider scenario.
+
+| Scenario | Adapter operations | Discovery | Candidate lists | Channel checks | Watcher reconciliations | Adapter constructions |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| idle / failed | 2 | 1 | 0 | 0 | 0 | 1 |
+| stable retained | 4 | 1 | 1 | 1 | 1 | 1 |
+| switch | 4 | 1 | 1 | 1 | 1 | 1 |
+| higher priority unavailable | 6 | 1 | 2 | 2 | 1 | 1 |
+| slow provider | 4 | 1 | 1 | 1 | 1 | 1 |
+
+| Host cells | State loads | State saves | Persistence attribution |
+| --- | ---: | ---: | ---: |
+| extension/Twitch and extension/Kick | 5 | 2 | 10 ms |
+| CLI/Twitch and CLI/Kick | 5 | 2 | not synthetically timed |
+
+The original baseline used three extension state loads and four CLI state loads. Snapshot-owned discovery and short commit boundaries make five shared-engine loads explicit in the final architecture; #458 removes the additional CLI-only post-tick load, restoring host parity. Two saves remain deliberate: authentication health is durable before fallible discovery, then the scheduler result is committed independently. Adapter construction falls from two per single-provider tick to one.
+
+| Scenario | Before total (extension / CLI) | Final total (extension / CLI) |
+| --- | ---: | ---: |
+| idle / failed | 40 / 30 ms | 40 / 30 ms |
+| stable retained | 55 / 45 ms | 65 / 55 ms |
+| switch | 65 / 55 ms | 65 / 55 ms |
+| higher priority unavailable | 95 / 85 ms | 85 / 75 ms |
+| slow provider | 515 / 505 ms | 515 / 505 ms |
+
+The stable path now spends an attributable extra 10 ms enumerating the coherent discovery snapshot; selection itself performs no provider work and unchanged decisions are reused. The unavailable-priority path removes one redundant channel check and 10 ms. Controlled values remain structural test costs rather than production latency claims.
+
+The heartbeat-overlap cells record one heartbeat attempt with both blocking counters at zero for all four host/provider combinations. Extension and CLI therefore exercise the same platform-scoped controller lanes and fixed heartbeat contract; neither Twitch nor Kick waits for its sibling. CLI startup recovery performs additional intentional constructions and discovery passes outside the isolated single-provider tick, which the overlap row records separately.
+
+Remaining work is unavoidable under the published safety contract: every normal tick probes auth, refreshes authoritative campaign data, commits auth health before fallible work, and merges the platform result against the latest persisted state. Provider caches remain inside adapters. No duplicated host timer, redundant unchanged-state publication, repeated target-selection provider call, or cross-provider blocking was found after the focused v1.13.0 changes, so this audit creates no additional performance issue.
+
+All measurements use normalized synthetic data. No credentials, cookies, tokens, authorization headers, raw authenticated payloads, or new browser permissions are recorded or introduced. Authenticated live timing was not required because the gate measures deterministic work ownership and controlled phase attribution, not provider latency.
+
 PR #450 / issue #339 merged before this baseline. Its Twitch campaign-details reuse is part of the starting behavior.

--- a/docs/superpowers/plans/2026-09-08-cli-committed-tick-result.md
+++ b/docs/superpowers/plans/2026-09-08-cli-committed-tick-result.md
@@ -1,0 +1,13 @@
+# CLI Committed Tick Result Plan
+
+**Goal:** Let the CLI consume the exact final state committed by its tick without reloading `state.json`.
+
+**Architecture:** Add a host-neutral optional committed-state result to `tickAndHandOff`. Capture state at the controller's successful persistence boundary, scope the capture to the invocation, and thread it through post-claim handoff ticks. The CLI uses that result for subscription-wait reporting and falls back to storage only when a successful invocation produces no commit.
+
+### Tasks
+
+1. Change deterministic CLI expectations from four state loads to three and add success/failure/handoff/overlap contract coverage.
+2. Capture exact merged state at successful platform persistence without publishing aborted or stale attempts.
+3. Return the last commit owned by the current tick-and-handoff invocation.
+4. Consume the result in the CLI and preserve disabled-platform cleanup and subscription-wait behavior.
+5. Run focused tests, `pnpm verify`, independent review, then open a PR stacked on #486.

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -21,6 +21,10 @@ export interface RunOptions {
   // transiently unavailable one. Stays independent of any browser cookie
   // observation — it reads only the CLI's file/env credential store.
   checkCredentialAvailability?: (platform: Platform) => Promise<CredentialAvailability>;
+  stateStore?: {
+    load(): Promise<SchedulerState>;
+    save(state: SchedulerState): Promise<void>;
+  };
 }
 
 function disabledPlatformsNeedingCleanup(
@@ -39,6 +43,39 @@ function disabledPlatformsNeedingCleanup(
   });
 }
 
+interface CliTickDriver {
+  tickAndHandOff(platforms?: Platform[]): Promise<SchedulerState | undefined>;
+}
+
+export async function runCliTickOnce(options: {
+  controller: CliTickDriver;
+  enabledPlatforms: Platform[];
+  engineSettings: ReturnType<typeof toEngineSettings>;
+  loadState(): Promise<SchedulerState>;
+  seenSubscriptionWaits: Set<string>;
+  logger: Logger;
+}): Promise<void> {
+  const { controller, enabledPlatforms, engineSettings, loadState, seenSubscriptionWaits, logger } = options;
+  try {
+    let state = await controller.tickAndHandOff(enabledPlatforms) ?? await loadState();
+    const staleDisabledPlatforms = disabledPlatformsNeedingCleanup(state, engineSettings);
+    if (staleDisabledPlatforms.length > 0) {
+      state = await controller.tickAndHandOff(staleDisabledPlatforms) ?? await loadState();
+    }
+    const waits = subscriptionWaitKeys([...state.campaigns.twitch, ...state.campaigns.kick]);
+    for (const key of seenSubscriptionWaits) {
+      if (!waits.has(key)) seenSubscriptionWaits.delete(key);
+    }
+    for (const [key, message] of waits) {
+      if (seenSubscriptionWaits.has(key)) continue;
+      seenSubscriptionWaits.add(key);
+      logger.info(message, key.slice(0, key.indexOf(":")) as Platform);
+    }
+  } catch (error) {
+    logger.error(error instanceof Error ? error.message : String(error), "tick");
+  }
+}
+
 // Headless farming loop. Reuses the engine's background controller — the same
 // tick (discovery → watch decisions → claims → state persistence) the extension
 // runs — backed by file storage and a self-driven interval instead of the
@@ -52,8 +89,10 @@ export async function runLoop(options: RunOptions): Promise<void> {
   const enabledPlatforms = (["twitch", "kick"] as const).filter((platform) =>
     engineSettings.platform[platform].enabled);
   const seenSubscriptionWaits = new Set<string>();
-  const loadRuntimeState = async (): Promise<SchedulerState> => loadState(statePath);
-  const saveRuntimeState = async (state: SchedulerState): Promise<void> => saveState(statePath, state);
+  const loadRuntimeState = options.stateStore?.load
+    ?? (async (): Promise<SchedulerState> => loadState(statePath));
+  const saveRuntimeState = options.stateStore?.save
+    ?? (async (state: SchedulerState): Promise<void> => saveState(statePath, state));
 
   const controller = createBackgroundController({
     loadSettings: async () => engineSettings,
@@ -71,26 +110,14 @@ export async function runLoop(options: RunOptions): Promise<void> {
   });
 
   const tickOnce = async () => {
-    try {
-      await controller.tickAndHandOff(enabledPlatforms);
-      let state = await loadRuntimeState();
-      const staleDisabledPlatforms = disabledPlatformsNeedingCleanup(state, engineSettings);
-      if (staleDisabledPlatforms.length > 0) {
-        await controller.tickAndHandOff(staleDisabledPlatforms);
-        state = await loadRuntimeState();
-      }
-      const waits = subscriptionWaitKeys([...state.campaigns.twitch, ...state.campaigns.kick]);
-      for (const key of seenSubscriptionWaits) {
-        if (!waits.has(key)) seenSubscriptionWaits.delete(key);
-      }
-      for (const [key, message] of waits) {
-        if (seenSubscriptionWaits.has(key)) continue;
-        seenSubscriptionWaits.add(key);
-        logger.info(message, key.slice(0, key.indexOf(":")) as Platform);
-      }
-    } catch (error) {
-      logger.error(error instanceof Error ? error.message : String(error), "tick");
-    }
+    await runCliTickOnce({
+      controller,
+      enabledPlatforms,
+      engineSettings,
+      loadState: loadRuntimeState,
+      seenSubscriptionWaits,
+      logger,
+    });
   };
 
   const heartbeatOnce = async () => {

--- a/packages/cli/tests/helpers/tickBaseline.ts
+++ b/packages/cli/tests/helpers/tickBaseline.ts
@@ -139,6 +139,7 @@ export async function runCliBaselineCell(
     adapterConstructions: 0,
     watcherReconciliations: 0,
   };
+  let stateLoads = 0;
   const durationsMs: Durations = {
     discovery: 0,
     selection: 0,
@@ -222,6 +223,13 @@ export async function runCliBaselineCell(
     transport,
     logger: silentLogger,
     once: true,
+    stateStore: {
+      load: async () => {
+        stateLoads += 1;
+        return loadState(statePath);
+      },
+      save: async (state) => saveState(statePath, state),
+    },
   });
   const finalState = await loadState(statePath);
 
@@ -230,6 +238,7 @@ export async function runCliBaselineCell(
     platform,
     scenario,
     counts,
+    stateLoads,
     durationsMs,
     outcomeCampaignId: finalState.sessions[platform].campaignId,
   };

--- a/packages/cli/tests/helpers/tickBaseline.ts
+++ b/packages/cli/tests/helpers/tickBaseline.ts
@@ -140,6 +140,7 @@ export async function runCliBaselineCell(
     watcherReconciliations: 0,
   };
   let stateLoads = 0;
+  let stateSaves = 0;
   const durationsMs: Durations = {
     discovery: 0,
     selection: 0,
@@ -228,7 +229,10 @@ export async function runCliBaselineCell(
         stateLoads += 1;
         return loadState(statePath);
       },
-      save: async (state) => saveState(statePath, state),
+      save: async (state) => {
+        stateSaves += 1;
+        await saveState(statePath, state);
+      },
     },
   });
   const finalState = await loadState(statePath);
@@ -239,6 +243,7 @@ export async function runCliBaselineCell(
     scenario,
     counts,
     stateLoads,
+    stateSaves,
     durationsMs,
     outcomeCampaignId: finalState.sessions[platform].campaignId,
   };

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -311,6 +311,7 @@ describe("CLI scheduler tick baseline", () => {
       // The stacked controller now performs five shared-engine loads in both
       // hosts; the former CLI-only post-tick reload would make this six.
       stateLoads: 5,
+      stateSaves: 2,
       counts: {
         adapterOperations: 2,
         campaignDiscovery: 1,

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -12,7 +12,7 @@ import type { EventEmitter } from "@lurkloot/shared/events";
 import { createTransport } from "../src/transport";
 import type { TransportHandle } from "../src/transport";
 import { DEFAULT_CLI_SETTINGS } from "../src/settings";
-import { runLoop } from "../src/runtime/run";
+import { runCliTickOnce, runLoop } from "../src/runtime/run";
 import { createLogger } from "../src/logger";
 import type { Logger } from "../src/logger";
 import { runCliBaselineCell } from "./helpers/tickBaseline";
@@ -102,6 +102,119 @@ async function runOnce(health: Record<Platform, PlatformAuthHealth>, availabilit
   });
   return statePath;
 }
+
+function stateWithSubscriptionWait(id: string): SchedulerState {
+  return {
+    ...structuredClone(DEFAULT_STATE),
+    campaigns: {
+      ...DEFAULT_STATE.campaigns,
+      twitch: [{
+        id: `campaign-${id}`,
+        platform: "twitch",
+        name: `Campaign ${id}`,
+        status: "active",
+        eligibility: "waiting_for_subscription",
+        rewards: [{
+          id: `reward-${id}`,
+          name: `Reward ${id}`,
+          requirement: "subscription",
+          requiredSubs: 1,
+          requiredMinutes: 0,
+          watchedMinutes: 0,
+          status: "in_progress",
+        }],
+      }],
+    },
+  };
+}
+
+describe("CLI committed tick consumption", () => {
+  const engineSettings = DEFAULT_CLI_SETTINGS as unknown as EngineSettings;
+  const enabledPlatforms: Platform[] = ["twitch"];
+
+  it("uses the returned committed state without a fallback load", async () => {
+    const state = stateWithSubscriptionWait("success");
+    const loadState = vi.fn(async () => structuredClone(DEFAULT_STATE));
+    const logger = createLogger("error");
+    logger.info = vi.fn();
+
+    await runCliTickOnce({
+      controller: { tickAndHandOff: vi.fn(async () => state) },
+      enabledPlatforms,
+      engineSettings,
+      loadState,
+      seenSubscriptionWaits: new Set(),
+      logger,
+    });
+
+    expect(loadState).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Reward success"), "twitch");
+  });
+
+  it("logs a failed tick without consuming fallback state", async () => {
+    const logger = createLogger("error");
+    logger.error = vi.fn();
+    const loadState = vi.fn(async () => stateWithSubscriptionWait("stale"));
+
+    await runCliTickOnce({
+      controller: { tickAndHandOff: vi.fn(async () => { throw new Error("tick failed"); }) },
+      enabledPlatforms,
+      engineSettings,
+      loadState,
+      seenSubscriptionWaits: new Set(),
+      logger,
+    });
+
+    expect(loadState).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith("tick failed", "tick");
+  });
+
+  it("consumes the final handoff result and clears resolved subscription waits", async () => {
+    const seen = new Set<string>();
+    const logger = createLogger("error");
+    logger.info = vi.fn();
+    const tickAndHandOff = vi.fn()
+      .mockResolvedValueOnce(stateWithSubscriptionWait("handoff"))
+      .mockResolvedValueOnce(structuredClone(DEFAULT_STATE))
+      .mockResolvedValueOnce(stateWithSubscriptionWait("handoff"));
+    const options = {
+      controller: { tickAndHandOff }, enabledPlatforms, engineSettings,
+      loadState: vi.fn(async () => structuredClone(DEFAULT_STATE)),
+      seenSubscriptionWaits: seen, logger,
+    };
+
+    await runCliTickOnce(options);
+    await runCliTickOnce(options);
+    await runCliTickOnce(options);
+
+    expect(logger.info).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not associate overlapping results with each other", async () => {
+    const first = deferred<SchedulerState>();
+    const second = deferred<SchedulerState>();
+    const logger = createLogger("error");
+    logger.info = vi.fn();
+    const tickAndHandOff = vi.fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const options = () => ({
+      controller: { tickAndHandOff }, enabledPlatforms, engineSettings,
+      loadState: vi.fn(async () => structuredClone(DEFAULT_STATE)),
+      seenSubscriptionWaits: new Set<string>(), logger,
+    });
+
+    const firstRun = runCliTickOnce(options());
+    const secondRun = runCliTickOnce(options());
+    second.resolve(stateWithSubscriptionWait("second"));
+    await secondRun;
+    first.resolve(stateWithSubscriptionWait("first"));
+    await firstRun;
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Reward first"), "twitch");
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Reward second"), "twitch");
+  });
+});
 
 describe("runLoop authentication health reporting", () => {
   it("records missing credentials without invoking the live probe", async () => {
@@ -195,6 +308,9 @@ describe("CLI scheduler tick baseline", () => {
       host: "cli",
       platform,
       scenario: "idle",
+      // The stacked controller now performs five shared-engine loads in both
+      // hosts; the former CLI-only post-tick reload would make this six.
+      stateLoads: 5,
       counts: {
         adapterOperations: 2,
         campaignDiscovery: 1,

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -56,7 +56,7 @@ export const TWITCH_INTEGRITY_REFRESH_LEAD_MS = 120_000;
 export const TWITCH_INTEGRITY_REFRESH_JITTER_MAX_MS = 30_000;
 
 interface BackgroundAlarmController {
-  tickAndHandOff(platforms?: Platform[], trigger?: TickTrigger): Promise<void>;
+  tickAndHandOff(platforms?: Platform[], trigger?: TickTrigger): Promise<SchedulerState | undefined>;
   runWatchHeartbeat(): Promise<void>;
   runTwitchIntegrityRefresh(): Promise<void>;
 }
@@ -1321,8 +1321,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     state: SchedulerState,
     events: readonly EngineEvent[] = [],
     isCurrent?: () => boolean,
+    onPersisted?: (state: SchedulerState) => void,
   ): Promise<boolean> {
-    const persisted = await persistPlatformState(platform, state, isCurrent);
+    const persisted = await persistPlatformState(platform, state, isCurrent, onPersisted);
     if (!persisted) return false;
     await reportBestEffort(events);
     return true;
@@ -1332,6 +1333,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     platform: Platform,
     state: SchedulerState,
     isCurrent?: () => boolean,
+    onPersisted?: (state: SchedulerState) => void,
   ): Promise<boolean> {
     return withStateCommit(async () => {
       // The registry can change while storage I/O is in flight (for example a
@@ -1376,8 +1378,12 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
             }
           : stateForMerge;
         if (isCurrent?.() === false) return false;
-        await saveOperationalStateDirect(mergePlatformState(latest, mergeSource, platform));
-        if (currentManagedPageContextTabsRevision() === pageContextRevision) return true;
+        const merged = mergePlatformState(latest, mergeSource, platform);
+        await saveOperationalStateDirect(merged);
+        if (currentManagedPageContextTabsRevision() === pageContextRevision) {
+          onPersisted?.(merged);
+          return true;
+        }
       }
     });
   }
@@ -1964,10 +1970,14 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     kick: 0,
   };
 
-  async function tick(platforms?: Platform[], trigger: TickTrigger = "unknown"): Promise<ClaimedRewards> {
+  async function tick(
+    platforms?: Platform[],
+    trigger: TickTrigger = "unknown",
+    onPersisted?: (state: SchedulerState) => void,
+  ): Promise<ClaimedRewards> {
     const requestedPlatforms = platforms ?? PLATFORMS;
     const settled = await Promise.allSettled(requestedPlatforms.map((platform) =>
-      tickPlatform(platform, trigger)));
+      tickPlatform(platform, trigger, onPersisted)));
     const failures = settled.flatMap((result) =>
       result.status === "rejected" ? [result.reason] : []);
     if (failures.length === 1) throw failures[0];
@@ -2203,6 +2213,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function tickPlatform(
     platform: Platform,
     trigger: TickTrigger,
+    onPersisted?: (state: SchedulerState) => void,
   ): Promise<readonly [Platform, string[]]> {
     const abort = new AbortController();
     activeTicks.add(abort);
@@ -2219,7 +2230,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       tickContext,
     );
     try {
-      const claimed = await runTick(tickContext, [platform], abort.signal, trigger);
+      const claimed = await runTick(tickContext, [platform], abort.signal, trigger, onPersisted);
       return [platform, claimed[platform] ?? []];
     } catch (error) {
       if (abort.signal.aborted) return [platform, []];
@@ -2242,6 +2253,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     platforms: Platform[] | undefined,
     signal: AbortSignal,
     trigger: TickTrigger,
+    onPersisted?: (state: SchedulerState) => void,
   ): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
     const settings = await deps.loadSettings();
@@ -2524,6 +2536,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
             return !prepared || (prepared.generation === selectionGeneration[selectionPlatform]
               && prepared.snapshotRevision === snapshot?.revision);
           }),
+          onPersisted,
         );
         if (!persisted) return;
         waitingClaimRewardIds[platform].clear();
@@ -3685,7 +3698,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // a reward other than the ones just claimed, then hands off to the immediate
   // heartbeat. Runs OUTSIDE the state lock: each inner tick() acquires the lock
   // on its own, so a long handoff never blocks telemetry or user actions.
-  async function runClaimHandoff(platform: Platform, justClaimedRewardIds: readonly string[] = []): Promise<void> {
+  async function runClaimHandoff(
+    platform: Platform,
+    justClaimedRewardIds: readonly string[] = [],
+    onPersisted?: (state: SchedulerState) => void,
+  ): Promise<void> {
     if (claimHandoffs.has(platform)) return;
     // Reserved synchronously, before the first await. Registering after the
     // async setup would let two triggers past the guard into concurrent loops,
@@ -3735,7 +3752,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         await wait(Math.min(intervalMs, deadline - Date.now()), abort.signal);
         if (abort.signal.aborted || Date.now() >= deadline) break;
 
-        await tick([platform], "claim_handoff");
+        await tick([platform], "claim_handoff", onPersisted);
         if (abort.signal.aborted) break;
 
         const session = (await deps.loadState()).sessions[platform];
@@ -3919,11 +3936,18 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // The normal entry point for alarm- and message-driven ticks: run the tick,
   // then hand off for every platform that claimed. Kept separate from tick() so
   // the handoff's own inner ticks cannot recurse into another handoff.
-  async function tickAndHandOff(platforms?: Platform[], trigger: TickTrigger = "unknown"): Promise<void> {
-    const claimed = await tick(platforms, trigger);
+  async function tickAndHandOff(
+    platforms?: Platform[],
+    trigger: TickTrigger = "unknown",
+  ): Promise<SchedulerState | undefined> {
+    let committedState: SchedulerState | undefined;
+    const captureCommittedState = (state: SchedulerState): void => {
+      committedState = state;
+    };
+    const claimed = await tick(platforms, trigger, captureCommittedState);
     const handoffPlatforms = Object.keys(claimed) as Platform[];
     const results = await Promise.allSettled(handoffPlatforms.map((platform) =>
-      runClaimHandoff(platform, claimed[platform] ?? [])));
+      runClaimHandoff(platform, claimed[platform] ?? [], captureCommittedState)));
     for (let index = 0; index < results.length; index += 1) {
       const result = results[index];
       if (result.status !== "rejected") continue;
@@ -3933,6 +3957,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         handoffPlatforms[index],
       );
     }
+    return committedState;
   }
 
   async function recordPlaybackTelemetry(

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -2875,6 +2875,45 @@ describe("background controller", () => {
     expect(env.state.authHealth.twitch.status).toBe("healthy");
   });
 
+  it("returns the state committed by the current tick invocation", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+
+    const committed = await env.controller.tickAndHandOff(["twitch"]);
+
+    expect(committed).toEqual(env.state);
+    expect(committed?.sessions.twitch.campaignId).toBe("twitch-campaign");
+  });
+
+  it("does not return a scheduler snapshot when the tick rolls back", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, tablessMode: true }));
+    env.twitch.supportsTabless = true;
+    env.twitch.createTablessWatcher = () => {
+      throw new Error("watcher setup failed");
+    };
+
+    const committed = await env.controller.tickAndHandOff(["twitch"]);
+
+    expect(committed).toBeUndefined();
+  });
+
+  it("keeps committed results scoped to overlapping tick invocations", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+    const twitchDiscovery = deferred<DropCampaign[]>();
+    const kickDiscovery = deferred<DropCampaign[]>();
+    vi.mocked(env.twitch.refreshCampaigns).mockReturnValueOnce(twitchDiscovery.promise);
+    vi.mocked(env.kick.refreshCampaigns).mockReturnValueOnce(kickDiscovery.promise);
+
+    const twitchTick = env.controller.tickAndHandOff(["twitch"]);
+    const kickTick = env.controller.tickAndHandOff(["kick"]);
+    kickDiscovery.resolve([campaign("kick")]);
+    const kickCommitted = await kickTick;
+    twitchDiscovery.resolve([campaign("twitch")]);
+    const twitchCommitted = await twitchTick;
+
+    expect(kickCommitted?.sessions.kick.campaignId).toBe("kick-campaign");
+    expect(twitchCommitted?.sessions.twitch.campaignId).toBe("twitch-campaign");
+  });
+
   it("blocks startup account work when credentials are missing without disabling the platform", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
@@ -8466,9 +8505,10 @@ describe("background controller", () => {
 
       const handoff = env.controller.tickAndHandOff();
       for (let index = 0; index < 12; index += 1) await env.timer.flush();
-      await handoff;
+      const committed = await handoff;
 
       expect(env.timer.wait).toHaveBeenCalled();
+      expect(committed).toEqual(env.state);
     });
 
     it("does not start a nested handoff for a claim inside a handoff", async () => {


### PR DESCRIPTION
## Summary
- return a host-neutral committed scheduler-state receipt from `tickAndHandOff`
- scope receipts per invocation and advance them through post-claim handoff commits
- consume the receipt for CLI subscription-wait reporting without rereading `state.json`
- add deterministic CLI coverage for success, rejection, handoff results, subscription add/clear, and overlap isolation

## Baseline note
The stacked #394/#395 architecture now performs five shared-engine state loads in both extension and CLI. This removes the CLI-only sixth post-tick load and restores parity; the issue's earlier absolute 4 → 3 count predates those stacked lifecycle changes.

## Testing
- `pnpm verify`
- 185 CLI tests and 1,773 extension tests passed
- Chromium and Firefox production builds passed

Closes #458

Stacked on #486.