### PR TITLE
chore: ignore HAR network captures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ lerna-debug.log*
 !.env.example
 *.pem
 
+# Network captures. A HAR records live session cookies, bearer tokens and
+# extension JWTs verbatim, so it must never be committed.
+*.har
+
 # CLI local runtime (config + credential/state stores)
 /config.json
 /auth/


### PR DESCRIPTION
## Summary

Adds `*.har` to `.gitignore`.

A HAR records live session cookies, bearer tokens and Twitch Extension JWTs verbatim. Captures used while reverse-engineering platform and extension protocols currently sit untracked in the working tree, so a `git add -A` would commit credentials into history.

The rule lives in the existing secrets block, next to `.env` and `*.pem`, with a comment saying why.

## Testing

`git check-ignore -v` confirms the rule matches at the repo root and in any subdirectory:

```
.gitignore:59:*.har	twitch.har
.gitignore:59:*.har	epic.har
.gitignore:59:*.har	packages/extension/foo.har
```

No tracked file is affected: no `.har` has ever been committed, so there is no history to clean up and nothing already in the index becomes ignored. Existing local captures stay on disk, simply untracked.

https://claude.ai/code/session_01ThHcjxfSYg764MYGe5u8FN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project exclusions to prevent network capture files and potentially sensitive session data from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->