### PR TITLE
feat(twitch): claim channel points from hermes with alarm fallback

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -226,7 +226,7 @@ Kick may retain an extension-owned page-context tab when its service-worker fetc
 - Followed channels come from an inline `FollowedLiveChannels` query (`currentUser.followedLiveUsers`), cached for 5 minutes in `TwitchDiscoveryState` (injected, so the cache survives the extension reconstructing `TwitchAdapter` every tick). A tick never blocks on this: a cached value, even a stale one, is returned immediately and refreshed in the background; only the very first lookup ever (nothing cached yet) awaits the request. A signed-out session or a failed lookup answers with an empty list, and selection falls back to viewer count.
 - Channel validation calls `StreamInfo` with an inline public query and anonymous credentials to avoid logged-in integrity-token failures. For live category matches, it briefly caches `DropsHighlightService_AvailableDrops` results to confirm the selected campaign; unavailable or malformed confirmation data falls back to the live/category result. If `StreamInfo` fails, validation falls back to parsing channel page HTML.
 - Reward claiming calls `DropsPage_ClaimDropRewards`.
-- Channel points claiming checks `ChannelPointsContext` and submits `ClaimCommunityPoints` when a claim is available.
+- Channel points claiming uses live Hermes `claim-available` when the advanced setting is on; `ChannelPointsContext` remains the alarm fallback.
 - Tabless watching sends Twitch's `sendSpadeEvents` minute-watched mutation once per watch alarm while the selected stream is live.
 
 ## Kick Integration

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -121,6 +121,9 @@ export function defaultConfigJsonc(): string {
         "categories": ${json(twitch.categories)},
         // Claim channel-point bonuses while farming this platform.
         "autoClaimChannelPoints": ${json(twitch.autoClaimChannelPoints)},
+        // Advanced: claim channel-point bonuses from Twitch's live Hermes
+        // notification. Has no effect without a WebSocket factory.
+        "channelPointsPushClaim": ${json(twitch.channelPointsPushClaim)},
         // Advanced: only farm a campaign on channels Twitch's AvailableDrops
         // query lists it for. Twitch often omits farmable campaigns there, so
         // enabling this can leave drops unfarmed.

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -123,7 +123,7 @@ const CLI_SETTING_KEYS = new Set<string>([
 ]);
 
 const CLI_PLATFORM_KEYS: Record<Platform, Set<string>> = {
-  twitch: new Set(["enabled", "idleWatchlistChannels", "excludedChannels", "categoryMode", "categories", "autoClaimChannelPoints", "strictCampaignAvailability"]),
+  twitch: new Set(["enabled", "idleWatchlistChannels", "excludedChannels", "categoryMode", "categories", "autoClaimChannelPoints", "strictCampaignAvailability", "channelPointsPushClaim"]),
   kick: new Set(["enabled", "idleWatchlistChannels", "excludedChannels", "categoryMode", "categories", "autoClaimChallenges"]),
 };
 const CLI_COMPATIBILITY_KEYS: Record<Platform, Set<string>> = {
@@ -380,6 +380,7 @@ function normalizePlatform(raw: EngineSettings["platform"] | undefined): Platfor
       ...twitch.base,
       autoClaimChannelPoints: booleanOr(twitch.ps.autoClaimChannelPoints, DEFAULT_CLI_SETTINGS.platform.twitch.autoClaimChannelPoints),
       strictCampaignAvailability: booleanOr(twitch.ps.strictCampaignAvailability, DEFAULT_CLI_SETTINGS.platform.twitch.strictCampaignAvailability),
+      channelPointsPushClaim: booleanOr(twitch.ps.channelPointsPushClaim, DEFAULT_CLI_SETTINGS.platform.twitch.channelPointsPushClaim),
     },
     kick: {
       ...kick.base,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "./discoverySnapshot": "./src/core/discoverySnapshot.ts",
     "./adapter": "./src/platforms/adapter.ts",
     "./twitch": "./src/platforms/twitch/index.ts",
+    "./twitch/channelPointsPush": "./src/platforms/twitch/channelPointsPush.ts",
     "./twitch/channelUrl": "./src/platforms/twitch/channelUrl.ts",
     "./twitch/parser": "./src/platforms/twitch/parser.ts",
     "./twitch/watch": "./src/platforms/twitch/watch.ts",

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -1625,7 +1625,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     } else {
       await deps.clearAlarm?.(TWITCH_CHANNEL_POINTS_ALARM_NAME);
     }
-    await reconcileTwitchChannelPointsPushFromSettings(settings);
+    reconcileTwitchChannelPointsPushFromSettingsInBackground(settings);
   }
 
   async function reconcileManualWatchClaimAlarms(settings: EngineSettings): Promise<void> {
@@ -4853,6 +4853,17 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     backgroundWork = backgroundWork.then(() => run, () => run);
   }
 
+  function reconcileTwitchChannelPointsPushFromSettingsInBackground(settings: S): void {
+    const run = reconcileTwitchChannelPointsPushFromSettings(settings).catch((error) => {
+      diagnosticEvent(
+        "warn",
+        `Twitch channel-points observer reconcile failed: ${error instanceof Error ? error.message : String(error)}`,
+        "twitch",
+      );
+    });
+    backgroundWork = backgroundWork.then(() => run, () => run);
+  }
+
   function twitchChannelPointsPushWanted(
     settings: EngineSettings,
     state: SchedulerState,
@@ -4899,6 +4910,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       });
     } catch (error) {
       emitHostCallbackError(emit, "twitch", error, "Could not start the Twitch channel-points observer");
+      if (twitchChannelPointsPush === controller) twitchChannelPointsPush = undefined;
     } finally {
       drainTwitchChannelPointsPushEvents(controller, emit);
     }

--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -25,6 +25,7 @@ import type { IntegrityHeader, TwitchIntegrity } from "../core/twitchIntegrity";
 import type { PlatformAdapter } from "../platforms/adapter";
 import type { TablessWatchController, WatchContext } from "../core/tablessWatch";
 import type { DiscoverySignalController } from "../core/discoverySignals";
+import type { TwitchChannelPointsClaimNotice, TwitchChannelPointsPushController } from "../platforms/twitch/channelPointsPush";
 import { applyPlatformAuthHealth } from "../core/authHealth";
 import { withActivityDiagnostics } from "../core/activityDiagnostics";
 import {
@@ -824,6 +825,8 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
   const campaignEvaluationFingerprints: Partial<Record<Platform, string>> = {};
   const discoverySignalControllers = new Map<Platform, DiscoverySignalController>();
+  let twitchChannelPointsPush: TwitchChannelPointsPushController | undefined;
+  const twitchChannelPointsClaimInFlight = new Set<string>();
   const discoverySignalPlatformBlocked: Record<Platform, boolean> = {
     twitch: false,
     kick: false,
@@ -1616,12 +1619,13 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     ]);
   }
 
-  async function reconcileTwitchChannelPointsAlarm(settings: EngineSettings): Promise<void> {
+  async function reconcileTwitchChannelPointsAlarm(settings: S): Promise<void> {
     if (settings.platform.twitch.enabled && autoClaimChannelPointsFor(settings, "twitch")) {
       await deps.createAlarm(TWITCH_CHANNEL_POINTS_ALARM_NAME, { periodInMinutes: 1 });
     } else {
       await deps.clearAlarm?.(TWITCH_CHANNEL_POINTS_ALARM_NAME);
     }
+    await reconcileTwitchChannelPointsPushFromSettings(settings);
   }
 
   async function reconcileManualWatchClaimAlarms(settings: EngineSettings): Promise<void> {
@@ -1903,6 +1907,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       });
       if (health.status !== "healthy") {
         await stopDiscoverySignalController(platform, emit);
+        if (platform === "twitch") await stopTwitchChannelPointsPush(emit);
       }
       await reportBestEffort(tickContext
         ? correlateTickDiagnostics(events, tickContext)
@@ -2036,6 +2041,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
           data: { reason: "platform_error", detail: failure.message },
         });
         await stopDiscoverySignalController(failure.platform, emit);
+        if (failure.platform === "twitch") await stopTwitchChannelPointsPush(emit);
       }
       await persistAndReport(
         state,
@@ -2800,6 +2806,9 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         signal.throwIfAborted();
         assertSelectionsCurrent();
         await reconcileDiscoverySignalControllers(result.state, settings, adapters, emit, schedulerPlatforms);
+        if (schedulerPlatforms.includes("twitch")) {
+          await reconcileTwitchChannelPointsPush(settings, result.state, adapters.twitch, emit);
+        }
         for (const schedulerPlatform of schedulerPlatforms) tickAdapters[schedulerPlatform]?.drain(claimObservingEmit);
         signal.throwIfAborted();
         assertSelectionsCurrent();
@@ -2946,6 +2955,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         if (transition.event) emit(transition.event);
         await saveOperationalState(transition.state);
         await stopDiscoverySignalController(platform, emit);
+        if (platform === "twitch") await stopTwitchChannelPointsPush(emit);
         await reportBestEffort(events);
       }));
     } finally {
@@ -4023,6 +4033,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     void cancelHeartbeatPublicationLeases(PLATFORMS);
     clearHeartbeatOwnershipInBackground(PLATFORMS);
     stopDiscoverySignalControllersInBackground(PLATFORMS);
+    stopTwitchChannelPointsPushInBackground();
   }
 
   async function prepareForHostReset(resetHostStorage?: () => Promise<void>): Promise<void> {
@@ -4039,6 +4050,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       closeTwitchIntegrityLifecycle("Host reset");
       abortClaimOnlyOperations("Host reset");
       await stopDiscoverySignalControllersAndReport(PLATFORMS);
+      await stopTwitchChannelPointsPushAndReport();
       await clearTwitchIntegrityAlarmBestEffort();
       await clearTwitchChannelPointsAlarmBestEffort();
       await clearManualWatchClaimAlarmsBestEffort();
@@ -4802,10 +4814,209 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     }
   }
 
+  function drainTwitchChannelPointsPushEvents(
+    controller: TwitchChannelPointsPushController,
+    emit: EventEmitter,
+  ): void {
+    for (const event of controller.drainEvents()) emit(event);
+  }
+
+  async function stopTwitchChannelPointsPush(emit: EventEmitter): Promise<void> {
+    const controller = twitchChannelPointsPush;
+    if (!controller) return;
+    twitchChannelPointsPush = undefined;
+    drainTwitchChannelPointsPushEvents(controller, emit);
+    try {
+      await controller.stop();
+    } catch (error) {
+      emitHostCallbackError(emit, "twitch", error, "Could not stop the Twitch channel-points observer");
+    } finally {
+      drainTwitchChannelPointsPushEvents(controller, emit);
+    }
+  }
+
+  async function stopTwitchChannelPointsPushAndReport(): Promise<void> {
+    await withEventCollector(async (emit, events) => {
+      await stopTwitchChannelPointsPush(emit);
+      await reportBestEffort(events);
+    });
+  }
+
+  function stopTwitchChannelPointsPushInBackground(): void {
+    const run = stopTwitchChannelPointsPushAndReport().catch((error) => {
+      diagnosticEvent(
+        "warn",
+        `Twitch channel-points observer cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+        "twitch",
+      );
+    });
+    backgroundWork = backgroundWork.then(() => run, () => run);
+  }
+
+  function twitchChannelPointsPushWanted(
+    settings: EngineSettings,
+    state: SchedulerState,
+    factory: PlatformAdapter["createChannelPointsPushController"],
+  ): boolean {
+    return discoverySignalLifecycleOpen
+      && !controllerShutdown
+      && settings.platform.twitch.enabled
+      && autoClaimChannelPointsFor(settings, "twitch")
+      && settings.platform.twitch.channelPointsPushClaim
+      && state.authHealth.twitch.status === "healthy"
+      && Boolean(eligibleTwitchChannelPointsChannel(settings, state))
+      && Boolean(factory);
+  }
+
+  async function reconcileTwitchChannelPointsPush(
+    settings: EngineSettings,
+    state: SchedulerState,
+    adapter: PlatformAdapter,
+    emit: EventEmitter,
+  ): Promise<void> {
+    const factory = adapter.createChannelPointsPushController;
+    if (!twitchChannelPointsPushWanted(settings, state, factory) || !factory) {
+      await stopTwitchChannelPointsPush(emit);
+      return;
+    }
+
+    let controller = twitchChannelPointsPush;
+    if (!controller) {
+      try {
+        controller = factory();
+        twitchChannelPointsPush = controller;
+      } catch (error) {
+        emitHostCallbackError(emit, "twitch", error, "Could not create the Twitch channel-points observer");
+        return;
+      }
+    }
+
+    drainTwitchChannelPointsPushEvents(controller, emit);
+    try {
+      await controller.start((notice) => {
+        if (twitchChannelPointsPush !== controller) return;
+        queueTwitchChannelPointsPushClaim(notice);
+      });
+    } catch (error) {
+      emitHostCallbackError(emit, "twitch", error, "Could not start the Twitch channel-points observer");
+    } finally {
+      drainTwitchChannelPointsPushEvents(controller, emit);
+    }
+
+    if (
+      twitchChannelPointsPush !== controller
+      || !discoverySignalLifecycleOpen
+      || controllerShutdown
+    ) {
+      if (twitchChannelPointsPush === controller) twitchChannelPointsPush = undefined;
+      try {
+        await controller.stop();
+      } catch (error) {
+        emitHostCallbackError(emit, "twitch", error, "Could not stop the Twitch channel-points observer");
+      } finally {
+        drainTwitchChannelPointsPushEvents(controller, emit);
+      }
+    }
+  }
+
+  async function reconcileTwitchChannelPointsPushFromSettings(settings: S): Promise<void> {
+    await withEventCollector(async (emit, events) => {
+      let adapter: PlatformAdapter | undefined;
+      try {
+        if (
+          controllerShutdown
+          || !discoverySignalLifecycleOpen
+          || !settings.platform.twitch.enabled
+          || !autoClaimChannelPointsFor(settings, "twitch")
+          || !settings.platform.twitch.channelPointsPushClaim
+        ) {
+          await stopTwitchChannelPointsPush(emit);
+          return;
+        }
+        const state = await deps.loadState();
+        if (
+          state.authHealth.twitch.status !== "healthy"
+          || !eligibleTwitchChannelPointsChannel(settings, state)
+        ) {
+          await stopTwitchChannelPointsPush(emit);
+          return;
+        }
+        adapter = createAdapter("twitch", settings, emit);
+        await reconcileTwitchChannelPointsPush(settings, state, adapter, emit);
+      } catch (error) {
+        emitHostCallbackError(emit, "twitch", error, "Could not reconcile the Twitch channel-points observer");
+        await stopTwitchChannelPointsPush(emit);
+      } finally {
+        adapter?.flushRouteDiagnostics?.(emit);
+        await reportBestEffort(events);
+      }
+    });
+  }
+
+  function queueTwitchChannelPointsPushClaim(notice: TwitchChannelPointsClaimNotice): void {
+    if (controllerShutdown) return;
+    if (twitchChannelPointsClaimInFlight.has(notice.claimId)) return;
+    twitchChannelPointsClaimInFlight.add(notice.claimId);
+    const run = withPlatformLock("twitch", () => withEventCollector(async (emit, events) => {
+      try {
+        if (twitchChannelPointsPush) drainTwitchChannelPointsPushEvents(twitchChannelPointsPush, emit);
+        await claimTwitchChannelPointsFromPush(notice, emit);
+      } finally {
+        twitchChannelPointsClaimInFlight.delete(notice.claimId);
+        if (twitchChannelPointsPush) drainTwitchChannelPointsPushEvents(twitchChannelPointsPush, emit);
+        await reportBestEffort(events);
+      }
+    }));
+    backgroundWork = backgroundWork.then(() => run, () => run);
+  }
+
+  async function claimTwitchChannelPointsFromPush(
+    notice: TwitchChannelPointsClaimNotice,
+    emit: EventEmitter,
+  ): Promise<void> {
+    if (controllerShutdown) return;
+    const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
+    if (!settings.platform.twitch.enabled
+      || !autoClaimChannelPointsFor(settings, "twitch")
+      || !settings.platform.twitch.channelPointsPushClaim
+      || state.authHealth.twitch.status !== "healthy") return;
+    const channel = eligibleTwitchChannelPointsChannel(settings, state);
+    if (!channel) return;
+    if (channel.channelId !== undefined && channel.channelId !== notice.channelId) return;
+    if (!twitchChannelPointsClaimInFlight.has(notice.claimId)) return;
+    try {
+      const adapter = createAdapter("twitch", settings, emit, true);
+      const claimed = await adapter.claimChannelPoints?.(channel, {
+        claimId: notice.claimId,
+        channelId: notice.channelId,
+      });
+      if (claimed) {
+        emit({
+          category: "diagnostic",
+          platform: "twitch",
+          level: "info",
+          message: `Claimed channel points for ${channel.displayName ?? channel.username}`,
+        });
+      }
+    } catch (error) {
+      emit({
+        category: "diagnostic",
+        platform: "twitch",
+        level: "warn",
+        message: error instanceof Error ? error.message : "Channel points claim failed",
+      });
+    }
+  }
+
   async function runTwitchChannelPointsClaim(): Promise<void> {
     if (controllerShutdown) return;
     await withPlatformLock("twitch", () => withEventCollector(async (emit, events) => {
       if (controllerShutdown) return;
+      if (twitchChannelPointsPush?.subscribed) {
+        drainTwitchChannelPointsPushEvents(twitchChannelPointsPush, emit);
+        await reportBestEffort(events);
+        return;
+      }
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
       if (!settings.platform.twitch.enabled
         || !autoClaimChannelPointsFor(settings, "twitch")

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -42,6 +42,11 @@ export interface AdapterOperationOptions {
   requireComplete?: boolean;
 }
 
+export interface ChannelPointsClaimOptions extends AdapterOperationOptions {
+  claimId?: string;
+  channelId?: string;
+}
+
 export interface ChannelCheckRequest {
   channel: ChannelCandidate;
   campaign?: DropCampaign;
@@ -107,7 +112,7 @@ export interface PlatformAdapter {
   // exposes the real drop-instance id once it releases the claim, so auto-claim
   // must defer until then instead of POSTing a value Twitch will reject.
   isClaimReady?(reward: DropReward): boolean;
-  claimChannelPoints?(channel: ChannelCandidate, options?: AdapterOperationOptions): Promise<boolean>;
+  claimChannelPoints?(channel: ChannelCandidate, options?: ChannelPointsClaimOptions): Promise<boolean>;
   // Claims any completed, unclaimed gamification challenges for the logged-in
   // account and reports what was won. Account-level, so it takes no channel and
   // runs regardless of whether a watch session is active.

--- a/packages/core/src/platforms/adapter.ts
+++ b/packages/core/src/platforms/adapter.ts
@@ -14,6 +14,7 @@ import type { ResolvedCompatibility } from "../compatibility/types";
 import type { LogLevel } from "@lurkloot/shared/logging";
 import type { TablessWatchController } from "../core/tablessWatch";
 import type { DiscoverySignalController } from "../core/discoverySignals";
+import type { TwitchChannelPointsPushController } from "./twitch/channelPointsPush";
 
 export const ignoreEvent: EventEmitter = () => {};
 
@@ -128,6 +129,7 @@ export interface PlatformAdapter {
   supportsTabless?: boolean;
   createTablessWatcher?(): TablessWatchController;
   createDiscoverySignalController?(): DiscoverySignalController;
+  createChannelPointsPushController?(): TwitchChannelPointsPushController;
   // Whether a bounded post-claim refresh is worthwhile on this platform. Twitch
   // only reveals the next reward in a campaign chain on a subsequent inventory
   // read, so re-polling recovers watch time the fixed alarm would otherwise

--- a/packages/core/src/platforms/twitch/channelPointsPush.ts
+++ b/packages/core/src/platforms/twitch/channelPointsPush.ts
@@ -1,0 +1,335 @@
+import type { DiagnosticEvent } from "@lurkloot/shared/events";
+import { PendingDiscoverySignalDiagnostics } from "../../core/discoverySignals";
+import type { WebSocketFactory, WebSocketLike } from "../../core/webSocket";
+
+export const TWITCH_HERMES_KEEPALIVE_DEFAULT_SEC = 15;
+export const TWITCH_CHANNEL_POINTS_TOPIC_PREFIX = "community-points-user-v1.";
+
+const DEFAULT_TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
+const RECONNECT_BASE_MS = 1_000;
+const WEBSOCKET_OPEN = 1;
+
+export interface TwitchChannelPointsClaimNotice {
+  claimId: string;
+  channelId: string;
+}
+
+export interface TwitchChannelPointsPushDeps {
+  createWebSocket: WebSocketFactory;
+  getAuthToken: () => Promise<string | undefined>;
+  resolveUserId: () => Promise<string | undefined>;
+  clientId?: string;
+  scheduleReconnect?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  cancelReconnect?: (timer: ReturnType<typeof setTimeout>) => void;
+  scheduleKeepAlive?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  cancelKeepAlive?: (timer: ReturnType<typeof setTimeout>) => void;
+}
+
+export class TwitchChannelPointsPushController {
+  private ws?: WebSocketLike;
+  private onClaimAvailable?: (notice: TwitchChannelPointsClaimNotice) => void;
+  private authToken?: string;
+  private userId?: string;
+  private pendingAuthId?: string;
+  private pendingSubscribeFrameId?: string;
+  private pendingSubscriptionId?: string;
+  private subscriptionId?: string;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private stopped = true;
+  private readonly clientId: string;
+  private readonly createWebSocket: WebSocketFactory;
+  private readonly getAuthToken: TwitchChannelPointsPushDeps["getAuthToken"];
+  private readonly resolveUserId: TwitchChannelPointsPushDeps["resolveUserId"];
+  private readonly scheduleReconnect: NonNullable<TwitchChannelPointsPushDeps["scheduleReconnect"]>;
+  private readonly cancelReconnect: NonNullable<TwitchChannelPointsPushDeps["cancelReconnect"]>;
+  private readonly diagnostics = new PendingDiscoverySignalDiagnostics();
+
+  constructor(deps: TwitchChannelPointsPushDeps) {
+    this.createWebSocket = deps.createWebSocket;
+    this.getAuthToken = deps.getAuthToken;
+    this.resolveUserId = deps.resolveUserId;
+    this.clientId = deps.clientId ?? DEFAULT_TWITCH_CLIENT_ID;
+    this.scheduleReconnect = deps.scheduleReconnect ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+    this.cancelReconnect = deps.cancelReconnect ?? ((timer) => clearTimeout(timer));
+  }
+
+  get subscribed(): boolean {
+    return this.subscriptionId !== undefined;
+  }
+
+  async start(onClaimAvailable: (notice: TwitchChannelPointsClaimNotice) => void): Promise<void> {
+    this.onClaimAvailable = onClaimAvailable;
+    if (!this.stopped) return;
+    this.stopped = false;
+    await this.connect();
+  }
+
+  drainEvents(): DiagnosticEvent[] {
+    return this.diagnostics.drain();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.clearReconnect();
+    this.closeCurrentSocket();
+    this.authToken = undefined;
+    this.userId = undefined;
+    this.onClaimAvailable = undefined;
+  }
+
+  private async connect(): Promise<void> {
+    if (this.stopped) return;
+
+    const token = await this.getAuthToken();
+    if (this.stopped) return;
+    if (typeof token !== "string" || token === "") {
+      this.log("debug", "Twitch channel-points push is missing an auth token");
+      this.scheduleNextReconnect();
+      return;
+    }
+    this.authToken = token;
+
+    const userId = (await this.resolveUserId())?.trim();
+    if (this.stopped) return;
+    this.userId = userId || undefined;
+
+    const url = `wss://hermes.twitch.tv/v1?clientId=${this.clientId}`;
+    let ws: WebSocketLike;
+    try {
+      ws = this.createWebSocket(url);
+    } catch (error) {
+      this.log("warn", `Failed to open Twitch channel-points WebSocket: ${errorMessage(error)}`);
+      this.scheduleNextReconnect();
+      return;
+    }
+    this.ws = ws;
+    this.log("debug", "Opening Twitch channel-points push connection");
+
+    ws.addEventListener("message", (event) => {
+      if (!this.isCurrent(ws)) return;
+      this.handleMessage(ws, event);
+    });
+  }
+
+  private isCurrent(ws: WebSocketLike): boolean {
+    return !this.stopped && ws === this.ws;
+  }
+
+  private handleMessage(ws: WebSocketLike, event: { data?: unknown }): void {
+    const frame = parseFrame(event.data);
+    if (!frame) {
+      this.log("debug", "Ignored malformed Twitch channel-points push frame");
+      return;
+    }
+
+    switch (frame.type) {
+      case "welcome":
+        this.handleWelcome(ws);
+        return;
+      case "authenticateResponse":
+        this.handleAuthenticateResponse(ws, frame);
+        return;
+      case "subscribeResponse":
+        this.handleSubscribeResponse(frame);
+        return;
+      case "notification":
+        this.handleNotification(frame);
+        return;
+      default:
+        this.log("debug", "Ignored Twitch channel-points push frame");
+        return;
+    }
+  }
+
+  private handleWelcome(ws: WebSocketLike): void {
+    const token = this.authToken;
+    if (typeof token !== "string" || token === "") {
+      this.log("debug", "Twitch channel-points push is missing an auth token");
+      this.closeCurrentSocket();
+      this.scheduleNextReconnect();
+      return;
+    }
+    const id = crypto.randomUUID();
+    this.pendingAuthId = id;
+    this.safeSend(ws, {
+      type: "authenticate",
+      id,
+      authenticate: { token },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  private handleAuthenticateResponse(ws: WebSocketLike, frame: HermesFrame): void {
+    const response = frame.authenticateResponse;
+    if (!isRecord(response)) {
+      this.log("debug", "Ignored malformed Twitch channel-points push frame");
+      return;
+    }
+    if (frame.parentId !== this.pendingAuthId) return;
+    if (response.result !== "ok") return;
+
+    const userId = this.userId;
+    if (!userId) {
+      this.log("debug", "Twitch channel-points push is missing a user id");
+      this.closeCurrentSocket();
+      this.scheduleNextReconnect();
+      return;
+    }
+
+    const id = crypto.randomUUID();
+    const subscriptionId = crypto.randomUUID();
+    this.pendingSubscribeFrameId = id;
+    this.pendingSubscriptionId = subscriptionId;
+    this.safeSend(ws, {
+      type: "subscribe",
+      id,
+      subscribe: {
+        id: subscriptionId,
+        type: "pubsub",
+        pubsub: { topic: `${TWITCH_CHANNEL_POINTS_TOPIC_PREFIX}${userId}` },
+      },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  private handleSubscribeResponse(frame: HermesFrame): void {
+    const response = frame.subscribeResponse;
+    if (!isRecord(response)) {
+      this.log("debug", "Ignored malformed Twitch channel-points push frame");
+      return;
+    }
+    const subscription = response.subscription;
+    if (
+      frame.parentId !== this.pendingSubscribeFrameId
+      || response.result !== "ok"
+      || !isRecord(subscription)
+      || subscription.id !== this.pendingSubscriptionId
+    ) return;
+    this.subscriptionId = this.pendingSubscriptionId;
+    this.log("debug", `Twitch channel-points push subscribed to ${TWITCH_CHANNEL_POINTS_TOPIC_PREFIX}${this.userId}`);
+  }
+
+  private handleNotification(frame: HermesFrame): void {
+    const notification = frame.notification;
+    if (!isRecord(notification)) {
+      this.log("debug", "Ignored malformed Twitch channel-points push frame");
+      return;
+    }
+    const subscription = notification.subscription;
+    if (!isRecord(subscription) || subscription.id !== this.subscriptionId) {
+      this.log("debug", "Ignored Twitch channel-points push notification");
+      return;
+    }
+    const inner = parsePubsub(notification.pubsub);
+    if (!inner) {
+      this.log("debug", "Ignored malformed Twitch channel-points push frame");
+      return;
+    }
+    const data = inner.data;
+    const claim = isRecord(data) ? data.claim : undefined;
+    if (
+      inner.type !== "claim-available"
+      || !isRecord(claim)
+      || typeof claim.id !== "string"
+      || claim.id.length === 0
+      || typeof claim.channel_id !== "string"
+      || claim.channel_id.length === 0
+    ) {
+      this.log("debug", "Ignored Twitch channel-points push notification");
+      return;
+    }
+    try {
+      this.onClaimAvailable?.({ claimId: claim.id, channelId: claim.channel_id });
+    } catch (error) {
+      this.log("warn", `Twitch channel-points push claim callback failed: ${errorMessage(error)}`);
+    }
+  }
+
+  private safeSend(ws: WebSocketLike, frame: Record<string, unknown>): void {
+    if (!this.isCurrent(ws) || ws.readyState !== WEBSOCKET_OPEN) return;
+    try {
+      ws.send(JSON.stringify(frame));
+    } catch (error) {
+      this.log("warn", `Failed to send Twitch channel-points push frame: ${errorMessage(error)}`);
+    }
+  }
+
+  private scheduleNextReconnect(): void {
+    if (this.stopped || this.reconnectTimer !== undefined) return;
+    let timer: ReturnType<typeof setTimeout>;
+    timer = this.scheduleReconnect(() => {
+      if (this.reconnectTimer !== timer) return;
+      this.reconnectTimer = undefined;
+      void this.connect();
+    }, RECONNECT_BASE_MS);
+    this.reconnectTimer = timer;
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimer === undefined) return;
+    this.cancelReconnect(this.reconnectTimer);
+    this.reconnectTimer = undefined;
+  }
+
+  private closeCurrentSocket(): void {
+    this.pendingAuthId = undefined;
+    this.pendingSubscribeFrameId = undefined;
+    this.pendingSubscriptionId = undefined;
+    this.subscriptionId = undefined;
+    const ws = this.ws;
+    if (!ws) return;
+    this.ws = undefined;
+    try {
+      ws.close();
+    } catch {
+      // Closing is best-effort; stale callbacks are inert once ws is cleared.
+    }
+  }
+
+  private log(level: "debug" | "warn", message: string): void {
+    this.diagnostics.push({ category: "diagnostic", platform: "twitch", level, message });
+  }
+}
+
+interface HermesFrame {
+  type: string;
+  parentId?: unknown;
+  authenticateResponse?: unknown;
+  subscribeResponse?: unknown;
+  notification?: unknown;
+}
+
+function parseFrame(value: unknown): HermesFrame | undefined {
+  if (typeof value !== "string") return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!isRecord(parsed) || typeof parsed.type !== "string") return undefined;
+    return {
+      type: parsed.type,
+      parentId: parsed.parentId,
+      authenticateResponse: parsed.authenticateResponse,
+      subscribeResponse: parsed.subscribeResponse,
+      notification: parsed.notification,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function parsePubsub(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== "string") return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/core/src/platforms/twitch/channelPointsPush.ts
+++ b/packages/core/src/platforms/twitch/channelPointsPush.ts
@@ -7,6 +7,7 @@ export const TWITCH_CHANNEL_POINTS_TOPIC_PREFIX = "community-points-user-v1.";
 
 const DEFAULT_TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
 const WEBSOCKET_OPEN = 1;
 
 export interface TwitchChannelPointsClaimNotice {
@@ -34,7 +35,10 @@ export class TwitchChannelPointsPushController {
   private pendingSubscribeFrameId?: string;
   private pendingSubscriptionId?: string;
   private subscriptionId?: string;
+  private reconnectAttempt = 0;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private keepAliveTimer?: ReturnType<typeof setTimeout>;
+  private keepaliveSec = TWITCH_HERMES_KEEPALIVE_DEFAULT_SEC;
   private stopped = true;
   private readonly clientId: string;
   private readonly createWebSocket: WebSocketFactory;
@@ -42,7 +46,10 @@ export class TwitchChannelPointsPushController {
   private readonly resolveUserId: TwitchChannelPointsPushDeps["resolveUserId"];
   private readonly scheduleReconnect: NonNullable<TwitchChannelPointsPushDeps["scheduleReconnect"]>;
   private readonly cancelReconnect: NonNullable<TwitchChannelPointsPushDeps["cancelReconnect"]>;
+  private readonly scheduleKeepAlive: NonNullable<TwitchChannelPointsPushDeps["scheduleKeepAlive"]>;
+  private readonly cancelKeepAlive: NonNullable<TwitchChannelPointsPushDeps["cancelKeepAlive"]>;
   private readonly diagnostics = new PendingDiscoverySignalDiagnostics();
+  private readonly intentionallyClosedSockets = new WeakSet<WebSocketLike>();
 
   constructor(deps: TwitchChannelPointsPushDeps) {
     this.createWebSocket = deps.createWebSocket;
@@ -51,6 +58,8 @@ export class TwitchChannelPointsPushController {
     this.clientId = deps.clientId ?? DEFAULT_TWITCH_CLIENT_ID;
     this.scheduleReconnect = deps.scheduleReconnect ?? ((callback, delayMs) => setTimeout(callback, delayMs));
     this.cancelReconnect = deps.cancelReconnect ?? ((timer) => clearTimeout(timer));
+    this.scheduleKeepAlive = deps.scheduleKeepAlive ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+    this.cancelKeepAlive = deps.cancelKeepAlive ?? ((timer) => clearTimeout(timer));
   }
 
   get subscribed(): boolean {
@@ -72,6 +81,7 @@ export class TwitchChannelPointsPushController {
     this.stopped = true;
     this.clearReconnect();
     this.closeCurrentSocket();
+    this.reconnectAttempt = 0;
     this.authToken = undefined;
     this.userId = undefined;
     this.onClaimAvailable = undefined;
@@ -109,6 +119,18 @@ export class TwitchChannelPointsPushController {
       if (!this.isCurrent(ws)) return;
       this.handleMessage(ws, event);
     });
+    ws.addEventListener("close", () => {
+      if (!this.isCurrent(ws)) {
+        this.intentionallyClosedSockets.delete(ws);
+        return;
+      }
+      if (this.intentionallyClosedSockets.delete(ws)) return;
+      this.ws = undefined;
+      this.clearKeepAlive();
+      this.clearHandshakeState();
+      this.log("debug", "Twitch channel-points push connection closed");
+      this.scheduleNextReconnect();
+    });
   }
 
   private isCurrent(ws: WebSocketLike): boolean {
@@ -124,7 +146,10 @@ export class TwitchChannelPointsPushController {
 
     switch (frame.type) {
       case "welcome":
-        this.handleWelcome(ws);
+        this.handleWelcome(ws, frame);
+        return;
+      case "keepalive":
+        this.resetSilenceTimeout();
         return;
       case "authenticateResponse":
         this.handleAuthenticateResponse(ws, frame);
@@ -141,7 +166,9 @@ export class TwitchChannelPointsPushController {
     }
   }
 
-  private handleWelcome(ws: WebSocketLike): void {
+  private handleWelcome(ws: WebSocketLike, frame: HermesFrame): void {
+    this.keepaliveSec = readKeepaliveSec(frame.welcome);
+    this.resetSilenceTimeout();
     const token = this.authToken;
     if (typeof token !== "string" || token === "") {
       this.log("debug", "Twitch channel-points push is missing an auth token");
@@ -166,7 +193,12 @@ export class TwitchChannelPointsPushController {
       return;
     }
     if (frame.parentId !== this.pendingAuthId) return;
-    if (response.result !== "ok") return;
+    if (response.result !== "ok") {
+      this.log("debug", "Twitch channel-points push authenticate was not ok");
+      this.closeCurrentSocket();
+      this.scheduleNextReconnect();
+      return;
+    }
 
     const userId = this.userId;
     if (!userId) {
@@ -206,6 +238,7 @@ export class TwitchChannelPointsPushController {
       || subscription.id !== this.pendingSubscriptionId
     ) return;
     this.subscriptionId = this.pendingSubscriptionId;
+    this.reconnectAttempt = 0;
     this.log("debug", `Twitch channel-points push subscribed to ${TWITCH_CHANNEL_POINTS_TOPIC_PREFIX}${this.userId}`);
   }
 
@@ -254,14 +287,31 @@ export class TwitchChannelPointsPushController {
     }
   }
 
+  private resetSilenceTimeout(): void {
+    this.clearKeepAlive();
+    const delayMs = 2 * this.keepaliveSec * 1000;
+    let timer: ReturnType<typeof setTimeout>;
+    timer = this.scheduleKeepAlive(() => {
+      if (this.keepAliveTimer !== timer) return;
+      this.keepAliveTimer = undefined;
+      if (this.stopped || !this.ws) return;
+      this.log("debug", "Twitch channel-points push keepalive timed out");
+      this.closeCurrentSocket();
+      this.scheduleNextReconnect();
+    }, delayMs);
+    this.keepAliveTimer = timer;
+  }
+
   private scheduleNextReconnect(): void {
     if (this.stopped || this.reconnectTimer !== undefined) return;
+    const delayMs = Math.min(RECONNECT_BASE_MS * (2 ** this.reconnectAttempt), RECONNECT_MAX_MS);
+    this.reconnectAttempt += 1;
     let timer: ReturnType<typeof setTimeout>;
     timer = this.scheduleReconnect(() => {
       if (this.reconnectTimer !== timer) return;
       this.reconnectTimer = undefined;
       void this.connect();
-    }, RECONNECT_BASE_MS);
+    }, delayMs);
     this.reconnectTimer = timer;
   }
 
@@ -271,14 +321,26 @@ export class TwitchChannelPointsPushController {
     this.reconnectTimer = undefined;
   }
 
-  private closeCurrentSocket(): void {
+  private clearKeepAlive(): void {
+    if (this.keepAliveTimer === undefined) return;
+    this.cancelKeepAlive(this.keepAliveTimer);
+    this.keepAliveTimer = undefined;
+  }
+
+  private clearHandshakeState(): void {
     this.pendingAuthId = undefined;
     this.pendingSubscribeFrameId = undefined;
     this.pendingSubscriptionId = undefined;
     this.subscriptionId = undefined;
+  }
+
+  private closeCurrentSocket(): void {
+    this.clearKeepAlive();
+    this.clearHandshakeState();
     const ws = this.ws;
     if (!ws) return;
     this.ws = undefined;
+    this.intentionallyClosedSockets.add(ws);
     try {
       ws.close();
     } catch {
@@ -294,6 +356,7 @@ export class TwitchChannelPointsPushController {
 interface HermesFrame {
   type: string;
   parentId?: unknown;
+  welcome?: unknown;
   authenticateResponse?: unknown;
   subscribeResponse?: unknown;
   notification?: unknown;
@@ -307,6 +370,7 @@ function parseFrame(value: unknown): HermesFrame | undefined {
     return {
       type: parsed.type,
       parentId: parsed.parentId,
+      welcome: parsed.welcome,
       authenticateResponse: parsed.authenticateResponse,
       subscribeResponse: parsed.subscribeResponse,
       notification: parsed.notification,
@@ -314,6 +378,14 @@ function parseFrame(value: unknown): HermesFrame | undefined {
   } catch {
     return undefined;
   }
+}
+
+function readKeepaliveSec(welcome: unknown): number {
+  if (!isRecord(welcome)) return TWITCH_HERMES_KEEPALIVE_DEFAULT_SEC;
+  const value = welcome.keepaliveSec;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : TWITCH_HERMES_KEEPALIVE_DEFAULT_SEC;
 }
 
 function parsePubsub(value: unknown): Record<string, unknown> | undefined {

--- a/packages/core/src/platforms/twitch/channelPointsPush.ts
+++ b/packages/core/src/platforms/twitch/channelPointsPush.ts
@@ -113,6 +113,8 @@ export class TwitchChannelPointsPushController {
       return;
     }
     this.ws = ws;
+    this.keepaliveSec = TWITCH_HERMES_KEEPALIVE_DEFAULT_SEC;
+    this.resetSilenceTimeout();
     this.log("debug", "Opening Twitch channel-points push connection");
 
     ws.addEventListener("message", (event) => {

--- a/packages/core/src/platforms/twitch/channelPointsPush.ts
+++ b/packages/core/src/platforms/twitch/channelPointsPush.ts
@@ -106,16 +106,14 @@ export class TwitchChannelPointsPushController {
     }
     this.authToken = token;
 
-    if (!this.userId) {
-      try {
-        const userId = (await this.resolveUserId())?.trim();
-        if (this.stopped) return;
-        this.userId = userId || undefined;
-      } catch (error) {
-        this.log("warn", `Failed to resolve the Twitch channel-points user id: ${errorMessage(error)}`);
-        this.scheduleNextReconnect();
-        return;
-      }
+    try {
+      const userId = (await this.resolveUserId())?.trim();
+      if (this.stopped) return;
+      this.userId = userId || undefined;
+    } catch (error) {
+      this.log("warn", `Failed to resolve the Twitch channel-points user id: ${errorMessage(error)}`);
+      this.scheduleNextReconnect();
+      return;
     }
 
     const url = `wss://hermes.twitch.tv/v1?clientId=${this.clientId}`;
@@ -242,18 +240,20 @@ export class TwitchChannelPointsPushController {
   }
 
   private handleSubscribeResponse(frame: HermesFrame): void {
+    if (frame.parentId !== this.pendingSubscribeFrameId) return;
     const response = frame.subscribeResponse;
-    if (!isRecord(response)) {
-      this.log("debug", "Ignored malformed Twitch channel-points push frame");
-      return;
-    }
-    const subscription = response.subscription;
+    const subscription = isRecord(response) ? response.subscription : undefined;
     if (
-      frame.parentId !== this.pendingSubscribeFrameId
+      !isRecord(response)
       || response.result !== "ok"
       || !isRecord(subscription)
       || subscription.id !== this.pendingSubscriptionId
-    ) return;
+    ) {
+      this.log("debug", "Twitch channel-points push subscribe was not ok");
+      this.closeCurrentSocket();
+      this.scheduleNextReconnect();
+      return;
+    }
     this.subscriptionId = this.pendingSubscriptionId;
     this.reconnectAttempt = 0;
     this.log("debug", `Twitch channel-points push subscribed to ${TWITCH_CHANNEL_POINTS_TOPIC_PREFIX}${this.userId}`);

--- a/packages/core/src/platforms/twitch/channelPointsPush.ts
+++ b/packages/core/src/platforms/twitch/channelPointsPush.ts
@@ -90,7 +90,14 @@ export class TwitchChannelPointsPushController {
   private async connect(): Promise<void> {
     if (this.stopped) return;
 
-    const token = await this.getAuthToken();
+    let token: string | undefined;
+    try {
+      token = await this.getAuthToken();
+    } catch (error) {
+      this.log("warn", `Failed to read the Twitch channel-points auth token: ${errorMessage(error)}`);
+      this.scheduleNextReconnect();
+      return;
+    }
     if (this.stopped) return;
     if (typeof token !== "string" || token === "") {
       this.log("debug", "Twitch channel-points push is missing an auth token");
@@ -99,9 +106,17 @@ export class TwitchChannelPointsPushController {
     }
     this.authToken = token;
 
-    const userId = (await this.resolveUserId())?.trim();
-    if (this.stopped) return;
-    this.userId = userId || undefined;
+    if (!this.userId) {
+      try {
+        const userId = (await this.resolveUserId())?.trim();
+        if (this.stopped) return;
+        this.userId = userId || undefined;
+      } catch (error) {
+        this.log("warn", `Failed to resolve the Twitch channel-points user id: ${errorMessage(error)}`);
+        this.scheduleNextReconnect();
+        return;
+      }
+    }
 
     const url = `wss://hermes.twitch.tv/v1?clientId=${this.clientId}`;
     let ws: WebSocketLike;

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -6,7 +6,7 @@ import type { TwitchIntegrityRequest } from "../../core/tabs";
 import type { TwitchIntegrity } from "../../core/twitchIntegrity";
 import { PendingWatcherDiagnostics, type HeartbeatResult, type TablessWatchController, type WatchContext } from "../../core/tablessWatch";
 import { StaleWhileRevalidateCache } from "../../core/staleCache";
-import { diagnostic, ignoreEvent, type AdapterOperationOptions, type CandidateChannelSelection, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
+import { diagnostic, ignoreEvent, type AdapterOperationOptions, type CandidateChannelSelection, type ChannelPointsClaimOptions, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
 import { campaignHasClaimableReward, mergeTwitchCampaignProgress, parseTwitchCampaigns, twitchCandidatesFromCampaign, withCampaignStatus } from "./parser";
 import type { ResolvedCompatibility, TwitchIdentity } from "../../compatibility/types";
 import { createTwitchHeartbeat } from "./heartbeat/factory";
@@ -2161,20 +2161,24 @@ export class TwitchAdapter implements PlatformAdapter {
 
   async claimChannelPoints(
     channel: ChannelCandidate,
-    { signal }: AdapterOperationOptions = {},
+    { signal, claimId: providedClaimId, channelId: providedChannelId }: ChannelPointsClaimOptions = {},
   ): Promise<boolean> {
-    const context = await this.gqlWithIntegrityRetry<TwitchChannelPointsData>(
-      "ChannelPointsContext",
-      TWITCH_QUERIES.channelPointsHash,
-      { channelLogin: channel.username },
-      undefined,
-      undefined,
-      this.emit,
-      signal,
-    );
-    const channelId = context.data?.community?.channel?.id;
-    const claimId = context.data?.community?.channel?.self?.communityPoints?.availableClaim?.id;
-    if (!channelId || !claimId) return false;
+    let claimId = providedClaimId;
+    let channelId = providedChannelId;
+    if (!claimId || !channelId) {
+      const context = await this.gqlWithIntegrityRetry<TwitchChannelPointsData>(
+        "ChannelPointsContext",
+        TWITCH_QUERIES.channelPointsHash,
+        { channelLogin: channel.username },
+        undefined,
+        undefined,
+        this.emit,
+        signal,
+      );
+      channelId = context.data?.community?.channel?.id;
+      claimId = context.data?.community?.channel?.self?.communityPoints?.availableClaim?.id;
+      if (!channelId || !claimId) return false;
+    }
 
     // Like a drop claim, this mutation is gated on Client-Integrity. Ensure one
     // exists first (a no-op fast path when a token is already captured), then

--- a/packages/core/src/platforms/twitch/index.ts
+++ b/packages/core/src/platforms/twitch/index.ts
@@ -6,7 +6,9 @@ import type { TwitchIntegrityRequest } from "../../core/tabs";
 import type { TwitchIntegrity } from "../../core/twitchIntegrity";
 import { PendingWatcherDiagnostics, type HeartbeatResult, type TablessWatchController, type WatchContext } from "../../core/tablessWatch";
 import { StaleWhileRevalidateCache } from "../../core/staleCache";
+import type { WebSocketFactory } from "../../core/webSocket";
 import { diagnostic, ignoreEvent, type AdapterOperationOptions, type CandidateChannelSelection, type ChannelPointsClaimOptions, type PageFetcher, type PlatformAdapter, type WatchTabOptions, type WatchTabPort } from "../adapter";
+import { TwitchChannelPointsPushController } from "./channelPointsPush";
 import { campaignHasClaimableReward, mergeTwitchCampaignProgress, parseTwitchCampaigns, twitchCandidatesFromCampaign, withCampaignStatus } from "./parser";
 import type { ResolvedCompatibility, TwitchIdentity } from "../../compatibility/types";
 import { createTwitchHeartbeat } from "./heartbeat/factory";
@@ -95,6 +97,13 @@ export interface TwitchAdapterOptions {
   // concurrent capture can swap it. Absent in runtimes that never carry integrity
   // at all (non-web client ids).
   currentIntegrity?: () => TwitchIntegrity | undefined;
+  // Factory for the Hermes channel-points WebSocket. The extension injects
+  // the browser WebSocket; headless runtimes omit it so live-event claiming
+  // stays off without a socket.
+  webSocketFactory?: WebSocketFactory;
+  // Reads the Twitch auth-token cookie. Injected so core stays browser-free
+  // and never logs the value.
+  getAuthToken?: () => Promise<string | undefined>;
 }
 
 const TWITCH_QUERIES = {
@@ -887,6 +896,7 @@ export function createTwitchGqlTransport(
 export class TwitchAdapter implements PlatformAdapter {
   platform = "twitch" as const;
   readonly compatibility?: ResolvedCompatibility["twitch"];
+  readonly createChannelPointsPushController?: () => TwitchChannelPointsPushController;
 
   async checkAuthHealth(signal?: AbortSignal): Promise<PlatformAuthHealth> {
     const checkedAt = new Date().toISOString();
@@ -961,6 +971,16 @@ export class TwitchAdapter implements PlatformAdapter {
     this.discoveryState = options.discoveryState ?? new TwitchDiscoveryState();
     this.gqlTransport = createTwitchGqlTransport(fetcher, options);
     this.inventoryCapability = createTwitchInventory(options.compatibility.inventory);
+    const createWebSocket = options.webSocketFactory;
+    const getAuthToken = options.getAuthToken;
+    if (createWebSocket && getAuthToken) {
+      this.createChannelPointsPushController = () => new TwitchChannelPointsPushController({
+        createWebSocket,
+        getAuthToken,
+        resolveUserId: () => this.resolveViewerUserId(),
+        clientId: this.options.clientId,
+      });
+    }
   }
 
   private async discoverCampaignSnapshot(
@@ -2236,6 +2256,25 @@ export class TwitchAdapter implements PlatformAdapter {
 
   createTablessWatcher(): TablessWatchController {
     return new TwitchWatcher(this.gqlTransport, this.options, this.ensureIntegrity);
+  }
+
+  // Same CurrentUser + one integrity retry as TwitchWatcher.resolveUserId.
+  // Failures stay unresolved so the push controller can reconnect rather than
+  // abort start(); do not log the auth token.
+  private async resolveViewerUserId(): Promise<string | undefined> {
+    try {
+      const response = await this.gqlWithIntegrityRetry<{ currentUser?: { id?: string } }>(
+        "CurrentUser",
+        "",
+        {},
+        CURRENT_USER_QUERY,
+      );
+      return response.data?.currentUser?.id;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      diagnostic(this.emit, "warn", `Could not resolve the Twitch viewer id for channel-points push: ${message}`, "twitch");
+      return undefined;
+    }
   }
 
   private async mergeCurrentSessionProgress(

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -111,6 +111,10 @@ function createExtensionAdapter(platform: Platform, emit: EventEmitter, settings
         heartbeatIdentity: "web",
         heartbeatFetchText: twitchHeartbeatFetchText,
         heartbeatPost: twitchHeartbeatPost,
+        webSocketFactory: createBrowserWebSocket,
+        getAuthToken: async () => (
+          await browser.cookies.get({ url: "https://www.twitch.tv", name: "auth-token" })
+        )?.value,
       },
       emit,
     )

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2563,6 +2563,56 @@ describe("TwitchAdapter", () => {
     expect(contextAttempts).toBe(2);
   });
 
+  it("claims channel points from supplied ids without ChannelPointsContext", async () => {
+    const operations: string[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      operations.push(op);
+      if (op === "ClaimCommunityPoints") {
+        return { data: { claimCommunityPoints: { status: "CLAIMED" } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    await expect(twitchAdapter(fetcher).claimChannelPoints(
+      { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+      { claimId: "claim-id", channelId: "channel-id" },
+    )).resolves.toBe(true);
+
+    expect(operations).toEqual(["ClaimCommunityPoints"]);
+  });
+
+  it("still looks up ChannelPointsContext when either id is missing", async () => {
+    const operations: string[] = [];
+    const fetcher = jsonFetcher((_url, init) => {
+      const op = operation(init);
+      operations.push(op);
+      if (op === "ChannelPointsContext") {
+        return {
+          data: {
+            community: {
+              channel: {
+                id: "channel-id",
+                self: { communityPoints: { availableClaim: { id: "claim-id" } } },
+              },
+            },
+          },
+        };
+      }
+      if (op === "ClaimCommunityPoints") {
+        return { data: { claimCommunityPoints: { status: "CLAIMED" } } };
+      }
+      throw new Error(`Unexpected op ${op}`);
+    });
+
+    await expect(twitchAdapter(fetcher).claimChannelPoints(
+      { platform: "twitch", username: "creator", url: "https://www.twitch.tv/creator" },
+      { claimId: "claim-id" },
+    )).resolves.toBe(true);
+
+    expect(operations).toContain("ChannelPointsContext");
+  });
+
   it("keeps the v1 inventory hash, variables, inline fallback, and parser paired", async () => {
     const fixture = JSON.parse(readFileSync(new URL("./fixtures/twitch-inventory-v1.json", import.meta.url), "utf8"));
     const inventoryBodies: Record<string, unknown>[] = [];

--- a/packages/extension/tests/adapters.test.ts
+++ b/packages/extension/tests/adapters.test.ts
@@ -2565,10 +2565,12 @@ describe("TwitchAdapter", () => {
 
   it("claims channel points from supplied ids without ChannelPointsContext", async () => {
     const operations: string[] = [];
+    let claimVariables: unknown;
     const fetcher = jsonFetcher((_url, init) => {
       const op = operation(init);
       operations.push(op);
       if (op === "ClaimCommunityPoints") {
+        claimVariables = requestBody(init).variables;
         return { data: { claimCommunityPoints: { status: "CLAIMED" } } };
       }
       throw new Error(`Unexpected op ${op}`);
@@ -2580,6 +2582,9 @@ describe("TwitchAdapter", () => {
     )).resolves.toBe(true);
 
     expect(operations).toEqual(["ClaimCommunityPoints"]);
+    expect(claimVariables).toEqual({
+      input: { claimID: "claim-id", channelID: "channel-id" },
+    });
   });
 
   it("still looks up ChannelPointsContext when either id is missing", async () => {

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -46,6 +46,7 @@ import {
 import { TAB_CHURN_LIMIT } from "@lurkloot/core/criticalHealth";
 import type { IntegrityHeader, TwitchIntegrity } from "@lurkloot/core/twitchIntegrity";
 import type { DiscoverySignalController, DiscoverySignalTarget } from "@lurkloot/core/discoverySignals";
+import type { TwitchChannelPointsClaimNotice } from "@lurkloot/core/twitch/channelPointsPush";
 
 const reward = (status: DropReward["status"] = "in_progress"): DropReward => ({
   id: "reward",
@@ -110,6 +111,37 @@ class FakeDiscoverySignalController implements DiscoverySignalController {
     this.stops += 1;
     this.targetKey = undefined;
     this.onSignal = undefined;
+  }
+}
+
+class FakeChannelPointsPushController {
+  subscribed = false;
+  starts = 0;
+  stops = 0;
+  private onClaimAvailable?: (notice: TwitchChannelPointsClaimNotice) => void;
+  private readonly events: DiagnosticEvent[] = [];
+
+  async start(onClaimAvailable: (notice: TwitchChannelPointsClaimNotice) => void): Promise<void> {
+    this.starts += 1;
+    this.onClaimAvailable = onClaimAvailable;
+  }
+
+  emitClaim(notice: TwitchChannelPointsClaimNotice): void {
+    this.onClaimAvailable?.(notice);
+  }
+
+  pushDiagnostic(message: string): void {
+    this.events.push({ category: "diagnostic", platform: "twitch", level: "warn", message });
+  }
+
+  drainEvents(): DiagnosticEvent[] {
+    return this.events.splice(0);
+  }
+
+  async stop(): Promise<void> {
+    this.stops += 1;
+    this.onClaimAvailable = undefined;
+    this.subscribed = false;
   }
 }
 
@@ -267,6 +299,9 @@ function harness(
   const discoverySignalController = new FakeDiscoverySignalController("kick");
   const discoverySignalFactory = vi.fn(() => discoverySignalController);
   kick.createDiscoverySignalController = discoverySignalFactory;
+  const channelPointsPushController = new FakeChannelPointsPushController();
+  const channelPointsPushFactory = vi.fn(() => channelPointsPushController);
+  twitch.createChannelPointsPushController = channelPointsPushFactory as unknown as PlatformAdapter["createChannelPointsPushController"];
   const reportEvents = vi.fn<(events: readonly EngineEvent[]) => Promise<void>>(async () => undefined);
   const deps = {
     loadSettings: vi.fn(async () => currentSettings),
@@ -352,6 +387,8 @@ function harness(
     kick,
     discoverySignalController,
     discoverySignalFactory,
+    channelPointsPushController,
+    channelPointsPushFactory,
     reportEvents: deps.reportEvents,
   };
 }
@@ -1065,6 +1102,259 @@ describe("background controller", () => {
 
       expect(maxConcurrentClaims).toBe(1);
       expect(env.twitch.refreshCampaigns).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("Twitch channel points push observer", () => {
+    function pushSettings(patch: Partial<ExtensionSettings["platform"]["twitch"]> = {}): ExtensionSettings {
+      const enabled = farming({ ...DEFAULT_SETTINGS, autoStartDropFarming: false });
+      return {
+        ...enabled,
+        platform: {
+          ...enabled.platform,
+          twitch: {
+            ...enabled.platform.twitch,
+            ...patch,
+          },
+        },
+      };
+    }
+
+    function configureEligibleChannel(
+      env: ReturnType<typeof harness>,
+      patch: Partial<ChannelCandidate> = { channelId: "channel-1" },
+    ): ChannelCandidate {
+      const eligible = channel("twitch", patch);
+      env.state.authHealth = {
+        ...env.state.authHealth,
+        twitch: { status: "healthy", checkedAt: new Date().toISOString() },
+      };
+      env.state.sessions.twitch = {
+        platform: "twitch",
+        status: "watching",
+        channel: eligible,
+        offlineChecks: 0,
+        watchMode: "tab",
+      };
+      return eligible;
+    }
+
+    async function startObserver(env: ReturnType<typeof harness>, patch?: Partial<ChannelCandidate>): Promise<void> {
+      configureEligibleChannel(env, patch);
+      env.twitch.claimChannelPoints = vi.fn(async () => true);
+      await env.controller.ensureAlarm();
+      expect(env.channelPointsPushController.starts).toBe(1);
+      expect(env.channelPointsPushController.stops).toBe(0);
+    }
+
+    it("starts the observer once and does not stop on a second reconcile", async () => {
+      const env = harness(pushSettings());
+      await startObserver(env);
+
+      await env.controller.ensureAlarm();
+
+      expect(env.channelPointsPushFactory).toHaveBeenCalledOnce();
+      expect(env.channelPointsPushController.stops).toBe(0);
+    });
+
+    it.each([
+      {
+        name: "the live-event setting is off",
+        apply: async (env: ReturnType<typeof harness>) => {
+          await env.controller.handleMessage({
+            type: "saveSettings",
+            settingsPatch: { platform: { twitch: { channelPointsPushClaim: false } } },
+          });
+        },
+      },
+      {
+        name: "auto-claim is off",
+        apply: async (env: ReturnType<typeof harness>) => {
+          await env.controller.handleMessage({
+            type: "saveSettings",
+            settingsPatch: { platform: { twitch: { autoClaimChannelPoints: false } } },
+          });
+        },
+      },
+      {
+        name: "Twitch is disabled",
+        apply: async (env: ReturnType<typeof harness>) => {
+          await env.controller.handleMessage({
+            type: "setPlatformEnabled",
+            platform: "twitch",
+            enabled: false,
+          });
+        },
+      },
+      {
+        name: "authentication is unhealthy",
+        apply: async (env: ReturnType<typeof harness>) => {
+          env.state.authHealth = {
+            ...env.state.authHealth,
+            twitch: {
+              status: "invalid_credentials",
+              checkedAt: new Date().toISOString(),
+              reasonCode: "credentials_rejected",
+              message: { key: "authInvalidCredentials" },
+            },
+          };
+          await env.controller.ensureAlarm();
+        },
+      },
+      {
+        name: "no eligible channel remains",
+        apply: async (env: ReturnType<typeof harness>) => {
+          env.state.sessions.twitch = { platform: "twitch", status: "idle", offlineChecks: 0 };
+          env.state.manualWatch = undefined;
+          await env.controller.ensureAlarm();
+        },
+      },
+    ])("stops the observer when $name", async ({ apply }) => {
+      const env = harness(pushSettings());
+      await startObserver(env);
+
+      await apply(env);
+
+      expect(env.channelPointsPushController.stops).toBe(1);
+    });
+
+    it.each(["reset", "shutdown"] as const)("stops the observer during host %s", async (cleanup) => {
+      const env = harness(pushSettings());
+      await startObserver(env);
+
+      if (cleanup === "reset") {
+        await env.controller.prepareForHostReset();
+      } else {
+        env.controller.shutdown();
+      }
+      await env.rawController.settleBackgroundWork();
+
+      expect(env.channelPointsPushController.stops).toBe(1);
+    });
+
+    it("starts or stops from a live-event setting toggle without waiting for the alarm", async () => {
+      const env = harness(pushSettings({ channelPointsPushClaim: false }));
+      configureEligibleChannel(env);
+      env.twitch.claimChannelPoints = vi.fn(async () => true);
+
+      await env.controller.ensureAlarm();
+      expect(env.channelPointsPushController.starts).toBe(0);
+
+      env.deps.createAlarm.mockClear();
+      await env.controller.handleMessage({
+        type: "saveSettings",
+        settingsPatch: { platform: { twitch: { channelPointsPushClaim: true } } },
+      });
+
+      expect(env.channelPointsPushController.starts).toBe(1);
+      expect(env.channelPointsPushController.stops).toBe(0);
+
+      await env.controller.handleMessage({
+        type: "saveSettings",
+        settingsPatch: { platform: { twitch: { channelPointsPushClaim: false } } },
+      });
+
+      expect(env.channelPointsPushController.stops).toBe(1);
+    });
+
+    it("skips the alarm lookup while the observer is subscribed", async () => {
+      const env = harness(pushSettings());
+      await startObserver(env);
+      env.channelPointsPushController.subscribed = true;
+      env.twitch.claimChannelPoints = vi.fn(async () => true);
+
+      await env.controller.runTwitchChannelPointsClaim();
+
+      expect(env.twitch.claimChannelPoints).not.toHaveBeenCalled();
+    });
+
+    it("still looks up channel points when the observer is not subscribed", async () => {
+      const env = harness(pushSettings());
+      const eligible = configureEligibleChannel(env);
+      env.twitch.claimChannelPoints = vi.fn(async () => true);
+      await env.controller.ensureAlarm();
+      env.channelPointsPushController.subscribed = false;
+
+      await env.controller.runTwitchChannelPointsClaim();
+
+      expect(env.twitch.claimChannelPoints).toHaveBeenCalledOnce();
+      expect(env.twitch.claimChannelPoints).toHaveBeenCalledWith(eligible);
+    });
+
+    it("claims from a live-event notice for the eligible channel", async () => {
+      const env = harness(pushSettings());
+      await startObserver(env);
+
+      env.channelPointsPushController.emitClaim({ claimId: "claim-1", channelId: "channel-1" });
+      await vi.waitFor(() => expect(env.twitch.claimChannelPoints).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: "channel-1" }),
+        expect.objectContaining({ claimId: "claim-1", channelId: "channel-1" }),
+      ));
+      expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+        platform: "twitch",
+        level: "info",
+        message: "Claimed channel points for twitch-creator",
+      }));
+    });
+
+    it("drops a live-event notice whose channel id does not match the eligible channel", async () => {
+      const env = harness(pushSettings());
+      await startObserver(env, { channelId: "a" });
+
+      env.channelPointsPushController.emitClaim({ claimId: "claim-1", channelId: "b" });
+      await env.controller.settleBackgroundWork();
+
+      expect(env.twitch.claimChannelPoints).not.toHaveBeenCalled();
+    });
+
+    it("claims a live-event notice when the eligible channel has no channel id", async () => {
+      const env = harness(pushSettings());
+      await startObserver(env, { username: "manual-creator" });
+
+      env.channelPointsPushController.emitClaim({ claimId: "claim-1", channelId: "channel-1" });
+      await vi.waitFor(() => expect(env.twitch.claimChannelPoints).toHaveBeenCalledWith(
+        expect.objectContaining({ username: "manual-creator" }),
+        expect.objectContaining({ claimId: "claim-1", channelId: "channel-1" }),
+      ));
+    });
+
+    it("dedupes an in-flight live-event claim id to a single mutation", async () => {
+      const env = harness(pushSettings());
+      await startObserver(env);
+      const firstClaim = deferred<boolean>();
+      env.twitch.claimChannelPoints = vi.fn(async () => firstClaim.promise);
+
+      env.channelPointsPushController.emitClaim({ claimId: "claim-1", channelId: "channel-1" });
+      await vi.waitFor(() => expect(env.twitch.claimChannelPoints).toHaveBeenCalledOnce());
+      env.channelPointsPushController.emitClaim({ claimId: "claim-1", channelId: "channel-1" });
+      expect(env.twitch.claimChannelPoints).toHaveBeenCalledOnce();
+      firstClaim.resolve(true);
+      await env.controller.settleBackgroundWork();
+      expect(env.twitch.claimChannelPoints).toHaveBeenCalledOnce();
+    });
+
+    it("does not mutate session error or heartbeat state when the observer reports a failure", async () => {
+      const env = harness(pushSettings());
+      configureEligibleChannel(env);
+      env.state.sessions.twitch = {
+        ...env.state.sessions.twitch,
+        errorChecks: 3,
+        heartbeatChecks: 4,
+        lastHeartbeatOk: false,
+        tablessFallback: true,
+        watchMode: "tabless",
+      };
+      const beforeSession = structuredClone(env.state.sessions.twitch);
+      env.channelPointsPushController.pushDiagnostic("Hermes reconnect failed");
+
+      await env.controller.ensureAlarm();
+
+      expect(env.state.sessions.twitch).toEqual(beforeSession);
+      expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({
+        platform: "twitch",
+        level: "warn",
+        message: "Hermes reconnect failed",
+      }));
     });
   });
 

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -118,11 +118,19 @@ class FakeChannelPointsPushController {
   subscribed = false;
   starts = 0;
   stops = 0;
+  startBarrier?: Promise<void>;
+  startError?: Error;
   private onClaimAvailable?: (notice: TwitchChannelPointsClaimNotice) => void;
   private readonly events: DiagnosticEvent[] = [];
 
   async start(onClaimAvailable: (notice: TwitchChannelPointsClaimNotice) => void): Promise<void> {
     this.starts += 1;
+    if (this.startError) {
+      const error = this.startError;
+      this.startError = undefined;
+      throw error;
+    }
+    if (this.startBarrier) await this.startBarrier;
     this.onClaimAvailable = onClaimAvailable;
   }
 
@@ -1143,6 +1151,7 @@ describe("background controller", () => {
       configureEligibleChannel(env, patch);
       env.twitch.claimChannelPoints = vi.fn(async () => true);
       await env.controller.ensureAlarm();
+      await env.rawController.settleBackgroundWork();
       expect(env.channelPointsPushController.starts).toBe(1);
       expect(env.channelPointsPushController.stops).toBe(0);
     }
@@ -1152,9 +1161,26 @@ describe("background controller", () => {
       await startObserver(env);
 
       await env.controller.ensureAlarm();
+      await env.rawController.settleBackgroundWork();
 
       expect(env.channelPointsPushFactory).toHaveBeenCalledOnce();
       expect(env.channelPointsPushController.stops).toBe(0);
+    });
+
+    it("recreates the observer after a start failure", async () => {
+      const env = harness(pushSettings());
+      configureEligibleChannel(env);
+      env.channelPointsPushController.startError = new Error("start failed");
+
+      await env.controller.ensureAlarm();
+      await env.rawController.settleBackgroundWork();
+      expect(env.channelPointsPushFactory).toHaveBeenCalledOnce();
+      expect(env.channelPointsPushController.starts).toBe(1);
+
+      await env.controller.ensureAlarm();
+      await env.rawController.settleBackgroundWork();
+      expect(env.channelPointsPushFactory).toHaveBeenCalledTimes(2);
+      expect(env.channelPointsPushController.starts).toBe(2);
     });
 
     it.each([
@@ -1214,6 +1240,7 @@ describe("background controller", () => {
       await startObserver(env);
 
       await apply(env);
+      await env.rawController.settleBackgroundWork();
 
       expect(env.channelPointsPushController.stops).toBe(1);
     });
@@ -1257,6 +1284,31 @@ describe("background controller", () => {
       expect(env.channelPointsPushController.stops).toBe(1);
     });
 
+    it("saveSettings that enables live-event claiming resolves while start is blocked", async () => {
+      const env = harness(pushSettings({ channelPointsPushClaim: false }));
+      configureEligibleChannel(env);
+      const blocked = deferred<void>();
+      env.channelPointsPushController.startBarrier = blocked.promise;
+
+      const save = env.rawController.handleMessage({
+        type: "saveSettings",
+        settingsPatch: { platform: { twitch: { channelPointsPushClaim: true } } },
+      });
+      const outcome = await Promise.race([
+        save.then(() => "saved" as const),
+        new Promise<"blocked">((resolve) => {
+          setTimeout(() => resolve("blocked"), 50);
+        }),
+      ]);
+
+      expect(outcome).toBe("saved");
+      expect(env.settings.platform.twitch.channelPointsPushClaim).toBe(true);
+
+      blocked.resolve();
+      await env.rawController.settleBackgroundWork();
+      expect(env.channelPointsPushController.starts).toBe(1);
+    });
+
     it("skips the alarm lookup while the observer is subscribed", async () => {
       const env = harness(pushSettings());
       await startObserver(env);
@@ -1273,6 +1325,7 @@ describe("background controller", () => {
       const eligible = configureEligibleChannel(env);
       env.twitch.claimChannelPoints = vi.fn(async () => true);
       await env.controller.ensureAlarm();
+      await env.rawController.settleBackgroundWork();
       env.channelPointsPushController.subscribed = false;
 
       await env.controller.runTwitchChannelPointsClaim();
@@ -1348,6 +1401,7 @@ describe("background controller", () => {
       env.channelPointsPushController.pushDiagnostic("Hermes reconnect failed");
 
       await env.controller.ensureAlarm();
+      await env.rawController.settleBackgroundWork();
 
       expect(env.state.sessions.twitch).toEqual(beforeSession);
       expect(allDiagnostics(env)).toContainEqual(expect.objectContaining({

--- a/packages/extension/tests/backgroundEntrypoint.test.ts
+++ b/packages/extension/tests/backgroundEntrypoint.test.ts
@@ -19,6 +19,7 @@ vi.mock("@lurkloot/core/controller", async (importOriginal) => ({
 vi.mock("wxt/browser", () => ({
   browser: {
     i18n: { getMessage: vi.fn() },
+    cookies: { get: vi.fn(async () => ({ value: "token" })) },
   },
 }));
 
@@ -207,5 +208,33 @@ describe("background integrity alarm wiring", () => {
     expect(sockets[0]?.sent).toEqual([
       JSON.stringify({ event: "pusher:subscribe", data: { auth: "", channel: "drops_category_42" } }),
     ]);
+  });
+
+  it("injects the extension WebSocket into the Twitch channel-points observer", async () => {
+    let deps: BackgroundAdapterDependencies | undefined;
+    createBackgroundController.mockImplementation((nextDeps) => {
+      deps = nextDeps;
+      return {};
+    });
+    const sockets: FakeSocket[] = [];
+    vi.stubGlobal("WebSocket", class {
+      constructor(url: string) {
+        expect(url).toBe("wss://hermes.twitch.tv/v1?clientId=kimne78kx3ncx6brgo4mv6wki5h1ko");
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+      }
+    });
+    vi.stubGlobal("defineBackground", vi.fn());
+    const { browser } = await import("wxt/browser");
+
+    await import("../entrypoints/background");
+
+    const observer = deps?.createAdapter?.("twitch", () => undefined, DEFAULT_SETTINGS).adapter.createChannelPointsPushController?.();
+    await observer?.start(() => undefined);
+
+    expect(observer).toBeDefined();
+    expect(sockets).toHaveLength(1);
+    expect(browser.cookies.get).toHaveBeenCalledWith({ url: "https://www.twitch.tv", name: "auth-token" });
   });
 });

--- a/packages/extension/tests/settingsRegistry.test.ts
+++ b/packages/extension/tests/settingsRegistry.test.ts
@@ -112,6 +112,7 @@ describe("settings registry", () => {
     const entries = allEntryIds(withoutCompatibility);
     expect(entries).not.toContain("twitch.compatibility.rows");
     expect(entries).not.toContain("kick.compatibility.rows");
+    expect(entries).toContain("twitch.advanced.channelPointsPushClaim");
     expect(entries).toContain("twitch.advanced.strictCampaignAvailability");
   });
 
@@ -154,6 +155,7 @@ describe("settings registry", () => {
         "twitch.autoClaimChannelPoints",
         "twitch.categories.mode",
         "twitch.channels.excluded",
+        "twitch.advanced.channelPointsPushClaim",
         "twitch.advanced.strictCampaignAvailability",
         "twitch.compatibility.rows",
         "kick.autoClaimChallenges",

--- a/packages/extension/tests/settingsSearchView.test.tsx
+++ b/packages/extension/tests/settingsSearchView.test.tsx
@@ -116,6 +116,8 @@ const labels: Record<string, string> = {
   lowAvailabilityFirst: "Low availability first",
   autoClaimChannelPointsTitle: "Auto-claim channel points",
   autoClaimChannelPointsDescription: "Claim channel-point bonuses while farming this platform.",
+  channelPointsPushClaimTitle: "Claim channel points from live events",
+  channelPointsPushClaimDescription: "Claim the bonus as soon as Twitch makes it available. Turn off to only check once a minute.",
   autoClaimChallengesTitle: "Auto-claim daily challenges",
   autoClaimChallengesDescription: "Claim Kick's daily challenge reward once its watch-time goal is met.",
   categoryModeTitle: "Category filter",

--- a/packages/extension/tests/twitchCampaignTrust.test.ts
+++ b/packages/extension/tests/twitchCampaignTrust.test.ts
@@ -369,3 +369,28 @@ describe("strict campaign availability setting", () => {
     expect(mergeEngineSettings(patched).platform.twitch.strictCampaignAvailability).toBe(true);
   });
 });
+
+describe("channel points push setting", () => {
+  it("defaults to true", () => {
+    expect(DEFAULT_ENGINE_SETTINGS.platform.twitch.channelPointsPushClaim).toBe(true);
+  });
+
+  const persisted = (twitch: Record<string, unknown>) =>
+    ({ platform: { twitch } }) as unknown as Partial<EngineSettings>;
+
+  it("normalizes a missing persisted property to true", () => {
+    expect(mergeEngineSettings(persisted({ enabled: true })).platform.twitch.channelPointsPushClaim).toBe(true);
+  });
+
+  it("preserves an explicitly disabled persisted value", () => {
+    expect(mergeEngineSettings(persisted({ channelPointsPushClaim: false })).platform.twitch.channelPointsPushClaim).toBe(false);
+  });
+
+  it("round-trips through a settings patch", () => {
+    const patched = applySettingsPatch(DEFAULT_SETTINGS, {
+      platform: { twitch: { channelPointsPushClaim: false } },
+    });
+    expect(patched.platform.twitch.channelPointsPushClaim).toBe(false);
+    expect(patched.platform.kick).toEqual(DEFAULT_SETTINGS.platform.kick);
+  });
+});

--- a/packages/extension/tests/twitchChannelPointsPush.test.ts
+++ b/packages/extension/tests/twitchChannelPointsPush.test.ts
@@ -372,6 +372,30 @@ describe("Twitch channel-points push", () => {
 });
 
 describe("keepalive, reconnect, and stop", () => {
+  it("closes and reconnects when the socket never welcomes", async () => {
+    const socket = new FakeSocket();
+    const keepAlive = keepAliveScheduler();
+    const reconnect = reconnectScheduler();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket: () => socket,
+      getAuthToken: async () => "token",
+      resolveUserId: async () => "78020132",
+      scheduleKeepAlive: keepAlive.scheduleKeepAlive,
+      cancelKeepAlive: keepAlive.cancelKeepAlive,
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+    await controller.start(() => undefined);
+
+    expect(keepAlive.scheduled).toHaveLength(1);
+    expect(keepAlive.scheduled[0]?.delayMs).toBe(2 * 15 * 1000);
+
+    keepAlive.scheduled[0]!.callback();
+    expect(socket.closed).toBe(true);
+    expect(controller.subscribed).toBe(false);
+    expect(reconnect.scheduled).toHaveLength(1);
+    expect(reconnect.scheduled[0]?.delayMs).toBe(1000);
+  });
+
   it("resets silence timeout on keepalive and reconnects after silence", async () => {
     const firstSocket = new FakeSocket();
     const secondSocket = new FakeSocket();
@@ -388,16 +412,16 @@ describe("keepalive, reconnect, and stop", () => {
     });
     await handshake(firstSocket, controller, () => undefined);
 
-    expect(keepAlive.scheduled).toHaveLength(1);
-    expect(keepAlive.scheduled[0]?.delayMs).toBe(2 * 15 * 1000);
+    expect(keepAlive.scheduled[0]?.cancelled).toBe(true);
+    expect(keepAlive.scheduled[1]?.delayMs).toBe(2 * 15 * 1000);
     expect(parsedSent(firstSocket).some((frame) => frame.type === "ping" || frame.type === "pong")).toBe(false);
 
     firstSocket.message({ type: "keepalive", id: "ka-1", timestamp: "2026-09-11T16:09:18.000Z" });
-    expect(keepAlive.scheduled[0]?.cancelled).toBe(true);
-    expect(keepAlive.scheduled[1]?.delayMs).toBe(30_000);
+    expect(keepAlive.scheduled[1]?.cancelled).toBe(true);
+    expect(keepAlive.scheduled[2]?.delayMs).toBe(30_000);
     expect(parsedSent(firstSocket).some((frame) => frame.type === "ping" || frame.type === "pong")).toBe(false);
 
-    keepAlive.scheduled[1]!.callback();
+    keepAlive.scheduled[2]!.callback();
     expect(firstSocket.closed).toBe(true);
     expect(controller.subscribed).toBe(false);
     expect(reconnect.scheduled).toHaveLength(1);
@@ -434,10 +458,10 @@ describe("keepalive, reconnect, and stop", () => {
     await controller.stop();
     expect(firstSocket.closed).toBe(true);
     expect(controller.subscribed).toBe(false);
-    expect(keepAlive.scheduled[0]?.cancelled).toBe(true);
+    expect(keepAlive.scheduled[1]?.cancelled).toBe(true);
     expect(reconnect.scheduled).toHaveLength(0);
 
-    keepAlive.scheduled[0]!.callback();
+    keepAlive.scheduled[1]!.callback();
     firstSocket.emit("close");
     expect(reconnect.scheduled).toHaveLength(0);
     expect(createWebSocket).toHaveBeenCalledOnce();

--- a/packages/extension/tests/twitchChannelPointsPush.test.ts
+++ b/packages/extension/tests/twitchChannelPointsPush.test.ts
@@ -524,13 +524,14 @@ describe("keepalive, reconnect, and stop", () => {
     expect(sockets).toEqual([]);
   });
 
-  it("resolves the user id once across a silence-timeout reconnect", async () => {
+  it("resolves the user id again across a silence-timeout reconnect", async () => {
     const firstSocket = new FakeSocket();
     const secondSocket = new FakeSocket();
     const sockets = [firstSocket, secondSocket];
     const keepAlive = keepAliveScheduler();
     const reconnect = reconnectScheduler();
-    const resolveUserId = vi.fn(async () => "78020132");
+    const userIds = ["78020132", "99031425"];
+    const resolveUserId = vi.fn(async () => userIds.shift());
     const controller = createPushController({
       createWebSocket: () => sockets.shift()!,
       getAuthToken: async () => "token",
@@ -549,7 +550,13 @@ describe("keepalive, reconnect, and stop", () => {
     completeHandshake(secondSocket);
 
     expect(controller.subscribed).toBe(true);
-    expect(resolveUserId).toHaveBeenCalledOnce();
+    expect(resolveUserId).toHaveBeenCalledTimes(2);
+    expect(parsedSent(secondSocket)).toContainEqual(expect.objectContaining({
+      type: "subscribe",
+      subscribe: expect.objectContaining({
+        pubsub: { topic: "community-points-user-v1.99031425" },
+      }),
+    }));
   });
 
   it("stop closes the socket, cancels timers, and does not reconnect", async () => {
@@ -682,6 +689,43 @@ describe("keepalive, reconnect, and stop", () => {
     });
 
     expect(parsedSent(socket).some((frame) => frame.type === "subscribe")).toBe(false);
+    expect(controller.subscribed).toBe(false);
+    expect(socket.closed).toBe(true);
+    expect(reconnect.scheduled).toHaveLength(1);
+    expect(reconnect.scheduled[0]?.delayMs).toBe(1000);
+    expect(JSON.stringify(controller.drainEvents())).not.toContain("auth-token-value");
+  });
+
+  it.each([
+    { name: "rejected", response: { result: "unauthorized" } },
+    { name: "malformed", response: undefined },
+  ])("closes and reconnects when subscribeResponse is $name", async ({ response }) => {
+    const socket = new FakeSocket();
+    const keepAlive = keepAliveScheduler();
+    const reconnect = reconnectScheduler();
+    const controller = createPushController({
+      createWebSocket: () => socket,
+      getAuthToken: async () => "auth-token-value",
+      resolveUserId: async () => "78020132",
+      scheduleKeepAlive: keepAlive.scheduleKeepAlive,
+      cancelKeepAlive: keepAlive.cancelKeepAlive,
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+    await controller.start(() => undefined);
+    socket.message(WELCOME);
+    const authenticate = JSON.parse(socket.sent[0]!);
+    socket.message({
+      type: "authenticateResponse",
+      authenticateResponse: { result: "ok" },
+      parentId: authenticate.id,
+    });
+    const subscribe = JSON.parse(socket.sent[1]!);
+    socket.message({
+      type: "subscribeResponse",
+      subscribeResponse: response,
+      parentId: subscribe.id,
+    });
+
     expect(controller.subscribed).toBe(false);
     expect(socket.closed).toBe(true);
     expect(reconnect.scheduled).toHaveLength(1);

--- a/packages/extension/tests/twitchChannelPointsPush.test.ts
+++ b/packages/extension/tests/twitchChannelPointsPush.test.ts
@@ -1,7 +1,21 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TwitchChannelPointsPushController } from "@lurkloot/core/twitch/channelPointsPush";
 import type { WebSocketLike, WebSocketMessageEventLike } from "@lurkloot/core/webSocket";
 import { twitchAdapter } from "./helpers/adapters";
+
+const liveControllers: TwitchChannelPointsPushController[] = [];
+
+afterEach(async () => {
+  await Promise.all(liveControllers.splice(0).map((controller) => controller.stop()));
+});
+
+function createPushController(
+  deps: ConstructorParameters<typeof TwitchChannelPointsPushController>[0],
+): TwitchChannelPointsPushController {
+  const controller = new TwitchChannelPointsPushController(deps);
+  liveControllers.push(controller);
+  return controller;
+}
 
 class FakeSocket implements WebSocketLike {
   readyState = 1;
@@ -144,7 +158,7 @@ describe("Twitch channel-points push", () => {
   it("authenticates then subscribes to the user community-points topic", async () => {
     const socket = new FakeSocket();
     const createWebSocket = vi.fn(() => socket);
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket,
       getAuthToken: async () => "auth-token-value",
       resolveUserId: async () => "78020132",
@@ -198,7 +212,7 @@ describe("Twitch channel-points push", () => {
     const socket = new FakeSocket();
     const createWebSocket = vi.fn(() => socket);
     const reconnect = reconnectScheduler();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket,
       getAuthToken: async () => undefined,
       resolveUserId: async () => "78020132",
@@ -221,7 +235,7 @@ describe("Twitch channel-points push", () => {
   it("logs debug and schedules reconnect when the user id is empty after authenticate ok", async () => {
     const socket = new FakeSocket();
     const reconnect = reconnectScheduler();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket: () => socket,
       getAuthToken: async () => "auth-token-value",
       resolveUserId: async () => undefined,
@@ -255,10 +269,82 @@ describe("Twitch channel-points push", () => {
     expect(JSON.stringify(events)).not.toContain("auth-token-value");
   });
 
+  it("warns and reconnects when getAuthToken rejects, then connects after recovery", async () => {
+    const socket = new FakeSocket();
+    const createWebSocket = vi.fn(() => socket);
+    const reconnect = reconnectScheduler();
+    const getAuthToken = vi.fn()
+      .mockRejectedValueOnce(new Error("cookie store failed"))
+      .mockResolvedValue("auth-token-value");
+    const controller = createPushController({
+      createWebSocket,
+      getAuthToken,
+      resolveUserId: async () => "78020132",
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+
+    await controller.start(() => undefined);
+
+    expect(createWebSocket).not.toHaveBeenCalled();
+    expect(reconnect.scheduled).toHaveLength(1);
+    expect(controller.subscribed).toBe(false);
+    const events = controller.drainEvents();
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      platform: "twitch",
+      level: "warn",
+      message: expect.stringMatching(/auth token/i),
+    }));
+    expect(JSON.stringify(events)).not.toContain("auth-token-value");
+
+    reconnect.scheduled[0]!.callback();
+    await afterReconnect();
+    expect(createWebSocket).toHaveBeenCalledOnce();
+
+    await controller.start(() => undefined);
+    expect(createWebSocket).toHaveBeenCalledOnce();
+  });
+
+  it("warns and reconnects when resolveUserId rejects, then connects after recovery", async () => {
+    const socket = new FakeSocket();
+    const createWebSocket = vi.fn(() => socket);
+    const reconnect = reconnectScheduler();
+    const resolveUserId = vi.fn()
+      .mockRejectedValueOnce(new Error("CurrentUser failed"))
+      .mockResolvedValue("78020132");
+    const controller = createPushController({
+      createWebSocket,
+      getAuthToken: async () => "auth-token-value",
+      resolveUserId,
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+
+    await controller.start(() => undefined);
+
+    expect(createWebSocket).not.toHaveBeenCalled();
+    expect(reconnect.scheduled).toHaveLength(1);
+    expect(controller.subscribed).toBe(false);
+    const events = controller.drainEvents();
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      platform: "twitch",
+      level: "warn",
+      message: expect.stringMatching(/user id/i),
+    }));
+    expect(JSON.stringify(events)).not.toContain("auth-token-value");
+
+    reconnect.scheduled[0]!.callback();
+    await afterReconnect();
+    expect(createWebSocket).toHaveBeenCalledOnce();
+
+    await controller.start(() => undefined);
+    expect(createWebSocket).toHaveBeenCalledOnce();
+  });
+
   it("notifies only for claim-available on the community-points subscription", async () => {
     const socket = new FakeSocket();
     const onClaim = vi.fn();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket: () => socket,
       getAuthToken: async () => "token",
       resolveUserId: async () => "78020132",
@@ -302,7 +388,7 @@ describe("Twitch channel-points push", () => {
   it("ignores malformed, incomplete, claimed, and foreign notifications", async () => {
     const socket = new FakeSocket();
     const onClaim = vi.fn();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket: () => socket,
       getAuthToken: async () => "token",
       resolveUserId: async () => "78020132",
@@ -343,7 +429,7 @@ describe("Twitch channel-points push", () => {
 
   it("warns when the claim callback throws and never includes the token", async () => {
     const socket = new FakeSocket();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket: () => socket,
       getAuthToken: async () => "auth-token-value",
       resolveUserId: async () => "78020132",
@@ -377,7 +463,7 @@ describe("keepalive, reconnect, and stop", () => {
     const socket = new FakeSocket();
     const keepAlive = keepAliveScheduler();
     const reconnect = reconnectScheduler();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket: () => socket,
       getAuthToken: async () => "token",
       resolveUserId: async () => "78020132",
@@ -403,7 +489,7 @@ describe("keepalive, reconnect, and stop", () => {
     const sockets = [firstSocket, secondSocket];
     const keepAlive = keepAliveScheduler();
     const reconnect = reconnectScheduler();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket: () => sockets.shift()!,
       getAuthToken: async () => "token",
       resolveUserId: async () => "78020132",
@@ -438,6 +524,34 @@ describe("keepalive, reconnect, and stop", () => {
     expect(sockets).toEqual([]);
   });
 
+  it("resolves the user id once across a silence-timeout reconnect", async () => {
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    const sockets = [firstSocket, secondSocket];
+    const keepAlive = keepAliveScheduler();
+    const reconnect = reconnectScheduler();
+    const resolveUserId = vi.fn(async () => "78020132");
+    const controller = createPushController({
+      createWebSocket: () => sockets.shift()!,
+      getAuthToken: async () => "token",
+      resolveUserId,
+      scheduleKeepAlive: keepAlive.scheduleKeepAlive,
+      cancelKeepAlive: keepAlive.cancelKeepAlive,
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+    await handshake(firstSocket, controller, () => undefined);
+    expect(resolveUserId).toHaveBeenCalledOnce();
+
+    keepAlive.scheduled.at(-1)!.callback();
+    expect(firstSocket.closed).toBe(true);
+    reconnect.scheduled[0]!.callback();
+    await afterReconnect();
+    completeHandshake(secondSocket);
+
+    expect(controller.subscribed).toBe(true);
+    expect(resolveUserId).toHaveBeenCalledOnce();
+  });
+
   it("stop closes the socket, cancels timers, and does not reconnect", async () => {
     const firstSocket = new FakeSocket();
     const secondSocket = new FakeSocket();
@@ -445,7 +559,7 @@ describe("keepalive, reconnect, and stop", () => {
     const keepAlive = keepAliveScheduler();
     const reconnect = reconnectScheduler();
     const createWebSocket = vi.fn(() => sockets.shift()!);
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket,
       getAuthToken: async () => "token",
       resolveUserId: async () => "78020132",
@@ -478,7 +592,7 @@ describe("keepalive, reconnect, and stop", () => {
     const firstClaim = vi.fn();
     const nextClaim = vi.fn();
     const keepAlive = keepAliveScheduler();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket,
       getAuthToken: async () => "token",
       resolveUserId: async () => "78020132",
@@ -513,7 +627,7 @@ describe("keepalive, reconnect, and stop", () => {
     const sockets = [firstSocket, secondSocket, thirdSocket];
     const keepAlive = keepAliveScheduler();
     const reconnect = reconnectScheduler();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket: () => sockets.shift()!,
       getAuthToken: async () => "token",
       resolveUserId: async () => "78020132",
@@ -548,7 +662,7 @@ describe("keepalive, reconnect, and stop", () => {
     const socket = new FakeSocket();
     const keepAlive = keepAliveScheduler();
     const reconnect = reconnectScheduler();
-    const controller = new TwitchChannelPointsPushController({
+    const controller = createPushController({
       createWebSocket: () => socket,
       getAuthToken: async () => "auth-token-value",
       resolveUserId: async () => "78020132",

--- a/packages/extension/tests/twitchChannelPointsPush.test.ts
+++ b/packages/extension/tests/twitchChannelPointsPush.test.ts
@@ -39,16 +39,21 @@ interface ScheduledReconnect {
   callback: () => void;
   delayMs: number;
   timer: ReturnType<typeof setTimeout>;
+  cancelled: boolean;
 }
 
 const reconnectScheduler = () => {
   const scheduled: ScheduledReconnect[] = [];
   const scheduleReconnect = (callback: () => void, delayMs: number): ReturnType<typeof setTimeout> => {
     const timer = { id: scheduled.length } as unknown as ReturnType<typeof setTimeout>;
-    scheduled.push({ callback, delayMs, timer });
+    scheduled.push({ callback, delayMs, timer, cancelled: false });
     return timer;
   };
-  return { scheduled, scheduleReconnect };
+  const cancelReconnect = (timer: ReturnType<typeof setTimeout>): void => {
+    const entry = scheduled.find((candidate) => candidate.timer === timer);
+    if (entry) entry.cancelled = true;
+  };
+  return { scheduled, scheduleReconnect, cancelReconnect };
 };
 
 interface ScheduledKeepAlive {
@@ -72,8 +77,6 @@ const keepAliveScheduler = () => {
   return { scheduled, scheduleKeepAlive, cancelKeepAlive };
 };
 
-void keepAliveScheduler;
-
 const WELCOME = {
   type: "welcome",
   welcome: { keepaliveSec: 15, sessionId: "session" },
@@ -93,12 +96,7 @@ const currentSubscriptionId = (socket: FakeSocket): string => {
   return (body as { id: string }).id;
 };
 
-const handshake = async (
-  socket: FakeSocket,
-  controller: TwitchChannelPointsPushController,
-  onClaim: (notice: { claimId: string; channelId: string }) => void,
-): Promise<void> => {
-  await controller.start(onClaim);
+const completeHandshake = (socket: FakeSocket): void => {
   socket.message(WELCOME);
   const authenticate = JSON.parse(socket.sent[0]!);
   socket.message({
@@ -116,6 +114,20 @@ const handshake = async (
     id: "sub-ok",
     timestamp: "2026-09-11T16:09:08.200Z",
   });
+};
+
+const handshake = async (
+  socket: FakeSocket,
+  controller: TwitchChannelPointsPushController,
+  onClaim: (notice: { claimId: string; channelId: string }) => void,
+): Promise<void> => {
+  await controller.start(onClaim);
+  completeHandshake(socket);
+};
+
+const afterReconnect = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
 };
 
 const pubsubNotification = (subscriptionId: string, inner: unknown) => ({
@@ -242,28 +254,6 @@ describe("Twitch channel-points push", () => {
     expect(JSON.stringify(events)).not.toContain("auth-token-value");
   });
 
-  it("does not subscribe when authenticateResponse is not ok", async () => {
-    const socket = new FakeSocket();
-    const controller = new TwitchChannelPointsPushController({
-      createWebSocket: () => socket,
-      getAuthToken: async () => "auth-token-value",
-      resolveUserId: async () => "78020132",
-    });
-    await controller.start(() => undefined);
-    socket.message(WELCOME);
-    const authenticate = JSON.parse(socket.sent[0]!);
-    socket.message({
-      type: "authenticateResponse",
-      authenticateResponse: { result: "unauthenticated" },
-      parentId: authenticate.id,
-      id: "auth-fail",
-      timestamp: "2026-09-11T16:09:08.100Z",
-    });
-
-    expect(parsedSent(socket).some((frame) => frame.type === "subscribe")).toBe(false);
-    expect(controller.subscribed).toBe(false);
-  });
-
   it("notifies only for claim-available on the community-points subscription", async () => {
     const socket = new FakeSocket();
     const onClaim = vi.fn();
@@ -378,5 +368,185 @@ describe("Twitch channel-points push", () => {
       message: expect.stringMatching(/claim callback failed/i),
     }));
     expect(JSON.stringify(events)).not.toContain("auth-token-value");
+  });
+});
+
+describe("keepalive, reconnect, and stop", () => {
+  it("resets silence timeout on keepalive and reconnects after silence", async () => {
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    const sockets = [firstSocket, secondSocket];
+    const keepAlive = keepAliveScheduler();
+    const reconnect = reconnectScheduler();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket: () => sockets.shift()!,
+      getAuthToken: async () => "token",
+      resolveUserId: async () => "78020132",
+      scheduleKeepAlive: keepAlive.scheduleKeepAlive,
+      cancelKeepAlive: keepAlive.cancelKeepAlive,
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+    await handshake(firstSocket, controller, () => undefined);
+
+    expect(keepAlive.scheduled).toHaveLength(1);
+    expect(keepAlive.scheduled[0]?.delayMs).toBe(2 * 15 * 1000);
+    expect(parsedSent(firstSocket).some((frame) => frame.type === "ping" || frame.type === "pong")).toBe(false);
+
+    firstSocket.message({ type: "keepalive", id: "ka-1", timestamp: "2026-09-11T16:09:18.000Z" });
+    expect(keepAlive.scheduled[0]?.cancelled).toBe(true);
+    expect(keepAlive.scheduled[1]?.delayMs).toBe(30_000);
+    expect(parsedSent(firstSocket).some((frame) => frame.type === "ping" || frame.type === "pong")).toBe(false);
+
+    keepAlive.scheduled[1]!.callback();
+    expect(firstSocket.closed).toBe(true);
+    expect(controller.subscribed).toBe(false);
+    expect(reconnect.scheduled).toHaveLength(1);
+    expect(reconnect.scheduled[0]?.delayMs).toBe(1000);
+
+    firstSocket.emit("close");
+    expect(reconnect.scheduled).toHaveLength(1);
+
+    reconnect.scheduled[0]!.callback();
+    await afterReconnect();
+    completeHandshake(secondSocket);
+    expect(controller.subscribed).toBe(true);
+    expect(sockets).toEqual([]);
+  });
+
+  it("stop closes the socket, cancels timers, and does not reconnect", async () => {
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    const sockets = [firstSocket, secondSocket];
+    const keepAlive = keepAliveScheduler();
+    const reconnect = reconnectScheduler();
+    const createWebSocket = vi.fn(() => sockets.shift()!);
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket,
+      getAuthToken: async () => "token",
+      resolveUserId: async () => "78020132",
+      scheduleKeepAlive: keepAlive.scheduleKeepAlive,
+      cancelKeepAlive: keepAlive.cancelKeepAlive,
+      scheduleReconnect: reconnect.scheduleReconnect,
+      cancelReconnect: reconnect.cancelReconnect,
+    });
+    await handshake(firstSocket, controller, () => undefined);
+
+    await controller.stop();
+    expect(firstSocket.closed).toBe(true);
+    expect(controller.subscribed).toBe(false);
+    expect(keepAlive.scheduled[0]?.cancelled).toBe(true);
+    expect(reconnect.scheduled).toHaveLength(0);
+
+    keepAlive.scheduled[0]!.callback();
+    firstSocket.emit("close");
+    expect(reconnect.scheduled).toHaveLength(0);
+    expect(createWebSocket).toHaveBeenCalledOnce();
+
+    await controller.start(() => undefined);
+    expect(createWebSocket).toHaveBeenCalledTimes(2);
+    expect(sockets).toEqual([]);
+  });
+
+  it("start while already running does not open a second socket but replaces onClaimAvailable", async () => {
+    const socket = new FakeSocket();
+    const createWebSocket = vi.fn(() => socket);
+    const firstClaim = vi.fn();
+    const nextClaim = vi.fn();
+    const keepAlive = keepAliveScheduler();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket,
+      getAuthToken: async () => "token",
+      resolveUserId: async () => "78020132",
+      scheduleKeepAlive: keepAlive.scheduleKeepAlive,
+      cancelKeepAlive: keepAlive.cancelKeepAlive,
+    });
+    await handshake(socket, controller, firstClaim);
+    await controller.start(nextClaim);
+
+    expect(createWebSocket).toHaveBeenCalledOnce();
+    socket.message(pubsubNotification(currentSubscriptionId(socket), {
+      type: "claim-available",
+      data: {
+        claim: {
+          id: "fd29a0b3-f804-4f58-905d-b33f235951c8",
+          channel_id: "119415848",
+        },
+      },
+    }));
+    expect(firstClaim).not.toHaveBeenCalled();
+    expect(nextClaim).toHaveBeenCalledOnce();
+    expect(nextClaim).toHaveBeenCalledWith({
+      claimId: "fd29a0b3-f804-4f58-905d-b33f235951c8",
+      channelId: "119415848",
+    });
+  });
+
+  it("reconnects with exponential backoff after unexpected close", async () => {
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    const thirdSocket = new FakeSocket();
+    const sockets = [firstSocket, secondSocket, thirdSocket];
+    const keepAlive = keepAliveScheduler();
+    const reconnect = reconnectScheduler();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket: () => sockets.shift()!,
+      getAuthToken: async () => "token",
+      resolveUserId: async () => "78020132",
+      scheduleKeepAlive: keepAlive.scheduleKeepAlive,
+      cancelKeepAlive: keepAlive.cancelKeepAlive,
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+    await handshake(firstSocket, controller, () => undefined);
+    expect(controller.subscribed).toBe(true);
+
+    firstSocket.emit("close");
+    expect(controller.subscribed).toBe(false);
+    expect(reconnect.scheduled[0]?.delayMs).toBe(1000);
+
+    reconnect.scheduled[0]!.callback();
+    await afterReconnect();
+    secondSocket.emit("close");
+    expect(reconnect.scheduled[1]?.delayMs).toBe(2000);
+
+    reconnect.scheduled[1]!.callback();
+    await afterReconnect();
+    completeHandshake(thirdSocket);
+    expect(controller.subscribed).toBe(true);
+
+    thirdSocket.emit("close");
+    expect(controller.subscribed).toBe(false);
+    expect(reconnect.scheduled[2]?.delayMs).toBe(1000);
+    expect(sockets).toEqual([]);
+  });
+
+  it("closes and reconnects when authenticateResponse is not ok", async () => {
+    const socket = new FakeSocket();
+    const keepAlive = keepAliveScheduler();
+    const reconnect = reconnectScheduler();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket: () => socket,
+      getAuthToken: async () => "auth-token-value",
+      resolveUserId: async () => "78020132",
+      scheduleKeepAlive: keepAlive.scheduleKeepAlive,
+      cancelKeepAlive: keepAlive.cancelKeepAlive,
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+    await controller.start(() => undefined);
+    socket.message(WELCOME);
+    const authenticate = JSON.parse(socket.sent[0]!);
+    socket.message({
+      type: "authenticateResponse",
+      authenticateResponse: { result: "unauthenticated" },
+      parentId: authenticate.id,
+      id: "auth-fail",
+      timestamp: "2026-09-11T16:09:08.100Z",
+    });
+
+    expect(parsedSent(socket).some((frame) => frame.type === "subscribe")).toBe(false);
+    expect(controller.subscribed).toBe(false);
+    expect(socket.closed).toBe(true);
+    expect(reconnect.scheduled).toHaveLength(1);
+    expect(reconnect.scheduled[0]?.delayMs).toBe(1000);
+    expect(JSON.stringify(controller.drainEvents())).not.toContain("auth-token-value");
   });
 });

--- a/packages/extension/tests/twitchChannelPointsPush.test.ts
+++ b/packages/extension/tests/twitchChannelPointsPush.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { TwitchChannelPointsPushController } from "@lurkloot/core/twitch/channelPointsPush";
 import type { WebSocketLike, WebSocketMessageEventLike } from "@lurkloot/core/webSocket";
+import { twitchAdapter } from "./helpers/adapters";
 
 class FakeSocket implements WebSocketLike {
   readyState = 1;
@@ -572,5 +573,21 @@ describe("keepalive, reconnect, and stop", () => {
     expect(reconnect.scheduled).toHaveLength(1);
     expect(reconnect.scheduled[0]?.delayMs).toBe(1000);
     expect(JSON.stringify(controller.drainEvents())).not.toContain("auth-token-value");
+  });
+});
+
+describe("Twitch channel-points push adapter factory", () => {
+  it("exposes a Hermes observer only when websocket and auth token deps exist", () => {
+    const fetcher = { fetchJson: async <T,>(): Promise<T> => ({}) as T };
+    expect(twitchAdapter(fetcher).createChannelPointsPushController).toBeUndefined();
+
+    const observer = twitchAdapter(
+      fetcher,
+      undefined,
+      undefined,
+      { webSocketFactory: () => new FakeSocket(), getAuthToken: async () => "token" },
+    ).createChannelPointsPushController?.();
+
+    expect(observer).toBeInstanceOf(TwitchChannelPointsPushController);
   });
 });

--- a/packages/extension/tests/twitchChannelPointsPush.test.ts
+++ b/packages/extension/tests/twitchChannelPointsPush.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, it, vi } from "vitest";
+import { TwitchChannelPointsPushController } from "@lurkloot/core/twitch/channelPointsPush";
+import type { WebSocketLike, WebSocketMessageEventLike } from "@lurkloot/core/webSocket";
+
+class FakeSocket implements WebSocketLike {
+  readyState = 1;
+  sent: string[] = [];
+  closed = false;
+  private readonly listeners: Record<string, Array<(event: WebSocketMessageEventLike) => void>> = {};
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = 3;
+  }
+
+  addEventListener(
+    type: "open" | "message" | "close" | "error",
+    listener: (event: WebSocketMessageEventLike) => void,
+  ): void {
+    (this.listeners[type] ??= []).push(listener);
+  }
+
+  emit(type: "open" | "close" | "error", event: WebSocketMessageEventLike = {}): void {
+    for (const listener of this.listeners[type] ?? []) listener(event);
+  }
+
+  message(value: unknown): void {
+    for (const listener of this.listeners.message ?? []) {
+      listener({ data: typeof value === "string" ? value : JSON.stringify(value) });
+    }
+  }
+}
+
+interface ScheduledReconnect {
+  callback: () => void;
+  delayMs: number;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const reconnectScheduler = () => {
+  const scheduled: ScheduledReconnect[] = [];
+  const scheduleReconnect = (callback: () => void, delayMs: number): ReturnType<typeof setTimeout> => {
+    const timer = { id: scheduled.length } as unknown as ReturnType<typeof setTimeout>;
+    scheduled.push({ callback, delayMs, timer });
+    return timer;
+  };
+  return { scheduled, scheduleReconnect };
+};
+
+interface ScheduledKeepAlive {
+  callback: () => void;
+  delayMs: number;
+  timer: ReturnType<typeof setTimeout>;
+  cancelled: boolean;
+}
+
+const keepAliveScheduler = () => {
+  const scheduled: ScheduledKeepAlive[] = [];
+  const scheduleKeepAlive = (callback: () => void, delayMs: number): ReturnType<typeof setTimeout> => {
+    const timer = { id: scheduled.length } as unknown as ReturnType<typeof setTimeout>;
+    scheduled.push({ callback, delayMs, timer, cancelled: false });
+    return timer;
+  };
+  const cancelKeepAlive = (timer: ReturnType<typeof setTimeout>): void => {
+    const entry = scheduled.find((candidate) => candidate.timer === timer);
+    if (entry) entry.cancelled = true;
+  };
+  return { scheduled, scheduleKeepAlive, cancelKeepAlive };
+};
+
+void keepAliveScheduler;
+
+const WELCOME = {
+  type: "welcome",
+  welcome: { keepaliveSec: 15, sessionId: "session" },
+  id: "welcome-1",
+  timestamp: "2026-09-11T16:09:08.000Z",
+};
+
+const parsedSent = (socket: FakeSocket): Array<Record<string, unknown>> =>
+  socket.sent.map((frame) => JSON.parse(frame) as Record<string, unknown>);
+
+const currentSubscriptionId = (socket: FakeSocket): string => {
+  const subscribe = parsedSent(socket).find((frame) => frame.type === "subscribe");
+  const body = subscribe?.subscribe;
+  if (!body || typeof body !== "object" || Array.isArray(body) || typeof (body as { id?: unknown }).id !== "string") {
+    throw new Error("missing community-points subscription id");
+  }
+  return (body as { id: string }).id;
+};
+
+const handshake = async (
+  socket: FakeSocket,
+  controller: TwitchChannelPointsPushController,
+  onClaim: (notice: { claimId: string; channelId: string }) => void,
+): Promise<void> => {
+  await controller.start(onClaim);
+  socket.message(WELCOME);
+  const authenticate = JSON.parse(socket.sent[0]!);
+  socket.message({
+    type: "authenticateResponse",
+    authenticateResponse: { result: "ok" },
+    parentId: authenticate.id,
+    id: "auth-ok",
+    timestamp: "2026-09-11T16:09:08.100Z",
+  });
+  const subscribe = JSON.parse(socket.sent[1]!);
+  socket.message({
+    type: "subscribeResponse",
+    subscribeResponse: { subscription: { id: subscribe.subscribe.id }, result: "ok" },
+    parentId: subscribe.id,
+    id: "sub-ok",
+    timestamp: "2026-09-11T16:09:08.200Z",
+  });
+};
+
+const pubsubNotification = (subscriptionId: string, inner: unknown) => ({
+  type: "notification",
+  notification: {
+    subscription: { id: subscriptionId },
+    type: "pubsub",
+    pubsub: typeof inner === "string" ? inner : JSON.stringify(inner),
+  },
+});
+
+describe("Twitch channel-points push", () => {
+  it("authenticates then subscribes to the user community-points topic", async () => {
+    const socket = new FakeSocket();
+    const createWebSocket = vi.fn(() => socket);
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket,
+      getAuthToken: async () => "auth-token-value",
+      resolveUserId: async () => "78020132",
+    });
+    await controller.start(() => undefined);
+
+    expect(createWebSocket).toHaveBeenCalledOnce();
+    expect(createWebSocket).toHaveBeenCalledWith(
+      "wss://hermes.twitch.tv/v1?clientId=kimne78kx3ncx6brgo4mv6wki5h1ko",
+    );
+    expect(socket.sent).toEqual([]);
+    socket.message(WELCOME);
+
+    const authenticate = JSON.parse(socket.sent[0]!);
+    expect(authenticate).toMatchObject({
+      type: "authenticate",
+      authenticate: { token: "auth-token-value" },
+    });
+    expect(controller.subscribed).toBe(false);
+
+    socket.message({
+      type: "authenticateResponse",
+      authenticateResponse: { result: "ok" },
+      parentId: authenticate.id,
+      id: "auth-ok",
+      timestamp: "2026-09-11T16:09:08.100Z",
+    });
+
+    const subscribe = JSON.parse(socket.sent[1]!);
+    expect(subscribe).toMatchObject({
+      type: "subscribe",
+      subscribe: {
+        type: "pubsub",
+        pubsub: { topic: "community-points-user-v1.78020132" },
+      },
+    });
+    expect(controller.subscribed).toBe(false);
+
+    socket.message({
+      type: "subscribeResponse",
+      subscribeResponse: { subscription: { id: subscribe.subscribe.id }, result: "ok" },
+      parentId: subscribe.id,
+      id: "sub-ok",
+      timestamp: "2026-09-11T16:09:08.200Z",
+    });
+    expect(controller.subscribed).toBe(true);
+    expect(JSON.stringify(controller.drainEvents())).not.toContain("auth-token-value");
+  });
+
+  it("logs debug and schedules reconnect when the auth token is empty", async () => {
+    const socket = new FakeSocket();
+    const createWebSocket = vi.fn(() => socket);
+    const reconnect = reconnectScheduler();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket,
+      getAuthToken: async () => undefined,
+      resolveUserId: async () => "78020132",
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+    await controller.start(() => undefined);
+
+    expect(createWebSocket).not.toHaveBeenCalled();
+    expect(reconnect.scheduled).toHaveLength(1);
+    expect(controller.subscribed).toBe(false);
+    const events = controller.drainEvents();
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      platform: "twitch",
+      level: "debug",
+    }));
+    expect(JSON.stringify(events)).not.toMatch(/OAuth /);
+  });
+
+  it("logs debug and schedules reconnect when the user id is empty after authenticate ok", async () => {
+    const socket = new FakeSocket();
+    const reconnect = reconnectScheduler();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket: () => socket,
+      getAuthToken: async () => "auth-token-value",
+      resolveUserId: async () => undefined,
+      scheduleReconnect: reconnect.scheduleReconnect,
+    });
+    await controller.start(() => undefined);
+    socket.message(WELCOME);
+
+    const authenticate = JSON.parse(socket.sent[0]!);
+    expect(authenticate).toMatchObject({
+      type: "authenticate",
+      authenticate: { token: "auth-token-value" },
+    });
+    socket.message({
+      type: "authenticateResponse",
+      authenticateResponse: { result: "ok" },
+      parentId: authenticate.id,
+      id: "auth-ok",
+      timestamp: "2026-09-11T16:09:08.100Z",
+    });
+
+    expect(parsedSent(socket).some((frame) => frame.type === "subscribe")).toBe(false);
+    expect(controller.subscribed).toBe(false);
+    expect(reconnect.scheduled).toHaveLength(1);
+    const events = controller.drainEvents();
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      platform: "twitch",
+      level: "debug",
+    }));
+    expect(JSON.stringify(events)).not.toContain("auth-token-value");
+  });
+
+  it("does not subscribe when authenticateResponse is not ok", async () => {
+    const socket = new FakeSocket();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket: () => socket,
+      getAuthToken: async () => "auth-token-value",
+      resolveUserId: async () => "78020132",
+    });
+    await controller.start(() => undefined);
+    socket.message(WELCOME);
+    const authenticate = JSON.parse(socket.sent[0]!);
+    socket.message({
+      type: "authenticateResponse",
+      authenticateResponse: { result: "unauthenticated" },
+      parentId: authenticate.id,
+      id: "auth-fail",
+      timestamp: "2026-09-11T16:09:08.100Z",
+    });
+
+    expect(parsedSent(socket).some((frame) => frame.type === "subscribe")).toBe(false);
+    expect(controller.subscribed).toBe(false);
+  });
+
+  it("notifies only for claim-available on the community-points subscription", async () => {
+    const socket = new FakeSocket();
+    const onClaim = vi.fn();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket: () => socket,
+      getAuthToken: async () => "token",
+      resolveUserId: async () => "78020132",
+    });
+    await handshake(socket, controller, onClaim);
+
+    socket.message({
+      type: "notification",
+      notification: {
+        subscription: { id: currentSubscriptionId(socket) },
+        type: "pubsub",
+        pubsub: JSON.stringify({
+          type: "points-earned",
+          data: { channel_id: "119415848" },
+        }),
+      },
+    });
+    socket.message({
+      type: "notification",
+      notification: {
+        subscription: { id: currentSubscriptionId(socket) },
+        type: "pubsub",
+        pubsub: JSON.stringify({
+          type: "claim-available",
+          data: {
+            claim: {
+              id: "fd29a0b3-f804-4f58-905d-b33f235951c8",
+              channel_id: "119415848",
+            },
+          },
+        }),
+      },
+    });
+    expect(onClaim).toHaveBeenCalledOnce();
+    expect(onClaim).toHaveBeenCalledWith({
+      claimId: "fd29a0b3-f804-4f58-905d-b33f235951c8",
+      channelId: "119415848",
+    });
+  });
+
+  it("ignores malformed, incomplete, claimed, and foreign notifications", async () => {
+    const socket = new FakeSocket();
+    const onClaim = vi.fn();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket: () => socket,
+      getAuthToken: async () => "token",
+      resolveUserId: async () => "78020132",
+    });
+    await handshake(socket, controller, onClaim);
+    const subscriptionId = currentSubscriptionId(socket);
+
+    socket.message(pubsubNotification(subscriptionId, "{not json"));
+    socket.message(pubsubNotification(subscriptionId, {
+      type: "claim-available",
+      data: { claim: { channel_id: "119415848" } },
+    }));
+    socket.message(pubsubNotification(subscriptionId, {
+      type: "claim-available",
+      data: { claim: { id: "fd29a0b3-f804-4f58-905d-b33f235951c8" } },
+    }));
+    socket.message(pubsubNotification(subscriptionId, {
+      type: "claim-claimed",
+      data: {
+        claim: {
+          id: "fd29a0b3-f804-4f58-905d-b33f235951c8",
+          channel_id: "119415848",
+        },
+      },
+    }));
+    socket.message(pubsubNotification("other-subscription", {
+      type: "claim-available",
+      data: {
+        claim: {
+          id: "fd29a0b3-f804-4f58-905d-b33f235951c8",
+          channel_id: "119415848",
+        },
+      },
+    }));
+
+    expect(onClaim).not.toHaveBeenCalled();
+  });
+
+  it("warns when the claim callback throws and never includes the token", async () => {
+    const socket = new FakeSocket();
+    const controller = new TwitchChannelPointsPushController({
+      createWebSocket: () => socket,
+      getAuthToken: async () => "auth-token-value",
+      resolveUserId: async () => "78020132",
+    });
+    await handshake(socket, controller, () => {
+      throw new Error("claim callback failed");
+    });
+    socket.message(pubsubNotification(currentSubscriptionId(socket), {
+      type: "claim-available",
+      data: {
+        claim: {
+          id: "fd29a0b3-f804-4f58-905d-b33f235951c8",
+          channel_id: "119415848",
+        },
+      },
+    }));
+
+    const events = controller.drainEvents();
+    expect(events).toContainEqual(expect.objectContaining({
+      category: "diagnostic",
+      platform: "twitch",
+      level: "warn",
+      message: expect.stringMatching(/claim callback failed/i),
+    }));
+    expect(JSON.stringify(events)).not.toContain("auth-token-value");
+  });
+});

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "استلم مكافآت نقاط القناة تلقائيًا أثناء الفارم على هذه المنصة."
   },
+  "channelPointsPushClaimTitle": {
+    "message": "استلام نقاط القناة من الأحداث المباشرة"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "استلم المكافأة فور إتاحتها من Twitch. عطّل الخيار للتحقق مرة واحدة فقط كل دقيقة."
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "توفر الحملات الصارم"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Beansprucht Kanalpunkt-Boni automatisch, während diese Plattform gefarmt wird."
   },
+  "channelPointsPushClaimTitle": {
+    "message": "Kanalpunkte aus Live-Ereignissen beanspruchen"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "Beansprucht den Bonus, sobald Twitch ihn verfügbar macht. Deaktivieren, um nur einmal pro Minute zu prüfen."
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "Strikte Kampagnenverfügbarkeit"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -686,6 +686,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Claim channel-point bonuses while farming this platform."
   },
+  "channelPointsPushClaimTitle": {
+    "message": "Claim channel points from live events"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "Claim the bonus as soon as Twitch makes it available. Turn off to only check once a minute."
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "Strict campaign availability"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Reclama automáticamente las bonificaciones de puntos de canal mientras se farmea esta plataforma."
   },
+  "channelPointsPushClaimTitle": {
+    "message": "Reclamar puntos de canal desde eventos en vivo"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "Reclama el bono en cuanto Twitch lo pone disponible. Desactívalo para comprobar solo una vez por minuto."
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "Disponibilidad estricta de campañas"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Réclame automatiquement les bonus de points de chaîne lors du farm sur cette plateforme."
   },
+  "channelPointsPushClaimTitle": {
+    "message": "Réclamer les points de chaîne depuis les événements en direct"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "Réclame le bonus dès que Twitch le rend disponible. Désactivez pour ne vérifier qu'une fois par minute."
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "Disponibilité stricte des campagnes"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "इस प्लेटफ़ॉर्म पर फ़ार्म करते समय चैनल-पॉइंट बोनस अपने आप क्लेम करें।"
   },
+  "channelPointsPushClaimTitle": {
+    "message": "लाइव इवेंट से चैनल पॉइंट क्लेम करें"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "जैसे ही Twitch बोनस उपलब्ध कराए, उसे क्लेम करें। बंद करने पर जाँच केवल एक बार प्रति मिनट होगी।"
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "सख्त अभियान उपलब्धता"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Riscatta automaticamente i bonus in punti canale durante il farming su questa piattaforma."
   },
+  "channelPointsPushClaimTitle": {
+    "message": "Riscatta i punti canale dagli eventi in diretta"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "Riscatta il bonus non appena Twitch lo rende disponibile. Disattiva per controllare solo una volta al minuto."
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "Disponibilità rigorosa delle campagne"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Resgata automaticamente os bônus de pontos de canal enquanto farma nesta plataforma."
   },
+  "channelPointsPushClaimTitle": {
+    "message": "Resgatar pontos de canal de eventos ao vivo"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "Resgata o bônus assim que a Twitch o disponibilizar. Desative para verificar apenas uma vez por minuto."
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "Disponibilidade estrita de campanhas"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Автоматически получает бонусы баллов канала во время фарма на этой платформе."
   },
+  "channelPointsPushClaimTitle": {
+    "message": "Получать баллы канала из событий в реальном времени"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "Получает бонус, как только Twitch делает его доступным. Отключите, чтобы проверять только раз в минуту."
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "Строгая проверка доступности кампаний"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "Yayın izlerken biriken kanal puanı bonuslarını otomatik toplar."
   },
+  "channelPointsPushClaimTitle": {
+    "message": "Canlı olaylardan kanal puanı al"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "Twitch bonus kullanılabilir olur olmaz al. Kapatırsanız yalnızca dakikada bir kontrol edilir."
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "Katı kampanya uygunluğu"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -678,6 +678,12 @@
   "autoClaimChannelPointsDescription": {
     "message": "在该平台挂机时自动领取频道点数奖励。"
   },
+  "channelPointsPushClaimTitle": {
+    "message": "从实时事件领取频道点数"
+  },
+  "channelPointsPushClaimDescription": {
+    "message": "一旦 Twitch 提供奖励即领取。关闭后每分钟只检查一次。"
+  },
   "strictCampaignAvailabilityTitle": {
     "message": "严格限制掉宝活动频道"
   },

--- a/packages/popup-ui/src/demo.ts
+++ b/packages/popup-ui/src/demo.ts
@@ -96,6 +96,7 @@ function demoSnapshot(): RuntimeSnapshot {
         idleWatchlistChannels: ["rivalspilot", "lootforge", "nightrunlive"],
         excludedChannels: ["spoilerboss"],
         strictCampaignAvailability: false,
+        channelPointsPushClaim: true,
         categoryMode: "include",
         categories: [
           { id: "marathon legends", name: "Marathon Legends" },

--- a/packages/popup-ui/src/settingsRegistry.tsx
+++ b/packages/popup-ui/src/settingsRegistry.tsx
@@ -445,7 +445,7 @@ export function buildSettingsRegistry(ctx: SettingsRegistryContext): SettingsSec
     // compatibility" rather than the General section's plain "Advanced" so the
     // two are told apart on sight: General tunes the scheduler, this one tunes
     // one platform. The subtitle is per-platform because the contents differ —
-    // Twitch adds a farming toggle and has three compatibility components to
+    // Twitch adds two farming toggles and has three compatibility components to
     // Kick's two — and three sections sharing one subtitle read as the same
     // section repeated. Twitch's group exists whether or not a compatibility
     // registry was supplied; Kick's holds the compatibility editor alone.

--- a/packages/popup-ui/src/settingsRegistry.tsx
+++ b/packages/popup-ui/src/settingsRegistry.tsx
@@ -451,6 +451,20 @@ export function buildSettingsRegistry(ctx: SettingsRegistryContext): SettingsSec
     // registry was supplied; Kick's holds the compatibility editor alone.
     const advancedEntries: SettingsEntryDef[] = platform === "twitch"
       ? [{
+        id: "twitch.advanced.channelPointsPushClaim",
+        titleKey: "channelPointsPushClaimTitle",
+        descriptionKey: "channelPointsPushClaimDescription",
+        render: () => (
+          <SettingRow
+            title={t("channelPointsPushClaimTitle")}
+            description={t("channelPointsPushClaimDescription")}
+            checked={settings.platform.twitch.channelPointsPushClaim}
+            onChange={(value) => void platformPatch("twitch", { channelPointsPushClaim: value })}
+            disabled={!settings.platform.twitch.autoClaimChannelPoints}
+            disabledReason={t("autoClaimChannelPointsDescription")}
+          />
+        ),
+      }, {
         id: "twitch.advanced.strictCampaignAvailability",
         titleKey: "strictCampaignAvailabilityTitle",
         descriptionKey: "strictCampaignAvailabilityDescription",

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -300,6 +300,10 @@ export interface TwitchPlatformSettings extends PlatformSettings {
   // before farming it on a channel. Off by default — see #400 and
   // TwitchAdapterOptions.strictCampaignAvailability.
   strictCampaignAvailability: boolean;
+  // Advanced: claim channel-point bonuses from Twitch's live Hermes
+  // notification. On by default. Off restores the one-minute ChannelPointsContext
+  // alarm as the only dedicated claim trigger. See #529.
+  channelPointsPushClaim: boolean;
 }
 
 export interface KickPlatformSettings extends PlatformSettings {

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -42,6 +42,7 @@ export const DEFAULT_ENGINE_SETTINGS: EngineSettings = {
       categories: [],
       autoClaimChannelPoints: true,
       strictCampaignAvailability: false,
+      channelPointsPushClaim: true,
     },
     kick: {
       enabled: false,
@@ -149,6 +150,7 @@ export function mergeEngineSettings(value: Partial<EngineSettings> | undefined):
         categories: normalizeCategorySelections(platform?.twitch?.categories),
         autoClaimChannelPoints: booleanOr(platform?.twitch?.autoClaimChannelPoints, DEFAULT_ENGINE_SETTINGS.platform.twitch.autoClaimChannelPoints),
         strictCampaignAvailability: booleanOr(platform?.twitch?.strictCampaignAvailability, DEFAULT_ENGINE_SETTINGS.platform.twitch.strictCampaignAvailability),
+        channelPointsPushClaim: booleanOr(platform?.twitch?.channelPointsPushClaim, DEFAULT_ENGINE_SETTINGS.platform.twitch.channelPointsPushClaim),
       },
       kick: {
         enabled: booleanOr(platform?.kick?.enabled, DEFAULT_ENGINE_SETTINGS.platform.kick.enabled),


### PR DESCRIPTION
## Summary
- Claim Twitch channel-point bonuses from Hermes `claim-available` as soon as they appear, using the existing `ClaimCommunityPoints` mutation with the notification ids
- Keep the one-minute `ChannelPointsContext` alarm as fallback while the socket is down; skip the lookup while subscribed
- Add a Twitch advanced toggle (`channelPointsPushClaim`, default on) to force alarm-only claiming; CLI accepts the field but has no WebSocket factory

## Testing
- [ ] `pnpm test` — 2034 extension, 195 CLI, 10 site tests passed locally
- [ ] Workspace typechecks and Chromium/Firefox `pnpm verify` passed on this branch (Playwright Chromium required)
- [ ] With Twitch farming + auto-claim on, confirm a live bonus is claimed from the Hermes event without waiting for the minute alarm
- [ ] Toggle **Claim channel points from live events** off and confirm claiming falls back to the one-minute alarm
- [ ] Disable auto-claim channel points and confirm the new toggle is disabled and no Hermes socket is opened
- [ ] Confirm host permissions are unchanged (`https://*.twitch.tv/*` already covers `wss://hermes.twitch.tv`)

Closes #529