### PR TITLE
fix(twitch): update stale ViewerDropsDashboard and DirectoryPage_Game hashes

### DIFF
--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -100,11 +100,11 @@ export interface TwitchAdapterOptions {
 const TWITCH_QUERIES = {
   dashboard: {
     operationName: "ViewerDropsDashboard",
-    sha256Hash: "5a4da2ab3d5b47c9f9ce864e727b2cb346af1e3ea8b897fe8f704a97ff017619",
+    sha256Hash: "c16bb890cc8ce7647a96ee69cd313d423a378a3dedadf630a1017cde18975feb",
     variables: { fetchRewardCampaigns: false },
   },
   campaignDetailsHash: "039277bf98f3130929262cc7c6efd9c141ca3749cb6dca442fc8ead9a53f77c1",
-  gameDirectoryHash: "cb5dc816e139dcb8a118f14b4b677d59abc224a4b016c4bc2bb00a47fe0ddec4",
+  gameDirectoryHash: "86bcceb4e8b1a51256ff8eed8bd8aae4acacf80d737efe904f84f3aeadf8cafd",
   streamInfoHash: "198492e0857f6aedead9665c81c5a06d67b25b58034649687124083ff288597d",
   currentDropHash: "4d06b702d25d652afb9ef835d2a550031f1cf762b193523a92166f40ea3d142b",
   availableDropsHash: "782dad0f032942260171d2d80a654f88bdd0c5a9dddc392e9bc92218a0f42d20",


### PR DESCRIPTION
## Summary

Two Twitch persisted query hashes had drifted from the ones Twitch's web client currently registers, confirmed against the TwitchDropsMiner reference snapshot.

| operation | before | after |
| --- | --- | --- |
| `ViewerDropsDashboard` | `5a4da2ab` | `c16bb890` |
| `DirectoryPage_Game` | `cb5dc816` | `86bcceb4` |

`ViewerDropsDashboard` was two rotations behind, skipping the intermediate `d9cae776`. That one matters most because its failure is silent: `fetchDashboard` catches the error, logs a warning, and reuses the last campaign list, so campaign discovery freezes on stale data instead of surfacing a failure. `DirectoryPage_Game` was one rotation behind and throws from `listCandidateChannels`, so it is at least visible.

Neither operation has an inline query fallback, unlike `Inventory`.

Both upstream bumps were pure hash changes with identical variables, which is mild evidence the response shape held. Not proof, so this is worth a live sanity check that campaigns still enumerate.

The v1 inventory hash is also retired upstream but is left alone, since that path falls back to its inline query and self-heals.

## Testing

- `pnpm test` — 1977 tests across 86 files pass
- `pnpm typecheck` — clean across the workspace

Both only prove nothing referenced the old constants. A wrong hash returns a GraphQL error at runtime rather than failing a build.

https://claude.ai/code/session_01H5Np3x3Hox9dVZGBhzVHxi
