### PR TITLE
fix(core): suppress historical reward notifications

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -5286,7 +5286,8 @@ function newlyEarnedRewards(
     for (const campaign of next.campaigns[platform]) {
       for (const reward of campaign.rewards) {
         const before = previousStatuses.get(`${platform}:${campaign.id}:${reward.id}`);
-        if ((reward.status === "claimable" || reward.status === "claimed") && before !== reward.status) {
+        const wasKnownAndUnearned = before !== undefined && before !== "claimable" && before !== "claimed";
+        if ((reward.status === "claimable" || reward.status === "claimed") && wasKnownAndUnearned) {
           earned.push({ campaign, reward });
         }
       }

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -6849,6 +6849,47 @@ describe("background controller", () => {
     });
   });
 
+  it.each(["claimable", "claimed"] as const)("does not notify for a newly discovered %s reward", async (status) => {
+    const env = harness(farming({
+      ...DEFAULT_SETTINGS,
+      notifyRewardEarned: true,
+      notifyNoDropsLeft: false,
+    }));
+    env.state.campaigns = { twitch: [], kick: [] };
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([campaign("twitch", status)]);
+
+    await env.controller.tick();
+
+    expect(env.deps.createNotification).not.toHaveBeenCalled();
+  });
+
+  it("does not notify again when an earned reward changes from claimable to claimed", async () => {
+    const env = harness(farming({
+      ...DEFAULT_SETTINGS,
+      notifyRewardEarned: true,
+      notifyNoDropsLeft: false,
+    }));
+    env.state.campaigns.twitch = [campaign("twitch", "claimable")];
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([campaign("twitch", "claimed")]);
+
+    await env.controller.tick();
+
+    expect(env.deps.createNotification).not.toHaveBeenCalled();
+  });
+
+  it("notifies when a known unearned reward transitions directly to claimed", async () => {
+    const env = harness(farming({ ...DEFAULT_SETTINGS, notifyRewardEarned: true }));
+    env.state.campaigns.twitch = [campaign("twitch", "in_progress")];
+    vi.mocked(env.twitch.refreshCampaigns).mockResolvedValue([campaign("twitch", "claimed")]);
+
+    await env.controller.tick();
+
+    expect(env.deps.createNotification).toHaveBeenCalledWith({
+      title: "Reward earned",
+      message: "Reward from twitch campaign",
+    });
+  });
+
   it("emits a notification when a Kick challenge is claimed", async () => {
     const env = harness(farming({ ...DEFAULT_SETTINGS, notifyRewardEarned: true }));
     env.kick.claimChallenges = vi.fn(async () => [{ id: "daily", rarity: "mythic", recurrence: "daily" }]);


### PR DESCRIPTION
## Summary

- notify only when a previously known unearned reward transitions to `claimable` or `claimed`
- treat newly discovered terminal rewards as inventory baseline after reinstall or state reset
- avoid a duplicate notification for `claimable -> claimed`
- preserve notifications for observed `in_progress -> claimable/claimed` transitions and Kick challenge events

## Testing

- `pnpm check`
- 1,997 extension tests passed
- 195 CLI tests passed
- workspace typechecks and Astro site build passed

Closes #527


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reward notifications now appear only when an existing unearned reward becomes claimable or claimed.
  - Newly discovered rewards no longer trigger notifications.
  - Rewards changing from claimable to claimed no longer generate duplicate notifications.
  - Rewards moving directly from in progress to claimed still trigger the appropriate notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->