### PR TITLE
fix(core): keep discovery persist when heartbeat invalidates selection

### DIFF
--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -736,9 +736,13 @@ describe("runLoop heartbeat driver", () => {
   });
 
   it("attempts heartbeats every minute independently of the seven-minute discovery period", async () => {
-    const { running, twitch, watcher } = await startHeartbeatDriver();
+    const { running, statePath, twitch, watcher } = await startHeartbeatDriver();
     try {
       expect(watcher.tick).not.toHaveBeenCalled();
+      await vi.waitFor(async () => {
+        const state = JSON.parse(await readFile(statePath, "utf8")) as SchedulerState;
+        expect(state.sessions.twitch.lastCheckedAt).toBeDefined();
+      });
 
       await vi.advanceTimersByTimeAsync(60_000);
       await vi.waitFor(() => expect(watcher.tick).toHaveBeenCalledTimes(1));
@@ -792,6 +796,12 @@ describe("runLoop heartbeat driver", () => {
       await vi.advanceTimersByTimeAsync(60_000);
       await vi.waitFor(() => expect(twitch.refreshCampaigns).toHaveBeenCalledTimes(2));
       await vi.waitFor(() => expect(watcher.tick).toHaveBeenCalledTimes(7));
+      await vi.waitFor(async () => {
+        const state = JSON.parse(await readFile(statePath, "utf8")) as SchedulerState;
+        expect(Date.parse(state.sessions.twitch.lastHeartbeatAt ?? "")).toBeGreaterThanOrEqual(
+          HEARTBEAT_TEST_START.getTime() + 7 * 60_000,
+        );
+      });
     } finally {
       blockedDiscovery.resolve([HEARTBEAT_TEST_CAMPAIGN]);
       await vi.waitFor(async () => {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2646,11 +2646,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           }
           selections[selectionPlatform] = prepared.result;
         }
+        // Snapshot revision is the publication gate. Heartbeat and playback
+        // health bump selectionGeneration without replacing discovery; dropping
+        // the tick for those would discard lastCheckedAt from current inventory.
         const selectionsAreCurrent = (): boolean => schedulerPlatforms.every((selectionPlatform) => {
           const prepared = preparedSelections[selectionPlatform];
           const snapshot = discoveryLanes[selectionPlatform].current().snapshot;
-          return !prepared || (prepared.generation === selectionGeneration[selectionPlatform]
-            && prepared.snapshotRevision === snapshot?.revision);
+          return !prepared || prepared.snapshotRevision === snapshot?.revision;
         });
         const staleSelection = new Error("Snapshot selection lifecycle changed before publication");
         const assertSelectionsCurrent = (): void => {
@@ -2679,7 +2681,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           selections,
           selectionIsCurrent: Object.fromEntries(schedulerPlatforms.map((selectionPlatform) => {
             const prepared = preparedSelections[selectionPlatform];
-            return [selectionPlatform, () => prepared?.generation === selectionGeneration[selectionPlatform]];
+            return [selectionPlatform, () => prepared?.snapshotRevision
+              === discoveryLanes[selectionPlatform].current().snapshot?.revision];
           })),
           discovery: Object.fromEntries(schedulerPlatforms.map((discoveryPlatform) => {
             const discoveryState = discoveryLanes[discoveryPlatform].current();
@@ -2773,8 +2776,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           () => schedulerPlatforms.every((selectionPlatform) => {
             const prepared = preparedSelections[selectionPlatform];
             const snapshot = discoveryLanes[selectionPlatform].current().snapshot;
-            return !prepared || (prepared.generation === selectionGeneration[selectionPlatform]
-              && prepared.snapshotRevision === snapshot?.revision);
+            return !prepared || prepared.snapshotRevision === snapshot?.revision;
           }),
           onPersisted,
         );

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -7053,7 +7053,7 @@ describe("background controller", () => {
     expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
   });
 
-  it("completes a due heartbeat while snapshot selection is blocked", async () => {
+  it("persists discovery after a due heartbeat invalidates a blocked snapshot selection", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-09-02T12:00:00.000Z"));
     const selectionStarted = deferred<void>();
@@ -7080,6 +7080,8 @@ describe("background controller", () => {
     env.twitch.supportsTabless = true;
     env.twitch.createTablessWatcher = () => watcher as unknown as TablessWatchController;
     await env.controller.tick(["twitch"]);
+    const firstCheckedAt = env.state.sessions.twitch.lastCheckedAt;
+    expect(firstCheckedAt).toBeDefined();
     advanceToNextHeartbeatDue();
     watcher.tick.mockClear();
 
@@ -7096,10 +7098,61 @@ describe("background controller", () => {
       await selection;
     }
     expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
-    expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
-      platform: "twitch",
-      message: expect.stringContaining("Snapshot selection discarded stale lifecycle work"),
-    }));
+    expect(Date.parse(env.state.sessions.twitch.lastCheckedAt ?? "")).toBeGreaterThan(
+      Date.parse(firstCheckedAt ?? ""),
+    );
+  });
+
+  it("persists discovery lastCheckedAt when a heartbeat commits during publication", async () => {
+    const { env, watcher } = await establishedTablessEnv("twitch");
+    const firstCheckedAt = env.state.sessions.twitch.lastCheckedAt;
+    expect(firstCheckedAt).toBeDefined();
+    const focusStarted = deferred<void>();
+    const allowFocus = deferred<void>();
+    env.deps.applyAdFocus.mockImplementation(async () => {
+      focusStarted.resolve();
+      await allowFocus.promise;
+    });
+    watcher.tick.mockClear();
+
+    const discovery = env.controller.tick(["twitch"]);
+    await focusStarted.promise;
+    await env.controller.runWatchHeartbeat();
+    allowFocus.resolve();
+    await discovery;
+
+    expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
+    expect(Date.parse(env.state.sessions.twitch.lastCheckedAt ?? "")).toBeGreaterThan(
+      Date.parse(firstCheckedAt ?? ""),
+    );
+  });
+
+  it("persists discovery when a heartbeat commits before the scheduler consumes its selection", async () => {
+    const { env, watcher } = await establishedTablessEnv("twitch");
+    const firstCheckedAt = env.state.sessions.twitch.lastCheckedAt;
+    expect(firstCheckedAt).toBeDefined();
+    const claimStarted = deferred<void>();
+    const allowClaim = deferred<boolean>();
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([
+      { ...campaign("twitch", "claimable"), id: "claimable-campaign" },
+      campaign("twitch"),
+    ]);
+    vi.mocked(env.twitch.claimReward).mockImplementation(async () => {
+      claimStarted.resolve();
+      return allowClaim.promise;
+    });
+    watcher.tick.mockClear();
+
+    const discovery = env.controller.tick(["twitch"], "manual_tick");
+    await claimStarted.promise;
+    await env.controller.runWatchHeartbeat();
+    allowClaim.resolve(false);
+    await discovery;
+
+    expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
+    expect(Date.parse(env.state.sessions.twitch.lastCheckedAt ?? "")).toBeGreaterThan(
+      Date.parse(firstCheckedAt ?? ""),
+    );
   });
 
   it("coalesces concurrent snapshot selection requests to one pending evaluation", async () => {


### PR DESCRIPTION
## Summary
- Heartbeat (and playback) health bumps `selectionGeneration` without replacing the discovery snapshot. Publication treated that as stale and dropped the tick, so `lastCheckedAt` never advanced when a heartbeat committed during ad-focus / CLI overlap.
- Gate publication on snapshot revision only, so current campaign inventory still persists. Watch-target decisions still re-prepare when generation or selection key changes.
- Adds a controller test for heartbeat-during-publication and waits for the 7th heartbeat commit in the CLI overlap test.

## Test plan
- [x] `pnpm --filter @lurkloot/cli test` (195 passed)
- [x] `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts` (402 passed)
- [x] `pnpm --filter @lurkloot/core typecheck` and CLI/extension typecheck
- [ ] CI verify on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved background monitoring so heartbeat updates are retained even when discovery processing is temporarily delayed.
  - Prevented valid discovery updates from being discarded when selection changes occur without a corresponding discovery revision.
  - Improved session tracking so heartbeat and discovery timestamps continue advancing correctly during concurrent background activity.

- **Tests**
  - Added coverage for delayed discovery and concurrent heartbeat scenarios to help ensure reliable background session updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->