### PR TITLE
fix(extension): anchor the in-page panel to Kick's rendered nav

### DIFF
--- a/packages/extension/src/core/inPagePanel.ts
+++ b/packages/extension/src/core/inPagePanel.ts
@@ -50,23 +50,41 @@ const EDGE_MARGIN = 16;
 // `z-navbar` to `z-[402]` between two page loads on the same afternoon, so a
 // selector keyed on that would already be dead. `--navbar-height` survives both
 // spellings Kick emits (`h-[var(--navbar-height)]` and `h-(--navbar-height)`).
+//
+// Each anchor yields every element its selector matches, not just the first,
+// because both sites keep responsive duplicates of the nav in the DOM at once
+// and only one of them is being rendered. Kick ships two: a mobile bar marked
+// `lg:hidden` and a desktop bar marked `max-lg:hidden`. The mobile one comes
+// first in document order, so taking the first match put the button inside a
+// `display:none` element at every desktop width — inserted, connected, and
+// invisible, which is also why the "no anchor" warning never fired.
 interface Anchor {
-  find(): Element | null | undefined;
+  find(): (Element | null | undefined)[];
   place: "before" | "append" | "prepend";
 }
 
 const ANCHORS: Record<Platform, Anchor[]> = {
   twitch: [
     // Immediately left of the Prime crown, inside the icon cluster.
-    { find: () => document.querySelector(".top-nav__prime"), place: "before" },
-    { find: () => document.querySelector(".top-nav__menu"), place: "append" },
+    { find: () => [...document.querySelectorAll(".top-nav__prime")], place: "before" },
+    { find: () => [...document.querySelectorAll(".top-nav__menu")], place: "append" },
   ],
   kick: [
     // Kick's nav carries no semantic hooks, so this keys off the layout
     // variable and takes the bar's right-hand cluster.
-    { find: () => document.querySelector('nav[class*="navbar-height"]')?.lastElementChild, place: "prepend" },
+    { find: () => [...document.querySelectorAll('nav[class*="navbar-height"]')].map((nav) => nav.lastElementChild), place: "prepend" },
   ],
 };
+
+// Whether an element is actually laid out. An element inside a `display:none`
+// ancestor generates no boxes, which is what separates the live nav from its
+// hidden responsive twin. `offsetParent` would not do: Kick's mobile nav is
+// `position:fixed`, so it reads as null even when it is the visible one.
+// `checkVisibility()` would not either — `applyVisibility` sets the button to
+// `visibility:hidden` during fullscreen, and only display matters here.
+function isRendered(element: Element | null | undefined): boolean {
+  return element != null && element.getClientRects().length > 0;
+}
 
 // Matched to each site's own nav buttons, measured against the live pages.
 const BUTTON_METRICS: Record<Platform, { height: number; radius: number; padding: number }> = {
@@ -124,8 +142,16 @@ async function start(): Promise<void> {
   // Twitch and Kick both put the player into the Fullscreen API. A floating
   // panel over fullscreen video is intrusive, and on Twitch it is drawn above
   // the player controls.
-  document.addEventListener("fullscreenchange", applyVisibility);
-  window.addEventListener("resize", clampIntoViewport);
+  document.addEventListener("fullscreenchange", () => {
+    applyVisibility();
+    queueEnsureButton();
+  });
+  window.addEventListener("resize", () => {
+    clampIntoViewport();
+    // Crossing a responsive breakpoint swaps which nav is rendered, and no
+    // mutation accompanies it.
+    queueEnsureButton();
+  });
 }
 
 async function reconcile(): Promise<void> {
@@ -169,12 +195,19 @@ function teardown(): void {
 /* -------------------------------------------------------------- nav button */
 
 function ensureButton(): void {
-  if (button?.isConnected) return;
+  // Being connected is not enough: crossing a responsive breakpoint hides the
+  // nav the button sits in without detaching it, so the parent has to still be
+  // laid out for the button to count as placed. Re-placing moves the existing
+  // node rather than adding a second one.
+  if (button?.isConnected && isRendered(button.parentElement)) return;
+  // Nothing to place while the player owns the screen; applyVisibility has
+  // already hidden the button, and re-anchoring here would only churn.
+  if (document.fullscreenElement) return;
 
   button ??= createButton();
-  const target = resolveAnchor();
-  if (!target) {
-    // No anchor matched, so the site reorganized its nav. Show nothing.
+  const target = resolveAnchorFor(platform, isRendered);
+  if (typeof target === "string") {
+    // Show nothing either way.
     //
     // An earlier revision fell back to a floating corner button so the feature
     // could not silently disappear. That was right while this was opt-in, and
@@ -182,7 +215,12 @@ function ensureButton(): void {
     // unexpected floating control on every user's screen at once, which is a
     // worse outcome than the absence it guards against. The toolbar popup still
     // works, so absence degrades rather than breaks.
-    warnOnce("could not find a place in the page nav for the Lurkloot button; the toolbar popup still works");
+    //
+    // Only "noMatch" is worth a warning. "noneRendered" means the nav is there
+    // but currently collapsed — Kick's theatre mode hides both of its bars —
+    // and warnOnce latches for the session, so warning on a state that
+    // resolves itself would burn the one message a real nav change needs.
+    if (target === "noMatch") warnOnce("could not find a place in the page nav for the Lurkloot button; the toolbar popup still works");
     return;
   }
   if (target.place === "before") target.element.parentElement?.insertBefore(button, target.element);
@@ -200,12 +238,27 @@ function warnOnce(message: string): void {
   console.warn(`[Lurkloot] ${message}`);
 }
 
-function resolveAnchor(): { element: Element; place: Anchor["place"] } | undefined {
-  for (const candidate of ANCHORS[platform] ?? []) {
-    const element = candidate.find();
-    if (element) return { element, place: candidate.place };
+// Exported for tests, which supply their own rendered predicate: the DOM
+// implementation the suite runs against has no layout, so getClientRects can
+// not distinguish the two navs the way a browser does.
+export type AnchorResolution =
+  | { element: Element; place: Anchor["place"] }
+  | "noneRendered"
+  | "noMatch";
+
+export function resolveAnchorFor(
+  forPlatform: Platform,
+  rendered: (element: Element | null | undefined) => boolean,
+): AnchorResolution {
+  let matched = false;
+  for (const candidate of ANCHORS[forPlatform] ?? []) {
+    for (const element of candidate.find()) {
+      if (!element) continue;
+      matched = true;
+      if (rendered(element)) return { element, place: candidate.place };
+    }
   }
-  return undefined;
+  return matched ? "noneRendered" : "noMatch";
 }
 
 function createButton(): HTMLButtonElement {
@@ -254,10 +307,22 @@ function createButton(): HTMLButtonElement {
 // button alive across route changes without polling.
 function watchAnchor(): void {
   anchorObserver?.disconnect();
-  anchorObserver = new MutationObserver(() => {
-    if (enabled && !button?.isConnected) ensureButton();
-  });
+  anchorObserver = new MutationObserver(queueEnsureButton);
   anchorObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// Coalesced because the check is no longer free. It reads layout, and whenever
+// no anchor is rendered — Kick's theatre mode collapses both of its navs —
+// there is no placed button to short-circuit on, so it would otherwise run
+// against every chat message.
+let queuedEnsureButton = false;
+function queueEnsureButton(): void {
+  if (queuedEnsureButton || !enabled) return;
+  queuedEnsureButton = true;
+  setTimeout(() => {
+    queuedEnsureButton = false;
+    if (enabled) ensureButton();
+  }, 250);
 }
 
 /* ------------------------------------------------------------ panel window */

--- a/packages/extension/tests/inPagePanel.test.ts
+++ b/packages/extension/tests/inPagePanel.test.ts
@@ -1,0 +1,92 @@
+import { parseHTML } from "linkedom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    runtime: { sendMessage: vi.fn(), getURL: vi.fn() },
+    storage: { local: { get: vi.fn(), set: vi.fn() }, onChanged: { addListener: vi.fn() } },
+  },
+}));
+
+const { resolveAnchorFor } = await import("../src/core/inPagePanel");
+
+// linkedom has no layout, so getClientRects cannot tell the responsive twins
+// apart the way a browser does. The predicate stands in for that: a nav marked
+// with one of Tailwind's hidden-at-this-breakpoint classes is the one the
+// viewport is not rendering.
+function renderedAtDesktopWidth(element: Element | null | undefined): boolean {
+  if (!element) return false;
+  const nav = element.closest("nav") ?? element;
+  return !nav.className.includes("lg:hidden") || nav.className.includes("max-lg:hidden");
+}
+
+function setDocument(html: string): void {
+  globalThis.document = parseHTML(`<html><body>${html}</body></html>`).document as unknown as Document;
+}
+
+// Kick renders both bars at all times and hides one with a media query. The
+// mobile bar comes first in document order, which is the whole bug.
+const KICK_NAVS = `
+  <nav class="fixed top-0 z-navbar flex h-[var(--navbar-height)] lg:hidden">
+    <div id="mobile-left"></div>
+    <div id="mobile-cluster"></div>
+  </nav>
+  <nav class="relative top-0 z-[402] flex h-(--navbar-height) max-lg:hidden">
+    <div id="desktop-left"></div>
+    <div id="desktop-cluster"></div>
+  </nav>
+`;
+
+describe("in-page panel anchor", () => {
+  beforeEach(() => {
+    setDocument("");
+  });
+
+  it("skips Kick's hidden mobile nav and takes the rendered desktop one", () => {
+    setDocument(KICK_NAVS);
+
+    const resolved = resolveAnchorFor("kick", renderedAtDesktopWidth);
+
+    expect(resolved).not.toBe("noneRendered");
+    expect(resolved).not.toBe("noMatch");
+    expect((resolved as { element: Element }).element.id).toBe("desktop-cluster");
+    expect((resolved as { place: string }).place).toBe("prepend");
+  });
+
+  it("reports no rendered anchor when every nav is collapsed", () => {
+    setDocument(KICK_NAVS);
+
+    expect(resolveAnchorFor("kick", () => false)).toBe("noneRendered");
+  });
+
+  it("reports no match when the nav is gone entirely", () => {
+    setDocument(`<div id="unrelated"></div>`);
+
+    expect(resolveAnchorFor("kick", renderedAtDesktopWidth)).toBe("noMatch");
+    expect(resolveAnchorFor("twitch", renderedAtDesktopWidth)).toBe("noMatch");
+  });
+
+  it("still places the Twitch button before the Prime crown", () => {
+    setDocument(`
+      <nav class="top-nav">
+        <div class="top-nav__menu">
+          <div class="top-nav__prime" id="prime"></div>
+        </div>
+      </nav>
+    `);
+
+    const resolved = resolveAnchorFor("twitch", renderedAtDesktopWidth);
+
+    expect((resolved as { element: Element }).element.id).toBe("prime");
+    expect((resolved as { place: string }).place).toBe("before");
+  });
+
+  it("falls back to Twitch's nav menu when the Prime crown is absent", () => {
+    setDocument(`<nav class="top-nav"><div class="top-nav__menu" id="menu"></div></nav>`);
+
+    const resolved = resolveAnchorFor("twitch", renderedAtDesktopWidth);
+
+    expect((resolved as { element: Element }).element.id).toBe("menu");
+    expect((resolved as { place: string }).place).toBe("append");
+  });
+});


### PR DESCRIPTION
## Summary

The in-page panel button shows up on Twitch but never on Kick. It was not missing: it was being inserted into a hidden element.

Kick renders **two** navbars at all times and hides one with a media query:

| nav | classes | at 1440px |
| --- | --- | --- |
| first in document order | `h-[var(--navbar-height)] … lg:hidden` | `display: none` |
| second | `h-(--navbar-height) … max-lg:hidden` | `display: flex` |

`document.querySelector('nav[class*="navbar-height"]')` returns the first match, which is the mobile bar. The button was appended to its right-hand cluster, stayed `isConnected`, and was never painted. That also explains why the module's own fallback diagnostic never fired, and why the mutation observer stopped re-checking: it short-circuits on a connected button.

Verified live on kick.com and www.twitch.tv with DevTools before and after.

## Changes

- Anchors now return **every** element their selector matches instead of the first, and resolution picks the first candidate that has a layout box (`getClientRects().length > 0`). Not `offsetParent`, because Kick's mobile nav is `position: fixed` and reads as null even when it is the visible one. Not `checkVisibility()`, because the button is deliberately set to `visibility: hidden` during fullscreen and only `display` should matter here.
- The same predicate is applied to Twitch. Both of its anchors were checked at 1440px and 700px and keep non-zero boxes, so its placement is unchanged.
- `ensureButton` no longer treats "connected" as "placed". Crossing the `lg` breakpoint hides the nav without detaching the button, which reproduced the exact reported symptom. Re-placing moves the existing node, so no duplicate button.
- Placement is re-evaluated on `resize` and `fullscreenchange`, since a breakpoint swap comes with no DOM mutation.
- The mutation observer is coalesced on a 250 ms trailing timer, matching the idiom in `playbackContent.ts`. It now reads layout, and in Kick's theatre mode (both navbars hidden) there is no placed button to short-circuit on, so it would otherwise run against every chat message.
- The "no place in the nav" warning is now limited to the case where the selector matches nothing at all. A matched-but-collapsed nav is transient and stays silent, so the one-shot warning is still available for a real nav reorganization.

## Testing

- `pnpm test` — 2057 passed, including a new `packages/extension/tests/inPagePanel.test.ts` with five cases. The first one fails against the current code: given both Kick navbars in document order, the anchor must resolve to the desktop one.
- `pnpm typecheck` — clean across all seven packages.
- `pnpm build` — clean. The Kick content script stays at 12 KB, so the dependency-free constraint on this module is intact.
- Manual: injected the button markup and metrics into Kick's rendered desktop nav cluster on a live page and confirmed it paints in the right place, left of the language switcher. That is a simulated placement, not a build load.

## Notes

`showInPagePanel` defaults to `true` and the feature is unreleased on `main` (1.12.2), so this is a fix to work already on `develop` for 1.13.0. No changelog entry: the feature's own entry covers it.

No screenshot of a real extension build is attached. Loading an unpacked build into the automated browser was out of reach here.

https://claude.ai/code/session_011sK9z7uLEJHp8KvBLyR851


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved in-page panel button placement across responsive navigation layouts.
  - Prevented buttons from appearing in hidden duplicate navigation menus.
  - Repositions buttons when their containing navigation becomes hidden or changes.
  - Improved behavior during fullscreen mode, resizing, and dynamic page updates.
  - Reduced unnecessary repositioning through coalesced updates.

- **Tests**
  - Added coverage for responsive navigation, collapsed menus, unmatched anchors, and platform-specific placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->