### PR TITLE
fix(core): coalesce scheduler ticks per platform

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,32 @@ Package-qualified paths below are written as `packages/<package>/...` when owner
 
 State and normalized settings are loaded and saved through `packages/extension/src/core/storage.ts` in the extension and through `packages/cli/src/storage.ts` in the CLI. The scheduler stores independent `WatchSession`, campaign, manual-watch, and managed-tab state for `twitch` and `kick`; diagnostics and activity events are emitted through the reporter outside `SchedulerState`. A short-lived Twitch Client-Integrity bundle is stored separately so claim mutations can replay page-issued Twitch headers while the token is valid.
 
+### Scheduler admission
+
+The shared controller reserves one active scheduler tick and at most one pending
+follow-up per platform, before loading settings or beginning tick diagnostics.
+Overlapping callers share the pending result promise. Twitch and Kick have
+independent lanes; extension alarms and CLI intervals request each platform
+separately. The CLI also shares result observers so repeated intervals cannot
+accumulate reporting continuations behind the same pending tick.
+
+Pending triggers merge by their existing selection semantics: `manual_tick`,
+`manual_resume`, and `claim_handoff` force selection and bypass backoff; `startup`
+forces selection without bypassing backoff. Other user actions, including
+settings and automation toggles, retain their persisted mutations through fresh
+settings/state loads. Ordinary alarms and discovery signals do not override a
+higher-priority trigger. Equal-priority triggers retain the first reason, while
+diagnostics count every merged reason. Valid discovery signals share an already
+pending scheduler follow-up instead of requesting another cycle afterward.
+
+Each executed follow-up reloads current settings/state and selects from the
+latest committed discovery revision. Disablement discards obsolete pending work;
+shutdown and host reset cancel it and abort active ticks. Reset also closes
+admission until cleanup finishes. Discovery signal controller/generation checks
+remain in force. Tick start/finish timing covers executed work only; separate
+diagnostics report merged or discarded trigger counts. Heartbeat admission and
+its fixed cadence remain independent of scheduler admission.
+
 ## Runtime Messages
 
 The popup and content scripts do not call adapters directly. They send typed runtime messages from `@lurkloot/shared/messages`:

--- a/docs/superpowers/plans/2026-09-09-scheduler-tick-coalescing.md
+++ b/docs/superpowers/plans/2026-09-09-scheduler-tick-coalescing.md
@@ -1,0 +1,42 @@
+# Scheduler tick coalescing implementation plan
+
+**Goal:** Satisfy #497 by bounding scheduler admission independently for Twitch and Kick.
+
+**Architecture:** Reserve one active and one pending request before loading settings or emitting tick lifecycle diagnostics. Pending requests share one result promise and merge trigger precedence; executed work alone owns persistence callbacks and claim handling. Lifecycle invalidation discards obsolete pending requests. Discovery signals enter the same admission lane.
+
+**Tech stack:** TypeScript, pnpm, Vitest; browser-free shared controller used by extension alarms and CLI intervals.
+
+**Spec:** GitHub issue #497 and its acceptance criteria.
+
+## Constraints and overlap
+
+- Keep heartbeat admission and cadence independent.
+- Preserve committed tick results and reload state/settings when pending work executes.
+- Precedence: backoff-bypassing manual/claim triggers > startup (forced selection) > settings/toggles/fallback/manual-watch > ordinary alarm/discovery signals. All reasons remain in diagnostic counts. Settings/toggles already persist and invalidate selection before requesting ticks.
+- PR #500 reconciles Kick recovery after scheduler persistence; keep that integration point unchanged. PR #490 changes publication revision checks and #496 adds a separate claim alarm; neither is a dependency. Remaining open PRs affect UI/dependencies or develop-to-main integration.
+- Work only in `.worktrees/scheduler-tick-coalescing`; no push, rebase, merge, or PR creation.
+
+## Task 1: Bounded scheduler requests
+
+- [x] Add deterministic alarm burst regression: block Twitch discovery, advance multiple one-minute intervals, prove one running tick and one follow-up while Kick progresses.
+- [x] Run `pnpm --filter @lurkloot/extension exec vitest run tests/backgroundController.test.ts` and observe red.
+- [x] Add synchronous per-platform admission and coalesced count/reason diagnostics; execute pending work with fresh settings/state.
+- [x] Prove manual/claim trigger force and backoff overrides survive an ordinary pending request; cover shared committed results, failures, disable/reset/shutdown, and discovery signal merging.
+- [x] Update existing discovery-overlap expectation to scheduler admission behavior; run controller and heartbeat tests.
+
+## Task 2: CLI and final verification
+
+- [x] Strengthen CLI interval regression to hold discovery across multiple intervals and count executed ticks/auth probes, not only provider coalescing.
+- [x] Observe red then green; label CLI interval requests as alarms.
+- [x] Document semantics in architecture documentation.
+- [x] Run `pnpm verify`, inspect the complete diff and `git diff --check`, then commit the focused implementation and tests.
+
+## Verification evidence
+
+- Initial controller baseline: 344 tests passed.
+- Alarm burst failed with six executed starts instead of one, then passed with one active and one pending execution.
+- Reset/shutdown cancellation, shared result promises, discovery-signal/alarm merging, coalesced diagnostic counts, and latest multi-platform committed-result ordering each had observed failing regressions before their fixes.
+- CLI shared-result observation and continuous all-disabled cleanup had observed red-green cycles. The interval regression checks five elapsed intervals, six independent Kick refreshes, and exactly three Twitch executions (initial, blocked interval, coalesced follow-up).
+- `pnpm verify` passed on 2026-09-09: script tests, all workspace typechecks, all package tests (including 193 CLI tests), site production build, Chromium MV3 build, and Firefox MV2 build. Existing bundle-size warnings remain.
+- Complete implementation/test/documentation diff self-reviewed; `git diff --check` passed.
+- Open-PR recheck: #500 remains `c8737826` and its post-persistence recovery hook is unchanged by this work. #490 publication validity and #496 dedicated claim alarms remain independent. #504 merged while work was paused; its settings UI changes do not require rebasing this branch before review.

--- a/docs/superpowers/plans/2026-09-09-scheduler-tick-coalescing.md
+++ b/docs/superpowers/plans/2026-09-09-scheduler-tick-coalescing.md
@@ -40,3 +40,24 @@
 - `pnpm verify` passed on 2026-09-09: script tests, all workspace typechecks, all package tests (including 193 CLI tests), site production build, Chromium MV3 build, and Firefox MV2 build. Existing bundle-size warnings remain.
 - Complete implementation/test/documentation diff self-reviewed; `git diff --check` passed.
 - Open-PR recheck: #500 remains `c8737826` and its post-persistence recovery hook is unchanged by this work. #490 publication validity and #496 dedicated claim alarms remain independent. #504 merged while work was paused; its settings UI changes do not require rebasing this branch before review.
+
+## Review follow-up: discovery signal lifecycle identity
+
+The review identified that a signal paused during its settings read could enter
+the scheduler's pending slot after an alarm acquired the platform. Admission
+discarded the signal controller/generation, so later auth invalidation could not
+cancel that contribution.
+
+- [x] Reproduce the paused-settings-read race with no other pending reason, and with independent alarm/manual reasons.
+- [x] Carry signal controller, generation, and count through private tick admission. Strip stale signal counts at lifecycle invalidation and again before execution; recompute the effective trigger and preserve all independent reasons.
+- [x] Run focused controller/heartbeat and CLI suites, then `pnpm verify`; inspect the complete follow-up diff and commit.
+
+Observed red: signal-only work refreshed twice instead of once; signal+alarm
+executed with the stale signal trigger. All three regression variants then
+passed. Focused controller/heartbeat tests passed (367), as did all CLI tests
+(193). Fresh full `pnpm verify` passed after the interruption: 1,816 extension
+tests, 193 CLI tests, 10 site tests, 95 script tests, workspace typechecks, site
+build, and Chromium/Firefox builds. Existing bundle-size warnings remain.
+The follow-up diff was self-reviewed and `git diff --check` passed. Current
+develop includes the independent #496 and #504 changes; no signal-admission
+interface changed, and read-only merge inspection found no conflict markers.

--- a/packages/cli/src/runtime/run.ts
+++ b/packages/cli/src/runtime/run.ts
@@ -1,4 +1,4 @@
-import { createBackgroundController, type CredentialAvailability } from "@lurkloot/core/controller";
+import { createBackgroundController, type CredentialAvailability, type TickTrigger } from "@lurkloot/core/controller";
 import { HEARTBEAT_INTERVAL_MS } from "@lurkloot/core/heartbeatCadence";
 import type { Platform, SchedulerState } from "@lurkloot/shared/models";
 import { loadState, saveState } from "../storage";
@@ -44,20 +44,47 @@ function disabledPlatformsNeedingCleanup(
 }
 
 interface CliTickDriver {
-  tickAndHandOff(platforms?: Platform[]): Promise<SchedulerState | undefined>;
+  tickAndHandOff(platforms?: Platform[], trigger?: TickTrigger): Promise<SchedulerState | undefined>;
 }
 
-export async function runCliTickOnce(options: {
+interface CliTickOptions {
   controller: CliTickDriver;
   enabledPlatforms: Platform[];
   engineSettings: ReturnType<typeof toEngineSettings>;
   loadState(): Promise<SchedulerState>;
   seenSubscriptionWaits: Set<string>;
   logger: Logger;
-}): Promise<void> {
-  const { controller, enabledPlatforms, engineSettings, loadState, seenSubscriptionWaits, logger } = options;
+}
+
+// Each stable driver options object owns one observer per admitted tick result.
+// Repeated intervals still request the coalesced follow-up, but do not attach
+// another reporting/fallback-state continuation to its shared promise.
+const cliTickResults = new WeakMap<CliTickOptions, WeakMap<Promise<SchedulerState | undefined>, Promise<void>>>();
+
+export function runCliTickOnce(options: CliTickOptions): Promise<void> {
+  let result: Promise<SchedulerState | undefined>;
   try {
-    let state = await controller.tickAndHandOff(enabledPlatforms) ?? await loadState();
+    result = options.controller.tickAndHandOff(options.enabledPlatforms, "alarm");
+  } catch (error) {
+    options.logger.error(error instanceof Error ? error.message : String(error), "tick");
+    return Promise.resolve();
+  }
+  let pending = cliTickResults.get(options);
+  if (!pending) {
+    pending = new WeakMap();
+    cliTickResults.set(options, pending);
+  }
+  const existing = pending.get(result);
+  if (existing) return existing;
+  const run = completeCliTickOnce(options, result);
+  pending.set(result, run);
+  return run;
+}
+
+async function completeCliTickOnce(options: CliTickOptions, result: Promise<SchedulerState | undefined>): Promise<void> {
+  const { controller, engineSettings, loadState, seenSubscriptionWaits, logger } = options;
+  try {
+    let state = await result ?? await loadState();
     const staleDisabledPlatforms = disabledPlatformsNeedingCleanup(state, engineSettings);
     if (staleDisabledPlatforms.length > 0) {
       state = await controller.tickAndHandOff(staleDisabledPlatforms) ?? await loadState();
@@ -109,15 +136,17 @@ export async function runLoop(options: RunOptions): Promise<void> {
     ...(options.checkCredentialAvailability ? { checkCredentialAvailability: options.checkCredentialAvailability } : {}),
   });
 
-  const tickOnce = async () => {
-    await runCliTickOnce({
-      controller,
-      enabledPlatforms,
-      engineSettings,
-      loadState: loadRuntimeState,
-      seenSubscriptionWaits,
-      logger,
-    });
+  const tickOptions: CliTickOptions = {
+    controller, enabledPlatforms, engineSettings,
+    loadState: loadRuntimeState, seenSubscriptionWaits, logger,
+  };
+  const platformTickOptions = enabledPlatforms.length > 0
+    ? enabledPlatforms.map((platform) => ({ ...tickOptions, enabledPlatforms: [platform] }))
+    : [tickOptions];
+  const requestTicks = () => {
+    // Admission is per platform all the way through the host driver: a fast
+    // Kick interval must not accumulate observers waiting for a slow Twitch.
+    for (const options of platformTickOptions) void runCliTickOnce(options);
   };
 
   const heartbeatOnce = async () => {
@@ -130,7 +159,7 @@ export async function runLoop(options: RunOptions): Promise<void> {
 
   logger.info("Starting farming loop", "run");
   if (options.once) {
-    await tickOnce();
+    await runCliTickOnce(tickOptions);
     await transport.dispose();
     return;
   }
@@ -138,7 +167,7 @@ export async function runLoop(options: RunOptions): Promise<void> {
   const periodMs = Math.max(1, settings.pollIntervalMinutes) * 60_000;
   await new Promise<void>((resolveLoop, rejectLoop) => {
     let stopped = false;
-    const discoveryTimer = setInterval(() => void tickOnce(), periodMs);
+    const discoveryTimer = setInterval(requestTicks, periodMs);
     const heartbeatTimer = setInterval(
       () => void heartbeatOnce(),
       HEARTBEAT_INTERVAL_MS,
@@ -170,6 +199,6 @@ export async function runLoop(options: RunOptions): Promise<void> {
     // cadence may already be due while the first campaign refresh is slow or
     // blocked, and signal handlers need to be live for that entire interval.
     void heartbeatOnce();
-    void tickOnce();
+    requestTicks();
   });
 }

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -214,6 +214,22 @@ describe("CLI committed tick consumption", () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Reward first"), "twitch");
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Reward second"), "twitch");
   });
+
+  it("processes a coalesced scheduler result once across recurring CLI calls", async () => {
+    const pending = deferred<SchedulerState>();
+    const logger = createLogger("error");
+    const loadState = vi.fn(async () => structuredClone(DEFAULT_STATE));
+    const options = {
+      controller: { tickAndHandOff: vi.fn(() => pending.promise) },
+      enabledPlatforms, engineSettings, loadState, seenSubscriptionWaits: new Set<string>(), logger,
+    };
+    const first = runCliTickOnce(options);
+    const second = runCliTickOnce(options);
+    const shared = first === second;
+    pending.resolve(structuredClone(DEFAULT_STATE));
+    await Promise.all([first, second]);
+    expect(shared).toBe(true);
+  });
 });
 
 describe("runLoop authentication health reporting", () => {
@@ -493,8 +509,30 @@ describe("runLoop disabled platform cleanup", () => {
 });
 
 describe("runLoop interval baseline", () => {
-  it("serializes provider discovery with at most one coalesced follow-up", async () => {
+  it("cleans persisted sessions when both CLI platforms are disabled", async () => {
+    let state = structuredClone(DEFAULT_STATE);
+    state.sessions.twitch = { ...state.sessions.twitch, status: "watching", channel: { platform: "twitch", username: "old", url: "https://twitch.tv/old" } };
+    const transport = await fakeTransport({ twitch: HEALTHY, kick: HEALTHY });
+    const running = runLoop({
+      settings: { ...DEFAULT_CLI_SETTINGS, platform: {
+        twitch: { ...DEFAULT_CLI_SETTINGS.platform.twitch, enabled: false },
+        kick: { ...DEFAULT_CLI_SETTINGS.platform.kick, enabled: false },
+      } },
+      statePath: join(dir, "disabled-state.json"), transport, logger: createLogger("error"),
+      stateStore: { load: async () => state, save: async (next) => { state = next; } },
+    });
+    try {
+      await vi.waitFor(() => expect(state.sessions.twitch.status).toBe("paused"));
+      expect(state.sessions.twitch.channel).toBeUndefined();
+    } finally {
+      process.emit("SIGTERM");
+      await running;
+    }
+  });
+
+  it("bounds alarm ticks across multiple intervals while the other platform progresses", async () => {
     vi.useFakeTimers();
+    let state = structuredClone(DEFAULT_STATE);
     const pendingRefresh = deferred<DropCampaign[]>();
     let refreshCalls = 0;
     const twitch = fakeAdapter("twitch", HEALTHY);
@@ -503,6 +541,9 @@ describe("runLoop interval baseline", () => {
       return refreshCalls === 1 ? [] : pendingRefresh.promise;
     });
     const kick = fakeAdapter("kick", HEALTHY);
+    kick.refreshCampaigns = vi.fn(kick.refreshCampaigns);
+    const logger = createLogger("error");
+    logger.log = vi.fn();
     const transport: TransportHandle = {
       adapters: { twitch, kick },
       createAdapter: (platform) => ({
@@ -520,26 +561,35 @@ describe("runLoop interval baseline", () => {
       pollIntervalMinutes: 1,
       platform: {
         twitch: { ...DEFAULT_CLI_SETTINGS.platform.twitch, enabled: true },
-        kick: { ...DEFAULT_CLI_SETTINGS.platform.kick, enabled: false },
+        kick: { ...DEFAULT_CLI_SETTINGS.platform.kick, enabled: true },
       },
     };
 
     const running = runLoop({
       settings,
       statePath: join(dir, "interval-state.json"),
+      stateStore: {
+        load: async () => state,
+        save: async (next) => { state = next; },
+      },
       transport,
-      logger: createLogger("error"),
+      logger,
       checkCredentialAvailability: async () => ({ status: "available" }),
     });
     await vi.waitFor(() => expect(refreshCalls).toBe(1));
 
     await vi.advanceTimersByTimeAsync(60_000);
     await vi.waitFor(() => expect(refreshCalls).toBe(2));
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(4 * 60_000);
     expect(refreshCalls).toBe(2);
+    await vi.waitFor(() => expect(kick.refreshCampaigns).toHaveBeenCalledTimes(6));
 
     pendingRefresh.resolve([]);
     await vi.waitFor(() => expect(refreshCalls).toBe(3));
+    await vi.waitFor(() => expect(logger.log).toHaveBeenCalledWith("debug", expect.stringMatching(/Tick #3 finished/), "twitch"));
+    const starts = vi.mocked(logger.log).mock.calls.filter(([, message, platform]) => platform === "twitch" && /Tick #\d+ started/.test(message));
+    expect(starts).toHaveLength(3);
+    expect(starts.every(([, message]) => message.includes("trigger=alarm"))).toBe(true);
     process.emit("SIGTERM");
     await running;
   });

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1641,6 +1641,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       afterLoad?.(current);
       const settings = deps.applySettingsPatch(current, patch);
       await deps.saveSettings(settings);
+      for (const platform of invalidatedPlatforms) {
+        if (!settings.platform[platform].enabled) cancelPendingTick(platform);
+      }
       afterPersist?.(settings);
       await ensureSchedulerAlarms(settings.pollIntervalMinutes);
       await reconcileTwitchChannelPointsAlarm(settings);
@@ -1981,6 +1984,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   type DiscoverySignalRefreshRequest = {
     controller: DiscoverySignalController;
     generation: number;
+    count: number;
   };
   const discoverySignalRefreshPending: Record<Platform, DiscoverySignalRefreshRequest | undefined> = {
     twitch: undefined,
@@ -1999,15 +2003,123 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     twitch: 0,
     kick: 0,
   };
+  type PlatformTickResult = readonly [Platform, string[], { state: SchedulerState; sequence: number }?];
+  let tickCommitSequence = 0;
+  interface TickRequest {
+    trigger: TickTrigger;
+    reasons: Partial<Record<TickTrigger, number>>;
+    promise: Promise<PlatformTickResult>;
+    resolve: (result: PlatformTickResult) => void;
+    reject: (error: unknown) => void;
+  }
+  const tickAdmission: Record<Platform, { active?: TickRequest; pending?: TickRequest }> = {
+    twitch: {},
+    kick: {},
+  };
+  let tickAdmissionSuspended = false;
 
-  async function tick(
+  function tickTriggerSummary(reasons: TickRequest["reasons"]): string {
+    const entries = Object.entries(reasons);
+    const count = entries.reduce((total, [, count]) => total + count, 0);
+    return `count=${count}, reasons=${entries.map(([reason, count]) => `${reason}:${count}`).join(",")}`;
+  }
+
+  function cancelPendingTick(platform: Platform): void {
+    const pending = tickAdmission[platform].pending;
+    tickAdmission[platform].pending = undefined;
+    if (pending) {
+      diagnosticEvent("debug", `Discarded pending scheduler triggers after lifecycle change (${tickTriggerSummary(pending.reasons)})`, platform);
+      pending.resolve([platform, []]);
+    }
+  }
+
+  function admitPlatformTick(platform: Platform, trigger: TickTrigger): Promise<PlatformTickResult> {
+    if (controllerShutdown || tickAdmissionSuspended) return Promise.resolve([platform, []]);
+    const lane = tickAdmission[platform];
+    if (lane.pending) {
+      lane.pending.reasons[trigger] = (lane.pending.reasons[trigger] ?? 0) + 1;
+      if (tickTriggerPriority(trigger) > tickTriggerPriority(lane.pending.trigger)) {
+        lane.pending.trigger = trigger;
+      }
+      return lane.pending.promise;
+    }
+    let resolve!: TickRequest["resolve"];
+    let reject!: TickRequest["reject"];
+    const promise = new Promise<PlatformTickResult>((onResolve, onReject) => {
+      resolve = onResolve;
+      reject = onReject;
+    });
+    const request: TickRequest = { trigger, reasons: { [trigger]: 1 }, promise, resolve, reject };
+    if (lane.active) lane.pending = request;
+    else executePlatformTick(platform, request);
+    return promise;
+  }
+
+  function tickTriggerPriority(trigger: TickTrigger): number {
+    // Existing trigger semantics are nested: bypass-backoff also forces
+    // selection; startup only forces selection. Other user actions persist
+    // their mutations before admission, so fresh settings/state retain them.
+    // Equal-priority reasons keep their first trigger and all diagnostic counts.
+    if (selectionBypassesBackoff(trigger)) return 3;
+    if (selectionIsForced(trigger)) return 2;
+    return trigger === "alarm" || trigger === "discovery_signal" || trigger === "unknown" ? 0 : 1;
+  }
+
+  function executePlatformTick(platform: Platform, request: TickRequest): void {
+    const lane = tickAdmission[platform];
+    lane.active = request;
+    let committed: PlatformTickResult[2];
+    void tickPlatform(platform, request.trigger, (state) => { committed = { state, sequence: ++tickCommitSequence }; })
+      .then(([platform, rewards]) => request.resolve([platform, rewards, committed]), request.reject)
+      .finally(() => {
+        lane.active = undefined;
+        const pending = lane.pending;
+        lane.pending = undefined;
+        if (pending) {
+          const signalRequest = discoverySignalRefreshPending[platform];
+          if (signalRequest && discoverySignalRefreshAllowed(platform, signalRequest)) {
+            pending.reasons.discovery_signal = (pending.reasons.discovery_signal ?? 0) + signalRequest.count;
+            discoverySignalRefreshPending[platform] = undefined;
+          }
+          diagnosticEvent("debug", `Coalesced scheduler triggers (${tickTriggerSummary(pending.reasons)})`, platform);
+          executePlatformTick(platform, pending);
+        } else startPendingDiscoverySignalRefresh(platform);
+      });
+  }
+
+  interface TickBatch {
+    requests: Promise<PlatformTickResult>[];
+    settled: Promise<PromiseSettledResult<PlatformTickResult>[]>;
+    claimed?: Promise<ClaimedRewards>;
+    handoff?: Promise<SchedulerState | undefined>;
+  }
+  const tickBatches = new Set<TickBatch>();
+
+  function requestTickBatch(platforms: Platform[] | undefined, trigger: TickTrigger): TickBatch {
+    const requests = [...new Set(platforms ?? PLATFORMS)].sort().map((platform) => admitPlatformTick(platform, trigger));
+    for (const batch of tickBatches) {
+      if (batch.requests.length === requests.length && batch.requests.every((request, index) => request === requests[index])) return batch;
+    }
+    const batch: TickBatch = { requests, settled: Promise.allSettled(requests) };
+    tickBatches.add(batch);
+    void batch.settled.then(() => tickBatches.delete(batch));
+    return batch;
+  }
+
+  function tick(
     platforms?: Platform[],
     trigger: TickTrigger = "unknown",
     onPersisted?: (state: SchedulerState) => void,
   ): Promise<ClaimedRewards> {
-    const requestedPlatforms = platforms ?? PLATFORMS;
-    const settled = await Promise.allSettled(requestedPlatforms.map((platform) =>
-      tickPlatform(platform, trigger, onPersisted)));
+    const batch = requestTickBatch(platforms, trigger);
+    if (onPersisted) return completeTickBatch(batch, onPersisted);
+    return batch.claimed ??= completeTickBatch(batch);
+  }
+
+  async function completeTickBatch(batch: TickBatch, onPersisted?: (state: SchedulerState) => void): Promise<ClaimedRewards> {
+    const settled = await batch.settled;
+    const commits = settled.flatMap((result) => result.status === "fulfilled" && result.value[2] ? [result.value[2]] : []);
+    for (const commit of commits.sort((left, right) => left.sequence - right.sequence)) onPersisted?.(commit.state);
     const failures = settled.flatMap((result) =>
       result.status === "rejected" ? [result.reason] : []);
     if (failures.length === 1) throw failures[0];
@@ -2268,7 +2380,6 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     } finally {
       activeTicks.delete(abort);
       activePlatformTicks[platform] -= 1;
-      if (activePlatformTicks[platform] === 0) startPendingDiscoverySignalRefresh(platform);
       diagnosticEvent(
         "debug",
         `Tick #${tickContext.platformTickId} finished after ${Date.now() - tickStartedAt}ms (trigger=${trigger}, platforms=${platform})`,
@@ -3637,6 +3748,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   function abortActiveTicks(reason: string): void {
+    for (const platform of PLATFORMS) cancelPendingTick(platform);
     for (const controller of activeTicks) {
       controller.abort(new Error(reason));
     }
@@ -3683,6 +3795,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function prepareForHostReset(resetHostStorage?: () => Promise<void>): Promise<void> {
+    tickAdmissionSuspended = true;
     discoverySignalLifecycleOpen = false;
     for (const platform of PLATFORMS) invalidateDiscoverySignalAdmission(platform);
     twitchSettingsTransitionGeneration += 1;
@@ -3722,7 +3835,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       lastPersistedTwitchEnabled = undefined;
       await reportBestEffort(events);
     })));
-    if (!controllerShutdown) discoverySignalLifecycleOpen = true;
+    if (!controllerShutdown) {
+      discoverySignalLifecycleOpen = true;
+      tickAdmissionSuspended = false;
+    }
   }
 
   // Bounded post-claim handoff (see docs/superpowers/specs/2026-07-19-twitch-claim-handoff-design.md).
@@ -3842,6 +3958,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     const request: DiscoverySignalRefreshRequest = {
       controller,
       generation: discoverySignalAdmissionGeneration[platform],
+      count: (discoverySignalRefreshPending[platform]?.count ?? 0) + 1,
     };
     if (!discoverySignalRefreshAllowed(platform, request)) return;
     discoverySignalRefreshPending[platform] = request;
@@ -3849,7 +3966,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   function startPendingDiscoverySignalRefresh(platform: Platform): void {
-    if (discoverySignalRefreshRunning[platform] || activePlatformTicks[platform] > 0) return;
+    if (discoverySignalRefreshRunning[platform] || tickAdmission[platform].active) return;
     const queued = discoverySignalRefreshPending[platform];
     if (!queued) return;
     if (!discoverySignalRefreshAllowed(platform, queued)) {
@@ -3878,6 +3995,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
             discoverySignalRefreshPending[platform] = undefined;
             break;
           }
+          diagnosticEvent("debug", `Coalesced scheduler triggers (${tickTriggerSummary({ discovery_signal: current.count })})`, platform);
           await tickAndHandOff([platform], "discovery_signal");
         }
       } finally {
@@ -3968,15 +4086,20 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   // The normal entry point for alarm- and message-driven ticks: run the tick,
   // then hand off for every platform that claimed. Kept separate from tick() so
   // the handoff's own inner ticks cannot recurse into another handoff.
-  async function tickAndHandOff(
+  function tickAndHandOff(
     platforms?: Platform[],
     trigger: TickTrigger = "unknown",
   ): Promise<SchedulerState | undefined> {
+    const batch = requestTickBatch(platforms, trigger);
+    return batch.handoff ??= completeTickAndHandOff(batch);
+  }
+
+  async function completeTickAndHandOff(batch: TickBatch): Promise<SchedulerState | undefined> {
     let committedState: SchedulerState | undefined;
     const captureCommittedState = (state: SchedulerState): void => {
       committedState = state;
     };
-    const claimed = await tick(platforms, trigger, captureCommittedState);
+    const claimed = await completeTickBatch(batch, captureCommittedState);
     const handoffPlatforms = Object.keys(claimed) as Platform[];
     const results = await Promise.allSettled(handoffPlatforms.map((platform) =>
       runClaimHandoff(platform, claimed[platform] ?? [], captureCommittedState)));

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2017,6 +2017,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     twitch: {},
     kick: {},
   };
+  const tickRequestHandoffs = new WeakMap<Promise<PlatformTickResult>, Promise<SchedulerState | undefined>>();
   let tickAdmissionSuspended = false;
 
   function tickTriggerSummary(reasons: TickRequest["reasons"]): string {
@@ -3829,47 +3830,50 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   async function prepareForHostReset(resetHostStorage?: () => Promise<void>): Promise<void> {
     tickAdmissionSuspended = true;
     discoverySignalLifecycleOpen = false;
-    for (const platform of PLATFORMS) invalidateDiscoverySignalAdmission(platform);
-    twitchSettingsTransitionGeneration += 1;
-    for (const platform of PLATFORMS) {
-      discoveryLanes[platform].invalidate();
-      invalidateSelection(platform);
-    }
-    abortActiveTicks("Host reset");
-    closeTwitchIntegrityLifecycle("Host reset");
-    await stopDiscoverySignalControllersAndReport(PLATFORMS);
-    await clearTwitchIntegrityAlarmBestEffort();
-    await clearTwitchChannelPointsAlarmBestEffort();
-    abortClaimHandoffs();
-    await clearHeartbeatOwnership(PLATFORMS);
-    await withSettingsLock(() => withStateLock(() => withEventCollector(async (emit, events) => {
-      const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
-      const adapters = createAdapters(settings, emit);
-      const managedTabs = Object.values(state.managedWatchTabs ?? {}).filter((tab): tab is ManagedWatchTab => tab?.ownedByExtension === true);
-      if (deps.closeManagedTabs && managedTabs.length > 0) await deps.closeManagedTabs(managedTabs);
+    try {
+      for (const platform of PLATFORMS) invalidateDiscoverySignalAdmission(platform);
+      twitchSettingsTransitionGeneration += 1;
       for (const platform of PLATFORMS) {
-        await deps.applyAdFocus?.(platform, state.sessions[platform].tabId, false, emit);
-        await adapters[platform].stopWatchTab?.(state.sessions[platform], { closeManagedTabs: true });
+        discoveryLanes[platform].invalidate();
+        invalidateSelection(platform);
       }
-      if (deps.stopPageContextTabs) {
-        await deps.stopPageContextTabs(state.managedPageContextTabs ?? {}, {
-          platforms: PLATFORMS,
-          reason: "automation_disabled",
-          emit,
-        });
+      abortActiveTicks("Host reset");
+      closeTwitchIntegrityLifecycle("Host reset");
+      await stopDiscoverySignalControllersAndReport(PLATFORMS);
+      await clearTwitchIntegrityAlarmBestEffort();
+      await clearTwitchChannelPointsAlarmBestEffort();
+      abortClaimHandoffs();
+      await clearHeartbeatOwnership(PLATFORMS);
+      await withSettingsLock(() => withStateLock(() => withEventCollector(async (emit, events) => {
+        const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+        const adapters = createAdapters(settings, emit);
+        const managedTabs = Object.values(state.managedWatchTabs ?? {}).filter((tab): tab is ManagedWatchTab => tab?.ownedByExtension === true);
+        if (deps.closeManagedTabs && managedTabs.length > 0) await deps.closeManagedTabs(managedTabs);
+        for (const platform of PLATFORMS) {
+          await deps.applyAdFocus?.(platform, state.sessions[platform].tabId, false, emit);
+          await adapters[platform].stopWatchTab?.(state.sessions[platform], { closeManagedTabs: true });
+        }
+        if (deps.stopPageContextTabs) {
+          await deps.stopPageContextTabs(state.managedPageContextTabs ?? {}, {
+            platforms: PLATFORMS,
+            reason: "automation_disabled",
+            emit,
+          });
+        }
+        registerManagedPageContextTabs({});
+        installedTwitchIntegrity = undefined;
+        persistedIntegrityToken = undefined;
+        twitchIntegrityRefreshDue = undefined;
+        setTwitchIntegrity(undefined);
+        await resetHostStorage?.();
+        lastPersistedTwitchEnabled = undefined;
+        await reportBestEffort(events);
+      })));
+    } finally {
+      if (!controllerShutdown) {
+        discoverySignalLifecycleOpen = true;
+        tickAdmissionSuspended = false;
       }
-      registerManagedPageContextTabs({});
-      installedTwitchIntegrity = undefined;
-      persistedIntegrityToken = undefined;
-      twitchIntegrityRefreshDue = undefined;
-      setTwitchIntegrity(undefined);
-      await resetHostStorage?.();
-      lastPersistedTwitchEnabled = undefined;
-      await reportBestEffort(events);
-    })));
-    if (!controllerShutdown) {
-      discoverySignalLifecycleOpen = true;
-      tickAdmissionSuspended = false;
     }
   }
 
@@ -4138,19 +4142,38 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       committedState = state;
     };
     const claimed = await completeTickBatch(batch, captureCommittedState);
-    const handoffPlatforms = Object.keys(claimed) as Platform[];
-    const results = await Promise.allSettled(handoffPlatforms.map((platform) =>
-      runClaimHandoff(platform, claimed[platform] ?? [], captureCommittedState)));
-    for (let index = 0; index < results.length; index += 1) {
-      const result = results[index];
-      if (result.status !== "rejected") continue;
-      diagnosticEvent(
-        "warn",
-        `Post-claim handoff failed: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
-        handoffPlatforms[index],
-      );
+    const results = await Promise.all((Object.keys(claimed) as Platform[]).map((platform) => {
+      return completePlatformHandoff(batch, platform, claimed[platform] ?? []);
+    }));
+    for (const state of results) {
+      if (state) committedState = state;
     }
     return committedState;
+  }
+
+  async function completePlatformHandoff(
+    batch: TickBatch,
+    platform: Platform,
+    claimedRewardIds: readonly string[],
+  ): Promise<SchedulerState | undefined> {
+    const settled = await batch.settled;
+    const index = settled.findIndex((result) => result.status === "fulfilled" && result.value[0] === platform);
+    if (index < 0) return undefined;
+    const request = batch.requests[index];
+    const existing = tickRequestHandoffs.get(request);
+    if (existing) return existing;
+    let committedState = settled[index].status === "fulfilled" ? settled[index].value[2]?.state : undefined;
+    const handoff = runClaimHandoff(platform, claimedRewardIds, (state) => {
+      committedState = state;
+    }).catch((error) => {
+      diagnosticEvent(
+        "warn",
+        `Post-claim handoff failed: ${error instanceof Error ? error.message : String(error)}`,
+        platform,
+      );
+    }).then(() => committedState);
+    tickRequestHandoffs.set(request, handoff);
+    return handoff;
   }
 
   async function recordPlaybackTelemetry(

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2008,6 +2008,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   interface TickRequest {
     trigger: TickTrigger;
     reasons: Partial<Record<TickTrigger, number>>;
+    discoverySignal?: DiscoverySignalRefreshRequest;
     promise: Promise<PlatformTickResult>;
     resolve: (result: PlatformTickResult) => void;
     reject: (error: unknown) => void;
@@ -2033,11 +2034,33 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
-  function admitPlatformTick(platform: Platform, trigger: TickTrigger): Promise<PlatformTickResult> {
+  function retainCurrentTickReasons(platform: Platform, request: TickRequest): boolean {
+    const signal = request.discoverySignal;
+    if (signal && !discoverySignalRefreshAllowed(platform, signal)) {
+      const remaining = (request.reasons.discovery_signal ?? 0) - signal.count;
+      if (remaining > 0) request.reasons.discovery_signal = remaining;
+      else delete request.reasons.discovery_signal;
+      request.discoverySignal = undefined;
+      diagnosticEvent("debug", `Discarded stale scheduler discovery signals (${tickTriggerSummary({ discovery_signal: signal.count })})`, platform);
+    }
+    const reasons = Object.keys(request.reasons) as TickTrigger[];
+    if (reasons.length === 0) return false;
+    request.trigger = reasons.reduce((selected, trigger) =>
+      tickTriggerPriority(trigger) > tickTriggerPriority(selected) ? trigger : selected);
+    return true;
+  }
+
+  function mergeDiscoverySignal(request: TickRequest, signal: DiscoverySignalRefreshRequest): void {
+    request.reasons.discovery_signal = (request.reasons.discovery_signal ?? 0) + signal.count;
+    request.discoverySignal = { ...signal, count: (request.discoverySignal?.count ?? 0) + signal.count };
+  }
+
+  function admitPlatformTick(platform: Platform, trigger: TickTrigger, discoverySignal?: DiscoverySignalRefreshRequest): Promise<PlatformTickResult> {
     if (controllerShutdown || tickAdmissionSuspended) return Promise.resolve([platform, []]);
     const lane = tickAdmission[platform];
     if (lane.pending) {
-      lane.pending.reasons[trigger] = (lane.pending.reasons[trigger] ?? 0) + 1;
+      if (discoverySignal) mergeDiscoverySignal(lane.pending, discoverySignal);
+      else lane.pending.reasons[trigger] = (lane.pending.reasons[trigger] ?? 0) + 1;
       if (tickTriggerPriority(trigger) > tickTriggerPriority(lane.pending.trigger)) {
         lane.pending.trigger = trigger;
       }
@@ -2049,7 +2072,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       resolve = onResolve;
       reject = onReject;
     });
-    const request: TickRequest = { trigger, reasons: { [trigger]: 1 }, promise, resolve, reject };
+    const request: TickRequest = { trigger, reasons: {}, promise, resolve, reject };
+    if (discoverySignal) mergeDiscoverySignal(request, discoverySignal);
+    else request.reasons[trigger] = 1;
     if (lane.active) lane.pending = request;
     else executePlatformTick(platform, request);
     return promise;
@@ -2066,6 +2091,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   function executePlatformTick(platform: Platform, request: TickRequest): void {
+    // Signal setup can yield before admission. Its controller/generation must
+    // still be current when the admitted request finally owns the platform.
+    if (!retainCurrentTickReasons(platform, request)) {
+      request.resolve([platform, []]);
+      startPendingDiscoverySignalRefresh(platform);
+      return;
+    }
     const lane = tickAdmission[platform];
     lane.active = request;
     let committed: PlatformTickResult[2];
@@ -2078,7 +2110,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         if (pending) {
           const signalRequest = discoverySignalRefreshPending[platform];
           if (signalRequest && discoverySignalRefreshAllowed(platform, signalRequest)) {
-            pending.reasons.discovery_signal = (pending.reasons.discovery_signal ?? 0) + signalRequest.count;
+            mergeDiscoverySignal(pending, signalRequest);
             discoverySignalRefreshPending[platform] = undefined;
           }
           diagnosticEvent("debug", `Coalesced scheduler triggers (${tickTriggerSummary(pending.reasons)})`, platform);
@@ -2095,8 +2127,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
   const tickBatches = new Set<TickBatch>();
 
-  function requestTickBatch(platforms: Platform[] | undefined, trigger: TickTrigger): TickBatch {
-    const requests = [...new Set(platforms ?? PLATFORMS)].sort().map((platform) => admitPlatformTick(platform, trigger));
+  function requestTickBatch(platforms: Platform[] | undefined, trigger: TickTrigger, discoverySignal?: DiscoverySignalRefreshRequest): TickBatch {
+    const requests = [...new Set(platforms ?? PLATFORMS)].sort().map((platform) => admitPlatformTick(platform, trigger, discoverySignal));
     for (const batch of tickBatches) {
       if (batch.requests.length === requests.length && batch.requests.every((request, index) => request === requests[index])) return batch;
     }
@@ -3923,6 +3955,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   function invalidateDiscoverySignalAdmission(platform: Platform): void {
     discoverySignalRefreshPending[platform] = undefined;
     discoverySignalAdmissionGeneration[platform] += 1;
+    const pending = tickAdmission[platform].pending;
+    if (pending && !retainCurrentTickReasons(platform, pending)) {
+      tickAdmission[platform].pending = undefined;
+      pending.resolve([platform, []]);
+    }
   }
 
   function discoverySignalRefreshAllowed(
@@ -3996,7 +4033,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
             break;
           }
           diagnosticEvent("debug", `Coalesced scheduler triggers (${tickTriggerSummary({ discovery_signal: current.count })})`, platform);
-          await tickAndHandOff([platform], "discovery_signal");
+          const batch = requestTickBatch([platform], "discovery_signal", current);
+          await (batch.handoff ??= completeTickAndHandOff(batch));
         }
       } finally {
         discoverySignalRefreshRunning[platform] = false;

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -3249,6 +3249,18 @@ describe("background controller", () => {
     expect(twitchCommitted?.sessions.twitch.campaignId).toBe("twitch-campaign");
   });
 
+  it("returns the latest committed platform state when Kick completes last", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+    const discovery = deferred<DropCampaign[]>();
+    vi.mocked(env.kick.refreshCampaigns).mockReturnValueOnce(discovery.promise);
+    const ticking = env.controller.tickAndHandOff();
+    await vi.waitFor(() => expect(env.state.sessions.twitch.campaignId).toBe("twitch-campaign"));
+    discovery.resolve([campaign("kick")]);
+    const committed = await ticking;
+    expect(committed?.sessions.kick.campaignId).toBe("kick-campaign");
+    expect(committed?.sessions.twitch.campaignId).toBe("twitch-campaign");
+  });
+
   it("blocks startup account work when credentials are missing without disabling the platform", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,
@@ -4524,7 +4536,7 @@ describe("background controller", () => {
     }));
   });
 
-  it("coalesces overlapping same-platform discovery instead of waiting on the scheduler lock", async () => {
+  it("coalesces same-platform ticks before discovery or the scheduler lock", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-07-29T12:00:00.000Z"));
     const env = harness(farming(DEFAULT_SETTINGS));
@@ -4553,7 +4565,7 @@ describe("background controller", () => {
       expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
         category: "diagnostic",
         platform: "twitch",
-        message: expect.stringMatching(/^Discovery refresh finished in 0ms \(complete, revision=2, .*coalesced=1,/),
+        message: "Coalesced scheduler triggers (count=1, reasons=manual_tick:1)",
       }));
       expect(allDiagnostics(env).some((event) =>
         event.message.includes("waited") && event.message.includes("platform work"),
@@ -4563,6 +4575,122 @@ describe("background controller", () => {
       await Promise.allSettled(secondTick ? [firstTick, secondTick] : [firstTick]);
       vi.useRealTimers();
     }
+  });
+
+  it("admits one Twitch tick and one follow-up across repeated alarm intervals while Kick progresses", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const env = harness(farming(DEFAULT_SETTINGS));
+    const discovery = deferred<DropCampaign[]>();
+    vi.mocked(env.twitch.refreshCampaigns).mockReturnValueOnce(discovery.promise);
+    const first = env.controller.tickAndHandOff(["twitch"], "alarm");
+    await vi.waitFor(() => expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce());
+    const pending: Promise<unknown>[] = [];
+    for (let interval = 0; interval < 5; interval += 1) {
+      vi.setSystemTime(Date.now() + 60_000);
+      pending.push(env.controller.tickAndHandOff(["twitch"], "alarm"));
+    }
+    const sharedPending = pending.every((request) => request === pending[0]);
+    await env.controller.tickAndHandOff(["kick"], "alarm");
+    expect(env.state.sessions.kick.campaignId).toBe("kick-campaign");
+    const starts = () => allDiagnostics(env).filter((event) => event.platform === "twitch" && /Tick #\d+ started/.test(event.message));
+    const activeStarts = starts().length;
+    discovery.resolve([campaign("twitch")]);
+    await Promise.all([first, ...pending]);
+    expect(activeStarts).toBe(1);
+    expect(sharedPending).toBe(true);
+    expect(starts()).toHaveLength(2);
+    expect(env.twitch.checkAuthHealth).toHaveBeenCalledTimes(2);
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(2);
+    expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+      platform: "twitch",
+      message: expect.stringContaining("Coalesced scheduler triggers (count=5, reasons=alarm:5)"),
+    }));
+    expect(allDiagnostics(env).filter((event) => event.platform === "twitch" && /Tick #2 finished/.test(event.message))[0]?.message).toContain("after 0ms");
+  });
+
+  it.each(["manual_tick", "manual_resume", "claim_handoff"] as const)("preserves %s backoff overrides behind a pending alarm", async (trigger) => {
+    const env = harness(farming(DEFAULT_SETTINGS), { selectWatchTarget: selectWatchTargetFromSnapshot });
+    const discovery = deferred<DropCampaign[]>();
+    vi.mocked(env.twitch.refreshCampaigns).mockReturnValueOnce(discovery.promise);
+    const first = env.controller.tick(["twitch"], "alarm");
+    await vi.waitFor(() => expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce());
+    const pending = env.controller.tick(["twitch"], "alarm");
+    const manual = env.controller.tick(["twitch"], trigger);
+    const laterAlarm = env.controller.tick(["twitch"], "alarm");
+    discovery.resolve([campaign("twitch")]);
+    await Promise.all([first, pending, manual, laterAlarm]);
+    expect(env.deps.selectWatchTarget).toHaveBeenCalledTimes(2);
+    expect(env.deps.selectWatchTarget).toHaveBeenLastCalledWith(expect.objectContaining({ bypassBackoff: true }));
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(2);
+  });
+
+  it("reloads settings and state and selects from the newest discovery revision for the follow-up", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS), { selectWatchTarget: selectWatchTargetFromSnapshot });
+    const discovery = deferred<DropCampaign[]>();
+    vi.mocked(env.twitch.refreshCampaigns)
+      .mockReturnValueOnce(discovery.promise)
+      .mockResolvedValue([{ ...campaign("twitch"), id: "new-campaign" }]);
+    const first = env.controller.tickAndHandOff(["twitch"], "alarm");
+    await vi.waitFor(() => expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce());
+    const pending = env.controller.tickAndHandOff(["twitch"], "alarm");
+    await env.rawController.handleMessage({
+      type: "saveSettings", settingsPatch: { autoClaim: false }, tickAfterSave: true, tickAfterSavePlatforms: ["twitch"],
+    });
+    await env.deps.saveState({ ...env.state, sessions: { ...env.state.sessions, twitch: { ...env.state.sessions.twitch, offlineChecks: 7 } } });
+    discovery.resolve([campaign("twitch")]);
+    await Promise.all([first, pending]);
+    await env.controller.settleBackgroundWork();
+    expect(env.deps.selectWatchTarget).toHaveBeenLastCalledWith(expect.objectContaining({
+      settings: expect.objectContaining({ autoClaim: false }),
+      previous: expect.objectContaining({ offlineChecks: 7 }),
+      snapshot: expect.objectContaining({ campaigns: [expect.objectContaining({ campaign: expect.objectContaining({ id: "new-campaign" }) })] }),
+    }));
+    expect(env.state.sessions.twitch.campaignId).toBe("new-campaign");
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(2);
+  });
+
+  it("executes the pending request after the active selection rejects", async () => {
+    const selection = deferred<void>();
+    const started = deferred<void>();
+    let attempts = 0;
+    const env = harness(farming(DEFAULT_SETTINGS), {
+      selectWatchTarget: async (input) => {
+        attempts += 1;
+        if (attempts === 1) {
+          started.resolve();
+          await selection.promise;
+        }
+        return selectWatchTargetFromSnapshot(input);
+      },
+    });
+    const first = env.controller.tickAndHandOff(["twitch"], "alarm");
+    await started.promise;
+    const pending = env.controller.tickAndHandOff(["twitch"], "alarm");
+    const results = Promise.allSettled([first, pending]);
+    selection.reject(new Error("selection failed"));
+    expect((await results).map((result) => result.status)).toEqual(["rejected", "fulfilled"]);
+    expect(env.state.sessions.twitch.campaignId).toBe("twitch-campaign");
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["shutdown", "reset", "disable"] as const)("discards obsolete pending alarm work on %s", async (action) => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+    const discovery = deferred<DropCampaign[]>();
+    vi.mocked(env.twitch.refreshCampaigns).mockReturnValueOnce(discovery.promise);
+    const first = env.controller.tickAndHandOff(["twitch"], "alarm");
+    await vi.waitFor(() => expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce());
+    const pending = env.controller.tickAndHandOff(["twitch"], "alarm");
+    if (action === "shutdown") env.controller.shutdown();
+    else if (action === "reset") await env.controller.prepareForHostReset();
+    else await env.rawController.handleMessage({ type: "setAutomation", platform: "twitch", enabled: false });
+    discovery.resolve([campaign("twitch")]);
+    await Promise.all([first, pending]);
+    await env.controller.settleBackgroundWork();
+    expect(allDiagnostics(env).filter((event) => event.platform === "twitch" && event.message.includes("started (trigger=alarm"))).toHaveLength(1);
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce();
+    expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+      message: expect.stringMatching(/Discarded pending scheduler triggers .*count=1, reasons=alarm:1/),
+    }));
   });
 
   it("does not report platform-lock waits for an uncontended tick", async () => {
@@ -6750,14 +6878,14 @@ describe("background controller", () => {
     await selectionStarted.promise;
     const second = env.controller.tick(["twitch"], "manual_tick");
     const third = env.controller.tick(["twitch"], "manual_tick");
-    await vi.waitFor(() => expect(vi.mocked(env.twitch.refreshCampaigns).mock.calls.length).toBeGreaterThanOrEqual(3));
+    expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(2);
     allowSelection.resolve();
     await Promise.all([first, second, third]);
 
     expect(selectWatchTarget).toHaveBeenCalledTimes(2);
     expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
       platform: "twitch",
-      message: expect.stringContaining("Snapshot selection discarded stale work"),
+      message: "Coalesced scheduler triggers (count=2, reasons=manual_tick:2)",
     }));
   });
 
@@ -9574,6 +9702,24 @@ describe("discovery signal refresh scheduling", () => {
     await ticking;
     await env.controller.settleBackgroundWork();
 
+    expect(env.kick.refreshCampaigns).toHaveBeenCalledTimes(2);
+    expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+      message: "Coalesced scheduler triggers (count=1, reasons=discovery_signal:1)",
+    }));
+  });
+
+  it("merges discovery signals and pending alarms into the same follow-up", async () => {
+    const env = await startedEnv();
+    const discovery = deferred<DropCampaign[]>();
+    vi.mocked(env.kick.refreshCampaigns).mockClear().mockReturnValueOnce(discovery.promise);
+    const first = env.controller.tick(["kick"], "alarm");
+    await vi.waitFor(() => expect(env.kick.refreshCampaigns).toHaveBeenCalledOnce());
+    const pending = env.controller.tick(["kick"], "alarm");
+    env.discoverySignalController.emitSignal();
+    env.discoverySignalController.emitSignal();
+    discovery.resolve([campaign("kick")]);
+    await Promise.all([first, pending]);
+    await env.controller.settleBackgroundWork();
     expect(env.kick.refreshCampaigns).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -4915,6 +4915,20 @@ describe("background controller", () => {
     }));
   });
 
+  it("restores scheduler admission when resetting host storage fails", async () => {
+    const env = harness(farming(DEFAULT_SETTINGS));
+    const resetFailure = new Error("storage reset failed");
+
+    await expect(env.controller.prepareForHostReset(async () => {
+      throw resetFailure;
+    })).rejects.toBe(resetFailure);
+
+    vi.mocked(env.kick.refreshCampaigns).mockClear();
+    await env.controller.tick(["kick"], "manual_tick");
+
+    expect(env.kick.refreshCampaigns).toHaveBeenCalledOnce();
+  });
+
   it("aborts in-flight scheduler work when the controller shuts down", async () => {
     const env = harness(farming(DEFAULT_SETTINGS));
     let tickSignal: AbortSignal | undefined;
@@ -9017,6 +9031,30 @@ describe("background controller", () => {
 
       expect(env.timer.wait).toHaveBeenCalled();
       expect(committed).toEqual(env.state);
+    });
+
+    it("starts one handoff for a shared platform tick across overlapping batches", async () => {
+      const kickRefresh = deferred<DropCampaign[]>();
+      const env = handoffEnv({
+        postClaimHandoffIntervalSeconds: 5,
+        postClaimHandoffMaxSeconds: 15,
+        platform: {
+          twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: true },
+          kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true, idleWatchlistChannels: [] },
+        },
+      });
+      env.twitch.refreshCampaigns = vi.fn(async () => [chainedCampaign(false)]);
+      env.kick.refreshCampaigns = vi.fn(() => kickRefresh.promise);
+
+      const twitchOnly = env.controller.tickAndHandOff(["twitch"]);
+      const bothPlatforms = env.controller.tickAndHandOff();
+      for (let index = 0; index < 6; index += 1) await env.timer.flush();
+      await twitchOnly;
+      kickRefresh.resolve([]);
+      for (let index = 0; index < 6; index += 1) await env.timer.flush();
+      await bothPlatforms;
+
+      expect(env.twitch.refreshCampaigns).toHaveBeenCalledTimes(4);
     });
 
     it("does not start a nested handoff for a claim inside a handoff", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -9723,6 +9723,44 @@ describe("discovery signal refresh scheduling", () => {
     expect(env.kick.refreshCampaigns).toHaveBeenCalledTimes(2);
   });
 
+  it.each([undefined, "alarm", "manual_tick"] as const)("invalidates an admitted signal while retaining an independent %s trigger", async (independentTrigger) => {
+    const env = await startedEnv();
+    const settingsRead = deferred<ExtensionSettings>();
+    const settingsReadStarted = deferred<void>();
+    const discovery = deferred<DropCampaign[]>();
+    env.deps.loadSettings.mockImplementationOnce(() => {
+      settingsReadStarted.resolve();
+      return settingsRead.promise;
+    });
+    env.discoverySignalController.emitSignal();
+    await settingsReadStarted.promise;
+    vi.mocked(env.kick.refreshCampaigns).mockClear().mockReturnValueOnce(discovery.promise);
+    env.reportEvents.mockClear();
+    const first = env.controller.tick(["kick"], "alarm");
+    let independent: Promise<unknown> | undefined;
+    try {
+      await vi.waitFor(() => expect(env.kick.refreshCampaigns).toHaveBeenCalledOnce());
+      settingsRead.resolve(env.settings);
+      // Let the paused signal finish admission behind the blocked alarm.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      if (independentTrigger) independent = env.controller.tick(["kick"], independentTrigger);
+      await env.controller.invalidateAuthHealth("kick");
+      discovery.resolve([campaign("kick")]);
+      await Promise.all([first, independent]);
+      await env.controller.settleBackgroundWork();
+
+      expect(env.kick.refreshCampaigns).toHaveBeenCalledTimes(independentTrigger ? 2 : 1);
+      const starts = allDiagnostics(env).filter((event) => /Tick #\d+ started/.test(event.message));
+      expect(starts).toHaveLength(independentTrigger ? 2 : 1);
+      if (independentTrigger) expect(starts.at(-1)?.message).toContain(`trigger=${independentTrigger}`);
+    } finally {
+      settingsRead.resolve(env.settings);
+      discovery.resolve([campaign("kick")]);
+      await Promise.allSettled([first, independent]);
+      await env.controller.settleBackgroundWork();
+    }
+  });
+
   it("coalesces bursts before and after an ordinary Kick tick fetch into one non-overlapping follow-up", async () => {
     const env = await startedEnv();
     const ordinaryAuth = deferred<void>();


### PR DESCRIPTION
## Summary

- admit at most one active scheduler tick and one coalesced pending follow-up per platform
- merge trigger precedence without losing manual, claim-handoff, or discovery-signal semantics
- preserve independent Twitch/Kick execution and fixed-cadence heartbeat behavior
- cancel obsolete pending work across reset, shutdown, auth invalidation, and discovery-signal lifecycle changes
- apply the same bounded admission behavior to the CLI interval runner

## Testing

- `pnpm verify`
- 1,816 extension tests passed
- 193 CLI tests passed
- workspace typechecks, site checks, Chrome build, and Firefox build passed

Fixes #497

## Stack

This is stack 1/3 and targets `develop`.

- Next: `perf/kick-discovery-performance`
- Then: `perf/kick-route-diagnostics`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduler activity is now coalesced independently for each platform, allowing one active tick and one pending follow-up.
  * Manual requests, alarms, startup events, and discovery signals are merged and processed with current settings and discovery data.
  * CLI interval runs avoid processing the same scheduler result more than once.
  * Scheduler diagnostics report merged and discarded triggers more clearly.

* **Bug Fixes**
  * Pending work is discarded when platforms are disabled or during shutdown and host resets.
  * Scheduler admission is safely restored after reset cleanup failures.

* **Documentation**
  * Documented scheduler admission, trigger handling, lifecycle behavior, and coalescing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->