### PR TITLE
fix(core): skip the state persist when a tick changed nothing

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -35,7 +35,7 @@ import {
   validHeartbeatGeneration,
   validTablessHeartbeatCadence,
 } from "../core/heartbeatCadence";
-import { mergePlatformState } from "./platformState";
+import { mergePlatformState, schedulerStateEquivalent } from "./platformState";
 import { twitchChannelFromUrl } from "../platforms/twitch/channelUrl";
 import {
   collectDiscoverySnapshot,
@@ -1500,9 +1500,18 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           : stateForMerge;
         if (isCurrent?.() === false) return false;
         const merged = mergePlatformState(latest, mergeSource, platform);
-        await saveOperationalStateDirect(merged);
+        // A tick that decided nothing still restamps lastTickAt, so an
+        // unguarded write churns storage every poll interval forever. The
+        // disabled platform is the clearest case: its tick reaches the
+        // scheduler's disabled branch and rebuilds the very same session on
+        // every pass, and both tick alarms keep firing whether or not the
+        // platform is enabled. Skip the write and leave lastTickAt where it
+        // was — storage already holds this state, so callers must still treat
+        // it as persisted, and `latest` (not `merged`) is what they observe.
+        const unchanged = schedulerStateEquivalent(latest, merged);
+        if (!unchanged) await saveOperationalStateDirect(merged);
         if (currentManagedPageContextTabsRevision() === pageContextRevision) {
-          onPersisted?.(merged);
+          onPersisted?.(unchanged ? latest : merged);
           return true;
         }
       }

--- a/packages/core/src/background/platformState.ts
+++ b/packages/core/src/background/platformState.ts
@@ -87,3 +87,36 @@ export function mergePlatformState(
     lastTickAt: newestTimestamp(destination.lastTickAt, source.lastTickAt),
   };
 }
+
+// Structural comparison for the JSON-shaped scheduler state. Every field that
+// reaches storage is JSON-serializable — the extension writes it to
+// storage.local, the CLI to a file — so a plain structural walk is exact here:
+// there are no Dates, Maps or class instances to miscompare.
+//
+// Keys whose value is undefined are ignored on both sides. That is not a
+// convenience: a round trip through storage drops them, so the freshly built
+// state (which sets `channel: undefined` and friends explicitly) must compare
+// equal to the stored state that simply lacks those keys.
+function jsonEquivalent(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (typeof left !== "object" || typeof right !== "object" || left === null || right === null) return false;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+    return left.every((value, index) => jsonEquivalent(value, right[index]));
+  }
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord).filter((key) => leftRecord[key] !== undefined);
+  const rightKeys = Object.keys(rightRecord).filter((key) => rightRecord[key] !== undefined);
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((key) => jsonEquivalent(leftRecord[key], rightRecord[key]));
+}
+
+// True when two scheduler states differ only by `lastTickAt`, which every tick
+// restamps whether or not it decided anything. It is display-only (the popup's
+// last-check line), so it must not by itself justify a storage write.
+export function schedulerStateEquivalent(left: SchedulerState, right: SchedulerState): boolean {
+  const { lastTickAt: _leftTickAt, ...leftRest } = left;
+  const { lastTickAt: _rightTickAt, ...rightRest } = right;
+  return jsonEquivalent(leftRest, rightRest);
+}

--- a/packages/core/src/core/criticalHealth.ts
+++ b/packages/core/src/core/criticalHealth.ts
@@ -43,6 +43,19 @@ export interface CriticalHealthObservation {
   // An accrual precondition broke mid-window (channel offline, category change,
   // heartbeat unhealthy, fallback, pause, manual watch, target switch).
   preconditionBroke: boolean;
+  // The tick reached no verdict at all — the platform is disabled, or signed
+  // out — as opposed to concluding that it is healthy. Without this the two are
+  // indistinguishable: a clean tick that simply did not accrue this minute
+  // reports the same three booleans as the seeded neutral observation, and only
+  // carries watchedMinutes to tell them apart.
+  //
+  // It exists so the reducer can decline to treat "no information" as evidence
+  // of a clean tick. Everything else about the reset branch still applies: an
+  // inconclusive observation must keep clearing the failing counters, keep
+  // pruning the churn window, and keep releasing the breaker, because a
+  // platform that only ever takes an early exit still has to be able to
+  // recover.
+  inconclusive?: boolean;
   watchedMinutes?: number;
   record?: Omit<FailureRecord, "at" | "platform">;
 }
@@ -145,14 +158,25 @@ export function observeCriticalHealth(
 
   // Any of these means the platform is not in a continuous no-value episode.
   if (!observation.failing || observation.progressed || observation.preconditionBroke) {
+    const { lastObservedAt: _previousObservedAt, ...carried } = health;
     const reset: CriticalHealthState = {
-      ...health,
+      ...carried,
       failingMs: 0,
       failingTicks: 0,
-      lastObservedAt: new Date(observation.at).toISOString(),
       managedTabOpens,
       breakerOpen,
       records,
+      // An inconclusive observation clears the stamp instead of advancing it.
+      // It is the tick clock for *failing* time, so a tick that concluded
+      // nothing is not a reading to measure the next gap from. Clearing sends
+      // the next genuinely failing tick down the cold-start path below, which
+      // charges delta = 0 — it under-counts, so it can only ever flag later,
+      // never sooner. Advancing it would also rewrite storage every tick for a
+      // platform that is doing nothing, and the stamp does not even survive the
+      // round trip (normalizeCriticalHealth drops it on load).
+      ...(observation.inconclusive
+        ? {}
+        : { lastObservedAt: new Date(observation.at).toISOString() }),
     };
     if (observation.watchedMinutes !== undefined) reset.lastWatchedMinutes = observation.watchedMinutes;
     return { state: withHealth(state, platform, reset) };

--- a/packages/core/src/core/scheduler.ts
+++ b/packages/core/src/core/scheduler.ts
@@ -111,10 +111,12 @@ function preconditionBreakObservation(): CriticalHealthObservation {
 }
 
 // The tick reached no conclusion about this platform. Not "healthy": it carries no
-// watchedMinutes and no record, it only keeps the detector's clock and its
-// time-based pruning running.
+// watchedMinutes and no record, it only keeps the detector's time-based pruning
+// and breaker release running. `inconclusive` is what separates it from a clean
+// tick that simply did not accrue — the other three booleans are identical — so
+// the reducer can decline to advance the failing-time clock from it.
 function neutralObservation(): CriticalHealthObservation {
-  return { at: Date.now(), failing: false, progressed: false, preconditionBroke: false };
+  return { at: Date.now(), failing: false, progressed: false, preconditionBroke: false, inconclusive: true };
 }
 
 // A failing observation with a breadcrumb built from a SafeFetchError when the

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -10778,3 +10778,84 @@ describe("background controller critical health", () => {
     expect(managedTabBreakerOpen("kick")).toBe(true);
   });
 });
+
+describe("no-op tick persistence", () => {
+  // The scheduler's disabled branch rebuilds the same session on every pass, so
+  // consecutive ticks differ only by the freshly stamped lastTickAt, which is
+  // display-only. Both tick alarms are created regardless of whether the
+  // platform is enabled, so without a guard this rewrites storage forever.
+  it("stops rewriting state once a disabled platform's tick decides nothing", async () => {
+    const env = harness(notFarming({ ...DEFAULT_SETTINGS, criticalFailurePromptEnabled: false }));
+    // tick() returns as soon as the tick commits, while handleMessage's harness
+    // wrapper settles first. Settle explicitly, or a straggling background write
+    // lands between the reads below and makes the assertions race.
+    const settledTick = async () => {
+      await env.controller.tick(["twitch"]);
+      await env.controller.settleBackgroundWork();
+    };
+
+    await settledTick();
+    const writesAfterFirstTick = env.deps.saveState.mock.calls.length;
+    const settledTickAt = env.state.lastTickAt;
+    expect(writesAfterFirstTick).toBeGreaterThan(0);
+    expect(env.state.sessions.twitch.reasonCode).toBe("automation_disabled");
+
+    await settledTick();
+    await settledTick();
+
+    expect(env.deps.saveState).toHaveBeenCalledTimes(writesAfterFirstTick);
+    expect(env.state.lastTickAt).toBe(settledTickAt);
+    env.controller.shutdown();
+  });
+
+  // Documents a real limitation rather than papering over it: with the critical
+  // failure prompt on (the default), observeCriticalHealth restamps
+  // lastObservedAt from the disabled branch's neutral observation, so the state
+  // genuinely differs every tick and the guard cannot fire. Whether a neutral
+  // observation — one that reached no conclusion — should advance that stamp at
+  // all is an open question for the detector, not for this guard.
+  it("still writes every tick while the critical failure prompt restamps lastObservedAt", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const env = harness(notFarming({ ...DEFAULT_SETTINGS, criticalFailurePromptEnabled: true }));
+    const settledTick = async () => {
+      await env.controller.tick(["twitch"]);
+      await env.controller.settleBackgroundWork();
+    };
+
+    await settledTick();
+    const writesAfterFirstTick = env.deps.saveState.mock.calls.length;
+    const firstObservedAt = env.state.criticalHealth?.twitch?.lastObservedAt;
+    expect(firstObservedAt).toBeDefined();
+    // The stamp has millisecond resolution, so two ticks in the same
+    // millisecond would compare equal and suppress the write. Real alarms are a
+    // minute apart; step the clock so the test exercises that case rather than
+    // racing it.
+    vi.setSystemTime(new Date(Date.now() + 60_000));
+
+    await settledTick();
+
+    expect(env.state.criticalHealth?.twitch?.lastObservedAt).not.toBe(firstObservedAt);
+    expect(env.deps.saveState.mock.calls.length).toBeGreaterThan(writesAfterFirstTick);
+    vi.useRealTimers();
+    env.controller.shutdown();
+  });
+
+  it("resumes writing when a later tick has something to record", async () => {
+    const env = harness(notFarming({ ...DEFAULT_SETTINGS, criticalFailurePromptEnabled: false }));
+
+    await env.controller.tick(["twitch"]);
+    await env.controller.settleBackgroundWork();
+    await env.controller.tick(["twitch"]);
+    await env.controller.settleBackgroundWork();
+    const settledWrites = env.deps.saveState.mock.calls.length;
+
+    await env.controller.handleMessage({
+      type: "setPlatformEnabled",
+      platform: "twitch",
+      enabled: true,
+    });
+
+    expect(env.deps.saveState.mock.calls.length).toBeGreaterThan(settledWrites);
+    env.controller.shutdown();
+  });
+});

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -10808,13 +10808,11 @@ describe("no-op tick persistence", () => {
     env.controller.shutdown();
   });
 
-  // Documents a real limitation rather than papering over it: with the critical
-  // failure prompt on (the default), observeCriticalHealth restamps
-  // lastObservedAt from the disabled branch's neutral observation, so the state
-  // genuinely differs every tick and the guard cannot fire. Whether a neutral
-  // observation — one that reached no conclusion — should advance that stamp at
-  // all is an open question for the detector, not for this guard.
-  it("still writes every tick while the critical failure prompt restamps lastObservedAt", async () => {
+  // The disabled branch reports an inconclusive observation, which clears
+  // lastObservedAt rather than restamping it. Before that distinction existed
+  // the critical health slice changed on every tick and this guard could never
+  // fire in the default configuration.
+  it("stops rewriting state with the critical failure prompt enabled", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const env = harness(notFarming({ ...DEFAULT_SETTINGS, criticalFailurePromptEnabled: true }));
     const settledTick = async () => {
@@ -10824,18 +10822,16 @@ describe("no-op tick persistence", () => {
 
     await settledTick();
     const writesAfterFirstTick = env.deps.saveState.mock.calls.length;
-    const firstObservedAt = env.state.criticalHealth?.twitch?.lastObservedAt;
-    expect(firstObservedAt).toBeDefined();
-    // The stamp has millisecond resolution, so two ticks in the same
-    // millisecond would compare equal and suppress the write. Real alarms are a
-    // minute apart; step the clock so the test exercises that case rather than
-    // racing it.
-    vi.setSystemTime(new Date(Date.now() + 60_000));
+    expect(env.state.criticalHealth?.twitch?.lastObservedAt).toBeUndefined();
 
+    // A full alarm period apart, so this is not passing because two ticks
+    // landed in the same millisecond.
+    vi.setSystemTime(new Date(Date.now() + 60_000));
+    await settledTick();
+    vi.setSystemTime(new Date(Date.now() + 60_000));
     await settledTick();
 
-    expect(env.state.criticalHealth?.twitch?.lastObservedAt).not.toBe(firstObservedAt);
-    expect(env.deps.saveState.mock.calls.length).toBeGreaterThan(writesAfterFirstTick);
+    expect(env.deps.saveState).toHaveBeenCalledTimes(writesAfterFirstTick);
     vi.useRealTimers();
     env.controller.shutdown();
   });

--- a/packages/extension/tests/criticalHealth.test.ts
+++ b/packages/extension/tests/criticalHealth.test.ts
@@ -569,3 +569,111 @@ describe("managed tab circuit breaker registry", () => {
     expect(managedTabBreakerOpen("kick")).toBe(false);
   });
 });
+
+describe("inconclusive observations", () => {
+  it("clears lastObservedAt instead of advancing it", () => {
+    const clean = observeCriticalHealth(baseState(), "twitch", {
+      at: START,
+      failing: false,
+      progressed: false,
+      preconditionBroke: false,
+    }).state;
+    expect(clean.criticalHealth?.twitch?.lastObservedAt).toBe(new Date(START).toISOString());
+
+    const inconclusive = observeCriticalHealth(clean, "twitch", {
+      at: START + 60_000,
+      failing: false,
+      progressed: false,
+      preconditionBroke: false,
+      inconclusive: true,
+    }).state;
+    expect(inconclusive.criticalHealth?.twitch?.lastObservedAt).toBeUndefined();
+  });
+
+  it("leaves the state untouched across repeated inconclusive observations", () => {
+    // What makes the persist guard able to skip the write for a disabled
+    // platform: once the counters are zero and the churn window is empty, a
+    // further inconclusive observation must produce an identical state.
+    const first = observeCriticalHealth(baseState(), "twitch", {
+      at: START,
+      failing: false,
+      progressed: false,
+      preconditionBroke: false,
+      inconclusive: true,
+    }).state;
+    const second = observeCriticalHealth(first, "twitch", {
+      at: START + 60_000,
+      failing: false,
+      progressed: false,
+      preconditionBroke: false,
+      inconclusive: true,
+    }).state;
+    expect(second.criticalHealth?.twitch).toEqual(first.criticalHealth?.twitch);
+  });
+
+  it("charges no failing time on the first failing tick after an inconclusive gap", () => {
+    // The conservative direction, and the reason to clear rather than keep a
+    // stale stamp: resuming after a disabled period looks like a cold start, so
+    // the gap is not billed as failing time.
+    const idle = observeCriticalHealth(baseState(), "twitch", {
+      at: START,
+      failing: false,
+      progressed: false,
+      preconditionBroke: false,
+      inconclusive: true,
+    }).state;
+    const resumed = observeCriticalHealth(idle, "twitch", {
+      at: START + 6 * 60 * 60 * 1000,
+      failing: true,
+      progressed: false,
+      preconditionBroke: false,
+    }).state;
+    expect(resumed.criticalHealth?.twitch?.failingMs).toBe(0);
+    expect(resumed.criticalHealth?.twitch?.failingTicks).toBe(1);
+  });
+
+  it("still resets failing counters, prunes the churn window and releases the breaker", () => {
+    const failing = runFailingTicks(baseState(), 3);
+    expect(failing.criticalHealth?.twitch?.failingTicks).toBe(3);
+
+    const idle = observeCriticalHealth(failing, "twitch", {
+      at: START + 4 * 5 * 60 * 1000,
+      failing: false,
+      progressed: false,
+      preconditionBroke: false,
+      inconclusive: true,
+    }).state;
+    expect(idle.criticalHealth?.twitch?.failingMs).toBe(0);
+    expect(idle.criticalHealth?.twitch?.failingTicks).toBe(0);
+
+    let churned = baseState();
+    for (let index = 0; index < TAB_CHURN_LIMIT; index += 1) {
+      churned = recordManagedTabOpen(churned, "twitch", START + index * 1000, PAGE_CONTEXT).state;
+    }
+    expect(churned.criticalHealth?.twitch?.breakerOpen).toBe(true);
+
+    const drained = observeCriticalHealth(churned, "twitch", {
+      at: START + TAB_CHURN_WINDOW_MS + 60_000,
+      failing: false,
+      progressed: false,
+      preconditionBroke: false,
+      inconclusive: true,
+    }).state;
+    expect(drained.criticalHealth?.twitch?.managedTabOpens).toEqual([]);
+    // Crossing the churn limit also flags, and a flagged platform holds the
+    // breaker open until the user dismisses it. The prune above is what an
+    // inconclusive observation contributes; the release waits for the dismiss.
+    expect(drained.criticalHealth?.twitch?.status).toBe("flagged");
+    expect(drained.criticalHealth?.twitch?.breakerOpen).toBe(true);
+
+    const dismissed = dismissCriticalFailure(drained, "twitch", START + TAB_CHURN_WINDOW_MS + 120_000).state;
+    const released = observeCriticalHealth(dismissed, "twitch", {
+      at: START + TAB_CHURN_WINDOW_MS + 180_000,
+      failing: false,
+      progressed: false,
+      preconditionBroke: false,
+      inconclusive: true,
+    }).state;
+    expect(released.criticalHealth?.twitch?.breakerOpen).toBe(false);
+  });
+});

--- a/packages/extension/tests/platformState.test.ts
+++ b/packages/extension/tests/platformState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Platform, SchedulerState } from "@lurkloot/shared/models";
-import { mergePlatformState } from "@lurkloot/core/background/platformState";
+import { mergePlatformState, schedulerStateEquivalent } from "@lurkloot/core/background/platformState";
 
 function state(label: string, lastTickAt: string): SchedulerState {
   const session = (platform: Platform) => ({
@@ -87,5 +87,53 @@ describe("mergePlatformState", () => {
       destination.deadlineInfeasibleRewardIds?.kick,
     );
     expect(merged.lastTickAt).toBe("2026-07-29T12:00:00.000Z");
+  });
+});
+
+describe("schedulerStateEquivalent", () => {
+  it("ignores lastTickAt, which every tick restamps regardless of what it decided", () => {
+    expect(schedulerStateEquivalent(
+      state("same", "2026-07-29T12:00:00.000Z"),
+      state("same", "2026-07-29T12:30:00.000Z"),
+    )).toBe(true);
+  });
+
+  it("reports a difference in any field that is not lastTickAt", () => {
+    expect(schedulerStateEquivalent(
+      state("before", "2026-07-29T12:00:00.000Z"),
+      state("after", "2026-07-29T12:00:00.000Z"),
+    )).toBe(false);
+  });
+
+  it("treats an explicit undefined as equal to an absent key", () => {
+    // The scheduler's disabled branch sets channel/campaignId/rewardId to
+    // undefined explicitly, while a state round-tripped through storage simply
+    // lacks those keys. Without this the guard would never fire.
+    const stored = state("idle", "2026-07-29T12:00:00.000Z");
+    const rebuilt = state("idle", "2026-07-29T12:00:00.000Z");
+    rebuilt.sessions.twitch = {
+      ...rebuilt.sessions.twitch,
+      channel: undefined,
+      campaignId: undefined,
+      rewardId: undefined,
+    };
+    expect(schedulerStateEquivalent(stored, rebuilt)).toBe(true);
+  });
+
+  it("does not treat a present value as equal to an absent key", () => {
+    const stored = state("idle", "2026-07-29T12:00:00.000Z");
+    const rebuilt = state("idle", "2026-07-29T12:00:00.000Z");
+    rebuilt.sessions.twitch = { ...rebuilt.sessions.twitch, campaignId: "campaign-1" };
+    expect(schedulerStateEquivalent(stored, rebuilt)).toBe(false);
+  });
+
+  it("compares nested arrays by position rather than by reference", () => {
+    const left = state("idle", "2026-07-29T12:00:00.000Z");
+    const right = state("idle", "2026-07-29T12:00:00.000Z");
+    left.campaigns = { twitch: [], kick: [] };
+    right.campaigns = { twitch: [], kick: [] };
+    expect(schedulerStateEquivalent(left, right)).toBe(true);
+    right.deadlineInfeasibleRewardIds = { twitch: ["reward-1"] };
+    expect(schedulerStateEquivalent(left, right)).toBe(false);
   });
 });

--- a/packages/extension/tests/scheduler.test.ts
+++ b/packages/extension/tests/scheduler.test.ts
@@ -4647,7 +4647,14 @@ describe("scheduler critical health observations", () => {
 
     expect(result.state.criticalHealth?.twitch?.managedTabOpens).toEqual([]);
     expect(result.state.criticalHealth?.twitch?.breakerOpen).toBe(false);
-    expect(result.state.criticalHealth?.twitch?.lastObservedAt).toBeDefined();
+    // Previously asserted to be defined, on the old contract where every
+    // observation advanced the clock. These early exits now report an
+    // inconclusive observation, which clears the stamp instead: a tick that
+    // reached no verdict is not a reading to measure the next failing gap from,
+    // so resuming looks like a cold start and charges delta = 0. The pruning and
+    // breaker release above are what these exits still have to do, and they are
+    // unchanged.
+    expect(result.state.criticalHealth?.twitch?.lastObservedAt).toBeUndefined();
   });
 
   it("prunes the tab churn window while authentication is unhealthy", async () => {

--- a/packages/shared/src/criticalHealth.ts
+++ b/packages/shared/src/criticalHealth.ts
@@ -24,7 +24,11 @@ export interface CriticalHealthState {
   // stale counters from an old outage must not accumulate across sessions.
   failingMs: number;
   failingTicks: number;
-  // Written on every observation, accruing or not — it is the tick clock, not an accrual marker.
+  // The clock for failing time, not an accrual marker: written on every
+  // observation that reached a verdict, accruing or not. An inconclusive
+  // observation (platform disabled, signed out) clears it instead, so the next
+  // failing tick starts from a cold start rather than measuring a gap across a
+  // period when nothing was being observed.
   lastObservedAt?: string;
   lastWatchedMinutes?: number;
   // Both managed page contexts and managed watch tabs, sharing one churn window.


### PR DESCRIPTION
## Summary

Two commits. The first adds a persist guard; the second makes it able to fire.

**1. Skip the state persist when a tick changed nothing.** A scheduler tick restamps `lastTickAt` whether or not it decided anything, and neither `persistPlatformState` nor the hosts' `saveState` had an equality guard. Both tick alarms are created regardless of the `enabled` flag, so a disabled platform keeps ticking, reaches the scheduler's disabled branch, rebuilds the same session, and rewrites storage at the poll interval indefinitely.

The guard compares the merged state against the state loaded inside the commit, ignoring `lastTickAt`, and skips the write when they match. Callers still treat it as persisted, since storage already holds that state, and observe `latest` rather than the merged value carrying the newer stamp. The comparison ignores keys whose value is `undefined` on either side — load-bearing, not cosmetic: the disabled branch sets `channel` / `campaignId` / `rewardId` explicitly to `undefined`, while a state round-tripped through storage simply lacks those keys.

**2. Stop advancing the failing clock on inconclusive ticks.** On its own the guard could not fire in the default configuration, because `observeCriticalHealth` restamped `lastObservedAt` from the disabled branch's neutral observation.

The reducer had no way to tell "reached no verdict" from "clean tick" — a healthy tick that simply did not accrue reports the same three booleans as the seeded neutral observation, differing only by carrying `watchedMinutes`. So this adds an explicit `inconclusive` flag, set by `neutralObservation`, and the reset branch clears `lastObservedAt` for it instead of advancing it.

## Why this is the conservative direction

The next genuinely failing tick after an inconclusive gap takes the existing cold-start path and charges `delta = 0`. It under-counts, so it can only ever flag **later**, never sooner. Keeping a stale stamp instead would have billed up to `MAX_TICK_DELTA_MS` of failing time that was never observed.

Everything else in the reset branch is deliberately untouched. An inconclusive observation still clears the failing counters, still prunes the tab churn window, and still releases the breaker, so a platform that only ever takes an early exit can still recover.

Not resetting the counters was considered and **rejected**: a platform disabled mid-window would resume with day-old evidence plus one fresh failing tick, which is the one version of this change that could genuinely cause a false positive.

Incidentally, the stamp never survived a round trip — `normalizeCriticalHealth` drops it on load — so every tick was writing a field the next read discarded.

## Changed test contract

One existing assertion in `scheduler.test.ts` is updated rather than worked around. It asserted `lastObservedAt` was defined after the disabled early exit, which was the old contract. Its pruning and breaker-release assertions are unchanged, and the reason is recorded inline.

## Testing

- `pnpm check` green: 2005 extension tests, 195 CLI tests, workspace typechecks, site build.
- Baselined the 36 existing critical health tests before touching the detector, so semantic drift would surface as a failure. It did: two scheduler tests caught the contract change, which is the assertion above.
- Added 4 detector tests and 3 controller tests. Verified each new guard test fails when its change is reverted, so none pass trivially.
- An earlier version of the controller tests was flaky, caused by two ticks landing in the same millisecond. They now step the clock across a full alarm period rather than racing it, and were run repeatedly to confirm.

No popup UI change, so no screenshots.

Closes #528

https://claude.ai/code/session_01H5Np3x3Hox9dVZGBhzVHxi
