### PR TITLE
fix(core): keep claims running during manual watch

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -832,6 +832,11 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     twitch: new Set<string>(),
     kick: new Set<string>(),
   };
+  const dropClaimOperations: Record<Platform, Set<AbortController>> = {
+    twitch: new Set<AbortController>(),
+    kick: new Set<AbortController>(),
+  };
+  const kickChallengeClaimOperations = new Set<AbortController>();
   let settingsMutation: Promise<unknown> = Promise.resolve();
   let twitchIntegrityAlarmMutation: Promise<unknown> = Promise.resolve();
   let twitchSettingsTransitionGeneration = 0;
@@ -1755,6 +1760,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       const current = await deps.loadSettings();
       afterLoad?.(current);
       const settings = deps.applySettingsPatch(current, patch);
+      abortIneligibleClaimOnlyOperations(settings, "Claim automation disabled");
       await deps.saveSettings(settings);
       for (const platform of invalidatedPlatforms) {
         if (!settings.platform[platform].enabled) cancelPendingTick(platform);
@@ -1765,6 +1771,23 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       await reconcileManualWatchClaimAlarms(settings);
       return settings;
     });
+  }
+
+  function abortIneligibleClaimOnlyOperations(settings: EngineSettings, reason: string): void {
+    for (const platform of PLATFORMS) {
+      if (settings.platform[platform].enabled && settings.autoClaim) continue;
+      for (const controller of dropClaimOperations[platform]) controller.abort(new Error(reason));
+    }
+    if (!settings.platform.kick.enabled || !autoClaimChallengesFor(settings, "kick")) {
+      for (const controller of kickChallengeClaimOperations) controller.abort(new Error(reason));
+    }
+  }
+
+  function abortClaimOnlyOperations(reason: string): void {
+    for (const platform of PLATFORMS) {
+      for (const controller of dropClaimOperations[platform]) controller.abort(new Error(reason));
+    }
+    for (const controller of kickChallengeClaimOperations) controller.abort(new Error(reason));
   }
 
   async function restoreTwitchIntegritySchedule(
@@ -3992,6 +4015,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     twitchSettingsTransitionGeneration += 1;
     abortActiveTicks("Controller shutdown");
     closeTwitchIntegrityLifecycle("Controller shutdown");
+    abortClaimOnlyOperations("Controller shutdown");
     void clearTwitchIntegrityAlarmBestEffort();
     void clearTwitchChannelPointsAlarmBestEffort();
     void clearManualWatchClaimAlarmsBestEffort();
@@ -4013,6 +4037,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       }
       abortActiveTicks("Host reset");
       closeTwitchIntegrityLifecycle("Host reset");
+      abortClaimOnlyOperations("Host reset");
       await stopDiscoverySignalControllersAndReport(PLATFORMS);
       await clearTwitchIntegrityAlarmBestEffort();
       await clearTwitchChannelPointsAlarmBestEffort();
@@ -4813,125 +4838,157 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
   async function runDropClaims(platform: Platform): Promise<void> {
     if (controllerShutdown) return;
-    await withStateLock(() => withEventCollector(async (emit, events) => {
-      if (controllerShutdown) return;
-      let adapter: PlatformAdapter | undefined;
-      try {
-        const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
-        if (!settings.platform[platform].enabled
-          || !settings.autoClaim
-          || state.authHealth[platform].status !== "healthy"
-          || !hasRecentManualWatchForClaims(settings, state, platform)) return;
+    const operation = new AbortController();
+    dropClaimOperations[platform].add(operation);
+    try {
+      await withStateLock(() => withEventCollector(async (emit, events) => {
+        if (controllerShutdown) return;
+        let adapter: PlatformAdapter | undefined;
+        try {
+          operation.signal.throwIfAborted();
+          const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+          operation.signal.throwIfAborted();
+          if (!settings.platform[platform].enabled
+            || !settings.autoClaim
+            || state.authHealth[platform].status !== "healthy"
+            || !hasRecentManualWatchForClaims(settings, state, platform)) return;
 
-        adapter = createAdapter(platform, settings, emit, true);
-        const refreshed = await adapter.refreshCampaigns(state.sessions[platform]);
-        const campaigns = preserveClaimedRewards(refreshed, state.campaigns[platform]);
-        const claimResult = await claimReadyRewards(
-          adapter,
-          campaigns,
-          waitingClaimRewardIds[platform],
-        );
-        const nextState: SchedulerState = {
-          ...state,
-          campaigns: {
-            ...state.campaigns,
-            [platform]: claimResult.campaigns,
-          },
-        };
-        for (const event of claimResult.events) {
-          if (event.claimed) {
-            emit({
-              category: "activity",
-              platform,
-              level: "info",
-              code: "reward_claimed",
-              data: {
-                campaignId: event.campaignId,
-                campaignName: event.campaignName,
-                rewardId: event.rewardId,
-                rewardName: event.rewardName,
-                ...(event.rewardImageUrl ? { rewardImageUrl: event.rewardImageUrl } : {}),
-                ...(event.campaignUrl ? { campaignUrl: event.campaignUrl } : {}),
-                method: "automatic",
-              },
-            });
-          } else {
-            emit({ category: "diagnostic", platform, level: event.level, message: event.message });
+          adapter = createAdapter(platform, settings, emit, true);
+          const refreshed = await adapter.refreshCampaigns(state.sessions[platform], {
+            signal: operation.signal,
+            requireComplete: true,
+          });
+          operation.signal.throwIfAborted();
+          const campaigns = preserveClaimedRewards(refreshed, state.campaigns[platform]);
+          const claimResult = await claimReadyRewards(
+            adapter,
+            campaigns,
+            waitingClaimRewardIds[platform],
+            operation.signal,
+          );
+          operation.signal.throwIfAborted();
+          const nextState: SchedulerState = {
+            ...state,
+            campaigns: {
+              ...state.campaigns,
+              [platform]: claimResult.campaigns,
+            },
+          };
+          for (const event of claimResult.events) {
+            if (event.claimed) {
+              emit({
+                category: "activity",
+                platform,
+                level: "info",
+                code: "reward_claimed",
+                data: {
+                  campaignId: event.campaignId,
+                  campaignName: event.campaignName,
+                  rewardId: event.rewardId,
+                  rewardName: event.rewardName,
+                  ...(event.rewardImageUrl ? { rewardImageUrl: event.rewardImageUrl } : {}),
+                  ...(event.campaignUrl ? { campaignUrl: event.campaignUrl } : {}),
+                  method: "automatic",
+                },
+              });
+            } else {
+              emit({ category: "diagnostic", platform, level: event.level, message: event.message });
+            }
           }
+          operation.signal.throwIfAborted();
+          adapter.flushRouteDiagnostics?.(emit);
+          await persistPlatformState(platform, nextState, () => !operation.signal.aborted);
+          operation.signal.throwIfAborted();
+          await emitNotifications(settings, state, nextState, events);
+          await reportBestEffort(events);
+        } catch (error) {
+          adapter?.flushRouteDiagnostics?.(emit);
+          clearOperationalEvents(events);
+          if (operation.signal.aborted) return;
+          emit({
+            category: "diagnostic",
+            platform,
+            level: "warn",
+            message: error instanceof Error ? error.message : "Drop claim refresh failed",
+          });
+          await reportBestEffort(events);
         }
-        adapter.flushRouteDiagnostics?.(emit);
-        await persistPlatformState(platform, nextState);
-        await emitNotifications(settings, state, nextState, events);
-        await reportBestEffort(events);
-      } catch (error) {
-        adapter?.flushRouteDiagnostics?.(emit);
-        clearOperationalEvents(events);
-        emit({
-          category: "diagnostic",
-          platform,
-          level: "warn",
-          message: error instanceof Error ? error.message : "Drop claim refresh failed",
-        });
-        await reportBestEffort(events);
-      }
-    }), [platform]);
+      }), [platform]);
+    } finally {
+      dropClaimOperations[platform].delete(operation);
+    }
   }
 
   async function runKickChallengeClaims(): Promise<void> {
     if (controllerShutdown) return;
-    await withStateLock(() => withEventCollector(async (emit, events) => {
-      if (controllerShutdown) return;
-      let adapter: PlatformAdapter | undefined;
-      try {
-        const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
-        if (!settings.platform.kick.enabled
-          || !autoClaimChallengesFor(settings, "kick")
-          || state.authHealth.kick.status !== "healthy"
-          || !hasRecentManualWatchForClaims(settings, state, "kick")
-          || !challengePollDue(state, "kick", Date.now())) return;
-
-        const nextState: SchedulerState = {
-          ...state,
-          gamification: {
-            ...state.gamification,
-            kick: { lastCheckedAt: new Date().toISOString() },
-          },
-        };
-        adapter = createAdapter("kick", settings, emit, true);
+    const operation = new AbortController();
+    kickChallengeClaimOperations.add(operation);
+    try {
+      await withStateLock(() => withEventCollector(async (emit, events) => {
+        if (controllerShutdown) return;
+        let adapter: PlatformAdapter | undefined;
         try {
-          for (const challenge of await adapter.claimChallenges?.() ?? []) {
+          operation.signal.throwIfAborted();
+          const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+          operation.signal.throwIfAborted();
+          if (!settings.platform.kick.enabled
+            || !autoClaimChallengesFor(settings, "kick")
+            || state.authHealth.kick.status !== "healthy"
+            || !hasRecentManualWatchForClaims(settings, state, "kick")
+            || !challengePollDue(state, "kick", Date.now())) return;
+
+          const nextState: SchedulerState = {
+            ...state,
+            gamification: {
+              ...state.gamification,
+              kick: { lastCheckedAt: new Date().toISOString() },
+            },
+          };
+          adapter = createAdapter("kick", settings, emit, true);
+          operation.signal.throwIfAborted();
+          try {
+            const challenges = await adapter.claimChallenges?.({ signal: operation.signal }) ?? [];
+            operation.signal.throwIfAborted();
+            for (const challenge of challenges) {
+              emit({
+                category: "activity",
+                code: "challenge_claimed",
+                level: "info",
+                platform: "kick",
+                data: { challengeId: challenge.id, rarity: challenge.rarity, recurrence: challenge.recurrence },
+              });
+            }
+          } catch (error) {
+            operation.signal.throwIfAborted();
             emit({
-              category: "activity",
-              code: "challenge_claimed",
-              level: "info",
+              category: "diagnostic",
               platform: "kick",
-              data: { challengeId: challenge.id, rarity: challenge.rarity, recurrence: challenge.recurrence },
+              level: "warn",
+              message: error instanceof Error ? error.message : "Challenge claim failed",
             });
           }
+          operation.signal.throwIfAborted();
+          adapter.flushRouteDiagnostics?.(emit);
+          await persistPlatformState("kick", nextState, () => !operation.signal.aborted);
+          operation.signal.throwIfAborted();
+          await emitNotifications(settings, state, nextState, events);
+          await reportBestEffort(events);
         } catch (error) {
+          adapter?.flushRouteDiagnostics?.(emit);
+          clearOperationalEvents(events);
+          if (operation.signal.aborted) return;
           emit({
             category: "diagnostic",
             platform: "kick",
             level: "warn",
             message: error instanceof Error ? error.message : "Challenge claim failed",
           });
+          await reportBestEffort(events);
         }
-        adapter.flushRouteDiagnostics?.(emit);
-        await persistPlatformState("kick", nextState);
-        await emitNotifications(settings, state, nextState, events);
-        await reportBestEffort(events);
-      } catch (error) {
-        adapter?.flushRouteDiagnostics?.(emit);
-        clearOperationalEvents(events);
-        emit({
-          category: "diagnostic",
-          platform: "kick",
-          level: "warn",
-          message: error instanceof Error ? error.message : "Challenge claim failed",
-        });
-        await reportBestEffort(events);
-      }
-    }), ["kick"]);
+      }), ["kick"]);
+    } finally {
+      kickChallengeClaimOperations.delete(operation);
+    }
   }
 
   async function safeNotify(title: string, message: string): Promise<void> {

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -2,10 +2,10 @@ import type { CategorySearchResult, CoreRuntimeMessage, PlaybackControl, Runtime
 import type { ChannelCandidate, DropCampaign, DropReward, EngineSettings, ManagedWatchTab, Platform, PlatformAuthHealth, PlaybackTelemetry, SchedulerState, TablessHeartbeatCadence, WatchReasonCode, WatchSession } from "@lurkloot/shared/models";
 import type { ActivityEvent, DiagnosticEvent, EngineEvent, EventEmitter, EventReporter, FarmingStopReason, PageContextOpenReason } from "@lurkloot/shared/events";
 import type { SettingsPatch } from "@lurkloot/shared/settings";
-import { autoClaimChannelPointsFor, isFarmingActive } from "@lurkloot/shared/settings";
+import { autoClaimChallengesFor, autoClaimChannelPointsFor, isFarmingActive } from "@lurkloot/shared/settings";
 import type { CompatibilityResolution, ResolvedCompatibility } from "@lurkloot/shared/compatibility";
 import { isWatchReward, reconcileCampaignAfterClaims } from "@lurkloot/shared/rewards";
-import { campaignSearchBackoffApplies, isPlaybackTelemetryHealthy, MANUAL_WATCH_TTL_MS, preserveClaimedRewards, runSchedulerTick, selectWatchTargetFromSnapshot, type SnapshotSelectionResult, type StopPageContextTabs } from "../core/scheduler";
+import { campaignSearchBackoffApplies, CHALLENGE_POLL_INTERVAL_MS, challengePollDue, claimReadyRewards, isPlaybackTelemetryHealthy, MANUAL_WATCH_TTL_MS, preserveClaimedRewards, runSchedulerTick, selectWatchTargetFromSnapshot, type SnapshotSelectionResult, type StopPageContextTabs } from "../core/scheduler";
 import { isTimestampStale } from "../core/timestamps";
 import {
   currentManagedPageContextTabs,
@@ -53,6 +53,9 @@ export const KICK_ALARM_NAME = "lurkloot.tick.kick";
 // 1-minute minimum, close enough to TwitchDropsMiner's 59s send cadence.
 export const WATCH_ALARM_NAME = "lurkloot.watch";
 export const TWITCH_CHANNEL_POINTS_ALARM_NAME = "lurkloot.twitch-channel-points";
+export const TWITCH_DROP_CLAIMS_ALARM_NAME = "lurkloot.twitch-drop-claims";
+export const KICK_DROP_CLAIMS_ALARM_NAME = "lurkloot.kick-drop-claims";
+export const KICK_CHALLENGES_ALARM_NAME = "lurkloot.kick-challenges";
 export const TWITCH_INTEGRITY_ALARM_NAME = "lurkloot.twitch-integrity";
 export const TWITCH_INTEGRITY_REFRESH_LEAD_MS = 120_000;
 export const TWITCH_INTEGRITY_REFRESH_JITTER_MAX_MS = 30_000;
@@ -61,6 +64,8 @@ interface BackgroundAlarmController {
   tickAndHandOff(platforms?: Platform[], trigger?: TickTrigger): Promise<SchedulerState | undefined>;
   runWatchHeartbeat(): Promise<void>;
   runTwitchChannelPointsClaim(): Promise<void>;
+  runDropClaims(platform: Platform): Promise<void>;
+  runKickChallengeClaims(): Promise<void>;
   runTwitchIntegrityRefresh(): Promise<void>;
 }
 
@@ -74,6 +79,12 @@ export function createBackgroundAlarmListener(controller: BackgroundAlarmControl
       void controller.runWatchHeartbeat();
     } else if (alarm.name === TWITCH_CHANNEL_POINTS_ALARM_NAME) {
       void controller.runTwitchChannelPointsClaim();
+    } else if (alarm.name === TWITCH_DROP_CLAIMS_ALARM_NAME) {
+      void controller.runDropClaims("twitch");
+    } else if (alarm.name === KICK_DROP_CLAIMS_ALARM_NAME) {
+      void controller.runDropClaims("kick");
+    } else if (alarm.name === KICK_CHALLENGES_ALARM_NAME) {
+      void controller.runKickChallengeClaims();
     } else if (alarm.name === TWITCH_INTEGRITY_ALARM_NAME) {
       void controller.runTwitchIntegrityRefresh();
     }
@@ -1066,6 +1077,24 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
+  async function clearManualWatchClaimAlarmsBestEffort(): Promise<void> {
+    await Promise.all([
+      TWITCH_DROP_CLAIMS_ALARM_NAME,
+      KICK_DROP_CLAIMS_ALARM_NAME,
+      KICK_CHALLENGES_ALARM_NAME,
+    ].map(async (name) => {
+      try {
+        await deps.clearAlarm?.(name);
+      } catch {
+        await reportBestEffort([{
+          category: "diagnostic",
+          level: "warn",
+          message: `Could not clear the ${name} alarm`,
+        }]);
+      }
+    }));
+  }
+
   async function scheduleTwitchIntegrityRefresh(
     integrity: TwitchIntegrity,
     emit?: EventEmitter,
@@ -1566,6 +1595,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     await ensureSchedulerAlarms(settings.pollIntervalMinutes);
     await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
     await reconcileTwitchChannelPointsAlarm(settings);
+    await reconcileManualWatchClaimAlarms(settings);
     if (settings.autoStartDropFarming && isFarmingActive(settings)) {
       await tick(undefined, "install");
     } else {
@@ -1587,6 +1617,20 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     } else {
       await deps.clearAlarm?.(TWITCH_CHANNEL_POINTS_ALARM_NAME);
     }
+  }
+
+  async function reconcileManualWatchClaimAlarms(settings: EngineSettings): Promise<void> {
+    await Promise.all([
+      settings.platform.twitch.enabled && settings.autoClaim
+        ? deps.createAlarm(TWITCH_DROP_CLAIMS_ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes })
+        : deps.clearAlarm?.(TWITCH_DROP_CLAIMS_ALARM_NAME),
+      settings.platform.kick.enabled && settings.autoClaim
+        ? deps.createAlarm(KICK_DROP_CLAIMS_ALARM_NAME, { periodInMinutes: settings.pollIntervalMinutes })
+        : deps.clearAlarm?.(KICK_DROP_CLAIMS_ALARM_NAME),
+      settings.platform.kick.enabled && autoClaimChallengesFor(settings, "kick")
+        ? deps.createAlarm(KICK_CHALLENGES_ALARM_NAME, { periodInMinutes: CHALLENGE_POLL_INTERVAL_MS / 60_000 })
+        : deps.clearAlarm?.(KICK_CHALLENGES_ALARM_NAME),
+    ]);
   }
 
   async function ensureInstalledAt(installedAt = new Date().toISOString()): Promise<void> {
@@ -1616,6 +1660,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       };
       await deps.saveSettings(nextSettings);
       await reconcileTwitchChannelPointsAlarm(nextSettings);
+      await reconcileManualWatchClaimAlarms(nextSettings);
       return nextSettings;
     });
   }
@@ -1628,6 +1673,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     await ensureSchedulerAlarms(settings.pollIntervalMinutes);
     await deps.createAlarm(WATCH_ALARM_NAME, { periodInMinutes: 1 });
     await reconcileTwitchChannelPointsAlarm(settings);
+    await reconcileManualWatchClaimAlarms(settings);
     // A restart kills any in-memory watchers; atomically release their lane
     // ownership before host cleanup, then let tick() rebuild fresh instances.
     await clearHeartbeatOwnership(PLATFORMS);
@@ -1716,6 +1762,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       afterPersist?.(settings);
       await ensureSchedulerAlarms(settings.pollIntervalMinutes);
       await reconcileTwitchChannelPointsAlarm(settings);
+      await reconcileManualWatchClaimAlarms(settings);
       return settings;
     });
   }
@@ -3947,6 +3994,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     closeTwitchIntegrityLifecycle("Controller shutdown");
     void clearTwitchIntegrityAlarmBestEffort();
     void clearTwitchChannelPointsAlarmBestEffort();
+    void clearManualWatchClaimAlarmsBestEffort();
     abortClaimHandoffs();
     void cancelHeartbeatPublicationLeases(PLATFORMS);
     clearHeartbeatOwnershipInBackground(PLATFORMS);
@@ -3968,6 +4016,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       await stopDiscoverySignalControllersAndReport(PLATFORMS);
       await clearTwitchIntegrityAlarmBestEffort();
       await clearTwitchChannelPointsAlarmBestEffort();
+      await clearManualWatchClaimAlarmsBestEffort();
       abortClaimHandoffs();
       await clearHeartbeatOwnership(PLATFORMS);
       await withSettingsLock(() => withStateLock(() => withEventCollector(async (emit, events) => {
@@ -4762,6 +4811,129 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }));
   }
 
+  async function runDropClaims(platform: Platform): Promise<void> {
+    if (controllerShutdown) return;
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      if (controllerShutdown) return;
+      let adapter: PlatformAdapter | undefined;
+      try {
+        const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+        if (!settings.platform[platform].enabled
+          || !settings.autoClaim
+          || state.authHealth[platform].status !== "healthy"
+          || !hasRecentManualWatchForClaims(settings, state, platform)) return;
+
+        adapter = createAdapter(platform, settings, emit, true);
+        const refreshed = await adapter.refreshCampaigns(state.sessions[platform]);
+        const campaigns = preserveClaimedRewards(refreshed, state.campaigns[platform]);
+        const claimResult = await claimReadyRewards(
+          adapter,
+          campaigns,
+          waitingClaimRewardIds[platform],
+        );
+        const nextState: SchedulerState = {
+          ...state,
+          campaigns: {
+            ...state.campaigns,
+            [platform]: claimResult.campaigns,
+          },
+        };
+        for (const event of claimResult.events) {
+          if (event.claimed) {
+            emit({
+              category: "activity",
+              platform,
+              level: "info",
+              code: "reward_claimed",
+              data: {
+                campaignId: event.campaignId,
+                campaignName: event.campaignName,
+                rewardId: event.rewardId,
+                rewardName: event.rewardName,
+                ...(event.rewardImageUrl ? { rewardImageUrl: event.rewardImageUrl } : {}),
+                ...(event.campaignUrl ? { campaignUrl: event.campaignUrl } : {}),
+                method: "automatic",
+              },
+            });
+          } else {
+            emit({ category: "diagnostic", platform, level: event.level, message: event.message });
+          }
+        }
+        adapter.flushRouteDiagnostics?.(emit);
+        await persistPlatformState(platform, nextState);
+        await emitNotifications(settings, state, nextState, events);
+        await reportBestEffort(events);
+      } catch (error) {
+        adapter?.flushRouteDiagnostics?.(emit);
+        clearOperationalEvents(events);
+        emit({
+          category: "diagnostic",
+          platform,
+          level: "warn",
+          message: error instanceof Error ? error.message : "Drop claim refresh failed",
+        });
+        await reportBestEffort(events);
+      }
+    }), [platform]);
+  }
+
+  async function runKickChallengeClaims(): Promise<void> {
+    if (controllerShutdown) return;
+    await withStateLock(() => withEventCollector(async (emit, events) => {
+      if (controllerShutdown) return;
+      let adapter: PlatformAdapter | undefined;
+      try {
+        const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+        if (!settings.platform.kick.enabled
+          || !autoClaimChallengesFor(settings, "kick")
+          || state.authHealth.kick.status !== "healthy"
+          || !hasRecentManualWatchForClaims(settings, state, "kick")
+          || !challengePollDue(state, "kick", Date.now())) return;
+
+        const nextState: SchedulerState = {
+          ...state,
+          gamification: {
+            ...state.gamification,
+            kick: { lastCheckedAt: new Date().toISOString() },
+          },
+        };
+        adapter = createAdapter("kick", settings, emit, true);
+        try {
+          for (const challenge of await adapter.claimChallenges?.() ?? []) {
+            emit({
+              category: "activity",
+              code: "challenge_claimed",
+              level: "info",
+              platform: "kick",
+              data: { challengeId: challenge.id, rarity: challenge.rarity, recurrence: challenge.recurrence },
+            });
+          }
+        } catch (error) {
+          emit({
+            category: "diagnostic",
+            platform: "kick",
+            level: "warn",
+            message: error instanceof Error ? error.message : "Challenge claim failed",
+          });
+        }
+        adapter.flushRouteDiagnostics?.(emit);
+        await persistPlatformState("kick", nextState);
+        await emitNotifications(settings, state, nextState, events);
+        await reportBestEffort(events);
+      } catch (error) {
+        adapter?.flushRouteDiagnostics?.(emit);
+        clearOperationalEvents(events);
+        emit({
+          category: "diagnostic",
+          platform: "kick",
+          level: "warn",
+          message: error instanceof Error ? error.message : "Challenge claim failed",
+        });
+        await reportBestEffort(events);
+      }
+    }), ["kick"]);
+  }
+
   async function safeNotify(title: string, message: string): Promise<void> {
     if (!deps.createNotification) return;
     try {
@@ -4849,6 +5021,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     discoverySnapshot,
     runWatchHeartbeat,
     runTwitchChannelPointsClaim,
+    runDropClaims,
+    runKickChallengeClaims,
     runClaimHandoff,
     abortClaimHandoffs,
     shutdown,
@@ -4871,6 +5045,20 @@ function eligibleTwitchChannelPointsChannel(
   }
   const session = state.sessions.twitch;
   return session.status === "watching" ? session.channel : undefined;
+}
+
+function hasRecentManualWatchForClaims(
+  settings: EngineSettings,
+  state: SchedulerState,
+  platform: Platform,
+  now = Date.now(),
+): boolean {
+  const manualWatch = state.manualWatch?.[platform];
+  return Boolean(
+    settings.pauseOnManualWatch
+    && manualWatch?.active
+    && !isTimestampStale(manualWatch.checkedAt, MANUAL_WATCH_TTL_MS, now),
+  );
 }
 
 function farmingLifecycleEvents(previous: SchedulerState, next: SchedulerState): ActivityEvent[] {

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -41,9 +41,9 @@ export const MANUAL_WATCH_TTL_MS = 20_000;
 
 // Kick's daily challenge window is hours long, so a ten-minute poll is far more
 // than responsive enough while keeping the request count negligible.
-const CHALLENGE_POLL_INTERVAL_MS = 10 * 60 * 1000;
+export const CHALLENGE_POLL_INTERVAL_MS = 10 * 60 * 1000;
 
-function challengePollDue(state: SchedulerState, platform: Platform, now: number): boolean {
+export function challengePollDue(state: SchedulerState, platform: Platform, now: number): boolean {
   const lastCheckedAt = state.gamification?.[platform]?.lastCheckedAt;
   if (!lastCheckedAt) return true;
   const last = Date.parse(lastCheckedAt);
@@ -1569,7 +1569,7 @@ function nextRetryAfter(errorChecks: number): string {
   return new Date(Date.now() + minutes * 60 * 1000).toISOString();
 }
 
-type ClaimReadyRewardEvent = {
+export type ClaimReadyRewardEvent = {
   level: "info";
   message: string;
   claimed: true;
@@ -1585,7 +1585,7 @@ type ClaimReadyRewardEvent = {
   claimed?: false;
 };
 
-async function claimReadyRewards(
+export async function claimReadyRewards(
   adapter: PlatformAdapter,
   campaigns: DropCampaign[],
   previouslyWaitingRewardIds: Set<string>,

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -492,6 +492,10 @@ describe("background controller", () => {
 
       await env.controller.runDropClaims(platform);
 
+      expect(platformAdapter.refreshCampaigns).toHaveBeenCalledWith(
+        beforeSession,
+        expect.objectContaining({ requireComplete: true }),
+      );
       expect(env.state.sessions[platform]).toEqual(beforeSession);
       expect(env.state.manualWatch?.[platform]?.active).toBe(true);
       expect(env.state.campaigns[platform][0]?.rewards[0]?.status).toBe("claimed");
@@ -673,6 +677,60 @@ describe("background controller", () => {
         level: "warn",
         message: "adapter unavailable",
       }));
+    });
+
+    it("cancels an in-flight drop claim when automatic claiming is disabled", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+      env.state.authHealth = {
+        ...env.state.authHealth,
+        twitch: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions.twitch = { platform: "twitch", status: "paused", offlineChecks: 0, reasonCode: "manual_watch" };
+      env.state.manualWatch = {
+        twitch: { platform: "twitch", tabId: 91, checkedAt: new Date().toISOString(), active: true },
+      };
+      const refresh = deferred<DropCampaign[]>();
+      env.twitch.refreshCampaigns = vi.fn(async () => refresh.promise);
+
+      const claiming = env.controller.runDropClaims("twitch");
+      await vi.waitFor(() => expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce());
+      await env.rawController.handleMessage({ type: "saveSettings", settingsPatch: { autoClaim: false } });
+      refresh.resolve([campaign("twitch", "claimable")]);
+      await claiming;
+
+      expect(env.twitch.claimReward).not.toHaveBeenCalled();
+      expect(env.state.campaigns.twitch).toEqual([]);
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events).some(
+        (event) => event.category === "activity" && event.code === "reward_claimed",
+      )).toBe(false);
+    });
+
+    it("cancels an in-flight Kick challenge claim when challenge claiming is disabled", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+      env.state.authHealth = {
+        ...env.state.authHealth,
+        kick: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions.kick = { platform: "kick", status: "paused", offlineChecks: 0, reasonCode: "manual_watch" };
+      env.state.manualWatch = {
+        kick: { platform: "kick", tabId: 92, checkedAt: new Date().toISOString(), active: true },
+      };
+      const challenges = deferred<Array<{ id: string; rarity: string; recurrence: string }>>();
+      env.kick.claimChallenges = vi.fn(async () => challenges.promise);
+
+      const claiming = env.controller.runKickChallengeClaims();
+      await vi.waitFor(() => expect(env.kick.claimChallenges).toHaveBeenCalledOnce());
+      await env.rawController.handleMessage({
+        type: "saveSettings",
+        settingsPatch: { platform: { kick: { autoClaimChallenges: false } } },
+      });
+      challenges.resolve([{ id: "daily", rarity: "epic", recurrence: "daily" }]);
+      await claiming;
+
+      expect(env.state.gamification?.kick).toBeUndefined();
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events).some(
+        (event) => event.category === "activity" && event.code === "challenge_claimed",
+      )).toBe(false);
     });
   });
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ALARM_NAME,
+  createBackgroundAlarmListener,
   createBackgroundController,
+  KICK_CHALLENGES_ALARM_NAME,
+  KICK_DROP_CLAIMS_ALARM_NAME,
   KICK_ALARM_NAME,
+  TWITCH_DROP_CLAIMS_ALARM_NAME,
   TWITCH_ALARM_NAME,
   TWITCH_CHANNEL_POINTS_ALARM_NAME,
   TWITCH_INTEGRITY_ALARM_NAME,
@@ -389,6 +393,287 @@ function dueHeartbeatCadence(session: WatchSession, dueAt = Date.now()) {
 describe("background controller", () => {
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  describe("manual-watch claim alarm lifecycle", () => {
+    it("creates drop alarms at the scheduler interval and a ten-minute Kick challenge alarm", async () => {
+      const env = harness(farming({ ...DEFAULT_SETTINGS, pollIntervalMinutes: 60 }));
+
+      await env.controller.ensureAlarm();
+
+      expect(env.deps.createAlarm).toHaveBeenCalledWith(
+        TWITCH_DROP_CLAIMS_ALARM_NAME,
+        { periodInMinutes: 60 },
+      );
+      expect(env.deps.createAlarm).toHaveBeenCalledWith(
+        KICK_DROP_CLAIMS_ALARM_NAME,
+        { periodInMinutes: 60 },
+      );
+      expect(env.deps.createAlarm).toHaveBeenCalledWith(
+        KICK_CHALLENGES_ALARM_NAME,
+        { periodInMinutes: 10 },
+      );
+    });
+
+    it("routes each claim alarm to its claim-only operation", () => {
+      const controller = {
+        tickAndHandOff: vi.fn(async () => undefined),
+        runWatchHeartbeat: vi.fn(async () => undefined),
+        runTwitchChannelPointsClaim: vi.fn(async () => undefined),
+        runTwitchIntegrityRefresh: vi.fn(async () => undefined),
+        runDropClaims: vi.fn(async () => undefined),
+        runKickChallengeClaims: vi.fn(async () => undefined),
+      };
+      const listener = createBackgroundAlarmListener(controller);
+
+      listener({ name: TWITCH_DROP_CLAIMS_ALARM_NAME });
+      listener({ name: KICK_DROP_CLAIMS_ALARM_NAME });
+      listener({ name: KICK_CHALLENGES_ALARM_NAME });
+
+      expect(controller.runDropClaims.mock.calls).toEqual([["twitch"], ["kick"]]);
+      expect(controller.runKickChallengeClaims).toHaveBeenCalledOnce();
+    });
+
+    it("reconciles claim alarms after settings changes", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+
+      await env.controller.handleMessage({
+        type: "saveSettings",
+        settingsPatch: {
+          autoClaim: false,
+          platform: { kick: { autoClaimChallenges: false } },
+        },
+      });
+
+      expect(env.deps.clearAlarm).toHaveBeenCalledWith(TWITCH_DROP_CLAIMS_ALARM_NAME);
+      expect(env.deps.clearAlarm).toHaveBeenCalledWith(KICK_DROP_CLAIMS_ALARM_NAME);
+      expect(env.deps.clearAlarm).toHaveBeenCalledWith(KICK_CHALLENGES_ALARM_NAME);
+    });
+
+    it("clears claim alarms during reset and shutdown", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+
+      await env.controller.prepareForHostReset();
+      env.controller.shutdown();
+      await env.controller.settleBackgroundWork();
+
+      for (const alarm of [TWITCH_DROP_CLAIMS_ALARM_NAME, KICK_DROP_CLAIMS_ALARM_NAME, KICK_CHALLENGES_ALARM_NAME]) {
+        expect(env.deps.clearAlarm).toHaveBeenCalledWith(alarm);
+      }
+    });
+  });
+
+  describe("manual-watch claim-only operations", () => {
+    it.each(["twitch", "kick"] as const)("claims %s drops without changing the paused session", async (platform) => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+      env.state.authHealth = {
+        ...env.state.authHealth,
+        [platform]: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions[platform] = {
+        platform,
+        status: "paused",
+        offlineChecks: 0,
+        reasonCode: "manual_watch",
+        message: "Manual watch detected",
+      };
+      env.state.manualWatch = {
+        [platform]: {
+          platform,
+          tabId: 91,
+          checkedAt: new Date().toISOString(),
+          active: true,
+        },
+      };
+      const beforeSession = structuredClone(env.state.sessions[platform]);
+      const platformAdapter = platform === "twitch" ? env.twitch : env.kick;
+      platformAdapter.refreshCampaigns = vi.fn(async () => [campaign(platform, "claimable")]);
+      platformAdapter.claimReward = vi.fn(async () => true);
+
+      await env.controller.runDropClaims(platform);
+
+      expect(env.state.sessions[platform]).toEqual(beforeSession);
+      expect(env.state.manualWatch?.[platform]?.active).toBe(true);
+      expect(env.state.campaigns[platform][0]?.rewards[0]?.status).toBe("claimed");
+      expect(allDiagnostics(env).some((event) => event.message.includes("Manual watch detected"))).toBe(false);
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(expect.objectContaining({
+        category: "activity",
+        code: "reward_claimed",
+        platform,
+        data: expect.objectContaining({ method: "automatic", rewardId: "reward" }),
+      }));
+      expect(platformAdapter.prepareWatchTab).not.toHaveBeenCalled();
+      expect(platformAdapter.stopWatchTab).not.toHaveBeenCalled();
+    });
+
+    it("claims Kick challenges without changing the paused session", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+      env.state.authHealth = {
+        ...env.state.authHealth,
+        kick: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions.kick = {
+        platform: "kick",
+        status: "paused",
+        offlineChecks: 0,
+        reasonCode: "manual_watch",
+        message: "Manual watch detected",
+      };
+      env.state.manualWatch = {
+        kick: {
+          platform: "kick",
+          tabId: 92,
+          checkedAt: new Date().toISOString(),
+          active: true,
+        },
+      };
+      const beforeSession = structuredClone(env.state.sessions.kick);
+      env.kick.claimChallenges = vi.fn(async () => [{ id: "daily", rarity: "epic", recurrence: "daily" }]);
+
+      await env.controller.runKickChallengeClaims();
+
+      expect(env.state.sessions.kick).toEqual(beforeSession);
+      expect(env.state.manualWatch?.kick?.active).toBe(true);
+      expect(env.state.gamification?.kick?.lastCheckedAt).toBeDefined();
+      expect(env.reportEvents.mock.calls.flatMap(([events]) => events)).toContainEqual(expect.objectContaining({
+        category: "activity",
+        code: "challenge_claimed",
+        platform: "kick",
+        data: { challengeId: "daily", rarity: "epic", recurrence: "daily" },
+      }));
+      expect(env.kick.prepareWatchTab).not.toHaveBeenCalled();
+      expect(env.kick.stopWatchTab).not.toHaveBeenCalled();
+    });
+
+    it("does not duplicate drop or challenge claims without a recent manual watch", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+      env.state.authHealth = {
+        twitch: { status: "healthy", checkedAt: new Date().toISOString() },
+        kick: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.kick.claimChallenges = vi.fn(async () => []);
+
+      await env.controller.runDropClaims("twitch");
+      await env.controller.runDropClaims("kick");
+      await env.controller.runKickChallengeClaims();
+
+      expect(env.twitch.refreshCampaigns).not.toHaveBeenCalled();
+      expect(env.kick.refreshCampaigns).not.toHaveBeenCalled();
+      expect(env.kick.claimChallenges).not.toHaveBeenCalled();
+    });
+
+    it("reports a drop refresh failure without changing paused state", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+      env.state.authHealth = {
+        ...env.state.authHealth,
+        twitch: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions.twitch = {
+        platform: "twitch",
+        status: "paused",
+        offlineChecks: 0,
+        reasonCode: "manual_watch",
+      };
+      env.state.manualWatch = {
+        twitch: { platform: "twitch", tabId: 91, checkedAt: new Date().toISOString(), active: true },
+      };
+      const before = structuredClone(env.state);
+      env.twitch.refreshCampaigns = vi.fn(async () => { throw new Error("inventory unavailable"); });
+
+      await env.controller.runDropClaims("twitch");
+
+      expect(env.state).toEqual(before);
+      expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+        platform: "twitch",
+        level: "warn",
+        message: "inventory unavailable",
+      }));
+    });
+
+    it("throttles repeated Kick challenge alarms", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+      env.state.authHealth = {
+        ...env.state.authHealth,
+        kick: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions.kick = { platform: "kick", status: "paused", offlineChecks: 0, reasonCode: "manual_watch" };
+      env.state.manualWatch = {
+        kick: { platform: "kick", tabId: 92, checkedAt: new Date().toISOString(), active: true },
+      };
+      env.state.gamification = { kick: { lastCheckedAt: new Date().toISOString() } };
+      env.kick.claimChallenges = vi.fn(async () => []);
+
+      await env.controller.runKickChallengeClaims();
+
+      expect(env.kick.claimChallenges).not.toHaveBeenCalled();
+    });
+
+    it("contains drop-claim persistence failures without publishing a claim event", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS), {
+        saveState: async () => { throw new Error("state storage unavailable"); },
+      });
+      env.state.authHealth = {
+        ...env.state.authHealth,
+        twitch: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions.twitch = { platform: "twitch", status: "paused", offlineChecks: 0, reasonCode: "manual_watch" };
+      env.state.manualWatch = {
+        twitch: { platform: "twitch", tabId: 91, checkedAt: new Date().toISOString(), active: true },
+      };
+      env.twitch.refreshCampaigns = vi.fn(async () => [campaign("twitch", "claimable")]);
+
+      await expect(env.controller.runDropClaims("twitch")).resolves.toBeUndefined();
+
+      const reported = env.reportEvents.mock.calls.flatMap(([events]) => events);
+      expect(reported.some((event) => event.category === "activity" && event.code === "reward_claimed")).toBe(false);
+      expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({ message: "state storage unavailable" }));
+    });
+
+    it("contains Kick challenge persistence failures without publishing a claim event", async () => {
+      const env = harness(farming(DEFAULT_SETTINGS), {
+        saveState: async () => { throw new Error("state storage unavailable"); },
+      });
+      env.state.authHealth = {
+        ...env.state.authHealth,
+        kick: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions.kick = { platform: "kick", status: "paused", offlineChecks: 0, reasonCode: "manual_watch" };
+      env.state.manualWatch = {
+        kick: { platform: "kick", tabId: 92, checkedAt: new Date().toISOString(), active: true },
+      };
+      env.kick.claimChallenges = vi.fn(async () => [{ id: "daily", rarity: "epic", recurrence: "daily" }]);
+
+      await expect(env.controller.runKickChallengeClaims()).resolves.toBeUndefined();
+
+      const reported = env.reportEvents.mock.calls.flatMap(([events]) => events);
+      expect(reported.some((event) => event.category === "activity" && event.code === "challenge_claimed")).toBe(false);
+      expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({ message: "state storage unavailable" }));
+    });
+
+    it.each([
+      { name: "drop", run: (env: ReturnType<typeof harness>) => env.controller.runDropClaims("twitch") },
+      { name: "challenge", run: (env: ReturnType<typeof harness>) => env.controller.runKickChallengeClaims() },
+    ])("contains $name adapter construction failures", async ({ run }) => {
+      const env = harness(farming(DEFAULT_SETTINGS));
+      env.state.authHealth = {
+        twitch: { status: "healthy", checkedAt: new Date().toISOString() },
+        kick: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions.twitch = { platform: "twitch", status: "paused", offlineChecks: 0, reasonCode: "manual_watch" };
+      env.state.sessions.kick = { platform: "kick", status: "paused", offlineChecks: 0, reasonCode: "manual_watch" };
+      env.state.manualWatch = {
+        twitch: { platform: "twitch", tabId: 91, checkedAt: new Date().toISOString(), active: true },
+        kick: { platform: "kick", tabId: 92, checkedAt: new Date().toISOString(), active: true },
+      };
+      env.deps.createAdapter.mockImplementationOnce(() => { throw new Error("adapter unavailable"); });
+
+      await expect(run(env)).resolves.toBeUndefined();
+
+      expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+        level: "warn",
+        message: "adapter unavailable",
+      }));
+    });
   });
 
   describe("Twitch channel points alarm lifecycle", () => {


### PR DESCRIPTION
## Summary

- add dedicated Twitch and Kick drop-claim alarms that operate during recent manual-watch pauses
- add an independent Kick daily-challenge alarm while preserving its existing 10-minute throttle
- keep paused sessions and manual-watch telemetry unchanged, serialize work per platform, and contain claim-only failures
- reconcile and clean up the new alarms across startup, settings changes, reset, and shutdown
- preserve normal scheduler claiming for the shared CLI runtime while avoiding duplicate extension requests outside manual watching

Closes #524

## Testing

- `pnpm check`
- 86 extension test files, 1,991 tests passed
- 12 CLI test files, 195 tests passed
- script tests and Astro site tests/build passed

## Review

An independent code review identified missing containment around state reads and adapter construction. The error boundary and regression coverage were expanded before final verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic claiming for eligible Twitch and Kick rewards after recent manual viewing activity.
  - Added automatic claiming for eligible Kick challenges.
  - Claim activity now reports successful reward and challenge claims.
  - Automatic claiming respects platform settings, authentication status, and configured claim preferences.

- **Bug Fixes**
  - Improved handling of claim refresh and persistence failures without disrupting active manual viewing sessions.
  - Prevented repeated Kick challenge claims from running too frequently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->