### PR TITLE
perf(kick): aggregate unchanged transport route diagnostics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -297,3 +297,18 @@ The extension stores activity in a bounded IndexedDB database owned by the backg
 The popup shows one category at a time. The activity/diagnostics switch selects a view rather than interleaving both, since the mirror means a merged list would state everything twice.
 
 The CLI has no activity store. Its output is already English, so it logs mirrored diagnostics at `debug` — their ids and reason codes stay available under `--log debug` without repeating each activity line at its own level. It formats each activity variant directly, passes diagnostic messages through, and routes each batch in its original order through the existing `--log`-filtered stderr logger. Retention belongs to Docker, systemd, Loki, or another external collector; `state.json` never contains new event data, and legacy event fields disappear after the state is loaded and saved.
+
+Kick fetch diagnostics keep individual initial-route, fallback, recovery, and
+lifecycle-update-failure evidence. Unchanged successes use fixed counters for
+`kick.com`, `web.kick.com`, `websockets.kick.com`, and one unknown-host bucket,
+split into background/page routes. Drained auth, discovery, scheduler, manual
+action, and watcher operations flush a `kick_fetch_summary` diagnostic with
+numeric counts and an English message usable in exports and CLI debug logs.
+No URL path, query value, arbitrary host, header, credential, or payload is kept.
+The last announced route lives in host-owned `KickDiscoveryState`, so adapter
+reconstruction does not repeat it; restarting the runtime begins a new history.
+Counters are fetcher-local and refuse to flush while a request or lifecycle
+callback is active. They never consume page-context recovery observations:
+successful HTTP counts also describe failed scheduler operations and must not be
+interpreted as committed recovery cycles. Transport evidence survives scheduler
+rollback, while activity-event mirroring and publication rules remain unchanged.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,8 +307,15 @@ numeric counts and an English message usable in exports and CLI debug logs.
 No URL path, query value, arbitrary host, header, credential, or payload is kept.
 The last announced route lives in host-owned `KickDiscoveryState`, so adapter
 reconstruction does not repeat it; restarting the runtime begins a new history.
-Counters are fetcher-local and refuse to flush while a request or lifecycle
-callback is active. They never consume page-context recovery observations:
+Counters are fetcher-local; a flush requested while a request or lifecycle
+callback is active defers one summary until all active work settles. They never
+consume page-context recovery observations:
 successful HTTP counts also describe failed scheduler operations and must not be
-interpreted as committed recovery cycles. Transport evidence survives scheduler
-rollback, while activity-event mirroring and publication rules remain unchanged.
+interpreted as committed recovery cycles. The controller reports these transport
+diagnostics independently of auth-generation and scheduler-publication gates,
+including late completions after an auth deadline. Closed operational collectors
+and tick handles discard late activity; diagnostic reporting promises are tracked
+and settled without waiting for unfinished network work. Activity-event mirroring
+and operational publication rules remain unchanged. CLI `discover --log debug`
+also constructs its adapters with an emitter and flushes/reports its discovery
+diagnostics before disposing the transport.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -314,8 +314,11 @@ successful HTTP counts also describe failed scheduler operations and must not be
 interpreted as committed recovery cycles. The controller reports these transport
 diagnostics independently of auth-generation and scheduler-publication gates,
 including late completions after an auth deadline. Closed operational collectors
-and tick handles discard late activity; diagnostic reporting promises are tracked
-and settled without waiting for unfinished network work. Activity-event mirroring
+and tick handles discard late activity. Each collector or tick adapter handle
+settles only its own diagnostic reporting promises, so a stalled Kick report
+cannot block Twitch discovery or heartbeat transmission. A controller-wide
+registry is drained only by explicit background-work settling. These report sets
+track emitted diagnostics, not unfinished transport requests. Activity-event mirroring
 and operational publication rules remain unchanged. CLI `discover --log debug`
 also constructs its adapters with an emitter and flushes/reports its discovery
 diagnostics before disposing the transport.

--- a/docs/superpowers/plans/2026-09-09-kick-route-diagnostics.md
+++ b/docs/superpowers/plans/2026-09-09-kick-route-diagnostics.md
@@ -1,0 +1,74 @@
+# Kick route diagnostics implementation plan
+
+> **For agentic workers:** Execute inline with superpowers:executing-plans, strict red/green tests, and no subagents, as requested for this sequential stack.
+
+**Goal:** Replace request-proportional Kick success diagnostics with operation summaries while preserving routing failures and transitions (#499).
+
+**Architecture:** Keep the last route per allowlisted host in host-owned `KickDiscoveryState`, shared across adapter reconstruction. Fetcher-local counters collect successful background/page requests; a separate flush hook publishes English diagnostic events at drained auth, discovery, and scheduler-operation boundaries. Never consume page-context recovery observations to obtain diagnostic counts.
+
+**Tech stack:** TypeScript, pnpm, Vitest, existing engine event collectors and reporters.
+
+**Design:** The existing fetcher emits every success and creates a fresh announcement map. Removing repeat events alone would lose volume evidence; retaining raw events until reporting would retain the memory cost. Fixed host/route counters preserve volume with bounded memory. Transition state survives adapter construction but intentionally resets when the runtime restarts. Counts describe successful requests, not successful scheduler publication. Failed/aborted operations must not masquerade as committed recovery cycles.
+
+## Constraints and dependency audit
+
+- Branch `perf/kick-route-diagnostics` from reviewed `9b4be632`, stacking #497 and #498; no push, merge, rebase, or PR.
+- Current `origin/develop` is `8f58c2b1`; its newer wrangler dependency change is unrelated.
+- Resumption audit (2026-09-10): `origin/develop` advanced to `3c4e3ac6` via dependency PR #493. New open PRs #515/#516 concern in-page panel documentation/UI only. #500 remains at `c8737826`; #490 remains independently scoped to heartbeat publication gates. Keep the exact reviewed stack base.
+- Open PR #500 introduces consume-once page-context observations. Keep the summary flush API independent and call it only after active requests drain. #498 already drains batch and followed-channel work.
+- PR #490 changes heartbeat/discovery persistence; preserve existing publication semantics. Other open PRs (#514, #513, #493, #466, #451, #283) are dependency or release work outside this scope.
+- English diagnostics only; no activity mirroring changes, network-policy changes, paths, query values, credentials, headers, payloads, or unbounded host cardinality.
+- Extension export and CLI event formatters consume ordinary diagnostic events without custom parsing.
+
+## Task 1: Transport aggregation
+
+Files: `packages/core/src/platforms/kick/index.ts`, new `routeDiagnostics.ts`, `packages/core/src/platforms/adapter.ts`, `packages/extension/tests/kickRouteDiagnostics.test.ts`.
+
+- [x] Write deterministic tests: thousands of requests emit only initial transitions before flush; flush emits exact host/route totals; reconstruction with shared state produces no new info transition; fallback/recovery/lifecycle failures retain individual evidence; unsafe URL material never enters output; in-flight flush cannot publish incomplete counts.
+- [x] Run `pnpm --filter @lurkloot/extension test tests/kickRouteDiagnostics.test.ts` and observe missing summary behavior fail.
+- [x] Implement fixed host/route counters and separate `flushRouteDiagnostics(emit)` hook. Preserve original request/abort/429 behavior and lifecycle callbacks.
+- [x] Repeat focused tests and existing adapter/discovery tests until green.
+
+## Task 2: Hosts and operation boundaries
+
+Files: extension background factory, CLI transport factory, controller, controller tests, CLI transport tests, architecture documentation.
+
+Additional owned integration files: `packages/core/src/platforms/kick/watch.ts`
+and `packages/extension/tests/tablessWatch.test.ts`. Retained watchers outlive
+their creating tick, so their event drain must flush reconnect/target-refresh
+counts, including the existing `websockets.kick.com` token host. Standalone
+category search and manual claim handlers also flush before reporting.
+
+- [x] Add failing integration tests using real Kick fetchers/adapters: fresh controller-created adapters across many ticks, complete discovery counts, no early flush of delayed workers, and useful CLI debug messages.
+- [x] Inject shared route state in both factories; CLI uses the background route without adding page fallback.
+- [x] Flush drained discovery/auth/tick operations, preserve route evidence during scheduler rollback, and leave PR #500's lifecycle consumption independent.
+- [x] Run controller, adapters, discovery, CLI transport, and event-reporting tests.
+
+## Task 3: Verification and handoff
+
+- [x] Self-review issue criteria, bounded event/memory growth, concurrent work, privacy, and #500 merge touchpoints.
+- [x] Run fresh `pnpm verify` and CLI tests. Record exact outcomes here.
+- [x] Commit focused Conventional Commits; return branch/base, commits, tests, and dependency decisions without pushing.
+
+## Verification and review record
+
+- Strict red/green: five initial route tests failed on missing aggregation and
+  repeated announcements; controller and CLI integration tests then failed on
+  missing flushes; rollback, watcher reconnect, and manual-operation regressions
+  each failed before their fixes.
+- Final focused run: 635 extension tests in five files and 14 CLI transport tests
+  passed. The long deterministic run covers 66,000 successful requests over 660
+  fresh fetchers: exactly 660 summaries and two initial host transitions.
+- Fresh `pnpm verify` on 2026-09-10 exited 0: 17 CWS tests, 78 release tests,
+  workspace typechecks, complete extension and CLI suites, Astro site build,
+  Chromium MV3 build, and Firefox MV2 build. Existing large-chunk build warnings
+  remain informational. `git diff --check` passed.
+- Fixed-size routing state has at most four host entries; counters at most eight
+  host/route entries. Request/lifecycle promises must settle before flush.
+- PR #500 is not included in this stack. Its recovery observation method remains
+  independent: do not replace it with summary counts or invoke it from a flush.
+  When combining the overlapping fetcher edits, retain #498's 429 guard and
+  drained workers plus #500's background/fallback host observations. Combined
+  #500 runtime behavior has not been tested on this branch.
+- PR #490's publication guards are untouched. No locale, permission, activity
+  mirror, network-policy, or release changes are part of this implementation.

--- a/docs/superpowers/plans/2026-09-09-kick-route-diagnostics.md
+++ b/docs/superpowers/plans/2026-09-09-kick-route-diagnostics.md
@@ -107,3 +107,14 @@ published. `git diff --check` passed.
 Overlap re-audit: `origin/develop` remains `3c4e3ac6`; #500 remains `c8737826`.
 The open PR set and the previously recorded independent scope decisions are
 unchanged. No branch integration or recovery-observation consumption is added.
+
+Final correlation follow-up: a real Kick watcher startup regression first failed
+because immediate route reporting bypassed the collector's later tick-ID
+decoration. The scheduler collector now passes its current tick context to that
+reporting boundary; standalone and auth collectors are unchanged. The regression
+asserts both startup host transitions and the drained summary carry distinct
+global/platform tick IDs (2/1). All 398 tests in the three focused controller,
+route, and watcher suites passed. Fresh `pnpm verify` exited 0 with 1,885 extension
+tests, 195 CLI tests, 10 site tests, 17 CWS tests, 78 release tests, all typechecks,
+and the site/Chromium/Firefox builds. Self-review and `git diff --check` passed;
+the summary/recovery observation separation is unchanged.

--- a/docs/superpowers/plans/2026-09-09-kick-route-diagnostics.md
+++ b/docs/superpowers/plans/2026-09-09-kick-route-diagnostics.md
@@ -118,3 +118,16 @@ route, and watcher suites passed. Fresh `pnpm verify` exited 0 with 1,885 extens
 tests, 195 CLI tests, 10 site tests, 17 CWS tests, 78 release tests, all typechecks,
 and the site/Chromium/Firefox builds. Self-review and `git diff --check` passed;
 the summary/recovery observation separation is unchanged.
+
+Cross-platform reporting follow-up: four deterministic regressions first failed
+with a stalled Kick summary preventing Twitch discovery or a due heartbeat's
+provider call, for both standalone-auth and tick-owned Kick summaries. Collectors
+and tick adapter handles now own separate report sets; only explicit
+`settleBackgroundWork()` drains the controller-wide registry. The regressions
+verify Twitch finishes while Kick's owning operation and explicit report
+settling remain pending until the summary is released. All 648 tests in five
+focused suites passed, including late auth completion, discarded activity, and
+tick-correlation regressions. Fresh `pnpm verify` exited 0: 1,889 extension tests,
+195 CLI tests, 10 site tests, 17 CWS tests, 78 release tests, all typechecks, and
+the site/Chromium/Firefox builds. Self-review and `git diff --check` passed.
+No PR #500 changes or recovery-observation consumption are included.

--- a/docs/superpowers/plans/2026-09-09-kick-route-diagnostics.md
+++ b/docs/superpowers/plans/2026-09-09-kick-route-diagnostics.md
@@ -72,3 +72,38 @@ category search and manual claim handlers also flush before reporting.
   #500 runtime behavior has not been tested on this branch.
 - PR #490's publication guards are untouched. No locale, permission, activity
   mirror, network-policy, or release changes are part of this implementation.
+
+## Review follow-up (2026-09-10)
+
+The review identified two discarded-evidence paths: route events were still
+gated by operational publication, and an auth deadline could abandon a flush
+while its lifecycle callback remained active. CLI `discover` also constructed
+its adapters without an emitter.
+
+- [x] Reproduce scheduler abort after drain, stale publication rejection, auth
+  abort, stale auth generation, and late lifecycle completion/failure with real
+  Kick fetchers in controller tests. Six initial regressions failed as expected.
+- [x] Report only the three safe transport diagnostic codes independently of
+  operational collectors, retaining tick correlation. Close collectors/handles
+  to discard late activity. Track reporting promises without awaiting unfinished
+  HTTP/lifecycle work or changing auth deadlines.
+- [x] Defer an active flush until the last request/lifecycle callback settles;
+  reset the pending flush before emitting to prevent duplicate summaries.
+- [x] Add a failing built-CLI command regression, then construct CLI discovery
+  adapters with their operation emitter and flush/report before disposal.
+- [x] Extend late-completion coverage to both standalone auth and tick-owned
+  adapters, and verify a later valid generation does not reannounce the route.
+- [x] Run fresh focused tests and `pnpm verify`, self-review, and commit.
+
+Review verification: the five focused extension files passed 643 tests; CLI
+command and transport suites passed 50 tests. Fresh `pnpm verify` exited 0,
+including 1,884 extension tests in 84 files, 195 CLI tests in 12 files, 10 site
+tests, 17 CWS tests, 78 release tests, all workspace typechecks, the site build,
+and both browser builds. Self-review confirmed that late transport reporting
+retains tick correlation without retaining an operational collector, summaries
+are emitted only once after active work drains, and discarded activities are not
+published. `git diff --check` passed.
+
+Overlap re-audit: `origin/develop` remains `3c4e3ac6`; #500 remains `c8737826`.
+The open PR set and the previously recorded independent scope decisions are
+unchanged. No branch integration or recovery-observation consumption is added.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import yargs, { type Argv, type ArgumentsCamelCase, type CommandModule } from "yargs";
 import { hideBin } from "yargs/helpers";
 import type { DropCampaign, Platform } from "@lurkloot/shared/models";
+import type { EngineEvent } from "@lurkloot/shared/events";
 import { KickWafBlockedError } from "@lurkloot/core/tabs";
 import { assertExportOutputPath, loadConfig, saveConfigSettings, TRANSPORTS, type CliConfig, type Transport } from "./config";
 import { buildCliSettingsExportPayload, parseCliSettingsImportPayload } from "./settings";
@@ -15,6 +16,8 @@ import { importCredentials } from "./auth/importCredentials";
 import { twitchDeviceLogin } from "./auth/twitchDeviceFlow";
 import { kickDeviceLogin } from "./auth/kickDeviceFlow";
 import { createLogger } from "./logger";
+import { reportCliEvents } from "./events";
+import { toEngineSettings } from "./settings";
 import type { LogLevel } from "@lurkloot/shared/logging";
 
 // Global options carried by every command (yargs makes them inheritable), so the
@@ -126,7 +129,15 @@ const discoverCommand: CommandModule = {
           logger.info("disabled in config — skipping", platform);
           continue;
         }
-        await discoverPlatform(platform, handle.adapters[platform], logger);
+        const events: EngineEvent[] = [];
+        const emit = (event: EngineEvent) => events.push(event);
+        const { adapter } = handle.createAdapter(platform, emit, toEngineSettings(config.settings));
+        try {
+          await discoverPlatform(platform, adapter, logger);
+        } finally {
+          adapter.flushRouteDiagnostics?.(emit);
+          await reportCliEvents(events, logger);
+        }
       }
     } finally {
       await handle.dispose();

--- a/packages/cli/src/transport/common.ts
+++ b/packages/cli/src/transport/common.ts
@@ -3,7 +3,7 @@ import type { EventEmitter } from "@lurkloot/shared/events";
 import { DEFAULT_ENGINE_SETTINGS } from "@lurkloot/shared/settings";
 import type { PageFetcher, PlatformAdapter, WatchTabPort } from "@lurkloot/core/adapter";
 import type { WebSocketFactory } from "@lurkloot/core/webSocket";
-import { KickAdapter, KickClaimState, KickDiscoveryState } from "@lurkloot/core/kick";
+import { createKickFetcher, KickAdapter, KickClaimState, KickDiscoveryState } from "@lurkloot/core/kick";
 import { TwitchAdapter, TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import type { TwitchHeartbeatFetchText, TwitchHeartbeatPost } from "@lurkloot/core/twitch/heartbeat";
 import { resolveCompatibility, type CompatibilityResolution } from "@lurkloot/core";
@@ -74,6 +74,7 @@ export function createCliAdapters(
     const identity = twitchClientIdentity(creds);
     const twitchIdentity = identity.userAgent ? "android" : "web";
     const resolution = resolveCompatibility(settings.compatibility, { host: "cli", twitchIdentity });
+    const kickFetcher = platform === "kick" ? deps.kickFetcher() : undefined;
     const adapter = platform === "twitch"
       ? new TwitchAdapter(
         deps.twitchFetcher(),
@@ -90,7 +91,10 @@ export function createCliAdapters(
         emit,
       )
       : new KickAdapter(
-        deps.kickFetcher(),
+        createKickFetcher({
+          background: (url, init) => kickFetcher!.fetchJson(url, init, emit),
+          routeState: kickDiscoveryState.routeDiagnostics,
+        }),
         tablessWatchPort,
         deps.kickWebSocketFactory?.(),
         { compatibility: resolution.compatibility.kick, claimState: kickClaimState, discoveryState: kickDiscoveryState },

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -267,6 +267,28 @@ describe("loadConfig", () => {
 });
 
 describe("CLI config warning integration", () => {
+  it("reports Kick route transitions and one summary from discover --log debug", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lurkloot-discover-routes-"));
+    try {
+      const configPath = join(dir, "config.json");
+      writeFileSync(configPath, JSON.stringify({ transport: "http", settings: {
+        platform: { twitch: { enabled: false }, kick: { enabled: true } },
+      } }));
+      const fakeNetwork = "globalThis.fetch = async (url) => { if (!['https://web.kick.com/api/v1/drops/campaigns', 'https://web.kick.com/api/v1/drops/progress'].includes(String(url))) throw new Error('Unexpected request'); return new Response(JSON.stringify({data: []}), {status: 200, headers: {'content-type': 'application/json'}}); };";
+      const result = spawnSync(process.execPath, ["--import", `data:text/javascript,${encodeURIComponent(fakeNetwork)}`, CLI_PATH, "discover", "--log", "debug", "--config", configPath], {
+        cwd: CLI_PACKAGE_DIR,
+        encoding: "utf8",
+        env: { ...process.env, SA_KICK_SESSION_TOKEN: undefined, SA_TWITCH_AUTH_TOKEN: undefined, SA_TWITCH_DEVICE_ID: undefined },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stderr).toContain("discovered 0 campaign(s)");
+      expect(result.stderr.match(/INFO \[kick\] Kick fetch web\.kick\.com/g) ?? []).toHaveLength(1);
+      expect(result.stderr.match(/DEBUG \[kick\] Kick fetch success summary: web\.kick\.com\.background=2/g) ?? []).toHaveLength(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     ["validate-config", ["validate-config"]],
     ["discover", ["discover"]],

--- a/packages/cli/tests/transport.test.ts
+++ b/packages/cli/tests/transport.test.ts
@@ -3,6 +3,9 @@ import { createTransport } from "../src/transport";
 import { tablessWatchPort, withHeartbeatTimeout } from "../src/transport/common";
 import { DEFAULT_ENGINE_SETTINGS } from "@lurkloot/shared/settings";
 import type { DropCampaign, DropReward } from "@lurkloot/shared/models";
+import type { DiagnosticEvent, EngineEvent } from "@lurkloot/shared/events";
+import { reportCliEvents } from "../src/events";
+import { createLogger } from "../src/logger";
 
 const ENABLED = { twitch: true, kick: true };
 
@@ -60,6 +63,34 @@ function retainedTwitchCampaignDetails(): unknown {
 }
 
 describe("createTransport", () => {
+  it("keeps route counts useful in CLI debug output across fresh adapters", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response('{"id":42}', { status: 200, headers: { "content-type": "application/json" } })));
+    const events: EngineEvent[] = [];
+    const emit = (event: EngineEvent) => events.push(event);
+    const handle = await createTransport("http", {}, "/tmp/auth", ENABLED);
+    try {
+      for (let tick = 0; tick < 3; tick += 1) {
+        const { adapter } = handle.createAdapter("kick", emit, DEFAULT_ENGINE_SETTINGS);
+        for (let request = 0; request < 10; request += 1) await adapter.checkAuthHealth();
+        adapter.flushRouteDiagnostics?.(emit);
+      }
+      const summaries = events.filter((event) => event.category === "diagnostic" && event.code === "kick_fetch_summary") as DiagnosticEvent[];
+      expect(summaries.map((event) => event.data)).toEqual(Array(3).fill({ "kick.com.background": 10 }));
+      expect(events.filter((event) => event.level === "info")).toHaveLength(1);
+      const output: string[] = [];
+      const write = vi.spyOn(process.stderr, "write").mockImplementation((line) => { output.push(String(line)); return true; });
+      try {
+        await reportCliEvents(events, createLogger("debug"));
+      } finally {
+        write.mockRestore();
+      }
+      expect(output.filter((line) => line.includes("DEBUG [kick]") && line.includes("kick.com.background=10"))).toHaveLength(3);
+      expect(output.join("\n")).not.toContain("service worker");
+    } finally {
+      await handle.dispose();
+    }
+  });
+
   it("builds a disposable http transport with both adapters", async () => {
     const handle = await createTransport("http", {}, "/tmp/auth", ENABLED);
     expect(handle.adapters.twitch.platform).toBe("twitch");

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -345,6 +345,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     ? crypto.randomUUID()
     : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
   const controllerRunLabel = controllerRunId.slice(0, 8);
+  // Explicit controller cleanup observes every report, but normal operation
+  // completion waits only on its own collector/adapter handle's reports.
   const pendingRouteReports = new Set<Promise<void>>();
   let controllerRunAnnouncement: Promise<void> | undefined;
   const platformMutations: Record<Platform, Promise<unknown>> = {
@@ -510,10 +512,12 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     adapter(settings: S, emit: EventEmitter, reportCompatibility?: boolean): PlatformAdapter;
     drain(emit: EventEmitter): void;
     close(): void;
+    settleRouteReports(): Promise<void>;
   }
 
   function createTickAdapterHandle(platform: Platform, tickContext: TickDiagnosticContext): TickAdapterHandle {
     let pendingEvents: EngineEvent[] | undefined = [];
+    const routeReports = new Set<Promise<void>>();
     let adapter: PlatformAdapter | undefined;
     let construction: ReturnType<BackgroundControllerDeps<S>["createAdapter"]> | undefined;
     let compatibilityReported = false;
@@ -524,7 +528,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         const nextFingerprint = JSON.stringify(settings);
         if (!adapter || settingsFingerprint !== nextFingerprint) {
           this.drain(emit);
-          construction = deps.createAdapter(platform, routeDiagnosticEmitter((event) => pendingEvents?.push(event), tickContext), settings);
+          construction = deps.createAdapter(platform, routeDiagnosticEmitter((event) => pendingEvents?.push(event), routeReports, tickContext), settings);
           adapter = construction.adapter;
           settingsFingerprint = nextFingerprint;
           compatibilityReported = false;
@@ -538,10 +542,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       },
       drain(emit) {
         for (const event of pendingEvents?.splice(0) ?? []) emit(event);
-        adapter?.flushRouteDiagnostics?.(routeDiagnosticEmitter(emit, tickContext));
+        adapter?.flushRouteDiagnostics?.(routeDiagnosticEmitter(emit, routeReports, tickContext));
       },
       close() {
         pendingEvents = undefined;
+      },
+      async settleRouteReports() {
+        await Promise.allSettled([...routeReports]);
       },
     };
   }
@@ -551,19 +558,24 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     tickContext?: TickDiagnosticContext,
   ): Promise<T> {
     const events: EngineEvent[] = [];
+    const routeReports = new Set<Promise<void>>();
     let collect: EventEmitter | undefined = (event) => events.push(event);
-    const emit = withActivityDiagnostics(routeDiagnosticEmitter((event) => collect?.(event), tickContext));
+    const emit = withActivityDiagnostics(routeDiagnosticEmitter((event) => collect?.(event), routeReports, tickContext));
     try {
       return await operation(emit, events);
     } finally {
       // A timed-out auth request can finish later. Only its safe transport
       // diagnostics still have a destination; discard late operational events.
       collect = undefined;
-      await Promise.allSettled([...pendingRouteReports]);
+      await Promise.allSettled([...routeReports]);
     }
   }
 
-  function routeDiagnosticEmitter(emit: EventEmitter, tickContext?: TickDiagnosticContext): EventEmitter {
+  function routeDiagnosticEmitter(
+    emit: EventEmitter,
+    routeReports: Set<Promise<void>>,
+    tickContext?: TickDiagnosticContext,
+  ): EventEmitter {
     return (event) => {
       if (event.category !== "diagnostic" || event.platform !== "kick"
         || (event.code !== "kick_fetch_route" && event.code !== "kick_fetch_summary"
@@ -578,8 +590,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         emittedAt: event.emittedAt ?? new Date().toISOString(),
         ...tickContext,
       }]);
+      routeReports.add(report);
       pendingRouteReports.add(report);
-      void report.then(() => pendingRouteReports.delete(report), () => pendingRouteReports.delete(report));
+      const settled = () => {
+        routeReports.delete(report);
+        pendingRouteReports.delete(report);
+      };
+      void report.then(settled, settled);
     };
   }
 
@@ -2469,7 +2486,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         platform,
         tickContext,
       );
-      await Promise.allSettled([...pendingRouteReports]);
+      await Promise.all(Object.values(tickAdapters).map((adapter) => adapter.settleRouteReports()));
     }
   }
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -546,10 +546,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     };
   }
 
-  async function withEventCollector<T>(operation: (emit: EventEmitter, events: EngineEvent[]) => Promise<T>): Promise<T> {
+  async function withEventCollector<T>(
+    operation: (emit: EventEmitter, events: EngineEvent[]) => Promise<T>,
+    tickContext?: TickDiagnosticContext,
+  ): Promise<T> {
     const events: EngineEvent[] = [];
     let collect: EventEmitter | undefined = (event) => events.push(event);
-    const emit = withActivityDiagnostics(routeDiagnosticEmitter((event) => collect?.(event)));
+    const emit = withActivityDiagnostics(routeDiagnosticEmitter((event) => collect?.(event), tickContext));
     try {
       return await operation(emit, events);
     } finally {
@@ -2769,7 +2772,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         await Promise.all(publicationLeases.map(([leasePlatform, lease]) =>
           releaseHeartbeatPublicationLease(leasePlatform, lease)));
       }
-    }), schedulerPlatforms);
+    }, tickContext), schedulerPlatforms);
     return claimedRewards;
   }
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -536,6 +536,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       },
       drain(emit) {
         for (const event of pendingEvents.splice(0)) emit(event);
+        adapter?.flushRouteDiagnostics?.(emit);
       },
     };
   }
@@ -547,10 +548,14 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   function clearOperationalEvents(events: EngineEvent[]): void {
-    const compatibilityEvents = events.filter((event) =>
+    // Transport evidence describes HTTP work that actually happened, even when
+    // scheduler publication rolls back. It is not a claim of a committed cycle.
+    const retainedEvents = events.filter((event) =>
       event.category === "diagnostic"
-      && (event.compatibilityProfile !== undefined || event.compatibilityCapability !== undefined));
-    events.splice(0, events.length, ...compatibilityEvents);
+      && (event.compatibilityProfile !== undefined || event.compatibilityCapability !== undefined
+        || event.code === "kick_fetch_route" || event.code === "kick_fetch_summary"
+        || event.code === "kick_fetch_lifecycle_failed"));
+    events.splice(0, events.length, ...retainedEvents);
   }
 
   // Persistent tabless watchers, one per platform, kept alive across discovery
@@ -856,6 +861,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
             );
           } finally {
             tickAdapter?.drain(emit);
+            if (!tickAdapter) adapter.flushRouteDiagnostics?.(emit);
             discoveryEvents[platform].push(...events);
           }
         });
@@ -1857,6 +1863,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
             : unavailableAfterAdapterSetup();
         } finally {
           tickAdapters?.[platform]?.drain(emit);
+          if (!tickAdapters?.[platform]) adapter?.flushRouteDiagnostics?.(emit);
         }
         return { health, events, setupFailure };
       });
@@ -2675,6 +2682,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       } catch (error) {
         // The tick was rolled back, so any partial claim set is not actionable.
         for (const key of Object.keys(claimedRewards) as Platform[]) delete claimedRewards[key];
+        for (const schedulerPlatform of schedulerPlatforms) tickAdapters[schedulerPlatform]?.drain(emit);
         clearOperationalEvents(events);
         try {
           if (signal.aborted) return;
@@ -4357,7 +4365,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
       let stateWithCampaigns: SchedulerState;
       try {
-        const claimed = await createAdapters(settings, emit)[message.platform].claimReward(campaign, reward);
+        const adapter = createAdapters(settings, emit)[message.platform];
+        let claimed: boolean;
+        try {
+          claimed = await adapter.claimReward(campaign, reward);
+        } finally {
+          adapter.flushRouteDiagnostics?.(emit);
+        }
         claimedManually = claimed;
         const nextCampaigns = campaigns.map((item) => {
           if (item.id !== campaign.id) return item;
@@ -4559,8 +4573,10 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       return withEventCollector(async (emit, events) => {
         const settings = await deps.loadSettings();
         let categories: CategorySearchResult["categories"] = [];
+        let adapter: PlatformAdapter | undefined;
         try {
-          categories = await createAdapters(settings, emit)[message.platform].searchCategories?.(message.query) ?? [];
+          adapter = createAdapters(settings, emit)[message.platform];
+          categories = await adapter.searchCategories?.(message.query) ?? [];
         } catch (error) {
           emit({
             category: "diagnostic",
@@ -4568,6 +4584,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
             message: `Category search failed: ${error instanceof Error ? error.message : String(error)}`,
             platform: message.platform,
           });
+        } finally {
+          adapter?.flushRouteDiagnostics?.(emit);
         }
         await reportBestEffort(events);
         return { categories };

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -601,13 +601,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   function clearOperationalEvents(events: EngineEvent[]): void {
-    // Transport evidence describes HTTP work that actually happened, even when
-    // scheduler publication rolls back. It is not a claim of a committed cycle.
+    // Route diagnostics bypass the operational collector in
+    // routeDiagnosticEmitter, so only compatibility evidence can remain here.
     const retainedEvents = events.filter((event) =>
       event.category === "diagnostic"
-      && (event.compatibilityProfile !== undefined || event.compatibilityCapability !== undefined
-        || event.code === "kick_fetch_route" || event.code === "kick_fetch_summary"
-        || event.code === "kick_fetch_lifecycle_failed"));
+      && (event.compatibilityProfile !== undefined || event.compatibilityCapability !== undefined));
     events.splice(0, events.length, ...retainedEvents);
   }
 

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -345,6 +345,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     ? crypto.randomUUID()
     : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
   const controllerRunLabel = controllerRunId.slice(0, 8);
+  const pendingRouteReports = new Set<Promise<void>>();
   let controllerRunAnnouncement: Promise<void> | undefined;
   const platformMutations: Record<Platform, Promise<unknown>> = {
     twitch: Promise.resolve(),
@@ -508,10 +509,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     readonly platform: Platform;
     adapter(settings: S, emit: EventEmitter, reportCompatibility?: boolean): PlatformAdapter;
     drain(emit: EventEmitter): void;
+    close(): void;
   }
 
-  function createTickAdapterHandle(platform: Platform): TickAdapterHandle {
-    const pendingEvents: EngineEvent[] = [];
+  function createTickAdapterHandle(platform: Platform, tickContext: TickDiagnosticContext): TickAdapterHandle {
+    let pendingEvents: EngineEvent[] | undefined = [];
     let adapter: PlatformAdapter | undefined;
     let construction: ReturnType<BackgroundControllerDeps<S>["createAdapter"]> | undefined;
     let compatibilityReported = false;
@@ -522,29 +524,60 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         const nextFingerprint = JSON.stringify(settings);
         if (!adapter || settingsFingerprint !== nextFingerprint) {
           this.drain(emit);
-          construction = deps.createAdapter(platform, (event) => pendingEvents.push(event), settings);
+          construction = deps.createAdapter(platform, routeDiagnosticEmitter((event) => pendingEvents?.push(event), tickContext), settings);
           adapter = construction.adapter;
           settingsFingerprint = nextFingerprint;
           compatibilityReported = false;
         }
         if (reportCompatibility && !compatibilityReported && construction) {
-          reportAdapterCompatibility(construction, settings, (event) => pendingEvents.push(event), [platform]);
+          reportAdapterCompatibility(construction, settings, (event) => pendingEvents?.push(event), [platform]);
           compatibilityReported = true;
         }
         this.drain(emit);
         return adapter;
       },
       drain(emit) {
-        for (const event of pendingEvents.splice(0)) emit(event);
-        adapter?.flushRouteDiagnostics?.(emit);
+        for (const event of pendingEvents?.splice(0) ?? []) emit(event);
+        adapter?.flushRouteDiagnostics?.(routeDiagnosticEmitter(emit, tickContext));
+      },
+      close() {
+        pendingEvents = undefined;
       },
     };
   }
 
   async function withEventCollector<T>(operation: (emit: EventEmitter, events: EngineEvent[]) => Promise<T>): Promise<T> {
     const events: EngineEvent[] = [];
-    const emit = withActivityDiagnostics((event) => events.push(event));
-    return operation(emit, events);
+    let collect: EventEmitter | undefined = (event) => events.push(event);
+    const emit = withActivityDiagnostics(routeDiagnosticEmitter((event) => collect?.(event)));
+    try {
+      return await operation(emit, events);
+    } finally {
+      // A timed-out auth request can finish later. Only its safe transport
+      // diagnostics still have a destination; discard late operational events.
+      collect = undefined;
+      await Promise.allSettled([...pendingRouteReports]);
+    }
+  }
+
+  function routeDiagnosticEmitter(emit: EventEmitter, tickContext?: TickDiagnosticContext): EventEmitter {
+    return (event) => {
+      if (event.category !== "diagnostic" || event.platform !== "kick"
+        || (event.code !== "kick_fetch_route" && event.code !== "kick_fetch_summary"
+          && event.code !== "kick_fetch_lifecycle_failed")) {
+        emit(event);
+        return;
+      }
+      // These describe transport work, not accepted auth/scheduler state. Report
+      // them once even if their operation is aborted, superseded, or times out.
+      const report = reportBestEffort([{
+        ...event,
+        emittedAt: event.emittedAt ?? new Date().toISOString(),
+        ...tickContext,
+      }]);
+      pendingRouteReports.add(report);
+      void report.then(() => pendingRouteReports.delete(report), () => pendingRouteReports.delete(report));
+    };
   }
 
   function clearOperationalEvents(events: EngineEvent[]): void {
@@ -2409,6 +2442,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       globalTickId: ++globalTickSequence,
       platformTickId: ++platformTickSequence[platform],
     };
+    const tickAdapters = { [platform]: createTickAdapterHandle(platform, tickContext) };
     const tickStartedAt = Date.now();
     diagnosticEvent(
       "debug",
@@ -2417,12 +2451,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       tickContext,
     );
     try {
-      const claimed = await runTick(tickContext, [platform], abort.signal, trigger, onPersisted);
+      const claimed = await runTick(tickContext, [platform], abort.signal, trigger, tickAdapters, onPersisted);
       return [platform, claimed[platform] ?? []];
     } catch (error) {
       if (abort.signal.aborted) return [platform, []];
       throw error;
     } finally {
+      for (const adapter of Object.values(tickAdapters)) adapter.close();
       activeTicks.delete(abort);
       activePlatformTicks[platform] -= 1;
       diagnosticEvent(
@@ -2431,6 +2466,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         platform,
         tickContext,
       );
+      await Promise.allSettled([...pendingRouteReports]);
     }
   }
 
@@ -2439,13 +2475,12 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     platforms: Platform[] | undefined,
     signal: AbortSignal,
     trigger: TickTrigger,
+    tickAdapters: Partial<Record<Platform, TickAdapterHandle>>,
     onPersisted?: (state: SchedulerState) => void,
   ): Promise<ClaimedRewards> {
     const claimedRewards: ClaimedRewards = {};
     const settings = await deps.loadSettings();
     const requestedPlatforms = platforms ?? PLATFORMS;
-    const tickAdapters = Object.fromEntries(requestedPlatforms.map((platform) =>
-      [platform, createTickAdapterHandle(platform)])) as Partial<Record<Platform, TickAdapterHandle>>;
     const excludedPlatforms = new Set<Platform>();
     if (isFarmingActive(settings)) {
       if (requestedPlatforms.includes("twitch")) {
@@ -4097,7 +4132,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     let pending = backgroundWork;
     for (;;) {
       await pending;
-      if (backgroundWork === pending) return;
+      await Promise.allSettled([...pendingRouteReports]);
+      if (backgroundWork === pending && pendingRouteReports.size === 0) return;
       pending = backgroundWork;
     }
   }

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -76,6 +76,9 @@ export interface ClaimedChallenge {
 
 export interface PlatformAdapter {
   platform: Platform;
+  // Call after a logical operation drains. Independent from consume-once
+  // page-context recovery observations; does not declare a cycle successful.
+  flushRouteDiagnostics?(emit: EventEmitter): void;
   readonly compatibility?: ResolvedCompatibility[Platform];
   checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth>;
   refreshCampaigns(session?: WatchSession, options?: AdapterOperationOptions): Promise<DropCampaign[]>;
@@ -124,6 +127,7 @@ export interface PlatformAdapter {
 }
 
 export interface PageFetcher {
+  flushRouteDiagnostics?(emit: EventEmitter): void;
   fetchJson<T>(url: string, init?: RequestInit, emit?: EventEmitter): Promise<T>;
 }
 

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -179,13 +179,13 @@ export function createKickFetcher(deps: {
           // Rate limiting applies to the request, not its execution context.
           // CLI transports have no page fallback and retain their original error.
           if (!pageFetch || (isSafeFetchError(error) && error.failure.status === 429)) throw error;
+          init?.signal?.throwIfAborted();
+          result = await pageFetch(url, init);
           routeState.report(emit, host, "page", error instanceof KickWafBlockedError
             ? "→ WAF-blocked from service worker, using page tab"
             : "→ service worker error, using page tab");
-          await notifyLifecycle(onPageFallback, host, emit);
-          init?.signal?.throwIfAborted();
-          result = await pageFetch(url, init);
           counts.record(host, "page");
+          await notifyLifecycle(onPageFallback, host, emit);
           return result as T;
         }
         routeState.report(emit, host, "background", pageFetch

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -149,6 +149,7 @@ export function createKickFetcher(deps: {
   const routeState = deps.routeState ?? new KickRouteState();
   const counts = new KickRouteCounts();
   let activeRequests = 0;
+  let pendingFlush: EventEmitter | undefined;
   const notifyLifecycle = async (
     callback: ((host: string, emit: EventEmitter) => Promise<void> | void) | undefined,
     host: string,
@@ -163,6 +164,7 @@ export function createKickFetcher(deps: {
   return {
     flushRouteDiagnostics(emit) {
       if (activeRequests === 0) counts.flush(emit);
+      else pendingFlush = emit;
     },
     fetchJson: async <T,>(url: string, init?: RequestInit, emit: EventEmitter = ignoreEvent): Promise<T> => {
       init?.signal?.throwIfAborted();
@@ -194,6 +196,11 @@ export function createKickFetcher(deps: {
         return result as T;
       } finally {
         activeRequests -= 1;
+        if (activeRequests === 0 && pendingFlush) {
+          const emitSummary = pendingFlush;
+          pendingFlush = undefined;
+          counts.flush(emitSummary);
+        }
       }
     },
   };

--- a/packages/core/src/platforms/kick/index.ts
+++ b/packages/core/src/platforms/kick/index.ts
@@ -16,6 +16,7 @@ import type { KickClaimCapability } from "./claim/types";
 import { safeHttpsUrl } from "./claim/types";
 import { KickClaimState } from "./claim/v2";
 import { isSafeFetchError } from "../../core/fetchError";
+import { KickRouteCounts, KickRouteState, safeKickRouteHost } from "./routeDiagnostics";
 
 export { createKickClaimCapability } from "./claim/factory";
 export type { KickClaimCapability, KickClaimOutcome } from "./claim/types";
@@ -28,12 +29,12 @@ const FOLLOWED_CHANNELS_CACHE_TTL_MS = 5 * 60_000;
 // Cross-tick cache for listFollowedChannels. A field on KickAdapter itself would
 // not do: every host reconstructs KickAdapter fresh each scheduler tick (see
 // TwitchDiscoveryState for the same constraint on the Twitch side), so only
-// state injected from outside the adapter survives to the next tick. Only one
-// field today, but this is the deliberate injection point for any future
-// cross-tick Kick state (mirroring TwitchDiscoveryState) — resist collapsing it
-// back into a bare StaleWhileRevalidateCache passed around directly.
+// state injected from outside the adapter survives to the next tick.
+// The route announcement state also shares this lifetime so unchanged routes
+// are not announced again when the next tick constructs an adapter.
 export class KickDiscoveryState {
   readonly followedChannels = new StaleWhileRevalidateCache<string[]>(FOLLOWED_CHANNELS_CACHE_TTL_MS);
+  readonly routeDiagnostics = new KickRouteState();
 }
 
 export interface KickAdapterOptions {
@@ -134,24 +135,20 @@ interface KickChallengeClaimResponse {
   data?: { challenge_id?: string; winner?: { id?: string; rarity?: string } } | null;
 }
 
-// Default Kick fetcher. Spike: try the service worker first (fully tabless) and
-// fall back to a retained kick.com page-context tab if Kick's WAF rejects the
-// extension origin. The outcome is logged once per host (then debug) so a
-// real-Chrome run shows exactly which calls are tabless-capable. The fallback
-// makes this risk-free: farming behaves as before regardless of the result.
+// Try the background transport first, then the host's optional page fallback.
+// Only route transitions emit per-request events; successful requests are
+// counted until the caller flushes the drained logical operation.
 export function createKickFetcher(deps: {
   background: (url: string, init?: RequestInit) => Promise<unknown>;
-  pageFetch: (url: string, init?: RequestInit) => Promise<unknown>;
+  pageFetch?: (url: string, init?: RequestInit) => Promise<unknown>;
   onBackgroundSuccess?: (host: string, emit: EventEmitter) => Promise<void> | void;
   onPageFallback?: (host: string, emit: EventEmitter) => Promise<void> | void;
+  routeState?: KickRouteState;
 }): PageFetcher {
   const { background, pageFetch, onBackgroundSuccess, onPageFallback } = deps;
-  const announced = new Map<string, "background" | "fallback">();
-  const report = (emit: EventEmitter, host: string, outcome: "background" | "fallback", detail: string): void => {
-    const repeat = announced.get(host) === outcome;
-    announced.set(host, outcome);
-    diagnostic(emit, repeat ? "debug" : "info", `Kick fetch ${host} ${detail}`, "kick");
-  };
+  const routeState = deps.routeState ?? new KickRouteState();
+  const counts = new KickRouteCounts();
+  let activeRequests = 0;
   const notifyLifecycle = async (
     callback: ((host: string, emit: EventEmitter) => Promise<void> | void) | undefined,
     host: string,
@@ -160,41 +157,46 @@ export function createKickFetcher(deps: {
     try {
       await callback?.(host, emit);
     } catch {
-      diagnostic(emit, "debug", `Kick page-context lifecycle update failed for ${host}`, "kick");
+      emit({ category: "diagnostic", platform: "kick", level: "debug", code: "kick_fetch_lifecycle_failed", message: `Kick page-context lifecycle update failed for ${host}` });
     }
   };
   return {
+    flushRouteDiagnostics(emit) {
+      if (activeRequests === 0) counts.flush(emit);
+    },
     fetchJson: async <T,>(url: string, init?: RequestInit, emit: EventEmitter = ignoreEvent): Promise<T> => {
       init?.signal?.throwIfAborted();
-      const host = safeHost(url);
-      let result: unknown;
+      const host = safeKickRouteHost(url);
+      activeRequests += 1;
       try {
-        result = await background(url, init);
-      } catch (error) {
-        init?.signal?.throwIfAborted();
-        // Rate limiting applies to the request, not its execution context.
-        if (isSafeFetchError(error) && error.failure.status === 429) throw error;
-        report(emit, host, "fallback", error instanceof KickWafBlockedError
-          ? "→ WAF-blocked from service worker, using page tab"
-          : "→ service worker error, using page tab");
-        await notifyLifecycle(onPageFallback, host, emit);
-        init?.signal?.throwIfAborted();
-        result = await pageFetch(url, init);
+        let result: unknown;
+        try {
+          result = await background(url, init);
+        } catch (error) {
+          init?.signal?.throwIfAborted();
+          // Rate limiting applies to the request, not its execution context.
+          // CLI transports have no page fallback and retain their original error.
+          if (!pageFetch || (isSafeFetchError(error) && error.failure.status === 429)) throw error;
+          routeState.report(emit, host, "page", error instanceof KickWafBlockedError
+            ? "→ WAF-blocked from service worker, using page tab"
+            : "→ service worker error, using page tab");
+          await notifyLifecycle(onPageFallback, host, emit);
+          init?.signal?.throwIfAborted();
+          result = await pageFetch(url, init);
+          counts.record(host, "page");
+          return result as T;
+        }
+        routeState.report(emit, host, "background", pageFetch
+          ? "→ service worker OK (tabless-capable)"
+          : "→ background transport OK (tabless-capable)");
+        counts.record(host, "background");
+        await notifyLifecycle(onBackgroundSuccess, host, emit);
         return result as T;
+      } finally {
+        activeRequests -= 1;
       }
-      report(emit, host, "background", "→ service worker OK (tabless-capable)");
-      await notifyLifecycle(onBackgroundSuccess, host, emit);
-      return result as T;
     },
   };
-}
-
-function safeHost(url: string): string {
-  try {
-    return new URL(url).host;
-  } catch {
-    return "unknown-host";
-  }
 }
 
 // Parses the `categories[]` array from Kick's `/api/search` response. Each entry
@@ -230,6 +232,10 @@ export class KickAdapter implements PlatformAdapter {
   private readonly claimCapability: KickClaimCapability;
   private readonly discoveryState: KickDiscoveryState;
   readonly createDiscoverySignalController?: () => DiscoverySignalController;
+
+  flushRouteDiagnostics(emit: EventEmitter): void {
+    this.fetcher.flushRouteDiagnostics?.(emit);
+  }
 
   async checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth> {
     const checkedAt = new Date().toISOString();

--- a/packages/core/src/platforms/kick/routeDiagnostics.ts
+++ b/packages/core/src/platforms/kick/routeDiagnostics.ts
@@ -1,0 +1,52 @@
+import type { EventEmitter } from "@lurkloot/shared/events";
+
+type KickRouteHost = "kick.com" | "web.kick.com" | "websockets.kick.com" | "unknown-host";
+type KickRoute = "background" | "page";
+
+export function safeKickRouteHost(url: string): KickRouteHost {
+  try {
+    const host = new URL(url).host;
+    if (host === "kick.com" || host === "web.kick.com" || host === "websockets.kick.com") return host;
+  } catch {
+    // Invalid URLs and unexpected hosts share one bounded, non-sensitive bucket.
+  }
+  return "unknown-host";
+}
+
+// Host-owned, runtime-lifetime state. Reconstructing adapters must not announce
+// an unchanged route as a transition. This contains no request or account data.
+export class KickRouteState {
+  private readonly routes = new Map<KickRouteHost, KickRoute>();
+
+  report(emit: EventEmitter, host: KickRouteHost, route: KickRoute, detail: string): void {
+    const previous = this.routes.get(host);
+    if (previous === route) return;
+    this.routes.set(host, route);
+    emit({
+      category: "diagnostic", platform: "kick", level: "info", code: "kick_fetch_route",
+      message: `Kick fetch ${host} ${detail}${previous === "page" && route === "background" ? " (background route recovered)" : ""}`,
+    });
+  }
+}
+
+// One operation's counters, separate from page-context recovery observations.
+// Flushing never consumes lifecycle evidence and never stores raw HTTP events.
+export class KickRouteCounts {
+  private counts = new Map<`${KickRouteHost}.${KickRoute}`, number>();
+
+  record(host: KickRouteHost, route: KickRoute): void {
+    const key = `${host}.${route}` as const;
+    this.counts.set(key, (this.counts.get(key) ?? 0) + 1);
+  }
+
+  flush(emit: EventEmitter): void {
+    if (this.counts.size === 0) return;
+    const entries = [...this.counts].sort(([left], [right]) => left.localeCompare(right));
+    this.counts = new Map();
+    emit({
+      category: "diagnostic", platform: "kick", level: "debug", code: "kick_fetch_summary",
+      message: `Kick fetch success summary: ${entries.map(([key, count]) => `${key}=${count}`).join(", ")}`,
+      data: Object.fromEntries(entries),
+    });
+  }
+}

--- a/packages/core/src/platforms/kick/watch.ts
+++ b/packages/core/src/platforms/kick/watch.ts
@@ -71,6 +71,9 @@ export class KickWatcher implements TablessWatchController {
   }
 
   drainEvents() {
+    // A watcher outlives its creating adapter/tick. Reconnect and target-refresh
+    // counts belong to its own drained heartbeat operation.
+    this.fetcher.flushRouteDiagnostics?.(this.diagnostics.emit);
     return this.diagnostics.drain();
   }
 

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -115,6 +115,7 @@ function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings
     )
     : new KickAdapter(
       createKickFetcher({
+        routeState: kickDiscoveryState.routeDiagnostics,
         background: (url, init) => fetchKickInBackground<unknown>(url, init),
         pageFetch: (url, init) => fetchJsonInPage<unknown>(KICK_PAGE_CONTEXT_URL, url, init, {
           retainPageContext: { platform: "kick" },

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -1072,7 +1072,7 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
     expect(onPageFallback).not.toHaveBeenCalled();
   });
 
-  it("records fallback before page execution even when the page request fails", async () => {
+  it("does not record a fallback when page execution fails", async () => {
     const order: string[] = [];
     const fetcher = createKickFetcher({
       background: async () => { throw new KickWafBlockedError("blocked"); },
@@ -1085,7 +1085,7 @@ describe("createKickFetcher (background-first, tab fallback)", () => {
 
     await expect(fetcher.fetchJson("https://web.kick.com/api/v1/drops/campaigns"))
       .rejects.toThrow("page unavailable");
-    expect(order).toEqual(["fallback", "page"]);
+    expect(order).toEqual(["page"]);
   });
 
   it("keeps fallback diagnostics free of request details and raw errors", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -7234,6 +7234,72 @@ describe("background controller", () => {
     ]);
   });
 
+  describe("platform-local route reporting", () => {
+    it.each([
+      ["auth", "discovery"],
+      ["tick", "discovery"],
+      ["auth", "heartbeat"],
+      ["tick", "heartbeat"],
+    ] as const)("does not let a stalled Kick %s summary block Twitch %s", async (kickOperation, twitchOperation) => {
+      const summaryStarted = deferred<void>();
+      const releaseSummary = deferred<void>();
+      const env = harness(farming({ ...DEFAULT_SETTINGS, tablessMode: true }), {
+        reportEvents: async (events) => {
+          if (events.some((event) => event.platform === "kick" && event.category === "diagnostic" && event.code === "kick_fetch_summary")) {
+            summaryStarted.resolve();
+            await releaseSummary.promise;
+          }
+        },
+      });
+      let providerRequests = 0;
+      const watcher = fakeTablessWatcher(async () => {
+        providerRequests += 1;
+        return { ok: true, live: true };
+      });
+      env.twitch.supportsTabless = true;
+      env.twitch.createTablessWatcher = () => watcher;
+      env.deps.createAdapter.mockImplementation((platform, emit, settings) => ({
+        adapter: platform === "kick" ? kickAdapter(createKickFetcher({
+          background: async (url) => url.endsWith("/user") ? { id: 42 } : { data: [] },
+        }), undefined, undefined, emit) : env.twitch,
+        ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
+      }));
+      if (twitchOperation === "heartbeat") {
+        await env.controller.tick(["twitch"]);
+        advanceToNextHeartbeatDue();
+      }
+      let kickCompleted = false;
+      const kickWork = (kickOperation === "auth"
+        ? env.controller.checkAuthHealth("kick")
+        : env.controller.tick(["kick"])).then(() => { kickCompleted = true; });
+      await summaryStarted.promise;
+      let twitchCompleted = false;
+      const twitchWork = (twitchOperation === "discovery"
+        ? env.controller.tick(["twitch"])
+        : env.controller.runWatchHeartbeat()).then(() => { twitchCompleted = true; });
+      let reportsSettled = false;
+      const settling = env.controller.settleBackgroundWork().then(() => { reportsSettled = true; });
+      try {
+        await drainMicrotasks();
+        if (twitchOperation === "discovery") {
+          expect(env.state.campaigns.twitch.map((item) => item.id)).toEqual(["twitch-campaign"]);
+          expect(env.state.sessions.twitch.watchMode).toBe("tabless");
+        } else {
+          expect(providerRequests).toBe(1);
+          expect(env.state.sessions.twitch.lastHeartbeatOk).toBe(true);
+        }
+        expect(twitchCompleted).toBe(true);
+        expect(kickCompleted).toBe(false);
+        expect(reportsSettled).toBe(false);
+      } finally {
+        releaseSummary.resolve();
+        await Promise.all([kickWork, twitchWork, settling]);
+        await env.controller.settleBackgroundWork();
+        env.controller.shutdown();
+      }
+    });
+  });
+
   it("correlates watcher startup route transitions and summary with the current scheduler tick", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -17,7 +17,7 @@ import type { RuntimeSnapshot } from "@lurkloot/shared/messages";
 import { applySettingsPatch, DEFAULT_SETTINGS, isFarmingActive } from "@lurkloot/shared/settings";
 import { DEFAULT_STATE } from "../src/core/storage";
 import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
-import { createKickFetcher, KickClaimState } from "@lurkloot/core/kick";
+import { createKickFetcher, KickClaimState, KickDiscoveryState } from "@lurkloot/core/kick";
 import { TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import { kickAdapter, twitchAdapter } from "./helpers/adapters";
 import type { TablessWatchController } from "@lurkloot/core/tablessWatch";
@@ -3887,6 +3887,29 @@ describe("background controller", () => {
     expect(batches[schedulerBatchIndex]).not.toContainEqual(expect.objectContaining({ message: "adapter-created" }));
   });
 
+  it("flushes standalone Kick search and manual claim successes into their own reports", async () => {
+    const env = harness(DEFAULT_SETTINGS, { initialState: {
+      ...DEFAULT_STATE,
+      campaigns: { twitch: [], kick: [campaign("kick", "claimable")] },
+    } });
+    const discoveryState = new KickDiscoveryState();
+    env.deps.createAdapters.mockImplementation((emit, settings) => ({
+      adapters: { twitch: env.twitch, kick: kickAdapter(createKickFetcher({
+        background: async (url) => url.includes("/search") ? { categories: [] } : { success: true },
+        routeState: discoveryState.routeDiagnostics,
+      }), undefined, undefined, emit, { discoveryState }) },
+      ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
+    }));
+    await env.controller.handleMessage({ type: "searchCategories", platform: "kick", query: "private-query" });
+    const searchReports = allDiagnostics(env).filter((event) => event.code === "kick_fetch_summary");
+    expect(searchReports.map((event) => event.data)).toEqual([{ "kick.com.background": 1 }]);
+    await env.controller.handleMessage({ type: "claimReward", platform: "kick", campaignId: "kick-campaign", rewardId: "reward" });
+    const summaries = allDiagnostics(env).filter((event) => event.code === "kick_fetch_summary");
+    expect(summaries.map((event) => event.data)).toEqual([{ "kick.com.background": 1 }, { "web.kick.com.background": 1 }]);
+    expect(JSON.stringify(summaries)).not.toContain("private-query");
+    env.controller.shutdown();
+  });
+
   it("publishes category-search diagnostics in their own operation without leaking into the next tick", async () => {
     const env = harness();
     env.twitch.searchCategories = vi.fn(async () => {
@@ -3965,6 +3988,82 @@ describe("background controller", () => {
       .flatMap(([events]) => events)
       .filter((event) => event.category === "diagnostic" && event.message.includes("waiting for"));
     expect(waitingEvents).toHaveLength(1);
+  });
+
+  it("preserves route transition and lifecycle failure evidence when scheduler publication fails", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      preferKnownChannels: false,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false },
+      },
+    });
+    const discoveryState = new KickDiscoveryState();
+    env.deps.createAdapter.mockImplementation((platform, emit, settings) => {
+      const kick = kickAdapter(createKickFetcher({
+        routeState: discoveryState.routeDiagnostics,
+        background: async (url) => {
+          if (url.endsWith("/user")) return { id: 42 };
+          throw new KickWafBlockedError("secret");
+        },
+        pageFetch: async () => ({ data: [] }),
+        onPageFallback: () => { throw new Error("secret lifecycle"); },
+      }), undefined, undefined, emit, { discoveryState });
+      // Simulate a host capability becoming unavailable during reconciliation,
+      // after network discovery but before scheduler publication.
+      Object.defineProperty(kick, "createDiscoverySignalController", { get: () => { throw new Error("publication failed"); } });
+      return {
+        adapter: platform === "kick" ? kick : env.twitch,
+        ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
+      };
+    });
+    await env.controller.tick(["kick"]);
+    const diagnostics = allDiagnostics(env);
+    expect(diagnostics.some((event) => event.code === "kick_fetch_route" && event.message.includes("using page tab"))).toBe(true);
+    expect(diagnostics.filter((event) => event.code === "kick_fetch_lifecycle_failed").length).toBeGreaterThanOrEqual(2);
+    expect(diagnostics.some((event) => event.code === "kick_fetch_summary" && Number(event.data?.["web.kick.com.page"]) >= 2)).toBe(true);
+    expect(JSON.stringify(diagnostics.filter((event) => event.code?.startsWith("kick_fetch_")))).not.toContain("secret");
+    env.controller.shutdown();
+  });
+
+  it("reports bounded complete route counts from fresh Kick adapters across repeated ticks", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      preferKnownChannels: false,
+      platform: {
+        ...DEFAULT_SETTINGS.platform,
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true, idleWatchlistChannels: Array.from({ length: 50 }, (_, index) => `channel-${index}`) },
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false },
+      },
+    });
+    const discoveryState = new KickDiscoveryState();
+    let requests = 0;
+    env.deps.createAdapter.mockImplementation((platform, emit, settings) => ({
+      adapter: platform === "kick" ? kickAdapter(createKickFetcher({
+        routeState: discoveryState.routeDiagnostics,
+        background: async (url) => {
+          requests += 1;
+          if (url.endsWith("/user")) return { id: 42 };
+          if (url.includes("/channels/")) return { livestream: null };
+          return { data: [] };
+        },
+        pageFetch: async () => { throw new Error("unexpected fallback"); },
+      }), undefined, undefined, emit, { discoveryState }) : env.twitch,
+      ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
+    }));
+    for (let tick = 0; tick < 50; tick += 1) await env.controller.tick(["kick"]);
+    const events = env.reportEvents.mock.calls.flatMap(([batch]) => batch);
+    const summaries = events.filter((event) => event.category === "diagnostic" && event.code === "kick_fetch_summary") as DiagnosticEvent[];
+    expect(requests).toBeGreaterThan(2500);
+    expect(summaries.length).toBeGreaterThanOrEqual(50);
+    expect(summaries.length).toBeLessThanOrEqual(150);
+    const summarized = summaries.reduce((total, event) => total + Object.values(event.data ?? {}).reduce<number>((sum, count) => sum + Number(count), 0), 0);
+    expect(summarized).toBe(requests);
+    expect(events.filter((event) => event.category === "diagnostic" && event.code === "kick_fetch_route")).toHaveLength(2);
+    expect(summaries.every((event) => event.controllerRunId && event.platformTickId)).toBe(true);
+    env.controller.shutdown();
   });
 
   it("publishes one actionable link-required diagnostic while repeated automatic claims are suppressed", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -18,6 +18,7 @@ import { applySettingsPatch, DEFAULT_SETTINGS, isFarmingActive } from "@lurkloot
 import { DEFAULT_STATE } from "../src/core/storage";
 import type { PageFetcher, PlatformAdapter } from "@lurkloot/core/adapter";
 import { createKickFetcher, KickClaimState, KickDiscoveryState } from "@lurkloot/core/kick";
+import { KickWatcher } from "@lurkloot/core/kick/watch";
 import { TwitchDiscoveryState } from "@lurkloot/core/twitch";
 import { kickAdapter, twitchAdapter } from "./helpers/adapters";
 import type { TablessWatchController } from "@lurkloot/core/tablessWatch";
@@ -7231,6 +7232,47 @@ describe("background controller", () => {
       "higher",
       "current",
     ]);
+  });
+
+  it("correlates watcher startup route transitions and summary with the current scheduler tick", async () => {
+    const env = harness({
+      ...DEFAULT_SETTINGS,
+      tablessMode: true,
+      platform: {
+        twitch: { ...DEFAULT_SETTINGS.platform.twitch, enabled: false },
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
+      },
+    });
+    const watcher = new KickWatcher({
+      fetcher: createKickFetcher({
+        background: async (url) => {
+          if (url === "https://kick.com/api/v2/channels/kick-creator") {
+            return { id: 42, livestream: { id: 84, is_live: true } };
+          }
+          if (url === "https://websockets.kick.com/viewer/v1/token") return { data: { token: "viewer-token" } };
+          throw new Error("Unexpected watcher request");
+        },
+      }),
+      createWebSocket: () => ({ readyState: 0, send() {}, close() {}, addEventListener() {} }),
+    });
+    env.kick.supportsTabless = true;
+    env.kick.createTablessWatcher = () => watcher;
+    try {
+      await env.controller.tick(["twitch"]);
+      await env.controller.tick(["kick"]);
+
+      expect(env.state.sessions.kick.watchMode).toBe("tabless");
+      const routes = allDiagnostics(env).filter((event) => event.code === "kick_fetch_route");
+      const summaries = allDiagnostics(env).filter((event) => event.code === "kick_fetch_summary");
+      expect(routes).toHaveLength(2);
+      expect(summaries.map((event) => event.data)).toEqual([{ "kick.com.background": 1, "websockets.kick.com.background": 1 }]);
+      for (const event of [...routes, ...summaries]) {
+        expect(event).toMatchObject({ platformTickId: 1, globalTickId: 2 });
+      }
+    } finally {
+      await watcher.stop();
+      env.controller.shutdown();
+    }
   });
 
   it("completes a due initial heartbeat while discovery-signal start is blocked after publication", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -3990,6 +3990,108 @@ describe("background controller", () => {
     expect(waitingEvents).toHaveLength(1);
   });
 
+  describe("route evidence independent of state publication", () => {
+    function routeEnv(onBackgroundSuccess?: (host: string, emit: EventEmitter) => Promise<void> | void) {
+      const env = harness({ ...DEFAULT_SETTINGS, preferKnownChannels: false, platform: {
+        ...DEFAULT_SETTINGS.platform,
+        kick: { ...DEFAULT_SETTINGS.platform.kick, enabled: true },
+      } }, { authProbeTimeoutMs: 25 });
+      const discoveryState = new KickDiscoveryState();
+      env.deps.createAdapter.mockImplementation((platform, emit, settings) => ({
+        adapter: platform === "kick" ? kickAdapter(createKickFetcher({
+          background: async (url) => {
+            if (url.endsWith("/user")) return { id: 42 };
+            throw new KickWafBlockedError("blocked");
+          },
+          pageFetch: async () => ({ data: [] }),
+          routeState: discoveryState.routeDiagnostics,
+          onBackgroundSuccess,
+          onPageFallback: (_host, operationEmit) => operationEmit({ category: "activity", code: "page_context_opened", level: "info", platform: "kick", data: { host: "kick.com", reason: "background_rejected" } }),
+        }), undefined, undefined, emit, { discoveryState }) : env.twitch,
+        ...resolveCompatibility(settings.compatibility, { host: "extension", twitchIdentity: "web" }),
+      }));
+      return env;
+    }
+
+    it.each(["abort after discovery drain", "stale publication rejection"])("keeps route evidence through %s without publishing discarded activity", async (mode) => {
+      const env = routeEnv();
+      let interrupted = false;
+      env.deps.applyAdFocus.mockImplementation(async () => {
+        if (mode === "abort after discovery drain") {
+          interrupted = true;
+          env.controller.shutdown();
+        } else {
+          env.deps.loadState.mockImplementationOnce(async () => {
+            interrupted = true;
+            env.controller.shutdown();
+            return env.state;
+          });
+        }
+      });
+      await env.controller.tick(["kick"]);
+      expect(interrupted).toBe(true);
+      expect(env.state.sessions.kick.lastCheckedAt).toBeUndefined();
+      const diagnostics = allDiagnostics(env);
+      expect(diagnostics.filter((event) => event.code === "kick_fetch_route" && event.message.includes("using page tab"))).toHaveLength(1);
+      expect(diagnostics.some((event) => event.code === "kick_fetch_summary" && event.data?.["web.kick.com.page"] === 2)).toBe(true);
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events).filter((event) => event.category === "activity" && event.code === "page_context_opened")).toEqual([]);
+    });
+
+    it.each(["abort", "stale generation"])("keeps auth route evidence after %s", async (mode) => {
+      const started = deferred<void>();
+      const finish = deferred<void>();
+      const env = routeEnv(async () => { started.resolve(); await finish.promise; });
+      const checking = mode === "abort" ? env.controller.tick(["kick"]) : env.controller.checkAuthHealth("kick");
+      await started.promise;
+      if (mode === "abort") env.controller.shutdown();
+      else await env.controller.invalidateAuthHealth("kick");
+      finish.resolve();
+      await checking;
+      await env.controller.settleBackgroundWork();
+      expect(env.state.authHealth.kick.status).not.toBe("healthy");
+      expect(allDiagnostics(env).filter((event) => event.code === "kick_fetch_route")).toHaveLength(1);
+      expect(allDiagnostics(env).filter((event) => event.code === "kick_fetch_summary").map((event) => event.data)).toEqual([{ "kick.com.background": 1 }]);
+      if (mode === "stale generation") {
+        await env.controller.checkAuthHealth("kick");
+        expect(env.state.authHealth.kick.status).toBe("healthy");
+        expect(allDiagnostics(env).filter((event) => event.code === "kick_fetch_route")).toHaveLength(1);
+      }
+      env.controller.shutdown();
+    });
+
+    it.each([[false, false], [false, true], [true, false], [true, true]])("reports a late auth completion once after the deadline (tick=%s, lifecycle failure=%s)", async (tickProbe, lifecycleFailure) => {
+      vi.useFakeTimers();
+      const started = deferred<void>();
+      const finish = deferred<void>();
+      const env = routeEnv(async (_host, emit) => {
+        started.resolve();
+        await finish.promise;
+        emit({ category: "activity", code: "page_context_closed", level: "info", platform: "kick", data: { host: "kick.com", reason: "background_recovered" } });
+        if (lifecycleFailure) throw new Error("secret late lifecycle error");
+      });
+      const checking = tickProbe ? env.controller.tick(["kick"]) : env.controller.checkAuthHealth("kick");
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(25);
+      await checking;
+      expect(env.state.authHealth.kick.reasonCode).toBe("network_unavailable");
+      const writes = env.deps.saveState.mock.calls.length;
+      expect(allDiagnostics(env).filter((event) => event.code === "kick_fetch_summary")).toHaveLength(0);
+      finish.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      await env.controller.settleBackgroundWork();
+      const diagnostics = allDiagnostics(env);
+      expect(diagnostics.filter((event) => event.code === "kick_fetch_route")).toHaveLength(1);
+      expect(diagnostics.filter((event) => event.code === "kick_fetch_summary").map((event) => event.data)).toEqual([{ "kick.com.background": 1 }]);
+      expect(diagnostics.filter((event) => event.code === "kick_fetch_lifecycle_failed")).toHaveLength(lifecycleFailure ? 1 : 0);
+      if (tickProbe) expect(diagnostics.filter((event) => event.code?.startsWith("kick_fetch_")).every((event) => event.platformTickId === 1)).toBe(true);
+      expect(env.deps.saveState).toHaveBeenCalledTimes(writes);
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events).filter((event) => event.category === "activity" && event.code === "page_context_closed")).toEqual([]);
+      expect(JSON.stringify(diagnostics.filter((event) => event.code?.startsWith("kick_fetch_")))).not.toContain("secret");
+      env.controller.shutdown();
+      vi.useRealTimers();
+    });
+  });
+
   it("preserves route transition and lifecycle failure evidence when scheduler publication fails", async () => {
     const env = harness({
       ...DEFAULT_SETTINGS,

--- a/packages/extension/tests/kickDiscoveryPerformance.test.ts
+++ b/packages/extension/tests/kickDiscoveryPerformance.test.ts
@@ -66,9 +66,8 @@ describe("Kick discovery batch", () => {
       .then((result) => { settled = true; return result; }, () => { settled = true; return undefined; });
     await vi.advanceTimersByTimeAsync(10);
     expect(settled).toBe(false);
-    await vi.advanceTimersByTimeAsync(25);
+    await vi.advanceTimersByTimeAsync(45);
     expect(fallbacks).toBe(1);
-    expect(settled).toBe(false);
     await vi.runAllTimersAsync();
     const result = await run;
     expect(settled).toBe(true);

--- a/packages/extension/tests/kickRouteDiagnostics.test.ts
+++ b/packages/extension/tests/kickRouteDiagnostics.test.ts
@@ -80,9 +80,31 @@ describe("Kick route diagnostics", () => {
     await expect(fetcher.fetchJson("https://kick.com/private", undefined, emit)).rejects.toThrow("secret page");
     fetcher.flushRouteDiagnostics?.(emit);
     const output = diagnostics(events);
-    expect(output.filter((event) => event.message.includes("lifecycle update failed"))).toHaveLength(2);
+    expect(output.filter((event) => event.message.includes("lifecycle update failed"))).toHaveLength(1);
     expect(output.find((event) => event.code === "kick_fetch_summary")?.data).toEqual({ "kick.com.page": 1 });
     expect(JSON.stringify(output)).not.toContain("secret");
+  });
+
+  it("does not announce recovery after a page route failed before succeeding", async () => {
+    const events: EngineEvent[] = [];
+    let backgroundFails = true;
+    const fetcher = createKickFetcher({
+      background: async () => {
+        if (backgroundFails) throw new Error("background unavailable");
+        return {};
+      },
+      pageFetch: async () => { throw new Error("page unavailable"); },
+      routeState: new KickDiscoveryState().routeDiagnostics,
+    });
+
+    await expect(fetcher.fetchJson("https://kick.com/private", undefined, (event) => events.push(event)))
+      .rejects.toThrow("page unavailable");
+    backgroundFails = false;
+    await fetcher.fetchJson("https://kick.com/private", undefined, (event) => events.push(event));
+
+    const transitions = diagnostics(events).filter((event) => event.code === "kick_fetch_route");
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0]?.message).not.toContain("recovered");
   });
 
   it("does not flush a partial observation while any fetch or lifecycle callback is active", async () => {

--- a/packages/extension/tests/kickRouteDiagnostics.test.ts
+++ b/packages/extension/tests/kickRouteDiagnostics.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { createKickFetcher, KickDiscoveryState } from "@lurkloot/core/kick";
+import { KickWafBlockedError } from "@lurkloot/core/tabs";
+import type { DiagnosticEvent, EngineEvent } from "@lurkloot/shared/events";
+
+function diagnostics(events: EngineEvent[]): DiagnosticEvent[] {
+  return events.filter((event): event is DiagnosticEvent => event.category === "diagnostic");
+}
+
+describe("Kick route diagnostics", () => {
+  it("bounds eleven hours of reconstructed adapters by operations, not request count", async () => {
+    const state = new KickDiscoveryState();
+    const events: EngineEvent[] = [];
+    const emit = (event: EngineEvent) => events.push(event);
+    for (let tick = 0; tick < 660; tick += 1) {
+      const fetcher = createKickFetcher({
+        background: async () => ({}),
+        pageFetch: async () => ({}),
+        routeState: state.routeDiagnostics,
+      });
+      for (let request = 0; request < 100; request += 1) {
+        await fetcher.fetchJson(`https://${request < 90 ? "kick.com" : "web.kick.com"}/private/${request}?secret=value`, undefined, emit);
+      }
+      fetcher.flushRouteDiagnostics?.(emit);
+      fetcher.flushRouteDiagnostics?.(emit);
+    }
+    const output = diagnostics(events);
+    expect(output.filter((event) => event.level === "info")).toHaveLength(2);
+    expect(output.filter((event) => event.code === "kick_fetch_summary")).toHaveLength(660);
+    expect(output).toHaveLength(662);
+    expect(output.at(-1)?.data).toEqual({
+      "kick.com.background": 90,
+      "web.kick.com.background": 10,
+    });
+  });
+
+  it("keeps fallback and recovery transitions across reconstruction with exact success totals", async () => {
+    const state = new KickDiscoveryState();
+    const events: EngineEvent[] = [];
+    const emit = (event: EngineEvent) => events.push(event);
+    let fallback = false;
+    for (const page of [false, true, true, false]) {
+      fallback = page;
+      const fetcher = createKickFetcher({
+        background: async () => {
+          if (fallback) throw new KickWafBlockedError("secret error");
+          return {};
+        },
+        pageFetch: async () => ({}),
+        routeState: state.routeDiagnostics,
+      });
+      for (let request = 0; request < 20; request += 1) {
+        await fetcher.fetchJson("https://kick.com/private?secret=value", undefined, emit);
+      }
+      fetcher.flushRouteDiagnostics?.(emit);
+    }
+    const output = diagnostics(events);
+    expect(output.filter((event) => event.level === "info")).toHaveLength(3);
+    expect(output.filter((event) => event.code === "kick_fetch_summary").map((event) => event.data)).toEqual([
+      { "kick.com.background": 20 }, { "kick.com.page": 20 },
+      { "kick.com.page": 20 }, { "kick.com.background": 20 },
+    ]);
+    expect(output.filter((event) => event.level === "info").at(-1)?.message).toContain("recovered");
+  });
+
+  it("reports lifecycle failures individually and never counts failed page execution as success", async () => {
+    const events: EngineEvent[] = [];
+    const emit = (event: EngineEvent) => events.push(event);
+    let failedPage = false;
+    const fetcher = createKickFetcher({
+      background: async () => { throw new Error("secret background"); },
+      pageFetch: async () => {
+        if (failedPage) throw new Error("secret page");
+        return {};
+      },
+      onPageFallback: () => { throw new Error("secret lifecycle"); },
+    });
+    await fetcher.fetchJson("https://kick.com/private", undefined, emit);
+    failedPage = true;
+    await expect(fetcher.fetchJson("https://kick.com/private", undefined, emit)).rejects.toThrow("secret page");
+    fetcher.flushRouteDiagnostics?.(emit);
+    const output = diagnostics(events);
+    expect(output.filter((event) => event.message.includes("lifecycle update failed"))).toHaveLength(2);
+    expect(output.find((event) => event.code === "kick_fetch_summary")?.data).toEqual({ "kick.com.page": 1 });
+    expect(JSON.stringify(output)).not.toContain("secret");
+  });
+
+  it("does not flush a partial observation while any fetch or lifecycle callback is active", async () => {
+    const events: EngineEvent[] = [];
+    const emit = (event: EngineEvent) => events.push(event);
+    let finish!: () => void;
+    const pending = new Promise<void>((resolve) => { finish = resolve; });
+    let delayed = false;
+    const fetcher = createKickFetcher({
+      background: async () => ({}),
+      pageFetch: async () => ({}),
+      onBackgroundSuccess: async () => { if (delayed) await pending; },
+    });
+    await fetcher.fetchJson("https://kick.com/a", undefined, emit);
+    delayed = true;
+    const request = fetcher.fetchJson("https://web.kick.com/b", undefined, emit);
+    await Promise.resolve();
+    fetcher.flushRouteDiagnostics?.(emit);
+    expect(diagnostics(events).filter((event) => event.code === "kick_fetch_summary")).toHaveLength(0);
+    finish();
+    await request;
+    fetcher.flushRouteDiagnostics?.(emit);
+    expect(diagnostics(events).filter((event) => event.code === "kick_fetch_summary").map((event) => event.data))
+      .toEqual([{ "kick.com.background": 1, "web.kick.com.background": 1 }]);
+  });
+
+  it("uses fixed safe host buckets even for arbitrary hosts and malformed URLs", async () => {
+    const events: EngineEvent[] = [];
+    const emit = (event: EngineEvent) => events.push(event);
+    const fetcher = createKickFetcher({ background: async () => ({ secret: "payload" }), pageFetch: async () => ({}) });
+    for (const url of ["https://user:password@kick.com/private?token=secret", "https://secret.example/private", "secret-malformed", "https://web.kick.com:8443/private"]) {
+      await fetcher.fetchJson(url, { headers: { Authorization: "Bearer secret" }, body: "secret" }, emit);
+    }
+    fetcher.flushRouteDiagnostics?.(emit);
+    const output = diagnostics(events);
+    expect(output.find((event) => event.code === "kick_fetch_summary")?.data).toEqual({
+      "kick.com.background": 1, "unknown-host.background": 3,
+    });
+    expect(JSON.stringify(output)).not.toMatch(/secret|private|password|Authorization|payload|8443/);
+  });
+});

--- a/packages/extension/tests/tablessWatch.test.ts
+++ b/packages/extension/tests/tablessWatch.test.ts
@@ -170,8 +170,9 @@ describe("kick viewer watcher", () => {
     await watcher?.tick({});
 
     const reconnectEvents = watcher?.drainEvents() ?? [];
-    const refreshFetches = reconnectEvents.filter((event) => event.message.includes("Kick fetch kick.com"));
+    const refreshFetches = reconnectEvents.filter((event) => event.code === "kick_fetch_summary");
     expect(refreshFetches).toHaveLength(1);
+    expect(refreshFetches[0].data).toEqual({ "kick.com.background": 1, "websockets.kick.com.background": 1 });
     expect(reconnectEvents).toContainEqual(expect.objectContaining({ message: "Kick viewer connection closed for creator" }));
     expect(creationEvents.filter((event) => event.message.includes("Kick fetch kick.com"))).toEqual([]);
     await watcher?.stop();


### PR DESCRIPTION
## Summary

- replace per-request unchanged Kick route messages with bounded per-operation host/route summaries
- retain individual route transitions, fallbacks, recovery, and lifecycle-failure evidence
- persist route transition state across adapter reconstruction
- preserve transport evidence across aborts, stale publication, late authentication callbacks, and scheduler rollback
- isolate report completion by operation so stalled Kick diagnostics cannot delay Twitch discovery or heartbeats
- emit correlated summaries for auth, discovery, scheduler, manual, watcher, and CLI operations
- add diagnostic support to CLI `discover --log debug`

## Bounded-growth regression

66,000 successful requests across 660 recreated fetchers produce 662 diagnostics: one summary per operation plus two initial host transitions.

## Testing

- `pnpm verify`
- 1,889 extension tests passed
- 195 CLI tests passed
- 10 site, 17 CWS, and 78 release tests passed
- workspace typechecks, Chrome build, and Firefox build passed

Fixes #499

## Stack

This is stack 3/3. Merge in order: #519, #520, then this PR; retarget each successor to `develop` after its dependency merges.

- Depends on #520, which depends on #519

## Integration note

PR #500 has an overlapping Kick fetcher change. Keep its page-context recovery observation separate from diagnostic summary consumption, preserve this stack’s HTTP-429 guard and drained discovery workers, and add combined lifecycle tests when integrating the two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Kick fetch diagnostics for route changes, recoveries, lifecycle failures, and aggregated success counts.
  - Added debug summaries for background and page routes across supported Kick hosts.
  - CLI discovery now reports Kick diagnostics when debug logging is enabled.

- **Bug Fixes**
  - Improved diagnostic delivery during discovery, authentication, searches, claims, watchers, and background activity.
  - Failed page requests are no longer reported as successful fallbacks.
  - Diagnostic output limits host details and excludes URLs, credentials, headers, and payload data.

- **Documentation**
  - Documented Kick fetch diagnostics, reporting behavior, aggregation, and privacy safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->