### PR TITLE
feat(store): densify extras, easy, and updated screenshots

### DIFF
--- a/docs/superpowers/plans/2026-09-08-store-screenshot-density.md
+++ b/docs/superpowers/plans/2026-09-08-store-screenshot-density.md
@@ -1,0 +1,623 @@
+# Store Screenshot Density Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Chrome Web Store screenshots 02, 03, and 05 the same finished density as 01 and 04 — live popups on extras and easy, a text-only runtime board on updated — without trademarked icons.
+
+**Architecture:** Keep one `StoreScreenshot` shell and the existing five-shot lineup. Promote `extras` and `steps` to popup-carrying variants (`watchlist` on Twitch, `drops` on Kick). `updated` stays popup-free and gains two large type tiles (Chromium-based browsers, CLI · Docker). Capture already keys off `STORE_SCREENSHOT_VARIANTS[].popup`; flip those two flags so Playwright waits on the real popup header.
+
+**Tech Stack:** TypeScript, React, Vitest, `@lurkloot/popup-ui`, `@lurkloot/locales`, WXT screenshot capture.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-store-screenshot-density-design.md`
+
+## Global Constraints
+
+- Work only in `.worktrees/store-screenshot-density` on `feat/store-screenshot-density`.
+- Do not change shots 01 or 04, farming behavior, promo tiles, store listing body copy, or CWS upload automation.
+- No third-party trademarked icons or logos in any screenshot (browser marks, Docker whale, GitHub, Twitch/Kick). Nominative text is allowed. Colored status dots that are not brand marks stay allowed.
+- Live popup is always the real `Popup` at 400×600 — no stretching, no illustrated fake popup UI.
+- Do not sell Kick watch time as farmable. Do not pitch the activity log. Do not mention Firefox on shot 05.
+- Diagnostic messages stay English literals. Screenshot UI copy is localized. Brand tokens stay untranslated: Twitch, Kick, Chrome Web Store, CLI, Docker, Apache-2.0, Chromium (as part of “Chromium-based browsers”, translate the surrounding words).
+- Two-space indentation, double quotes, semicolons, ES modules, `type` imports.
+- Use pnpm. Do not regenerate or upload PNGs in this work (`pnpm screenshot:store` is operator follow-up).
+- Do not import `demo.ts` from `Popup.tsx` (that would ship demo code into the real popup).
+
+---
+
+### Task 1: Variant model and capture popup flags
+
+**Files:**
+- Modify: `packages/popup-ui/src/types.ts`
+- Modify: `packages/popup-ui/src/constants.ts`
+- Modify: `packages/extension/scripts/store-screenshot-config.mjs`
+- Modify: `packages/extension/tests/storeScreenshot.test.tsx`
+- Modify: `packages/extension/tests/storeScreenshotFiles.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type ScreenshotPopupVariant = ScreenshotCopy & {
+  layout: "hero" | "extras" | "steps" | "settings";
+  platform: Platform;
+  view: "drops" | "settings" | "watchlist";
+};
+
+export type ScreenshotMarketingVariant = ScreenshotCopy & {
+  layout: "updated";
+};
+
+export function variantShowsPopup(variant: ScreenshotVariant): variant is ScreenshotPopupVariant {
+  return variant.layout !== "updated";
+}
+```
+
+- `extras` → `{ layout: "extras", platform: "twitch", view: "watchlist", glow: EXTRAS_GLOW, eyebrowKey/headlineKey/subcopyKey unchanged }`
+- `easy` → `{ layout: "steps", platform: "kick", view: "drops", glow: EASY_GLOW, keys unchanged }`
+- `STORE_SCREENSHOT_VARIANTS` extras and easy: `popup: true`. Updated stays `popup: false`.
+
+- [ ] **Step 1: Rewrite the failing variant tests**
+
+In `packages/extension/tests/storeScreenshot.test.tsx`, replace the popup-gating tests with:
+
+```tsx
+  it("mounts a live popup on every shot except updated", () => {
+    expect(variantShowsPopup(screenshotVariant("drops"))).toBe(true);
+    expect(variantShowsPopup(screenshotVariant("extras"))).toBe(true);
+    expect(variantShowsPopup(screenshotVariant("easy"))).toBe(true);
+    expect(variantShowsPopup(screenshotVariant("settings"))).toBe(true);
+    expect(variantShowsPopup(screenshotVariant("updated"))).toBe(false);
+  });
+
+  it("wires extras to the Twitch watchlist and easy to Kick drops", () => {
+    const extras = screenshotVariant("extras");
+    const easy = screenshotVariant("easy");
+    const drops = screenshotVariant("drops");
+    const settings = screenshotVariant("settings");
+    if (!variantShowsPopup(extras) || !variantShowsPopup(easy) || !variantShowsPopup(drops) || !variantShowsPopup(settings)) {
+      throw new Error("expected popup shots");
+    }
+    expect(extras.platform).toBe("twitch");
+    expect(extras.view).toBe("watchlist");
+    expect(easy.platform).toBe("kick");
+    expect(easy.view).toBe("drops");
+    expect(drops.platform).toBe("twitch");
+    expect(drops.view).toBe("drops");
+    expect(settings.view).toBe("settings");
+  });
+```
+
+Keep the canonical-id and five-layout tests unchanged.
+
+In `packages/extension/tests/storeScreenshotFiles.test.ts`, add inside `"describes the exact upload order"`:
+
+```ts
+expect(STORE_SCREENSHOT_VARIANTS.map((variant: { popup: boolean }) => variant.popup)).toEqual([
+  true, true, true, true, false,
+]);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/storeScreenshot.test.tsx tests/storeScreenshotFiles.test.ts`
+
+Expected: FAIL — extras/easy still `variantShowsPopup === false` and `popup: false`.
+
+- [ ] **Step 3: Update types and constants**
+
+Replace the variant types in `packages/popup-ui/src/types.ts` with the signatures in Interfaces above.
+
+In `packages/popup-ui/src/constants.ts`, change only `extras` and `easy`:
+
+```ts
+const extras: ScreenshotVariant = {
+  layout: "extras",
+  platform: "twitch",
+  view: "watchlist",
+  glow: EXTRAS_GLOW,
+  eyebrowKey: "screenshotExtrasEyebrow",
+  headlineKey: "screenshotExtrasHeadline",
+  subcopyKey: "screenshotExtrasSubcopy",
+};
+const easy: ScreenshotVariant = {
+  layout: "steps",
+  platform: "kick",
+  view: "drops",
+  glow: EASY_GLOW,
+  eyebrowKey: "screenshotEasyEyebrow",
+  headlineKey: "screenshotEasyHeadline",
+  subcopyKey: "screenshotEasyHeadline",
+};
+```
+
+In `packages/extension/scripts/store-screenshot-config.mjs`:
+
+```js
+export const STORE_SCREENSHOT_VARIANTS = Object.freeze([
+  Object.freeze({ id: "drops", file: "01-drops", popup: true }),
+  Object.freeze({ id: "extras", file: "02-extras", popup: true }),
+  Object.freeze({ id: "easy", file: "03-easy", popup: true }),
+  Object.freeze({ id: "settings", file: "04-settings", popup: true }),
+  Object.freeze({ id: "updated", file: "05-updated", popup: false }),
+]);
+```
+
+`capture-store-screenshot.mjs` already waits on `header img[alt="Lurkloot"]` when `variant.popup` is true. Do not change it.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/storeScreenshot.test.tsx tests/storeScreenshotFiles.test.ts`
+
+Expected: FAIL on camera tests that still assert extras has no `LIVE_POPUP` and updated/easy layout class names — leave those for Task 3. Variant-model tests and the popup-flag assertion must PASS. If the whole file fails only on camera tests, that is expected; do not weaken the new variant assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/popup-ui/src/types.ts packages/popup-ui/src/constants.ts packages/extension/scripts/store-screenshot-config.mjs packages/extension/tests/storeScreenshot.test.tsx packages/extension/tests/storeScreenshotFiles.test.ts
+git commit -m "$(cat <<'EOF'
+feat(store): mount extras and easy screenshot popups
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Screenshot copy catalogs
+
+**Files:**
+- Modify: `packages/locales/messages/{en,es,fr,it,ru,de,zh_CN,hi,pt_BR,ar,tr}.json`
+- Modify: `packages/extension/tests/i18n.test.ts`
+
+**Interfaces:**
+- Delete keys: `screenshotExtrasWatchlistName`, `screenshotExtrasWatchlistMeta`
+- Add keys (message values below):
+  - `screenshotUpdatedBrowsersTitle`
+  - `screenshotUpdatedBrowsersSub`
+  - `screenshotUpdatedHeadlessTitle` (`CLI · Docker` in every locale)
+  - `screenshotUpdatedHeadlessSub`
+  - `screenshotUpdatedLicense` (`Apache-2.0` in every locale)
+
+- [ ] **Step 1: Extend the English screenshot copy test**
+
+In `packages/extension/tests/i18n.test.ts`, in `"defines the reworked store-screenshot copy in English"`:
+
+- Remove `screenshotExtrasWatchlistName` and `screenshotExtrasWatchlistMeta` from the expected object.
+- Add:
+
+```ts
+screenshotUpdatedBrowsersTitle: "Chromium-based browsers",
+screenshotUpdatedBrowsersSub: "Chrome Web Store listing. Same extension.",
+screenshotUpdatedHeadlessTitle: "CLI · Docker",
+screenshotUpdatedHeadlessSub: "Headless. Same engine.",
+screenshotUpdatedLicense: "Apache-2.0",
+```
+
+- Add those two deleted keys to the existing `stale` array.
+- In `"does not leave non-English catalogs as English except product/common terms"`, add to `allowedSameAsEnglish`:
+
+```ts
+"screenshotUpdatedHeadlessTitle",
+"screenshotUpdatedLicense",
+```
+
+- [ ] **Step 2: Run the i18n test to verify RED**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/i18n.test.ts`
+
+Expected: FAIL — new English keys missing; watchlist card keys still present.
+
+- [ ] **Step 3: Update all 11 catalogs**
+
+Delete the two watchlist card keys from every catalog. Insert the five new keys immediately after `screenshotUpdatedSubcopy` (before `autoClaimReady`).
+
+English:
+
+```json
+"screenshotUpdatedBrowsersTitle": { "message": "Chromium-based browsers" },
+"screenshotUpdatedBrowsersSub": { "message": "Chrome Web Store listing. Same extension." },
+"screenshotUpdatedHeadlessTitle": { "message": "CLI · Docker" },
+"screenshotUpdatedHeadlessSub": { "message": "Headless. Same engine." },
+"screenshotUpdatedLicense": { "message": "Apache-2.0" }
+```
+
+Other locales (keep `CLI · Docker`, `Apache-2.0`, and `Chrome Web Store` intact):
+
+| locale | browsersTitle | browsersSub | headlessSub |
+|--------|---------------|-------------|-------------|
+| es | Navegadores basados en Chromium | Ficha de Chrome Web Store. La misma extensión. | Sin interfaz. El mismo motor. |
+| fr | Navigateurs basés sur Chromium | Fiche Chrome Web Store. La même extension. | Sans interface. Le même moteur. |
+| it | Browser basati su Chromium | Scheda Chrome Web Store. La stessa estensione. | Senza interfaccia. Lo stesso motore. |
+| ru | Браузеры на базе Chromium | Страница Chrome Web Store. То же расширение. | Без интерфейса. Тот же движок. |
+| de | Chromium-basierte Browser | Chrome Web Store-Eintrag. Dieselbe Erweiterung. | Headless. Dieselbe Engine. |
+| zh_CN | 基于 Chromium 的浏览器 | Chrome Web Store 上架。同一扩展。 | 无界面。同一引擎。 |
+| hi | Chromium-आधारित ब्राउज़र | Chrome Web Store लिस्टिंग। वही एक्सटेंशन। | हेडलेस। वही इंजन। |
+| pt_BR | Navegadores baseados em Chromium | Página da Chrome Web Store. A mesma extensão. | Sem interface. O mesmo motor. |
+| ar | متصفحات مبنية على Chromium | صفحة Chrome Web Store. نفس الإضافة. | بلا واجهة. نفس المحرك. |
+| tr | Chromium tabanlı tarayıcılar | Chrome Web Store kaydı. Aynı eklenti. | Arayüzsüz. Aynı motor. |
+
+Do not add `diagnostic*` keys. Do not invent extra screenshot keys.
+
+- [ ] **Step 4: Run the i18n test**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/i18n.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/locales/messages packages/extension/tests/i18n.test.ts
+git commit -m "$(cat <<'EOF'
+feat(i18n): add screenshot runtime copy
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Extras, easy, and updated cameras
+
+**Files:**
+- Modify: `packages/popup-ui/src/marketing.tsx`
+- Modify: `packages/extension/tests/storeScreenshot.test.tsx`
+
+**Interfaces:**
+- Consumes Task 1 layouts (`extras` now shows `children` via `variantShowsPopup`) and Task 2 copy keys.
+- `StoreScreenshot` still accepts `{ variant, children, locale }`. Popup child remains wrapped in `PopupFrame` (400×600).
+
+- [ ] **Step 1: Rewrite the camera tests**
+
+Replace the `"store screenshot cameras"` describe in `packages/extension/tests/storeScreenshot.test.tsx` with:
+
+```tsx
+describe("store screenshot cameras", () => {
+  it("places extras copy and chips beside a live popup", async () => {
+    const container = await mountShot("extras", "LIVE_POPUP");
+    expect(container.textContent).toContain("More than drops.");
+    expect(container.textContent).toContain("Channel points");
+    expect(container.textContent).toContain("Daily challenges");
+    expect(container.textContent).toContain("LIVE_POPUP");
+    expect(container.textContent).not.toContain("Idle watchlist");
+    expect(container.querySelector('[data-layout="extras"]')).not.toBeNull();
+  });
+
+  it("stacks easy steps on the start side and mounts a live popup", async () => {
+    const container = await mountShot("easy", "LIVE_POPUP");
+    expect(container.textContent).toContain("That easy.");
+    expect(container.textContent).toContain("Install");
+    expect(container.textContent).toContain("Pin it");
+    expect(container.textContent).toContain("Enable a platform");
+    expect(container.textContent).toContain("Profit");
+    expect(container.textContent).toContain("LIVE_POPUP");
+    const steps = container.querySelector('[data-layout="steps"] [data-steps]');
+    expect(steps).not.toBeNull();
+    const className = steps?.getAttribute("class") ?? "";
+    expect(className).toMatch(/\bstart-\[7%\]/);
+    expect(className).not.toMatch(/\bgap-7\b/);
+  });
+
+  it("places the live popup inside hero and settings cameras", async () => {
+    const hero = await mountShot("drops", "LIVE_POPUP");
+    expect(hero.textContent).toContain("Farm drops while you do anything else.");
+    expect(hero.textContent).toContain("LIVE_POPUP");
+    const settings = await mountShot("settings", "LIVE_POPUP");
+    expect(settings.textContent).toContain("Farm exactly how you want.");
+    expect(settings.textContent).toContain("LIVE_POPUP");
+  });
+
+  it("fills updated with a text runtime board and no popup", async () => {
+    const container = await mountShot("updated", "LIVE_POPUP");
+    expect(container.textContent).toContain("Featureful. Always updated.");
+    expect(container.textContent).toContain("Chromium-based browsers");
+    expect(container.textContent).toContain("Chrome Web Store listing. Same extension.");
+    expect(container.textContent).toContain("CLI · Docker");
+    expect(container.textContent).toContain("Headless. Same engine.");
+    expect(container.textContent).toContain("Apache-2.0");
+    expect(container.textContent).not.toContain("LIVE_POPUP");
+  });
+});
+```
+
+- [ ] **Step 2: Run camera tests to verify RED**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/storeScreenshot.test.tsx`
+
+Expected: FAIL — extras still cards the watchlist and omits the popup; steps still use a horizontal `gap-7` row; updated has no runtime board.
+
+- [ ] **Step 3: Implement the three cameras in `marketing.tsx`**
+
+Remove the `Gem`, `Gift`, `ListVideo`, and `LucideIcon` imports.
+
+Replace `ExtrasCard` with a platform-dotted callout (no Lucide icons):
+
+```tsx
+function ExtraCallout({
+  dot,
+  name,
+  meta,
+}: {
+  dot: string;
+  name: string;
+  meta: string;
+}): React.ReactElement {
+  return (
+    <div className="flex min-w-0 items-start gap-3">
+      <span
+        className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+        style={{ background: dot, boxShadow: `0 0 9px ${dot}` }}
+      />
+      <div className="min-w-0">
+        <div className="text-[17px] font-semibold text-[#ecedf5]">{name}</div>
+        <div className="mt-1 text-[13px] leading-snug text-[#9c9db4]">{meta}</div>
+      </div>
+    </div>
+  );
+}
+```
+
+Use Twitch `#a970ff` and Kick `#53fc18` (same dots as `PromoPills`).
+
+Replace the extras layout so copy sits upper-start, callouts under the subcopy, popup on the end side at −2deg (rtl +2deg):
+
+```tsx
+{variant.layout === "extras" ? (
+  <>
+    <div className="absolute start-[7%] top-[12%] end-[42%] z-10">
+      <CopyBlock
+        eyebrowKey={variant.eyebrowKey}
+        headlineKey={variant.headlineKey}
+        subcopyKey={variant.subcopyKey}
+        translate={translate}
+      />
+      <div className="mt-8 flex flex-col gap-5">
+        <ExtraCallout
+          dot="#a970ff"
+          name={translate("screenshotExtrasPointsName")}
+          meta={translate("screenshotExtrasPointsMeta")}
+        />
+        <ExtraCallout
+          dot="#53fc18"
+          name={translate("screenshotExtrasChallengesName")}
+          meta={translate("screenshotExtrasChallengesMeta")}
+        />
+      </div>
+    </div>
+    {popup ? (
+      <div className={`absolute end-[7%] top-[9%] z-20 origin-center ${rtl ? "rotate-[2deg]" : "rotate-[-2deg]"}`}>
+        <PopupFrame>{popup}</PopupFrame>
+      </div>
+    ) : null}
+  </>
+) : null}
+```
+
+Replace `StepItem` so it is a vertical row with a number, and replace the steps layout with a start-side stack plus end-side popup at +2deg (rtl −2deg). Put `data-steps` on the stack. Draw the spine with a 2px purple→lime gradient (`bg-linear-to-b from-[#9147ff] to-[#53fc18]`). Keep numbers `01`–`04`.
+
+```tsx
+{variant.layout === "steps" ? (
+  <>
+    <CopyBlock
+      className="absolute start-[7%] top-[10%] end-[46%] z-10"
+      eyebrowKey={variant.eyebrowKey}
+      headlineKey={variant.headlineKey}
+      subcopyKey={variant.subcopyKey}
+      translate={translate}
+      showSubcopy={false}
+    />
+    <div data-steps className="absolute start-[7%] top-[34%] bottom-[10%] z-10 flex w-[34%] flex-col justify-between">
+      <div className="pointer-events-none absolute start-0 top-2 bottom-6 w-0.5 bg-linear-to-b from-[#9147ff] to-[#53fc18]" />
+      <StepItem number="01" title={translate("screenshotEasyInstallTitle")} sub={translate("screenshotEasyInstallSub")} />
+      <StepItem number="02" title={translate("screenshotEasyPinTitle")} sub={translate("screenshotEasyPinSub")} />
+      <StepItem number="03" title={translate("screenshotEasyEnableTitle")} sub={translate("screenshotEasyEnableSub")} />
+      <StepItem number="04" title={translate("screenshotEasyProfitTitle")} sub={translate("screenshotEasyProfitSub")} />
+    </div>
+    {popup ? (
+      <div className={`absolute end-[7%] top-[9%] z-20 origin-center ${rtl ? "rotate-[-2deg]" : "rotate-[2deg]"}`}>
+        <PopupFrame>{popup}</PopupFrame>
+      </div>
+    ) : null}
+  </>
+) : null}
+```
+
+`StepItem` should indent from the spine (`ps-5`) so the number/title do not sit on the line.
+
+Replace the updated layout with copy on the start side, `Apache-2.0` as a quiet footer, and a 400px-wide board of two equal glass tiles (no glyphs, no SVGs):
+
+```tsx
+function RuntimeTile({ title, sub }: { title: string; sub: string }): React.ReactElement {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col justify-center rounded-2xl border border-white/8 bg-white/[0.03] px-8 py-7">
+      <div className="font-display text-[32px] font-bold leading-[1.05] tracking-normal text-[#ecedf5]">{title}</div>
+      <div className="mt-3 text-[16px] leading-snug text-[#9c9db4]">{sub}</div>
+    </div>
+  );
+}
+
+{variant.layout === "updated" ? (
+  <>
+    <CopyBlock
+      className="absolute start-[7%] top-[14%] end-[42%] z-10"
+      eyebrowKey={variant.eyebrowKey}
+      headlineKey={variant.headlineKey}
+      subcopyKey={variant.subcopyKey}
+      translate={translate}
+    />
+    <p className="absolute start-[7%] bottom-[12%] z-10 text-[13px] tracking-[0.08em] text-[#9c9db4]">
+      {translate("screenshotUpdatedLicense")}
+    </p>
+    <div className="absolute end-[7%] top-[12%] bottom-[12%] z-10 flex w-[400px] flex-col gap-4">
+      <RuntimeTile
+        title={translate("screenshotUpdatedBrowsersTitle")}
+        sub={translate("screenshotUpdatedBrowsersSub")}
+      />
+      <RuntimeTile
+        title={translate("screenshotUpdatedHeadlessTitle")}
+        sub={translate("screenshotUpdatedHeadlessSub")}
+      />
+    </div>
+  </>
+) : null}
+```
+
+Leave hero and settings cameras untouched. Leave `PromoTile` untouched.
+
+- [ ] **Step 4: Run camera tests**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/storeScreenshot.test.tsx tests/i18n.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/popup-ui/src/marketing.tsx packages/extension/tests/storeScreenshot.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(store): densify extras easy and updated cameras
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Watchlist screenshot demo data
+
+**Files:**
+- Modify: `packages/popup-ui/src/constants.ts`
+- Modify: `packages/popup-ui/src/Popup.tsx`
+- Modify: `packages/extension/tests/storeScreenshot.test.tsx`
+
+**Interfaces:**
+- Consumes Task 1 `view: "watchlist"` on extras.
+- Add beside `SCREENSHOT_VARIANTS`:
+
+```ts
+export const SCREENSHOT_WATCHLIST_LIVE: Record<string, { displayName: string; viewers: number; subtitle: string }> = {
+  rivalspilot: { displayName: "RivalsPilot", viewers: 18420, subtitle: "Marathon Legends" },
+  lootforge: { displayName: "LootForge", viewers: 6210, subtitle: "Starfall Arena" },
+  nightrunlive: { displayName: "NightRunLive", viewers: 2480, subtitle: "Spellforge" },
+};
+```
+
+- `Popup` initializes `watchlistExpanded` when `preview && variantShowsPopup(initialVariant) && initialVariant.view === "watchlist"`.
+- When that same condition holds, map `idleWatchlist` through `SCREENSHOT_WATCHLIST_LIVE` so those usernames are live with viewer counts. Production and the site demo (`twitch-drops`) must be unchanged.
+- Kick selection for easy is already `useState(preview && variantShowsPopup(initialVariant) ? initialVariant.platform : "twitch")`. Do not add a second Kick special case.
+
+- [ ] **Step 1: Write a failing Popup watchlist test**
+
+Add to `packages/extension/tests/storeScreenshot.test.tsx` (import `Popup` and `createDemoPopupAdapter` from `@lurkloot/popup-ui`):
+
+```tsx
+describe("extras screenshot popup", () => {
+  it("expands the idle watchlist with live demo rows", async () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.getElementById("app")!;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Popup
+          adapter={createDemoPopupAdapter()}
+          initialState={{ preview: true, locale: "en", variant: screenshotVariant("extras") }}
+        />,
+      );
+    });
+    await waitForCatalog();
+    expect(container.textContent).toContain("RivalsPilot");
+    expect(container.textContent).toContain("LootForge");
+    expect(container.textContent).toContain("NightRunLive");
+  });
+});
+```
+
+If collapsed, channel names are not in the DOM. This test fails until expansion and live decoration land.
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/storeScreenshot.test.tsx`
+
+Expected: FAIL — watchlist collapsed and/or rows are idle usernames without display names.
+
+- [ ] **Step 3: Implement expansion and live decoration**
+
+Add `SCREENSHOT_WATCHLIST_LIVE` to `packages/popup-ui/src/constants.ts`.
+
+In `packages/popup-ui/src/Popup.tsx`:
+
+```ts
+const [watchlistExpanded, setWatchlistExpanded] = useState(
+  preview && variantShowsPopup(initialVariant) && initialVariant.view === "watchlist",
+);
+```
+
+After `idleWatchlist` is built from settings + session, replace the value used by `IdleWatchlistPanel` when the extras screenshot is active:
+
+```ts
+const idleWatchlist = idleWatchlistChannels.map((username) => streamerItemFromFallback(username, session, t));
+const screenshotWatchlist = preview && variantShowsPopup(initialVariant) && initialVariant.view === "watchlist"
+  ? idleWatchlist.map((item) => {
+      const live = SCREENSHOT_WATCHLIST_LIVE[item.id];
+      if (!live) return item;
+      return { ...item, name: live.displayName, live: true, viewers: live.viewers, subtitle: live.subtitle };
+    })
+  : idleWatchlist;
+```
+
+Pass `screenshotWatchlist` into `IdleWatchlistPanel`. Import `SCREENSHOT_WATCHLIST_LIVE` from `./constants`. Do not import `./demo`.
+
+- [ ] **Step 4: Run screenshot tests**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run tests/storeScreenshot.test.tsx tests/i18n.test.ts tests/storeScreenshotFiles.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/popup-ui/src/constants.ts packages/popup-ui/src/Popup.tsx packages/extension/tests/storeScreenshot.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(popup): expand watchlist in extras screenshot
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Workspace verification
+
+**Files:**
+- None unless a test or type error names a file.
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm -r typecheck`
+
+Expected: PASS. `variantShowsPopup` narrowing must satisfy `Popup.tsx` and `entrypoints/popup/app.tsx` (extras/easy now mount `<Popup>`).
+
+- [ ] **Step 2: Extension tests**
+
+Run: `pnpm --filter @lurkloot/extension exec vitest run`
+
+Expected: PASS.
+
+- [ ] **Step 3: Confirm docs need no edit**
+
+`docs/chrome-web-store-submission.md` does not describe 02/03/05 as popup-free marketing frames (verified during planning). Do not rewrite store listing copy. Do not run `pnpm screenshot:store`.
+
+- [ ] **Step 4: Commit only if Step 1–2 forced a fix**
+
+If no files changed, skip. If a type/test fix landed, commit it with a message that names the fix, e.g. `fix(store): narrow extras screenshot variant`.
+
+---
+
+## Self-review
+
+1. **Spec coverage:** 02 watchlist popup + two dotted callouts → Tasks 1, 3, 4. 03 vertical steps + Kick popup +2deg → Tasks 1, 3. 05 text runtime board, no icons → Tasks 2, 3. Capture `popup: true` on extras/easy → Task 1. i18n add/delete keys → Task 2. 01/04 untouched. No Firefox, no trademarked marks, no Kick watch-time, no activity log, no PNG upload.
+2. **Placeholders:** none.
+3. **Types:** `view: "watchlist"` is defined in Task 1 and consumed in Tasks 3–4. `variantShowsPopup` is `layout !== "updated"` everywhere. `screenshotUpdatedHeadlessTitle` / `screenshotUpdatedLicense` are allowed to stay English.

--- a/docs/superpowers/specs/2026-09-08-store-screenshot-density-design.md
+++ b/docs/superpowers/specs/2026-09-08-store-screenshot-density-design.md
@@ -45,18 +45,18 @@ Copy stays:
 
 - Eyebrow: `Beyond campaigns`
 - Headline: `More than drops.`
-- Subcopy: `Channel points and Kick challenges, also claimed for you. An idle watchlist when nothing is left to farm.`
+- Subcopy: `Channel points, Kick challenges, and 2-minute drops — also claimed for you. An idle watchlist when nothing is left to farm.`
 
-Camera: copy **upper-left** (not 01’s lower-third). Two compact platform-dotted callouts under the subcopy, not three equal glass cards:
+Camera: copy **upper-left** (not 01’s lower-third). Four platform-dotted callouts in a 2×2 under the subcopy, names at 24px:
 
 - Channel points — `Twitch · also claimed for you`
 - Daily challenges — `Kick · also claimed for you`
+- Idle watchlist — `Watches your streamers between campaigns`
+- 2-minute drops — `Kick · picked up as they land`
 
-The idle watchlist is the only extra with a real UI, so it is the product object: a 400×600 popup on the end side, slight −2deg tilt, Twitch selected, watchlist section expanded, 2–3 rows showing live pills and viewer counts. Do not card the watchlist. Do not sell Kick watch time as farmable.
+The idle watchlist is also the product object: a 400×600 popup on the end side, slight −2deg tilt, Twitch selected, watchlist section expanded, 2–3 rows showing live pills and viewer counts. Do not sell Kick watch time as farmable. 2-minute drops are Kick flash campaigns discovered immediately, not a watch-time outcome.
 
 Demo data for this capture must mark watchlist channels live (today only the current farming session channel counts as live). Screenshot-specific demo overlay is allowed; do not change normal demo behavior for the site popup demo.
-
-Remove `screenshotExtrasWatchlistName` / `screenshotExtrasWatchlistMeta` from the layout. Delete those keys from every catalog in the same change so they do not drift.
 
 ## Shot 03 — easy
 
@@ -80,14 +80,12 @@ Copy stays:
 - Eyebrow: `Open source`
 - Headline: `Featureful. Always updated.`
 - Subcopy: `Frequent releases as Twitch and Kick change — and open to ideas and improvements.`
-- Quiet footer on the copy column: `Apache-2.0`
+No popup, no changelog dump, no activity-log pitch, no Firefox. Legal constraint: we may say Chromium-based browsers are supported; we must not put trademarked browser (or Docker) marks in the screenshots. Generic window / terminal / box icons and a GitHub mark are allowed.
 
-No popup, no changelog dump, no activity-log pitch, no Firefox, **no icons**. Legal constraint: we may say Chromium-based browsers are supported; we must not put trademarked browser (or Docker) marks in the screenshots.
+Copy sits upper-left, aligned with the rating. The object that fills the void is a **listing board** on the end side (400×600), one glass plaque rather than stretched tiles:
 
-The object that fills the void is a **runtime board** on the end side (~400×560): two stacked glass tiles, display-size type, no glyphs.
-
-1. **Browsers** — title `Chromium-based browsers`. Sub `Chrome Web Store listing. Same extension.`
-2. **Headless** — title `CLI · Docker`. Sub `Headless. Same engine.`
+- Rating `4.9` with five generic stars, then `1,000+ users`. No review count — that number moves too often to bake into store screenshots.
+- Compact runtime rows, one icon each: Chromium-based browsers, CLI, Docker, GitHub / Apache-2.0.
 
 Do not list Edge/Brave/Opera/Vivaldi by name on this shot, and do not copy site browser SVGs into popup-ui. `CLI`, `Docker`, and `Chrome Web Store` stay untranslated.
 
@@ -111,15 +109,15 @@ Do not list Edge/Brave/Opera/Vivaldi by name on this shot, and do not copy site 
 
 Keep existing extras/easy/updated copy keys except:
 
-- Delete `screenshotExtrasWatchlistName` and `screenshotExtrasWatchlistMeta` from all 11 catalogs.
-- Add `screenshotUpdatedBrowsersTitle` (`Chromium-based browsers`), `screenshotUpdatedBrowsersSub` (`Chrome Web Store listing. Same extension.`), `screenshotUpdatedHeadlessTitle` (`CLI · Docker`), `screenshotUpdatedHeadlessSub` (`Headless. Same engine.`), and `screenshotUpdatedLicense` (`Apache-2.0`) to all 11 catalogs.
+- Keep `screenshotExtrasWatchlistName` / `screenshotExtrasWatchlistMeta` and add `screenshotExtrasFlashName` (`2-minute drops`) / `screenshotExtrasFlashMeta` (`Kick · picked up as they land`) in all 11 catalogs.
+- Add `screenshotUpdatedBrowsersTitle` (`Chromium-based browsers`), `screenshotUpdatedBrowsersSub` (`Chrome Web Store listing. Same extension.`), `screenshotUpdatedHeadlessTitle` (`CLI`), `screenshotUpdatedHeadlessSub` (`Headless. Same engine.`), `screenshotUpdatedDockerTitle` (`Docker`), `screenshotUpdatedDockerSub` (`Same engine. In a container.`), `screenshotUpdatedLicense` (`Apache-2.0`), `screenshotUpdatedRating` (`4.9`), and `screenshotUpdatedUsers` (`1,000+ users`) to all 11 catalogs. Do not bake a review count into screenshot copy.
 
 `CLI`, `Docker`, `Apache-2.0`, and `Chrome Web Store` stay untranslated, same as Twitch / Kick. Translate `Chromium-based browsers`, the rest of the browsers sub around the `Chrome Web Store` token, and `Headless. Same engine.`
 
 ## Tests and docs
 
 - `packages/extension/tests/storeScreenshot.test.tsx`: extras and easy show a popup; updated does not; `variantShowsPopup` matches the table above; watchlist view is wired.
-- `packages/extension/tests/i18n.test.ts`: new keys exist in every catalog; deleted watchlist card keys are gone; placeholders still match.
+- `packages/extension/tests/i18n.test.ts`: new keys exist in every catalog; extras watchlist and flash keys are present; placeholders still match.
 - Capture config tests: extras and easy are `popup: true`.
 - `docs/chrome-web-store-submission.md` only if it still describes 02/03/05 as popup-free marketing frames.
 

--- a/docs/superpowers/specs/2026-09-08-store-screenshot-density-design.md
+++ b/docs/superpowers/specs/2026-09-08-store-screenshot-density-design.md
@@ -1,0 +1,140 @@
+# Store screenshot density design
+
+## Goal
+
+Give Chrome Web Store screenshots 02, 03, and 05 the same finished density as 01 and 04. Those two work because a real 400×600 popup is a solid object on the canvas. 02–03–05 were specified as marketing frames with “lots of void,” so they read empty at store-thumbnail size.
+
+Keep the locked five-shot stories, the signal-broadcast look, and shots 01 and 04 unchanged.
+
+## Scope
+
+This covers the store-screenshot React shell (`StoreScreenshot`), screenshot variant types, demo data used by capture, English marketing copy plus the other ten locale catalogs for any new keys, Playwright capture waits, and `STORE_SCREENSHOT_VARIANTS` popup flags.
+
+It does not change 01/04 layout or copy, farming behavior, listing short/detailed descriptions, promo tiles, or Chrome Web Store upload automation.
+
+## Shot lineup
+
+Chrome still allows five 1280×800 screenshots. Upload order is the number prefix.
+
+| # | File stem | Story | Live popup |
+|---|-----------|--------|------------|
+| 01 | `01-drops` | Hero: farm Twitch and Kick drops | Yes — drops view, Twitch selected (unchanged) |
+| 02 | `02-extras` | Overview of extras besides drop campaigns | Yes — Twitch, idle watchlist expanded |
+| 03 | `03-easy` | Install → pin → enable → profit | Yes — Kick selected, both platform toggles on |
+| 04 | `04-settings` | Configurable | Yes — settings view (unchanged) |
+| 05 | `05-updated` | Featureful, always updated, open source | No — text runtime board (Chromium browsers + CLI/Docker) |
+
+Aliases stay: `twitch-drops` → 01, `settings` → 04, `kick-drops` → 01, `idle-watchlist` → 02, `activity` → 05.
+
+## Visual language
+
+Unchanged from the 2026-08-16 rework, so the set still reads as one listing:
+
+- Canvas `#060609`, Bricolage Grotesque display type, zinc subcopy (`#9c9db4`).
+- Purple (`#9147ff`) and lime (`#53fc18`) only as atmospheric radial glows. No decorative gradient bars, no full-canvas wallpaper blobs, no illustrated fake popup UI.
+- No third-party trademarked icons or logos anywhere in the five shots: no browser marks, no Docker whale, no GitHub mark, no Twitch/Kick logos. Nominative text is allowed (Twitch, Kick, Chromium, CLI, Docker). Colored status dots that are not brand marks stay allowed, matching the existing promo pills.
+- Eyebrows keep the purple→lime text gradient.
+- Every live popup is the real `Popup` at **400×600**. Scale, crop (overflow hidden), or slight rotate are allowed. Stretching is not.
+- 05’s runtime board is sized to similar mass (~400×560) so it fills like a popup.
+
+Use logical `start`/`end` placement, same as today. In LTR, 01/02/03/05 put the object on the right (`end`); 04 keeps the popup on the left (`start`). RTL flips those sides. 03 step order stays 01→04.
+
+## Shot 02 — extras
+
+Copy stays:
+
+- Eyebrow: `Beyond campaigns`
+- Headline: `More than drops.`
+- Subcopy: `Channel points and Kick challenges, also claimed for you. An idle watchlist when nothing is left to farm.`
+
+Camera: copy **upper-left** (not 01’s lower-third). Two compact platform-dotted callouts under the subcopy, not three equal glass cards:
+
+- Channel points — `Twitch · also claimed for you`
+- Daily challenges — `Kick · also claimed for you`
+
+The idle watchlist is the only extra with a real UI, so it is the product object: a 400×600 popup on the end side, slight −2deg tilt, Twitch selected, watchlist section expanded, 2–3 rows showing live pills and viewer counts. Do not card the watchlist. Do not sell Kick watch time as farmable.
+
+Demo data for this capture must mark watchlist channels live (today only the current farming session channel counts as live). Screenshot-specific demo overlay is allowed; do not change normal demo behavior for the site popup demo.
+
+Remove `screenshotExtrasWatchlistName` / `screenshotExtrasWatchlistMeta` from the layout. Delete those keys from every catalog in the same change so they do not drift.
+
+## Shot 03 — easy
+
+Copy stays. Headline `That easy.` Steps stay a real sequence, so they stay numbered:
+
+1. Install — `Chrome Web Store. No account.`
+2. Pin it — `Keep the popup one click away.`
+3. Enable a platform — `Twitch, Kick, or both.`
+4. Profit — `It farms. You do other things.`
+
+Camera: vertical stack on the start side with a 2px purple→lime spine. The live popup sits on the end side as the destination of the sequence (step 4 is the product, not a fourth text column). Slight **+2deg** tilt so it does not rhyme with 01’s −2deg.
+
+Popup: Kick selected, both platform automation toggles on, drops view with the Kick demo campaign visible. That is the dual-platform proof for “Twitch, Kick, or both,” against 01’s Twitch drops shot.
+
+No fake Chrome toolbar for “Pin it.” Pin remains copy.
+
+## Shot 05 — updated
+
+Copy stays:
+
+- Eyebrow: `Open source`
+- Headline: `Featureful. Always updated.`
+- Subcopy: `Frequent releases as Twitch and Kick change — and open to ideas and improvements.`
+- Quiet footer on the copy column: `Apache-2.0`
+
+No popup, no changelog dump, no activity-log pitch, no Firefox, **no icons**. Legal constraint: we may say Chromium-based browsers are supported; we must not put trademarked browser (or Docker) marks in the screenshots.
+
+The object that fills the void is a **runtime board** on the end side (~400×560): two stacked glass tiles, display-size type, no glyphs.
+
+1. **Browsers** — title `Chromium-based browsers`. Sub `Chrome Web Store listing. Same extension.`
+2. **Headless** — title `CLI · Docker`. Sub `Headless. Same engine.`
+
+Do not list Edge/Brave/Opera/Vivaldi by name on this shot, and do not copy site browser SVGs into popup-ui. `CLI`, `Docker`, and `Chrome Web Store` stay untranslated.
+
+## Variant model
+
+`ScreenshotVariant` still uses a `layout` discriminant. Popup-carrying layouts gain `platform` and `view`:
+
+| layout | popup | platform | view |
+|--------|-------|----------|------|
+| `hero` | yes | twitch | drops |
+| `extras` | yes | twitch | watchlist |
+| `steps` | yes | kick | drops |
+| `settings` | yes | twitch | settings |
+| `updated` | no | — | — |
+
+`variantShowsPopup` is true for every layout except `updated`. `Popup` initializes `watchlistExpanded` when `view === "watchlist"`, and selects Kick when the variant’s platform is Kick.
+
+`STORE_SCREENSHOT_VARIANTS` sets `popup: true` on extras and easy so capture waits on `header img[alt="Lurkloot"]`. Updated still waits on the marketing `h1`.
+
+## i18n
+
+Keep existing extras/easy/updated copy keys except:
+
+- Delete `screenshotExtrasWatchlistName` and `screenshotExtrasWatchlistMeta` from all 11 catalogs.
+- Add `screenshotUpdatedBrowsersTitle` (`Chromium-based browsers`), `screenshotUpdatedBrowsersSub` (`Chrome Web Store listing. Same extension.`), `screenshotUpdatedHeadlessTitle` (`CLI · Docker`), `screenshotUpdatedHeadlessSub` (`Headless. Same engine.`), and `screenshotUpdatedLicense` (`Apache-2.0`) to all 11 catalogs.
+
+`CLI`, `Docker`, `Apache-2.0`, and `Chrome Web Store` stay untranslated, same as Twitch / Kick. Translate `Chromium-based browsers`, the rest of the browsers sub around the `Chrome Web Store` token, and `Headless. Same engine.`
+
+## Tests and docs
+
+- `packages/extension/tests/storeScreenshot.test.tsx`: extras and easy show a popup; updated does not; `variantShowsPopup` matches the table above; watchlist view is wired.
+- `packages/extension/tests/i18n.test.ts`: new keys exist in every catalog; deleted watchlist card keys are gone; placeholders still match.
+- Capture config tests: extras and easy are `popup: true`.
+- `docs/chrome-web-store-submission.md` only if it still describes 02/03/05 as popup-free marketing frames.
+
+## Out of scope
+
+- Regenerating and uploading PNGs (`pnpm screenshot:store` after implementation; artifacts stay gitignored).
+- Changing 01/04, promo tiles, or store listing body copy.
+- Firefox on shot 05, AMO, or promising Firefox Add-ons availability.
+- Any trademarked third-party icons in screenshots (browser logos, Docker whale, GitHub, Twitch/Kick).
+- Kick watch-time outcomes, activity log as a selling point, illustrated fake popups.
+
+## Self-review
+
+- No TBD/TODO in shot copy or layout rules.
+- 02 does not sell Kick watch time; 05 does not sell the activity log, Firefox, or any trademarked icons.
+- Five shots, 1280×800, popup 400×600 only — no contradiction with CWS limits.
+- One capture pipeline and one `StoreScreenshot` component, not a second marketing site.
+- Implementation is one focused change: density of 02/03/05, not a new screenshot lineup.

--- a/packages/extension/scripts/store-screenshot-config.mjs
+++ b/packages/extension/scripts/store-screenshot-config.mjs
@@ -1,7 +1,7 @@
 export const STORE_SCREENSHOT_VARIANTS = Object.freeze([
   Object.freeze({ id: "drops", file: "01-drops", popup: true }),
-  Object.freeze({ id: "extras", file: "02-extras", popup: false }),
-  Object.freeze({ id: "easy", file: "03-easy", popup: false }),
+  Object.freeze({ id: "extras", file: "02-extras", popup: true }),
+  Object.freeze({ id: "easy", file: "03-easy", popup: true }),
   Object.freeze({ id: "settings", file: "04-settings", popup: true }),
   Object.freeze({ id: "updated", file: "05-updated", popup: false }),
 ]);

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -174,11 +174,15 @@ describe("i18n", () => {
       screenshotHeroSubcopy: "Auto-claim from your own logged-in session. No passwords.",
       screenshotExtrasEyebrow: "Beyond campaigns",
       screenshotExtrasHeadline: "More than drops.",
-      screenshotExtrasSubcopy: "Channel points and Kick challenges, also claimed for you. An idle watchlist when nothing is left to farm.",
+      screenshotExtrasSubcopy: "Channel points, Kick challenges, and 2-minute drops — also claimed for you. An idle watchlist when nothing is left to farm.",
       screenshotExtrasPointsName: "Channel points",
       screenshotExtrasPointsMeta: "Twitch · also claimed for you",
       screenshotExtrasChallengesName: "Daily challenges",
       screenshotExtrasChallengesMeta: "Kick · also claimed for you",
+      screenshotExtrasWatchlistName: "Idle watchlist",
+      screenshotExtrasWatchlistMeta: "Watches your streamers between campaigns",
+      screenshotExtrasFlashName: "2-minute drops",
+      screenshotExtrasFlashMeta: "Kick · picked up as they land",
       screenshotEasyEyebrow: "Easy to use",
       screenshotEasyHeadline: "That easy.",
       screenshotEasyInstallTitle: "Install",
@@ -197,9 +201,13 @@ describe("i18n", () => {
       screenshotUpdatedSubcopy: "Frequent releases as Twitch and Kick change — and open to ideas and improvements.",
       screenshotUpdatedBrowsersTitle: "Chromium-based browsers",
       screenshotUpdatedBrowsersSub: "Chrome Web Store listing. Same extension.",
-      screenshotUpdatedHeadlessTitle: "CLI · Docker",
+      screenshotUpdatedHeadlessTitle: "CLI",
       screenshotUpdatedHeadlessSub: "Headless. Same engine.",
+      screenshotUpdatedDockerTitle: "Docker",
+      screenshotUpdatedDockerSub: "Same engine. In a container.",
       screenshotUpdatedLicense: "Apache-2.0",
+      screenshotUpdatedRating: "4.9",
+      screenshotUpdatedUsers: "1,000+ users",
     };
     const catalog = readCatalog("en");
     for (const [key, message] of Object.entries(english)) {
@@ -214,8 +222,7 @@ describe("i18n", () => {
       "screenshotIdleWatchlistSubcopy",
       "screenshotActivityHeadline",
       "screenshotActivitySubcopy",
-      "screenshotExtrasWatchlistName",
-      "screenshotExtrasWatchlistMeta",
+      "screenshotUpdatedReviews",
     ]) {
       expect(catalog[stale], stale).toBeUndefined();
     }
@@ -251,7 +258,9 @@ describe("i18n", () => {
       // Brand-only store screenshot eyebrow.
       "screenshotHeroEyebrow",
       "screenshotUpdatedHeadlessTitle",
+      "screenshotUpdatedDockerTitle",
       "screenshotUpdatedLicense",
+      "screenshotUpdatedRating",
     ]);
 
     for (const locale of localeCodes().filter((entry) => entry !== "en")) {

--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -179,8 +179,6 @@ describe("i18n", () => {
       screenshotExtrasPointsMeta: "Twitch · also claimed for you",
       screenshotExtrasChallengesName: "Daily challenges",
       screenshotExtrasChallengesMeta: "Kick · also claimed for you",
-      screenshotExtrasWatchlistName: "Idle watchlist",
-      screenshotExtrasWatchlistMeta: "Watches your streamers between campaigns",
       screenshotEasyEyebrow: "Easy to use",
       screenshotEasyHeadline: "That easy.",
       screenshotEasyInstallTitle: "Install",
@@ -197,6 +195,11 @@ describe("i18n", () => {
       screenshotUpdatedEyebrow: "Open source",
       screenshotUpdatedHeadline: "Featureful. Always updated.",
       screenshotUpdatedSubcopy: "Frequent releases as Twitch and Kick change — and open to ideas and improvements.",
+      screenshotUpdatedBrowsersTitle: "Chromium-based browsers",
+      screenshotUpdatedBrowsersSub: "Chrome Web Store listing. Same extension.",
+      screenshotUpdatedHeadlessTitle: "CLI · Docker",
+      screenshotUpdatedHeadlessSub: "Headless. Same engine.",
+      screenshotUpdatedLicense: "Apache-2.0",
     };
     const catalog = readCatalog("en");
     for (const [key, message] of Object.entries(english)) {
@@ -211,6 +214,8 @@ describe("i18n", () => {
       "screenshotIdleWatchlistSubcopy",
       "screenshotActivityHeadline",
       "screenshotActivitySubcopy",
+      "screenshotExtrasWatchlistName",
+      "screenshotExtrasWatchlistMeta",
     ]) {
       expect(catalog[stale], stale).toBeUndefined();
     }
@@ -245,6 +250,8 @@ describe("i18n", () => {
       "diagnosticsViewTab",
       // Brand-only store screenshot eyebrow.
       "screenshotHeroEyebrow",
+      "screenshotUpdatedHeadlessTitle",
+      "screenshotUpdatedLicense",
     ]);
 
     for (const locale of localeCodes().filter((entry) => entry !== "en")) {

--- a/packages/extension/tests/storeScreenshot.test.tsx
+++ b/packages/extension/tests/storeScreenshot.test.tsx
@@ -3,7 +3,14 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { parseHTML } from "linkedom";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SCREENSHOT_VARIANTS, StoreScreenshot, screenshotVariant, variantShowsPopup } from "@lurkloot/popup-ui";
+import {
+  createDemoPopupAdapter,
+  Popup,
+  SCREENSHOT_VARIANTS,
+  StoreScreenshot,
+  screenshotVariant,
+  variantShowsPopup,
+} from "@lurkloot/popup-ui";
 import { resetCatalogTracking, waitForCatalog } from "./helpers/popupCatalog";
 
 vi.mock("@lurkloot/locales", async (importOriginal) =>
@@ -81,6 +88,44 @@ describe("store screenshot variants", () => {
       "drops", "extras", "easy", "settings", "updated",
       "twitch-drops", "kick-drops", "idle-watchlist", "activity",
     ]));
+  });
+});
+
+describe("extras screenshot popup", () => {
+  it("expands the idle watchlist with live demo rows", async () => {
+    const { document, window } = parseHTML("<div id=app></div>");
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(Date.now());
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+    const container = document.getElementById("app")!;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Popup
+          adapter={createDemoPopupAdapter()}
+          initialState={{ preview: true, locale: "en", variant: screenshotVariant("extras") }}
+        />,
+      );
+    });
+    await waitForCatalog();
+    const watchlistToggle = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("Idle Watchlist"));
+    expect(watchlistToggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("RivalsPilot");
+    expect(container.textContent).toContain("LootForge");
+    expect(container.textContent).toContain("NightRunLive");
+    expect(container.textContent).toContain("Marathon Legends");
+    expect(container.textContent).toContain("Starfall Arena");
+    expect(container.textContent).toContain("Spellforge");
+    expect(container.textContent).toContain("18K");
+    expect(container.textContent).toContain("6.2K");
+    expect(container.textContent).toContain("2.5K");
   });
 });
 

--- a/packages/extension/tests/storeScreenshot.test.tsx
+++ b/packages/extension/tests/storeScreenshot.test.tsx
@@ -51,18 +51,26 @@ describe("store screenshot variants", () => {
     expect(screenshotVariant("nope").layout).toBe("hero");
   });
 
-  it("only hero and settings mount a live popup", () => {
+  it("mounts a live popup on every shot except updated", () => {
     expect(variantShowsPopup(screenshotVariant("drops"))).toBe(true);
+    expect(variantShowsPopup(screenshotVariant("extras"))).toBe(true);
+    expect(variantShowsPopup(screenshotVariant("easy"))).toBe(true);
     expect(variantShowsPopup(screenshotVariant("settings"))).toBe(true);
-    expect(variantShowsPopup(screenshotVariant("extras"))).toBe(false);
-    expect(variantShowsPopup(screenshotVariant("easy"))).toBe(false);
     expect(variantShowsPopup(screenshotVariant("updated"))).toBe(false);
   });
 
-  it("keeps popup shots at Twitch drops or settings views", () => {
+  it("wires extras to the Twitch watchlist and easy to Kick drops", () => {
+    const extras = screenshotVariant("extras");
+    const easy = screenshotVariant("easy");
     const drops = screenshotVariant("drops");
     const settings = screenshotVariant("settings");
-    if (!variantShowsPopup(drops) || !variantShowsPopup(settings)) throw new Error("expected popup shots");
+    if (!variantShowsPopup(extras) || !variantShowsPopup(easy) || !variantShowsPopup(drops) || !variantShowsPopup(settings)) {
+      throw new Error("expected popup shots");
+    }
+    expect(extras.platform).toBe("twitch");
+    expect(extras.view).toBe("watchlist");
+    expect(easy.platform).toBe("kick");
+    expect(easy.view).toBe("drops");
     expect(drops.platform).toBe("twitch");
     expect(drops.view).toBe("drops");
     expect(settings.view).toBe("settings");

--- a/packages/extension/tests/storeScreenshot.test.tsx
+++ b/packages/extension/tests/storeScreenshot.test.tsx
@@ -85,28 +85,29 @@ describe("store screenshot variants", () => {
 });
 
 describe("store screenshot cameras", () => {
-  it("renders extras cards and no live popup chrome", async () => {
+  it("places extras copy and chips beside a live popup", async () => {
     const container = await mountShot("extras", "LIVE_POPUP");
     expect(container.textContent).toContain("More than drops.");
-    expect(container.textContent).toContain("also claimed for you");
-    expect(container.textContent).toContain("Idle watchlist");
-    expect(container.textContent).not.toContain("LIVE_POPUP");
+    expect(container.textContent).toContain("Channel points");
+    expect(container.textContent).toContain("Daily challenges");
+    expect(container.textContent).toContain("LIVE_POPUP");
+    expect(container.textContent).not.toContain("Idle watchlist");
+    expect(container.querySelector('[data-layout="extras"]')).not.toBeNull();
   });
 
-  it("renders the four easy steps", async () => {
-    const container = await mountShot("easy");
+  it("stacks easy steps on the start side and mounts a live popup", async () => {
+    const container = await mountShot("easy", "LIVE_POPUP");
     expect(container.textContent).toContain("That easy.");
     expect(container.textContent).toContain("Install");
     expect(container.textContent).toContain("Pin it");
     expect(container.textContent).toContain("Enable a platform");
     expect(container.textContent).toContain("Profit");
-
-    const stepsRow = container.querySelector('[data-layout="steps"] div.absolute.flex.gap-7');
-    expect(stepsRow).not.toBeNull();
-    const className = stepsRow?.getAttribute("class") ?? "";
-    expect(className).not.toContain("inset-inline-[7%]");
+    expect(container.textContent).toContain("LIVE_POPUP");
+    const steps = container.querySelector('[data-layout="steps"] [data-steps]');
+    expect(steps).not.toBeNull();
+    const className = steps?.getAttribute("class") ?? "";
     expect(className).toMatch(/\bstart-\[7%\]/);
-    expect(className).toMatch(/\bend-\[7%\]/);
+    expect(className).not.toMatch(/\bgap-7\b/);
   });
 
   it("places the live popup inside hero and settings cameras", async () => {
@@ -118,10 +119,14 @@ describe("store screenshot cameras", () => {
     expect(settings.textContent).toContain("LIVE_POPUP");
   });
 
-  it("keeps updated as type-only", async () => {
+  it("fills updated with a text runtime board and no popup", async () => {
     const container = await mountShot("updated", "LIVE_POPUP");
     expect(container.textContent).toContain("Featureful. Always updated.");
-    expect(container.textContent).toContain("open to ideas");
+    expect(container.textContent).toContain("Chromium-based browsers");
+    expect(container.textContent).toContain("Chrome Web Store listing. Same extension.");
+    expect(container.textContent).toContain("CLI · Docker");
+    expect(container.textContent).toContain("Headless. Same engine.");
+    expect(container.textContent).toContain("Apache-2.0");
     expect(container.textContent).not.toContain("LIVE_POPUP");
   });
 });

--- a/packages/extension/tests/storeScreenshot.test.tsx
+++ b/packages/extension/tests/storeScreenshot.test.tsx
@@ -134,8 +134,9 @@ describe("store screenshot cameras", () => {
     expect(container.textContent).toContain("More than drops.");
     expect(container.textContent).toContain("Channel points");
     expect(container.textContent).toContain("Daily challenges");
+    expect(container.textContent).toContain("Idle watchlist");
+    expect(container.textContent).toContain("2-minute drops");
     expect(container.textContent).toContain("LIVE_POPUP");
-    expect(container.textContent).not.toContain("Idle watchlist");
     expect(container.querySelector('[data-layout="extras"]')).not.toBeNull();
   });
 
@@ -166,11 +167,21 @@ describe("store screenshot cameras", () => {
   it("fills updated with a text runtime board and no popup", async () => {
     const container = await mountShot("updated", "LIVE_POPUP");
     expect(container.textContent).toContain("Featureful. Always updated.");
+    expect(container.textContent).toContain("4.9");
+    expect(container.textContent).toContain("1,000+ users");
+    expect(container.textContent).not.toContain("25 reviews");
     expect(container.textContent).toContain("Chromium-based browsers");
     expect(container.textContent).toContain("Chrome Web Store listing. Same extension.");
-    expect(container.textContent).toContain("CLI · Docker");
+    expect(container.textContent).toContain("CLI");
     expect(container.textContent).toContain("Headless. Same engine.");
+    expect(container.textContent).toContain("Docker");
+    expect(container.textContent).toContain("Same engine. In a container.");
+    expect(container.textContent).not.toContain("CLI · Docker");
+    expect(container.textContent).toContain("GitHub");
+    expect(container.textContent).toContain("Open source");
     expect(container.textContent).toContain("Apache-2.0");
     expect(container.textContent).not.toContain("LIVE_POPUP");
+    expect(container.querySelector('[data-layout="updated"] svg')).not.toBeNull();
+    expect(container.querySelector("[data-updated-board]")).not.toBeNull();
   });
 });

--- a/packages/extension/tests/storeScreenshot.test.tsx
+++ b/packages/extension/tests/storeScreenshot.test.tsx
@@ -103,6 +103,8 @@ describe("extras screenshot popup", () => {
     });
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     vi.stubGlobal("getComputedStyle", () => ({ direction: "ltr", columnGap: "0" }));
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", { value: scrollIntoView });
     const container = document.getElementById("app")!;
     await act(async () => {
       root = createRoot(container);
@@ -117,13 +119,10 @@ describe("extras screenshot popup", () => {
     const watchlistToggle = Array.from(container.querySelectorAll("button"))
       .find((button) => button.textContent?.includes("Idle Watchlist"));
     expect(watchlistToggle?.getAttribute("aria-expanded")).toBe("true");
-    expect(container.textContent).toContain("RivalsPilot");
+    expect(container.querySelector("#idle-watchlist")).not.toBeNull();
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
     expect(container.textContent).toContain("LootForge");
     expect(container.textContent).toContain("NightRunLive");
-    expect(container.textContent).toContain("Marathon Legends");
-    expect(container.textContent).toContain("Starfall Arena");
-    expect(container.textContent).toContain("Spellforge");
-    expect(container.textContent).toContain("18K");
     expect(container.textContent).toContain("6.2K");
     expect(container.textContent).toContain("2.5K");
   });

--- a/packages/extension/tests/storeScreenshotFiles.test.ts
+++ b/packages/extension/tests/storeScreenshotFiles.test.ts
@@ -52,6 +52,9 @@ describe("store screenshot manifest", () => {
       "lurkloot-04-settings-1280x800.png",
       "lurkloot-05-updated-1280x800.png",
     ]);
+    expect(STORE_SCREENSHOT_VARIANTS.map((variant: { popup: boolean }) => variant.popup)).toEqual([
+      true, true, true, true, false,
+    ]);
   });
 
   it("parses locale filters without accepting unknown or duplicate work", () => {

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -813,7 +813,7 @@
     "message": "أكثر من دروبس."
   },
   "screenshotExtrasSubcopy": {
-    "message": "نقاط القناة وتحديات Kick تُطالب أيضاً لأجلك. قائمة مشاهدة خاملة عندما لا يبقى شيء للفارم."
+    "message": "نقاط القناة وتحديات Kick ودروبات الدقيقتين تُطالب أيضاً لأجلك. قائمة مشاهدة خاملة عندما لا يبقى شيء للفارم."
   },
   "screenshotExtrasPointsName": {
     "message": "نقاط القناة"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · تُطالب أيضاً لأجلك"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "قائمة المشاهدة الخاملة"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "تشاهد ستريمرك بين الحملات"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "دروبات دقيقتين"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · لحظة إعلانها"
   },
   "screenshotEasyEyebrow": {
     "message": "سهل الاستخدام"
@@ -882,13 +894,25 @@
     "message": "صفحة Chrome Web Store. نفس الإضافة."
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "بلا واجهة. نفس المحرك."
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "نفس المحرك. في حاوية."
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "أكثر من 1,000 مستخدم"
   },
   "autoClaimReady": {
     "message": "الاستلام التلقائي جاهز"

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · تُطالب أيضاً لأجلك"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "قائمة المشاهدة الخاملة"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "تشاهد ستريمرك بين الحملات"
-  },
   "screenshotEasyEyebrow": {
     "message": "سهل الاستخدام"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "إصدارات متكررة كلما تغيّر Twitch وKick — ومفتوح للأفكار والتحسينات."
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "متصفحات مبنية على Chromium"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "صفحة Chrome Web Store. نفس الإضافة."
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "بلا واجهة. نفس المحرك."
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "الاستلام التلقائي جاهز"

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · ebenfalls für dich geclaimt"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "Idle-Watchlist"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "Schaut deine Streamer zwischen Kampagnen"
-  },
   "screenshotEasyEyebrow": {
     "message": "Einfach zu nutzen"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "Häufige Releases, wenn sich Twitch und Kick ändern — und offen für Ideen und Verbesserungen."
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "Chromium-basierte Browser"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Chrome Web Store-Eintrag. Dieselbe Erweiterung."
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "Headless. Dieselbe Engine."
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "Auto-Beanspruchen bereit"

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -813,7 +813,7 @@
     "message": "Mehr als Drops."
   },
   "screenshotExtrasSubcopy": {
-    "message": "Kanalpunkte und Kick-Challenges, ebenfalls für dich geclaimt. Eine Idle-Watchlist, wenn nichts mehr zu farmen ist."
+    "message": "Kanalpunkte, Kick-Challenges und 2-Minuten-Drops, ebenfalls für dich geclaimt. Eine Idle-Watchlist, wenn nichts mehr zu farmen ist."
   },
   "screenshotExtrasPointsName": {
     "message": "Kanalpunkte"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · ebenfalls für dich geclaimt"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "Idle-Watchlist"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "Schaut deine Streamer zwischen Kampagnen"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "2-Minuten-Drops"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · sobald sie live gehen"
   },
   "screenshotEasyEyebrow": {
     "message": "Einfach zu nutzen"
@@ -882,13 +894,25 @@
     "message": "Chrome Web Store-Eintrag. Dieselbe Erweiterung."
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "Headless. Dieselbe Engine."
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "Dieselbe Engine. Im Container."
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "über 1.000 Nutzer"
   },
   "autoClaimReady": {
     "message": "Auto-Beanspruchen bereit"

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · also claimed for you"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "Idle watchlist"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "Watches your streamers between campaigns"
-  },
   "screenshotEasyEyebrow": {
     "message": "Easy to use"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "Frequent releases as Twitch and Kick change — and open to ideas and improvements."
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "Chromium-based browsers"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Chrome Web Store listing. Same extension."
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "Headless. Same engine."
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "Auto-claim ready"

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -813,7 +813,7 @@
     "message": "More than drops."
   },
   "screenshotExtrasSubcopy": {
-    "message": "Channel points and Kick challenges, also claimed for you. An idle watchlist when nothing is left to farm."
+    "message": "Channel points, Kick challenges, and 2-minute drops — also claimed for you. An idle watchlist when nothing is left to farm."
   },
   "screenshotExtrasPointsName": {
     "message": "Channel points"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · also claimed for you"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "Idle watchlist"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "Watches your streamers between campaigns"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "2-minute drops"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · picked up as they land"
   },
   "screenshotEasyEyebrow": {
     "message": "Easy to use"
@@ -882,13 +894,25 @@
     "message": "Chrome Web Store listing. Same extension."
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "Headless. Same engine."
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "Same engine. In a container."
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "1,000+ users"
   },
   "autoClaimReady": {
     "message": "Auto-claim ready"

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -813,7 +813,7 @@
     "message": "Más que drops."
   },
   "screenshotExtrasSubcopy": {
-    "message": "Puntos de canal y desafíos de Kick, también reclamados por ti. Una lista de visualización inactiva cuando no queda nada que farmear."
+    "message": "Puntos de canal, desafíos de Kick y drops de 2 minutos, también reclamados por ti. Una lista de visualización inactiva cuando no queda nada que farmear."
   },
   "screenshotExtrasPointsName": {
     "message": "Puntos de canal"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · también reclamados por ti"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "Lista de visualización inactiva"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "Ve a tus streamers entre campañas"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "Drops de 2 minutos"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · en el momento"
   },
   "screenshotEasyEyebrow": {
     "message": "Fácil de usar"
@@ -882,13 +894,25 @@
     "message": "Ficha de Chrome Web Store. La misma extensión."
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "Sin interfaz. El mismo motor."
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "El mismo motor. En un contenedor."
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "más de 1.000 usuarios"
   },
   "autoClaimReady": {
     "message": "Reclama automáticamente"

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · también reclamados por ti"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "Lista de visualización inactiva"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "Ve a tus streamers entre campañas"
-  },
   "screenshotEasyEyebrow": {
     "message": "Fácil de usar"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "Lanzamientos frecuentes cuando Twitch y Kick cambian, y abierto a ideas y mejoras."
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "Navegadores basados en Chromium"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Ficha de Chrome Web Store. La misma extensión."
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "Sin interfaz. El mismo motor."
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "Reclama automáticamente"

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -813,7 +813,7 @@
     "message": "Plus que des drops."
   },
   "screenshotExtrasSubcopy": {
-    "message": "Points de chaîne et défis Kick, aussi réclamés pour vous. Une liste de veille quand il n'y a plus rien à farmer."
+    "message": "Points de chaîne, défis Kick et drops de 2 minutes, aussi réclamés pour vous. Une liste de veille quand il n'y a plus rien à farmer."
   },
   "screenshotExtrasPointsName": {
     "message": "Points de chaîne"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · aussi réclamés pour vous"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "Liste de veille"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "Regarde vos streamers entre les campagnes"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "Drops de 2 minutes"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · dès qu'ils tombent"
   },
   "screenshotEasyEyebrow": {
     "message": "Simple à utiliser"
@@ -882,13 +894,25 @@
     "message": "Fiche Chrome Web Store. La même extension."
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "Sans interface. Le même moteur."
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "Le même moteur. Dans un conteneur."
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "plus de 1 000 utilisateurs"
   },
   "autoClaimReady": {
     "message": "Réclamation auto prête"

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · aussi réclamés pour vous"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "Liste de veille"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "Regarde vos streamers entre les campagnes"
-  },
   "screenshotEasyEyebrow": {
     "message": "Simple à utiliser"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "Des versions fréquentes quand Twitch et Kick changent — et ouvert aux idées et améliorations."
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "Navigateurs basés sur Chromium"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Fiche Chrome Web Store. La même extension."
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "Sans interface. Le même moteur."
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "Réclamation auto prête"

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · तुम्हारे लिए भी क्लेम"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "आइडल वॉचलिस्ट"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "कैंपेन के बीच तुम्हारे स्ट्रीमर देखे जाते हैं"
-  },
   "screenshotEasyEyebrow": {
     "message": "आसान"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "Twitch और Kick बदलें तो रिलीज़ आती रहें — और सुझाव खुले हैं।"
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "Chromium-आधारित ब्राउज़र"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Chrome Web Store लिस्टिंग। वही एक्सटेंशन।"
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "हेडलेस। वही इंजन।"
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "ऑटो-क्लेम तैयार"

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -813,7 +813,7 @@
     "message": "सिर्फ़ drops नहीं।"
   },
   "screenshotExtrasSubcopy": {
-    "message": "चैनल पॉइंट्स और Kick चैलेंज भी तुम्हारे लिए क्लेम। जब फार्म करने को कुछ न हो, idle watchlist।"
+    "message": "चैनल पॉइंट्स, Kick चैलेंज और 2-मिनट ड्रॉप्स भी तुम्हारे लिए क्लेम। जब फार्म करने को कुछ न हो, idle watchlist।"
   },
   "screenshotExtrasPointsName": {
     "message": "चैनल पॉइंट्स"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · तुम्हारे लिए भी क्लेम"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "आइडल वॉचलिस्ट"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "कैंपेन के बीच तुम्हारे स्ट्रीमर देखे जाते हैं"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "2-मिनट ड्रॉप्स"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · जैसे ही आएं"
   },
   "screenshotEasyEyebrow": {
     "message": "आसान"
@@ -882,13 +894,25 @@
     "message": "Chrome Web Store लिस्टिंग। वही एक्सटेंशन।"
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "हेडलेस। वही इंजन।"
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "वही इंजन। कंटेनर में।"
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "1,000+ उपयोगकर्ता"
   },
   "autoClaimReady": {
     "message": "ऑटो-क्लेम तैयार"

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · riscattate anche per te"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "Lista di attesa"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "Guarda i tuoi streamer tra una campagna e l'altra"
-  },
   "screenshotEasyEyebrow": {
     "message": "Facile da usare"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "Rilasci frequenti quando Twitch e Kick cambiano — e aperto a idee e miglioramenti."
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "Browser basati su Chromium"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Scheda Chrome Web Store. La stessa estensione."
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "Senza interfaccia. Lo stesso motore."
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "Auto-riscatto pronto"

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -813,7 +813,7 @@
     "message": "Più dei drop."
   },
   "screenshotExtrasSubcopy": {
-    "message": "Punti canale e sfide Kick, riscattati anche per te. Una lista di attesa quando non resta nulla da farmare."
+    "message": "Punti canale, sfide Kick e drop da 2 minuti, riscattati anche per te. Una lista di attesa quando non resta nulla da farmare."
   },
   "screenshotExtrasPointsName": {
     "message": "Punti canale"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · riscattate anche per te"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "Lista di attesa"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "Guarda i tuoi streamer tra una campagna e l'altra"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "Drop da 2 minuti"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · appena arrivano"
   },
   "screenshotEasyEyebrow": {
     "message": "Facile da usare"
@@ -882,13 +894,25 @@
     "message": "Scheda Chrome Web Store. La stessa estensione."
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "Senza interfaccia. Lo stesso motore."
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "Lo stesso motore. In un container."
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "oltre 1.000 utenti"
   },
   "autoClaimReady": {
     "message": "Auto-riscatto pronto"

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · também resgatados para você"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "Lista ociosa"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "Assiste seus streamers entre campanhas"
-  },
   "screenshotEasyEyebrow": {
     "message": "Fácil de usar"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "Lançamentos frequentes quando Twitch e Kick mudam — e aberto a ideias e melhorias."
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "Navegadores baseados em Chromium"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Página da Chrome Web Store. A mesma extensão."
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "Sem interface. O mesmo motor."
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "Auto-resgate pronto"

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -813,7 +813,7 @@
     "message": "Mais do que drops."
   },
   "screenshotExtrasSubcopy": {
-    "message": "Pontos de canal e desafios da Kick, também resgatados para você. Uma lista ociosa quando não resta nada para farmar."
+    "message": "Pontos de canal, desafios da Kick e drops de 2 minutos, também resgatados para você. Uma lista ociosa quando não resta nada para farmar."
   },
   "screenshotExtrasPointsName": {
     "message": "Pontos de canal"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · também resgatados para você"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "Lista ociosa"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "Assiste seus streamers entre campanhas"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "Drops de 2 minutos"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · assim que aparecem"
   },
   "screenshotEasyEyebrow": {
     "message": "Fácil de usar"
@@ -882,13 +894,25 @@
     "message": "Página da Chrome Web Store. A mesma extensão."
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "Sem interface. O mesmo motor."
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "O mesmo motor. Em um container."
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "mais de 1.000 usuários"
   },
   "autoClaimReady": {
     "message": "Auto-resgate pronto"

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -813,7 +813,7 @@
     "message": "Больше, чем дропы."
   },
   "screenshotExtrasSubcopy": {
-    "message": "Баллы канала и челленджи Kick тоже клеймятся за вас. Idle-список, когда фармить больше нечего."
+    "message": "Баллы канала, челленджи Kick и 2-минутные дропы тоже клеймятся за вас. Idle-список, когда фармить больше нечего."
   },
   "screenshotExtrasPointsName": {
     "message": "Баллы канала"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · тоже клеймятся за вас"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "Idle-список"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "Смотрит ваших стримеров между кампаниями"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "2-минутные дропы"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · сразу как появляются"
   },
   "screenshotEasyEyebrow": {
     "message": "Просто использовать"
@@ -882,13 +894,25 @@
     "message": "Страница Chrome Web Store. То же расширение."
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "Без интерфейса. Тот же движок."
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "Тот же движок. В контейнере."
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "более 1 000 пользователей"
   },
   "autoClaimReady": {
     "message": "Автополучение готово"

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · тоже клеймятся за вас"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "Idle-список"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "Смотрит ваших стримеров между кампаниями"
-  },
   "screenshotEasyEyebrow": {
     "message": "Просто использовать"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "Частые релизы, когда Twitch и Kick меняются — и открыты к идеям и улучшениям."
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "Браузеры на базе Chromium"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Страница Chrome Web Store. То же расширение."
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "Без интерфейса. Тот же движок."
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "Автополучение готово"

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · senin için de teslim"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "Idle izleme listesi"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "Kampanyalar arasında yayıncılarını izler"
-  },
   "screenshotEasyEyebrow": {
     "message": "Kullanması kolay"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "Twitch ve Kick değişince sık sürümler — fikirlere ve iyileştirmelere açık."
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "Chromium tabanlı tarayıcılar"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Chrome Web Store kaydı. Aynı eklenti."
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "Arayüzsüz. Aynı motor."
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "Otomatik alma aktif"

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -813,7 +813,7 @@
     "message": "Sadece drop değil."
   },
   "screenshotExtrasSubcopy": {
-    "message": "Kanal puanları ve Kick görevleri de senin için teslim. Kasacak bir şey kalmayınca idle izleme listesi."
+    "message": "Kanal puanları, Kick görevleri ve 2 dakikalık droplar da senin için teslim. Kasacak bir şey kalmayınca idle izleme listesi."
   },
   "screenshotExtrasPointsName": {
     "message": "Kanal puanları"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · senin için de teslim"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "Idle izleme listesi"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "Kampanyalar arasında yayıncılarını izler"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "2 dakikalık droplar"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · çıkar çıkmaz"
   },
   "screenshotEasyEyebrow": {
     "message": "Kullanması kolay"
@@ -882,13 +894,25 @@
     "message": "Chrome Web Store kaydı. Aynı eklenti."
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "Arayüzsüz. Aynı motor."
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "Aynı motor. Konteynerde."
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "1.000+ kullanıcı"
   },
   "autoClaimReady": {
     "message": "Otomatik alma aktif"

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -827,12 +827,6 @@
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · 也会帮你领取"
   },
-  "screenshotExtrasWatchlistName": {
-    "message": "备用观看列表"
-  },
-  "screenshotExtrasWatchlistMeta": {
-    "message": "掉宝活动间隙，自动观看选定的主播"
-  },
   "screenshotEasyEyebrow": {
     "message": "上手很简单"
   },
@@ -880,6 +874,21 @@
   },
   "screenshotUpdatedSubcopy": {
     "message": "持续跟进 Twitch 和 Kick 的变化，欢迎提出建议和参与改进。"
+  },
+  "screenshotUpdatedBrowsersTitle": {
+    "message": "基于 Chromium 的浏览器"
+  },
+  "screenshotUpdatedBrowsersSub": {
+    "message": "Chrome Web Store 上架。同一扩展。"
+  },
+  "screenshotUpdatedHeadlessTitle": {
+    "message": "CLI · Docker"
+  },
+  "screenshotUpdatedHeadlessSub": {
+    "message": "无界面。同一引擎。"
+  },
+  "screenshotUpdatedLicense": {
+    "message": "Apache-2.0"
   },
   "autoClaimReady": {
     "message": "自动领取就绪"

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -813,7 +813,7 @@
     "message": "不只是掉宝。"
   },
   "screenshotExtrasSubcopy": {
-    "message": "频道点数和 Kick 每日挑战奖励也会自动领取。没有掉宝可挂机时，自动观看备用观看列表中的频道。"
+    "message": "频道点数、Kick 每日挑战和两分钟掉落也会自动领取。没有掉宝可挂机时，自动观看备用观看列表中的频道。"
   },
   "screenshotExtrasPointsName": {
     "message": "频道点数"
@@ -826,6 +826,18 @@
   },
   "screenshotExtrasChallengesMeta": {
     "message": "Kick · 也会帮你领取"
+  },
+  "screenshotExtrasWatchlistName": {
+    "message": "备用观看列表"
+  },
+  "screenshotExtrasWatchlistMeta": {
+    "message": "掉宝活动间隙，自动观看选定的主播"
+  },
+  "screenshotExtrasFlashName": {
+    "message": "两分钟掉落"
+  },
+  "screenshotExtrasFlashMeta": {
+    "message": "Kick · 一出现就跟上"
   },
   "screenshotEasyEyebrow": {
     "message": "上手很简单"
@@ -882,13 +894,25 @@
     "message": "Chrome Web Store 上架。同一扩展。"
   },
   "screenshotUpdatedHeadlessTitle": {
-    "message": "CLI · Docker"
+    "message": "CLI"
   },
   "screenshotUpdatedHeadlessSub": {
     "message": "无界面。同一引擎。"
   },
+  "screenshotUpdatedDockerTitle": {
+    "message": "Docker"
+  },
+  "screenshotUpdatedDockerSub": {
+    "message": "同一引擎。在容器中运行。"
+  },
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
+  },
+  "screenshotUpdatedRating": {
+    "message": "4.9"
+  },
+  "screenshotUpdatedUsers": {
+    "message": "1,000+ 用户"
   },
   "autoClaimReady": {
     "message": "自动领取就绪"

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -82,6 +82,7 @@ function isPlatform(value: unknown): value is Platform {
 export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initialState?: PopupInitialState }): React.ReactElement {
   const preview = initialState?.preview ?? false;
   const initialVariant = initialState?.variant ?? screenshotVariant("drops");
+  const watchlistShot = preview && variantShowsPopup(initialVariant) && initialVariant.view === "watchlist";
   const [snapshot, setSnapshot] = useState<RuntimeSnapshot | null>(null);
   const [overrideCatalog, setOverrideCatalog] = useState<MessageCatalog | undefined>();
   const [fallbackCatalog, setFallbackCatalog] = useState<MessageCatalog | undefined>();
@@ -90,9 +91,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   );
   // Drops and the Idle Watchlist share one view; the watchlist folds away under
   // the campaigns until asked for (or until a screenshot variant wants it).
-  const [watchlistExpanded, setWatchlistExpanded] = useState(
-    preview && variantShowsPopup(initialVariant) && initialVariant.view === "watchlist",
-  );
+  const [watchlistExpanded, setWatchlistExpanded] = useState(watchlistShot);
   const [watchlistAdding, setWatchlistAdding] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(
     preview && variantShowsPopup(initialVariant) && initialVariant.view === "settings",
@@ -199,6 +198,11 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
       setSnapshot(snapshotWithMergedSettings(nextSnapshot));
     });
   }, [adapter, previewPlatform, preview]);
+
+  useEffect(() => {
+    if (!watchlistShot || !snapshot) return;
+    document.getElementById("idle-watchlist")?.scrollIntoView?.({ block: "start" });
+  }, [snapshot, watchlistShot]);
 
   useEffect(() => {
     if (preview || !adapter.getPendingChangelogVersion) return;
@@ -631,7 +635,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const gameMap = Object.fromEntries(games.map((game) => [game.id, game]));
   const idleWatchlistChannels = settings.platform[platform].idleWatchlistChannels;
   const idleWatchlist = idleWatchlistChannels.map((username) => streamerItemFromFallback(username, session, t));
-  const screenshotWatchlist = preview && variantShowsPopup(initialVariant) && initialVariant.view === "watchlist"
+  const screenshotWatchlist = watchlistShot
     ? idleWatchlist.map((item) => {
         const live = SCREENSHOT_WATCHLIST_LIVE[item.id];
         if (!live) return item;

--- a/packages/popup-ui/src/Popup.tsx
+++ b/packages/popup-ui/src/Popup.tsx
@@ -21,6 +21,7 @@ import {
   PLATFORMS,
   RATE_NUDGE_MIN_DAYS,
   SCREENSHOT_VARIANTS,
+  SCREENSHOT_WATCHLIST_LIVE,
   SELECTED_PLATFORM_KEY,
 } from "./constants";
 import type {
@@ -89,7 +90,9 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   );
   // Drops and the Idle Watchlist share one view; the watchlist folds away under
   // the campaigns until asked for (or until a screenshot variant wants it).
-  const [watchlistExpanded, setWatchlistExpanded] = useState(false);
+  const [watchlistExpanded, setWatchlistExpanded] = useState(
+    preview && variantShowsPopup(initialVariant) && initialVariant.view === "watchlist",
+  );
   const [watchlistAdding, setWatchlistAdding] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(
     preview && variantShowsPopup(initialVariant) && initialVariant.view === "settings",
@@ -628,6 +631,13 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
   const gameMap = Object.fromEntries(games.map((game) => [game.id, game]));
   const idleWatchlistChannels = settings.platform[platform].idleWatchlistChannels;
   const idleWatchlist = idleWatchlistChannels.map((username) => streamerItemFromFallback(username, session, t));
+  const screenshotWatchlist = preview && variantShowsPopup(initialVariant) && initialVariant.view === "watchlist"
+    ? idleWatchlist.map((item) => {
+        const live = SCREENSHOT_WATCHLIST_LIVE[item.id];
+        if (!live) return item;
+        return { ...item, name: live.displayName, live: true, viewers: live.viewers, subtitle: live.subtitle };
+      })
+    : idleWatchlist;
   const automation = {
     twitch: pendingAutomation.twitch ?? settings.platform.twitch.enabled,
     kick: pendingAutomation.kick ?? settings.platform.kick.enabled,
@@ -834,7 +844,7 @@ export function Popup({ adapter, initialState }: { adapter: PopupAdapter; initia
                 <IdleWatchlistPanel
                   key={platform}
                   platform={platform}
-                  streamers={idleWatchlist}
+                  streamers={screenshotWatchlist}
                   expanded={watchlistExpanded}
                   adding={watchlistAdding}
                   onExpandedChange={(next) => { setWatchlistExpanded(next); if (!next) setWatchlistAdding(false); }}

--- a/packages/popup-ui/src/constants.ts
+++ b/packages/popup-ui/src/constants.ts
@@ -112,6 +112,8 @@ const drops: ScreenshotVariant = {
 };
 const extras: ScreenshotVariant = {
   layout: "extras",
+  platform: "twitch",
+  view: "watchlist",
   glow: EXTRAS_GLOW,
   eyebrowKey: "screenshotExtrasEyebrow",
   headlineKey: "screenshotExtrasHeadline",
@@ -119,6 +121,8 @@ const extras: ScreenshotVariant = {
 };
 const easy: ScreenshotVariant = {
   layout: "steps",
+  platform: "kick",
+  view: "drops",
   glow: EASY_GLOW,
   eyebrowKey: "screenshotEasyEyebrow",
   headlineKey: "screenshotEasyHeadline",

--- a/packages/popup-ui/src/constants.ts
+++ b/packages/popup-ui/src/constants.ts
@@ -157,5 +157,11 @@ export const SCREENSHOT_VARIANTS: Record<string, ScreenshotVariant> = {
   activity: updated,
 };
 
+export const SCREENSHOT_WATCHLIST_LIVE: Record<string, { displayName: string; viewers: number; subtitle: string }> = {
+  rivalspilot: { displayName: "RivalsPilot", viewers: 18420, subtitle: "Marathon Legends" },
+  lootforge: { displayName: "LootForge", viewers: 6210, subtitle: "Starfall Arena" },
+  nightrunlive: { displayName: "NightRunLive", viewers: 2480, subtitle: "Spellforge" },
+};
+
 export const PROMO_GRADIENT =
   "radial-gradient(circle at 16% 18%, rgba(145,71,255,0.40), transparent 38%), radial-gradient(circle at 86% 82%, rgba(83,252,24,0.26), transparent 40%)";

--- a/packages/popup-ui/src/idleWatchlist.tsx
+++ b/packages/popup-ui/src/idleWatchlist.tsx
@@ -52,7 +52,7 @@ export function IdleWatchlistPanel({ platform, streamers, expanded, adding, onEx
   }
 
   return (
-    <section className="space-y-1.5">
+    <section id="idle-watchlist" className="space-y-1.5">
       <SectionHeader
         label={t("idleWatchlistTab")}
         count={`${streamers.length}/20`}

--- a/packages/popup-ui/src/marketing.tsx
+++ b/packages/popup-ui/src/marketing.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { AppWindow, Box, SquareTerminal, Star, type LucideIcon } from "lucide-react";
 import type { SupportedLocale } from "@lurkloot/shared/models";
 import { DEFAULT_LOCALE, isRtlLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
 import { loadCatalog } from "@lurkloot/locales";
@@ -74,12 +75,12 @@ function ExtraCallout({
   return (
     <div className="flex min-w-0 items-start gap-3">
       <span
-        className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
-        style={{ background: dot, boxShadow: `0 0 9px ${dot}` }}
+        className="mt-2 h-2.5 w-2.5 shrink-0 rounded-full"
+        style={{ background: dot, boxShadow: `0 0 12px ${dot}` }}
       />
       <div className="min-w-0">
-        <div className="text-[17px] font-semibold text-[#ecedf5]">{name}</div>
-        <div className="mt-1 text-[13px] leading-snug text-[#9c9db4]">{meta}</div>
+        <div className="text-[24px] font-semibold leading-tight text-[#ecedf5]">{name}</div>
+        <div className="mt-1 text-[16px] leading-snug text-[#9c9db4]">{meta}</div>
       </div>
     </div>
   );
@@ -103,11 +104,64 @@ function StepItem({
   );
 }
 
-function RuntimeTile({ title, sub }: { title: string; sub: string }): React.ReactElement {
+function RuntimeIcon({
+  accent,
+  className,
+  children,
+}: {
+  accent: string;
+  className?: string;
+  children: React.ReactNode;
+}): React.ReactElement {
   return (
-    <div className="flex min-h-0 flex-1 flex-col justify-center rounded-2xl border border-white/8 bg-white/[0.03] px-8 py-7">
-      <div className="font-display text-[32px] font-bold leading-[1.05] tracking-normal text-[#ecedf5]">{title}</div>
-      <div className="mt-3 text-[16px] leading-snug text-[#9c9db4]">{sub}</div>
+    <span
+      className={`relative flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-[#101014] ${className ?? ""}`}
+      style={{ color: accent, boxShadow: `inset 0 1px 0 rgba(255,255,255,0.06), 0 0 8px -6px ${accent}` }}
+      aria-hidden
+    >
+      {children}
+    </span>
+  );
+}
+
+function LucideMark({ icon: Icon, size = 26 }: { icon: LucideIcon; size?: number }): React.ReactElement {
+  return <Icon size={size} strokeWidth={1.6} />;
+}
+
+function GithubMark({ size = 26 }: { size?: number }): React.ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor" aria-hidden>
+      <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.39 1.24-3.23-.12-.31-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.24 2.87.12 3.18.77.84 1.24 1.92 1.24 3.23 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 24 12.5C24 5.87 18.63.5 12 .5Z" />
+    </svg>
+  );
+}
+
+function StarRow(): React.ReactElement {
+  return (
+    <div className="mt-4 flex items-center justify-center gap-1.5 text-[#c4a7ff]" aria-hidden>
+      {Array.from({ length: 5 }, (_, index) => (
+        <Star key={index} size={28} fill="currentColor" strokeWidth={0} />
+      ))}
+    </div>
+  );
+}
+
+function RuntimeRow({
+  title,
+  sub,
+  marks,
+}: {
+  title: string;
+  sub: string;
+  marks: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className="flex min-w-0 items-center gap-4">
+      <div className="flex shrink-0">{marks}</div>
+      <div className="min-w-0">
+        <div className="text-[20px] font-semibold leading-tight text-[#ecedf5]">{title}</div>
+        <div className="mt-1 text-[14px] leading-snug text-[#9c9db4]">{sub}</div>
+      </div>
     </div>
   );
 }
@@ -160,7 +214,7 @@ export function StoreScreenshot({
               subcopyKey={variant.subcopyKey}
               translate={translate}
             />
-            <div className="mt-8 flex flex-col gap-5">
+            <div className="mt-8 grid grid-cols-2 gap-x-8 gap-y-7">
               <ExtraCallout
                 dot="#a970ff"
                 name={translate("screenshotExtrasPointsName")}
@@ -170,6 +224,16 @@ export function StoreScreenshot({
                 dot="#53fc18"
                 name={translate("screenshotExtrasChallengesName")}
                 meta={translate("screenshotExtrasChallengesMeta")}
+              />
+              <ExtraCallout
+                dot="#c4a7ff"
+                name={translate("screenshotExtrasWatchlistName")}
+                meta={translate("screenshotExtrasWatchlistMeta")}
+              />
+              <ExtraCallout
+                dot="#b7ff6a"
+                name={translate("screenshotExtrasFlashName")}
+                meta={translate("screenshotExtrasFlashMeta")}
               />
             </div>
           </div>
@@ -241,25 +305,69 @@ export function StoreScreenshot({
 
       {variant.layout === "updated" ? (
         <>
-          <CopyBlock
-            className="absolute start-[7%] top-[14%] end-[42%] z-10"
-            eyebrowKey={variant.eyebrowKey}
-            headlineKey={variant.headlineKey}
-            subcopyKey={variant.subcopyKey}
-            translate={translate}
-          />
-          <p className="absolute start-[7%] bottom-[12%] z-10 text-[13px] tracking-[0.08em] text-[#9c9db4]">
-            {translate("screenshotUpdatedLicense")}
-          </p>
-          <div className="absolute end-[7%] top-[12%] bottom-[12%] z-10 flex w-[400px] flex-col gap-4">
-            <RuntimeTile
-              title={translate("screenshotUpdatedBrowsersTitle")}
-              sub={translate("screenshotUpdatedBrowsersSub")}
+          <div className="absolute start-[7%] end-[40%] top-[9%] z-10 flex h-[600px] flex-col justify-center">
+            <CopyBlock
+              className="text-center [&_p]:mx-auto"
+              eyebrowKey={variant.eyebrowKey}
+              headlineKey={variant.headlineKey}
+              subcopyKey={variant.subcopyKey}
+              translate={translate}
             />
-            <RuntimeTile
-              title={translate("screenshotUpdatedHeadlessTitle")}
-              sub={translate("screenshotUpdatedHeadlessSub")}
-            />
+          </div>
+          <div
+            data-updated-board
+            className="absolute end-[7%] top-[9%] z-10 flex h-[600px] w-[400px] flex-col justify-between overflow-hidden rounded-3xl border border-white/8 bg-[#0c0c10]/80 px-8 py-9"
+          >
+            <div className="flex flex-col items-center text-center">
+              <div className="font-display text-[80px] font-bold leading-none tracking-tight text-[#ecedf5]">
+                {translate("screenshotUpdatedRating")}
+              </div>
+              <StarRow />
+              <p className="mt-5 text-[20px] leading-snug text-[#9c9db4]">
+                {translate("screenshotUpdatedUsers")}
+              </p>
+            </div>
+            <div>
+              <div className="mb-7 h-px bg-white/10" />
+              <div className="flex flex-col gap-5">
+                <RuntimeRow
+                  title={translate("screenshotUpdatedBrowsersTitle")}
+                  sub={translate("screenshotUpdatedBrowsersSub")}
+                  marks={(
+                    <RuntimeIcon accent="#c4a7ff">
+                      <LucideMark icon={AppWindow} />
+                    </RuntimeIcon>
+                  )}
+                />
+                <RuntimeRow
+                  title={translate("screenshotUpdatedHeadlessTitle")}
+                  sub={translate("screenshotUpdatedHeadlessSub")}
+                  marks={(
+                    <RuntimeIcon accent="#b7ff6a">
+                      <LucideMark icon={SquareTerminal} />
+                    </RuntimeIcon>
+                  )}
+                />
+                <RuntimeRow
+                  title={translate("screenshotUpdatedDockerTitle")}
+                  sub={translate("screenshotUpdatedDockerSub")}
+                  marks={(
+                    <RuntimeIcon accent="#9c9db4">
+                      <LucideMark icon={Box} />
+                    </RuntimeIcon>
+                  )}
+                />
+                <RuntimeRow
+                  title={translate("githubAttributionShort")}
+                  sub={`${translate("screenshotUpdatedEyebrow")} · ${translate("screenshotUpdatedLicense")}`}
+                  marks={(
+                    <RuntimeIcon accent="#ecedf5">
+                      <GithubMark />
+                    </RuntimeIcon>
+                  )}
+                />
+              </div>
+            </div>
           </div>
         </>
       ) : null}

--- a/packages/popup-ui/src/marketing.tsx
+++ b/packages/popup-ui/src/marketing.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { Gem, Gift, ListVideo, type LucideIcon } from "lucide-react";
 import type { SupportedLocale } from "@lurkloot/shared/models";
 import { DEFAULT_LOCALE, isRtlLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
 import { loadCatalog } from "@lurkloot/locales";
@@ -63,20 +62,25 @@ function PopupFrame({ children, className }: { children: React.ReactNode; classN
   );
 }
 
-function ExtrasCard({
-  icon: Icon,
+function ExtraCallout({
+  dot,
   name,
   meta,
 }: {
-  icon: LucideIcon;
+  dot: string;
   name: string;
   meta: string;
 }): React.ReactElement {
   return (
-    <div className="flex min-w-0 flex-1 flex-col rounded-2xl border border-white/8 bg-white/[0.03] p-5 backdrop-blur-sm">
-      <Icon size={22} className="mb-4 text-[#c4a7ff]" strokeWidth={1.75} />
-      <div className="text-[17px] font-semibold text-[#ecedf5]">{name}</div>
-      <div className="mt-1.5 text-[13px] leading-snug text-[#9c9db4]">{meta}</div>
+    <div className="flex min-w-0 items-start gap-3">
+      <span
+        className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+        style={{ background: dot, boxShadow: `0 0 9px ${dot}` }}
+      />
+      <div className="min-w-0">
+        <div className="text-[17px] font-semibold text-[#ecedf5]">{name}</div>
+        <div className="mt-1 text-[13px] leading-snug text-[#9c9db4]">{meta}</div>
+      </div>
     </div>
   );
 }
@@ -91,10 +95,19 @@ function StepItem({
   sub: string;
 }): React.ReactElement {
   return (
-    <div className="min-w-0 flex-1">
+    <div className="relative min-w-0 ps-5">
       <div className="font-display text-[32px] font-bold leading-none text-[#c4a7ff]/80">{number}</div>
       <div className="mt-3 text-[18px] font-semibold text-[#ecedf5]">{title}</div>
       <div className="mt-1.5 text-[14px] leading-snug text-[#9c9db4]">{sub}</div>
+    </div>
+  );
+}
+
+function RuntimeTile({ title, sub }: { title: string; sub: string }): React.ReactElement {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col justify-center rounded-2xl border border-white/8 bg-white/[0.03] px-8 py-7">
+      <div className="font-display text-[32px] font-bold leading-[1.05] tracking-normal text-[#ecedf5]">{title}</div>
+      <div className="mt-3 text-[16px] leading-snug text-[#9c9db4]">{sub}</div>
     </div>
   );
 }
@@ -140,44 +153,46 @@ export function StoreScreenshot({
 
       {variant.layout === "extras" ? (
         <>
-          <CopyBlock
-            className="absolute start-[7%] top-[12%] end-[40%] z-10"
-            eyebrowKey={variant.eyebrowKey}
-            headlineKey={variant.headlineKey}
-            subcopyKey={variant.subcopyKey}
-            translate={translate}
-          />
-          <div className="absolute start-[7%] bottom-[12%] end-[7%] z-10 flex gap-3">
-            <ExtrasCard
-              icon={Gem}
-              name={translate("screenshotExtrasPointsName")}
-              meta={translate("screenshotExtrasPointsMeta")}
+          <div className="absolute start-[7%] top-[12%] end-[42%] z-10">
+            <CopyBlock
+              eyebrowKey={variant.eyebrowKey}
+              headlineKey={variant.headlineKey}
+              subcopyKey={variant.subcopyKey}
+              translate={translate}
             />
-            <ExtrasCard
-              icon={Gift}
-              name={translate("screenshotExtrasChallengesName")}
-              meta={translate("screenshotExtrasChallengesMeta")}
-            />
-            <ExtrasCard
-              icon={ListVideo}
-              name={translate("screenshotExtrasWatchlistName")}
-              meta={translate("screenshotExtrasWatchlistMeta")}
-            />
+            <div className="mt-8 flex flex-col gap-5">
+              <ExtraCallout
+                dot="#a970ff"
+                name={translate("screenshotExtrasPointsName")}
+                meta={translate("screenshotExtrasPointsMeta")}
+              />
+              <ExtraCallout
+                dot="#53fc18"
+                name={translate("screenshotExtrasChallengesName")}
+                meta={translate("screenshotExtrasChallengesMeta")}
+              />
+            </div>
           </div>
+          {popup ? (
+            <div className={`absolute end-[7%] top-[9%] z-20 origin-center ${rtl ? "rotate-[2deg]" : "rotate-[-2deg]"}`}>
+              <PopupFrame>{popup}</PopupFrame>
+            </div>
+          ) : null}
         </>
       ) : null}
 
       {variant.layout === "steps" ? (
         <>
           <CopyBlock
-            className="absolute start-[7%] top-[12%] end-[40%] z-10"
+            className="absolute start-[7%] top-[10%] end-[46%] z-10"
             eyebrowKey={variant.eyebrowKey}
             headlineKey={variant.headlineKey}
             subcopyKey={variant.subcopyKey}
             translate={translate}
             showSubcopy={false}
           />
-          <div className="absolute start-[7%] end-[7%] bottom-[14%] z-10 flex gap-7">
+          <div data-steps className="absolute start-[7%] top-[34%] bottom-[10%] z-10 flex w-[34%] flex-col justify-between">
+            <div className="pointer-events-none absolute start-0 top-2 bottom-6 w-0.5 bg-linear-to-b from-[#9147ff] to-[#53fc18]" />
             <StepItem
               number="01"
               title={translate("screenshotEasyInstallTitle")}
@@ -199,6 +214,11 @@ export function StoreScreenshot({
               sub={translate("screenshotEasyProfitSub")}
             />
           </div>
+          {popup ? (
+            <div className={`absolute end-[7%] top-[9%] z-20 origin-center ${rtl ? "rotate-[-2deg]" : "rotate-[2deg]"}`}>
+              <PopupFrame>{popup}</PopupFrame>
+            </div>
+          ) : null}
         </>
       ) : null}
 
@@ -220,13 +240,28 @@ export function StoreScreenshot({
       ) : null}
 
       {variant.layout === "updated" ? (
-        <CopyBlock
-          className="absolute start-[8%] end-[18%] bottom-[14%] max-w-[640px] z-10"
-          eyebrowKey={variant.eyebrowKey}
-          headlineKey={variant.headlineKey}
-          subcopyKey={variant.subcopyKey}
-          translate={translate}
-        />
+        <>
+          <CopyBlock
+            className="absolute start-[7%] top-[14%] end-[42%] z-10"
+            eyebrowKey={variant.eyebrowKey}
+            headlineKey={variant.headlineKey}
+            subcopyKey={variant.subcopyKey}
+            translate={translate}
+          />
+          <p className="absolute start-[7%] bottom-[12%] z-10 text-[13px] tracking-[0.08em] text-[#9c9db4]">
+            {translate("screenshotUpdatedLicense")}
+          </p>
+          <div className="absolute end-[7%] top-[12%] bottom-[12%] z-10 flex w-[400px] flex-col gap-4">
+            <RuntimeTile
+              title={translate("screenshotUpdatedBrowsersTitle")}
+              sub={translate("screenshotUpdatedBrowsersSub")}
+            />
+            <RuntimeTile
+              title={translate("screenshotUpdatedHeadlessTitle")}
+              sub={translate("screenshotUpdatedHeadlessSub")}
+            />
+          </div>
+        </>
       ) : null}
     </div>
   );

--- a/packages/popup-ui/src/types.ts
+++ b/packages/popup-ui/src/types.ts
@@ -113,19 +113,19 @@ type ScreenshotCopy = {
 };
 
 export type ScreenshotPopupVariant = ScreenshotCopy & {
-  layout: "hero" | "settings";
+  layout: "hero" | "extras" | "steps" | "settings";
   platform: Platform;
-  view: "drops" | "settings";
+  view: "drops" | "settings" | "watchlist";
 };
 
 export type ScreenshotMarketingVariant = ScreenshotCopy & {
-  layout: "extras" | "steps" | "updated";
+  layout: "updated";
 };
 
 export type ScreenshotVariant = ScreenshotPopupVariant | ScreenshotMarketingVariant;
 
 export function variantShowsPopup(variant: ScreenshotVariant): variant is ScreenshotPopupVariant {
-  return variant.layout === "hero" || variant.layout === "settings";
+  return variant.layout !== "updated";
 }
 
 export interface PopupAdapter {


### PR DESCRIPTION
## Summary
- Give store shots 02, 03, and 05 the same density as 01 and 04: extras mounts the live idle-watchlist popup with two platform-dotted callouts; easy is a vertical how-to plus a Kick popup; updated is a text-only Chromium / CLI·Docker board.
- No trademarked browser or Docker icons — nominative text only, matching the Twitch/Kick logo rule.
- Capture waits on popup chrome for extras and easy; extras screenshot scrolls the watchlist into the 400×600 crop.

## Test plan
- [x] `pnpm --filter @lurkloot/extension exec vitest run tests/storeScreenshot.test.tsx tests/i18n.test.ts tests/storeScreenshotFiles.test.ts`
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @lurkloot/extension exec vitest run` (1774 tests)
- [ ] Operator follow-up: `pnpm screenshot:store` and eyeball 02/03/05 in `en`, `ar`, and a long locale (`ru`/`de`) before uploading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live popup previews to additional Chrome Web Store screenshots, including watchlist and drops views.
  * Watchlist previews now show expanded, realistic live channel rows with viewer counts and status details.
  * Redesigned screenshot layouts with clearer callouts, step-based guidance, and runtime information for browser and headless usage.
* **Localization**
  * Updated screenshot marketing copy across supported languages, including browser support, headless operation, and Apache-2.0 licensing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->