### PR TITLE
fix(manual-watch): react promptly to playback and tab changes

### DIFF
--- a/packages/core/src/background/controller.ts
+++ b/packages/core/src/background/controller.ts
@@ -37,6 +37,7 @@ import {
   validTablessHeartbeatCadence,
 } from "../core/heartbeatCadence";
 import { mergePlatformState, schedulerStateEquivalent } from "./platformState";
+import { kickChannelFromUrl } from "../platforms/kick/channelUrl";
 import { twitchChannelFromUrl } from "../platforms/twitch/channelUrl";
 import {
   collectDiscoverySnapshot,
@@ -2973,25 +2974,14 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
   }
 
   async function handleTabRemoved(tabId: number): Promise<void> {
-    // Serialize the load-modify-persist under the state lock so it cannot race a
-    // concurrent tick()/heartbeat (both fire on a ~1-minute cadence while the
-    // user can close a tab at any moment). A removal never runs the scheduler
-    // directly (#193): it only records state, and the next ordinary alarm reads
-    // it. Closing a tab LurkLoot owns now records a per-platform pause, so the
-    // alarm keeps the platform paused instead of reopening the tab a minute
-    // later. The user's enabled/running settings are deliberately untouched;
-    // the popup shows the pause with a one-click resume.
+    const changed: Platform[] = [];
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const state = await deps.loadState();
-      const manualPlatforms = (["twitch", "kick"] as Platform[]).filter((platform) => state.manualWatch?.[platform]?.tabId === tabId);
       let nextState = state;
-      if (manualPlatforms.length > 0) {
-        const manualWatch = { ...state.manualWatch };
-        for (const platform of manualPlatforms) delete manualWatch[platform];
-        nextState = {
-          ...state,
-          manualWatch,
-        };
+      for (const platform of PLATFORMS) {
+        if (state.manualWatch?.[platform]?.tabId !== tabId && !state.manualWatchTabs?.[platform]?.[tabId]) continue;
+        nextState = updateManualWatchTab(nextState, platform, tabId);
+        if (hasRecentManualWatch(state, platform) !== hasRecentManualWatch(nextState, platform)) changed.push(platform);
       }
 
       const closedManagedPlatforms: Platform[] = [];
@@ -3034,6 +3024,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
 
       if (nextState !== state || events.length > 0) await persistAndReport(nextState, events);
     }));
+    if (changed.length) tickInBackground(changed, "manual_watch");
   }
 
   // Explicit user action: clears the manual-close pause so the next tick may
@@ -4403,7 +4394,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     senderTabId?: number,
     senderTabUrl?: string,
   ): Promise<void> {
-    let manualWatchStarted = false;
+    let manualWatchChanged = false;
     await withStateLock(() => withEventCollector(async (emit, events) => {
       const [settings, state] = await Promise.all([deps.loadSettings(), deps.loadState()]);
       const session = state.sessions[message.platform];
@@ -4415,7 +4406,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
       if (!isManagedWatchTab) {
         if (senderTabId != null) {
           const manualWatch = recordManualWatchTelemetry(state, settings, message, senderTabId, senderTabUrl);
-          manualWatchStarted = manualWatch.started;
+          manualWatchChanged = manualWatch.changed;
           await persistPlatformAndReport(
             message.platform,
             manualWatch.state,
@@ -4468,7 +4459,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
         await reportBestEffort(events);
       }
     }), [message.platform]);
-    if (manualWatchStarted) tickInBackground([message.platform], "manual_watch");
+    if (manualWatchChanged) tickInBackground([message.platform], "manual_watch");
   }
 
   function recordManualWatchTelemetry(
@@ -4477,33 +4468,76 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     message: Extract<CoreRuntimeMessage, { type: "playbackTelemetry" }>,
     senderTabId: number,
     senderTabUrl?: string,
-  ): { state: SchedulerState; started: boolean } {
+  ): { state: SchedulerState; changed: boolean } {
+    const channel = message.platform === "twitch"
+      ? twitchChannelFromUrl(senderTabUrl) : kickChannelFromUrl(senderTabUrl);
+    const owned = state.managedWatchTabs?.[message.platform]?.tabId === senderTabId
+      || state.managedPageContextTabs?.[message.platform]?.tabId === senderTabId;
+    const active = Boolean(channel) && !owned && settings.pauseOnManualWatch
+      && message.telemetry.playingVideoCount > 0 && !message.telemetry.documentHidden;
+    const next = updateManualWatchTab(state, message.platform, senderTabId, {
+      platform: message.platform, tabId: senderTabId,
+      checkedAt: new Date().toISOString(), active,
+      ...(channel ? { channel } : {}),
+    }, settings.pauseOnManualWatch);
+    return { state: next, changed: hasRecentManualWatch(state, message.platform)
+      !== hasRecentManualWatch(next, message.platform) };
+  }
+
+  function hasRecentManualWatch(state: SchedulerState, platform: Platform): boolean {
+    const watch = state.manualWatch?.[platform];
+    return Boolean(watch?.active && !isTimestampStale(watch.checkedAt, MANUAL_WATCH_TTL_MS, Date.now()));
+  }
+
+  function updateManualWatchTab(
+    state: SchedulerState, platform: Platform, tabId: number,
+    record?: NonNullable<SchedulerState["manualWatch"]>[Platform], enabled = true,
+  ): SchedulerState {
+    const previous = state.manualWatch?.[platform];
+    const tabs = { ...state.manualWatchTabs?.[platform] };
+    // Backfill the single-tab record saved by earlier versions.
+    if (!state.manualWatchTabs?.[platform] && previous) tabs[previous.tabId] = previous;
+    for (const [id, entry] of Object.entries(tabs)) {
+      if (!entry.active || isTimestampStale(entry.checkedAt, MANUAL_WATCH_TTL_MS, Date.now())) delete tabs[id];
+    }
+    delete tabs[tabId];
+    if (enabled && record?.active) tabs[tabId] = record;
     const manualWatch = { ...state.manualWatch };
-    if (!settings.pauseOnManualWatch) {
-      delete manualWatch[message.platform];
-      return { state: { ...state, manualWatch }, started: false };
+    const manualWatchTabs = { ...state.manualWatchTabs };
+    if (enabled) {
+      manualWatchTabs[platform] = tabs;
+      const remaining = Object.values(tabs);
+      const selected = remaining.find((entry) => entry.tabId === tabId)
+        ?? remaining.find((entry) => entry.tabId === previous?.tabId) ?? remaining[0] ?? record;
+      if (selected) manualWatch[platform] = selected;
+      else delete manualWatch[platform];
+    } else {
+      delete manualWatch[platform];
+      delete manualWatchTabs[platform];
     }
+    return { ...state, manualWatch, manualWatchTabs };
+  }
 
-    const active = message.telemetry.playingVideoCount > 0 && !message.telemetry.documentHidden;
-    const previous = manualWatch[message.platform];
-    const recentPrevious = previous?.active && !isTimestampStale(previous.checkedAt, MANUAL_WATCH_TTL_MS, Date.now());
-    if (!active && previous?.tabId !== senderTabId && recentPrevious) {
-      return { state, started: false };
-    }
-
-    manualWatch[message.platform] = {
-      platform: message.platform,
-      tabId: senderTabId,
-      checkedAt: new Date().toISOString(),
-      active,
-      ...(message.platform === "twitch"
-        ? { channel: twitchChannelFromUrl(senderTabUrl) }
-        : {}),
-    };
-    return {
-      state: { ...state, manualWatch },
-      started: active && !recentPrevious,
-    };
+  async function handleTabUpdated(tabId: number, url: string): Promise<void> {
+    const changed: Platform[] = [];
+    await withStateLock(() => withEventCollector(async (_emit, events) => {
+      const original = await deps.loadState();
+      let state = original;
+      for (const platform of PLATFORMS) {
+        const record = state.manualWatchTabs?.[platform]?.[tabId]
+          ?? (state.manualWatch?.[platform]?.tabId === tabId ? state.manualWatch[platform] : undefined);
+        if (!record) continue;
+        const channel = platform === "twitch" ? twitchChannelFromUrl(url) : kickChannelFromUrl(url);
+        // Keep the pause during channel switches until fresh playback arrives.
+        // Clearing here would reopen farming while the new player is loading.
+        if (channel) continue;
+        const wasActive = hasRecentManualWatch(state, platform);
+        state = updateManualWatchTab(state, platform, tabId);
+        if (wasActive !== hasRecentManualWatch(state, platform)) changed.push(platform);
+      }
+      if (state !== original) await persistAndReport(state, events);
+    }));
+    if (changed.length) tickInBackground(changed, "manual_watch");
   }
 
   async function applyAdFocusForState(
@@ -5298,6 +5332,7 @@ export function createBackgroundController<S extends EngineSettings = EngineSett
     ensureInstalledAt,
     handleStartup,
     handleTabRemoved,
+    handleTabUpdated,
     handleMessage,
     resumeAfterManualClose,
     captureTwitchIntegrity,

--- a/packages/core/src/background/platformState.ts
+++ b/packages/core/src/background/platformState.ts
@@ -64,6 +64,11 @@ export function mergePlatformState(
       source.manualWatch,
       platform,
     ),
+    manualWatchTabs: mergeOptionalEntry(
+      destination.manualWatchTabs,
+      source.manualWatchTabs,
+      platform,
+    ),
     manualClosePause: mergeOptionalEntry(
       destination.manualClosePause,
       source.manualClosePause,

--- a/packages/core/src/core/defaults.ts
+++ b/packages/core/src/core/defaults.ts
@@ -137,6 +137,7 @@ export function mergeSchedulerState(stored: Partial<SchedulerState> | undefined)
     managedWatchTabs: { ...DEFAULT_STATE.managedWatchTabs, ...stored?.managedWatchTabs },
     managedPageContextTabs: { ...DEFAULT_STATE.managedPageContextTabs, ...stored?.managedPageContextTabs },
     manualWatch: { ...stored?.manualWatch },
+    manualWatchTabs: { ...stored?.manualWatchTabs },
     campaigns: { ...DEFAULT_STATE.campaigns, ...stored?.campaigns },
     ...(criticalHealth ? { criticalHealth } : {}),
   };

--- a/packages/core/src/platforms/kick/channelUrl.ts
+++ b/packages/core/src/platforms/kick/channelUrl.ts
@@ -1,0 +1,23 @@
+import type { ChannelCandidate } from "@lurkloot/shared/models";
+
+const RESERVED_ROUTES = new Set([
+  "about", "account", "auth", "browse", "categories", "category", "clips",
+  "dashboard", "drops", "following", "help", "inventory", "login", "moderator",
+  "payments", "privacy", "search", "settings", "signup", "subscriptions",
+  "terms", "videos", "wallet", "directory",
+]);
+
+export function kickChannelFromUrl(url: string | undefined): ChannelCandidate | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" || !["kick.com", "www.kick.com"].includes(parsed.hostname.toLowerCase())) return undefined;
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length !== 1) return undefined;
+    const username = segments[0].toLowerCase();
+    if (!/^[a-z0-9_-]+$/i.test(username) || RESERVED_ROUTES.has(username)) return undefined;
+    return { platform: "kick", username, url: `https://kick.com/${username}` };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -295,6 +295,29 @@ export default defineBackground(() => {
 
   browser.alarms.onAlarm.addListener(createBackgroundAlarmListener(controller));
 
+  async function reconsiderTab(tabId: number, url: string | undefined): Promise<void> {
+    if (!url) return;
+    await controller.handleTabUpdated(tabId, url);
+    // Ask for current playback rather than interpreting a platform URL as watching.
+    try {
+      const parsed = new URL(url);
+      if (!["twitch.tv", "www.twitch.tv", "kick.com", "www.kick.com"].includes(parsed.hostname)) return;
+      await browser.tabs.sendMessage(tabId, { type: "requestPlaybackTelemetry" });
+    } catch {
+      // A newly opened/navigating tab may not have its content script yet.
+      // Its initial report and periodic telemetry cover that case.
+    }
+  }
+
+  browser.tabs.onCreated.addListener((tab) => {
+    if (tab.id != null) void reconsiderTab(tab.id, tab.pendingUrl ?? tab.url);
+  });
+  browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.url || changeInfo.status === "complete") {
+      void reconsiderTab(tabId, changeInfo.url ?? tab.url);
+    }
+  });
+
   browser.tabs.onRemoved.addListener((tabId) => {
     void controller.handleTabRemoved(tabId);
   });

--- a/packages/extension/src/core/playbackContent.ts
+++ b/packages/extension/src/core/playbackContent.ts
@@ -13,6 +13,17 @@ let queuedPlaybackControl = false;
 let suppressControlUntil = 0;
 
 export function startPlaybackTelemetry(platform: Platform): void {
+  browser.runtime.onMessage.addListener((message) => {
+    if (message?.type === "requestPlaybackTelemetry") queuePlaybackControl(platform);
+  });
+  // Media events do not bubble; capture also covers players inserted later.
+  for (const event of ["playing", "pause", "ended", "emptied"]) {
+    document.addEventListener(event, (event) => {
+      if ((event.target as Element | null)?.tagName !== "VIDEO") return;
+      if (Date.now() < suppressControlUntil) return;
+      queuePlaybackControl(platform);
+    }, true);
+  }
   void controlPlaybackAndReport(platform);
   setInterval(() => {
     void controlPlaybackAndReport(platform);

--- a/packages/extension/tests/backgroundController.test.ts
+++ b/packages/extension/tests/backgroundController.test.ts
@@ -6286,6 +6286,107 @@ describe("background controller", () => {
     expect(env.state.sessions.twitch.playbackChecks).toBe(0);
   });
 
+  describe("manual-watch event transitions", () => {
+    const telemetry = { videoCount: 1, mutedVideoCount: 0, unmutedVideoCount: 1,
+      playingVideoCount: 1, blockedPlaybackCount: 0, documentHidden: false };
+    async function report(env: ReturnType<typeof harness>, platform: Platform, id: number, url: string,
+      patch: Partial<typeof telemetry> = {}) {
+      await env.controller.handleMessage({ type: "playbackTelemetry", platform,
+        telemetry: { ...telemetry, ...patch } }, { tab: { id, url } });
+      await env.controller.settleBackgroundWork();
+    }
+
+    it.each(["twitch", "kick"] as const)("resumes %s immediately after playback stops or becomes hidden", async (platform) => {
+      for (const patch of [{ playingVideoCount: 0 }, { documentHidden: true }]) {
+        const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+        const url = platform === "twitch" ? "https://www.twitch.tv/creator" : "https://kick.com/creator";
+        await report(env, platform, 999, url);
+        expect(env.state.sessions[platform].reasonCode).toBe("manual_watch");
+        await report(env, platform, 999, url, patch);
+        expect(env.state.sessions[platform].status).toBe("watching");
+      }
+    });
+
+    it.each(["twitch", "kick"] as const)("ignores non-stream %s pages even with visible video", async (platform) => {
+      const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+      await env.controller.tick();
+      const host = platform === "twitch" ? "https://www.twitch.tv" : "https://kick.com";
+      for (const route of ["settings", "settings/profile", "inventory", "drops/inventory", "directory", ...(platform === "kick" ? ["categories"] : []), "videos/123", "creator/clips", "creator/videos/123"]) {
+        await report(env, platform, 999, `${host}/${route}`);
+        expect(env.state.manualWatch?.[platform]?.active).not.toBe(true);
+        expect(env.state.sessions[platform].status).toBe("watching");
+      }
+    });
+
+    it.each(["twitch", "kick"] as const)("keeps %s paused until the last manual tab closes", async (platform) => {
+      const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+      const host = platform === "twitch" ? "https://www.twitch.tv" : "https://kick.com";
+      await report(env, platform, 999, `${host}/firstcreator`);
+      await report(env, platform, 1000, `${host}/secondcreator`);
+      await env.controller.handleTabRemoved(1000);
+      await env.controller.settleBackgroundWork();
+      expect(env.state.sessions[platform].reasonCode).toBe("manual_watch");
+      expect(env.state.manualWatch?.[platform]?.tabId).toBe(999);
+      await env.controller.handleTabRemoved(999);
+      await env.controller.settleBackgroundWork();
+      expect(env.state.sessions[platform].status).toBe("watching");
+    });
+
+    it("keeps another stream active when an unrelated tab reports inactive playback", async () => {
+      const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+      await report(env, "twitch", 999, "https://www.twitch.tv/firstcreator");
+      await report(env, "twitch", 1000, "https://www.twitch.tv/secondcreator", { playingVideoCount: 0 });
+      expect(env.state.manualWatch?.twitch?.tabId).toBe(999);
+      expect(env.state.sessions.twitch.reasonCode).toBe("manual_watch");
+    });
+
+    it("persists both manual tabs across controller recreation", async () => {
+      const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+      await report(env, "twitch", 999, "https://www.twitch.tv/firstcreator");
+      await report(env, "twitch", 1000, "https://www.twitch.tv/secondcreator");
+      const restored = createBackgroundController(env.deps);
+      await restored.handleTabRemoved(1000);
+      await restored.settleBackgroundWork();
+      expect(env.state.manualWatch?.twitch?.tabId).toBe(999);
+      expect(env.state.sessions.twitch.reasonCode).toBe("manual_watch");
+    });
+
+    it("does not pause when manual-watch pausing is disabled", async () => {
+      const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: false }));
+      await env.controller.tick();
+      await report(env, "kick", 999, "https://kick.com/creator");
+      expect(env.state.manualWatch?.kick).toBeUndefined();
+      expect(env.state.sessions.kick.status).toBe("watching");
+    });
+
+    it.each([undefined, "https://example.com/creator", "https://clips.twitch.tv/SomeClip"])("requires a supported stream URL (%s)", async (url) => {
+      const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+      await env.controller.tick();
+      await env.controller.handleMessage({ type: "playbackTelemetry", platform: "twitch", telemetry }, { tab: { id: 999, url } });
+      await env.controller.settleBackgroundWork();
+      expect(env.state.manualWatch?.twitch?.active).not.toBe(true);
+      expect(env.state.sessions.twitch.status).toBe("watching");
+    });
+
+    it("stays paused during navigation between stream channels", async () => {
+      const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+      await report(env, "twitch", 999, "https://www.twitch.tv/firstcreator");
+      await env.controller.handleTabUpdated(999, "https://www.twitch.tv/secondcreator");
+      await env.controller.settleBackgroundWork();
+      expect(env.state.sessions.twitch.reasonCode).toBe("manual_watch");
+      await report(env, "twitch", 999, "https://www.twitch.tv/secondcreator");
+      expect(env.state.manualWatch?.twitch?.channel?.username).toBe("secondcreator");
+    });
+
+    it("resumes when a manual tab navigates to inventory before new telemetry", async () => {
+      const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
+      await report(env, "twitch", 999, "https://www.twitch.tv/creator");
+      await env.controller.handleTabUpdated(999, "https://www.twitch.tv/drops/inventory");
+      await env.controller.settleBackgroundWork();
+      expect(env.state.sessions.twitch.status).toBe("watching");
+    });
+  });
+
   it("pauses Twitch immediately when visible playback starts in a non-managed tab", async () => {
     const env = harness(farming({ ...DEFAULT_SETTINGS, pauseOnManualWatch: true }));
     await env.controller.tick();
@@ -6377,8 +6478,8 @@ describe("background controller", () => {
       documentHidden: false,
     };
 
-    await env.controller.handleMessage({ type: "playbackTelemetry", platform: "twitch", telemetry }, { tab: { id: 999 } });
-    await env.controller.handleMessage({ type: "playbackTelemetry", platform: "twitch", telemetry }, { tab: { id: 999 } });
+    await env.controller.handleMessage({ type: "playbackTelemetry", platform: "twitch", telemetry }, { tab: { id: 999, url: "https://www.twitch.tv/creator" } });
+    await env.controller.handleMessage({ type: "playbackTelemetry", platform: "twitch", telemetry }, { tab: { id: 999, url: "https://www.twitch.tv/creator" } });
 
     const immediateTickStarts = allDiagnostics(env).filter((event) =>
       event.message.includes("started (trigger=manual_watch"));
@@ -6685,7 +6786,7 @@ describe("background controller", () => {
         documentHidden: false,
         adActive: true,
       },
-    }, { tab: { id: 10 } });
+    }, { tab: { id: 10, url: "https://www.twitch.tv/creator" } });
 
     expect(env.state.sessions.twitch.playback).toBeUndefined();
     expect(env.state.manualWatch?.twitch).toMatchObject({

--- a/packages/extension/tests/playbackTelemetryEvents.test.ts
+++ b/packages/extension/tests/playbackTelemetryEvents.test.ts
@@ -1,0 +1,35 @@
+import { parseHTML } from "linkedom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sendMessage = vi.fn(async (message: { type: string }) =>
+  message.type === "getPlaybackControl" ? { managed: false, keepVideosUnmuted: false } : undefined);
+const addListener = vi.fn();
+vi.mock("wxt/browser", () => ({ browser: { runtime: { sendMessage: (...args: unknown[]) => sendMessage(...args as [{ type: string }]),
+  onMessage: { addListener: (...args: unknown[]) => addListener(...args) } } } }));
+
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.clearAllMocks(); });
+
+describe("manual playback event reporting", () => {
+  it.each(["playing", "pause", "ended"])("reports %s without waiting for the five-second interval", async (event) => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    const { document, window } = parseHTML("<html><body><video></video></body></html>");
+    vi.stubGlobal("document", document);
+    vi.stubGlobal("window", window);
+    vi.stubGlobal("MutationObserver", window.MutationObserver);
+    vi.stubGlobal("HTMLMediaElement", { HAVE_CURRENT_DATA: 2 });
+    const video = document.querySelector("video")!;
+    Object.assign(video, { paused: false, ended: false, readyState: 4, muted: false, volume: 1 });
+    const { startPlaybackTelemetry } = await import("../src/core/playbackContent");
+    startPlaybackTelemetry("twitch");
+    await vi.advanceTimersByTimeAsync(0);
+    sendMessage.mockClear();
+    Object.assign(video, event === "pause" ? { paused: true } : event === "ended" ? { ended: true } : {});
+    video.dispatchEvent(new window.Event(event, { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(300);
+    const report = sendMessage.mock.calls.find(([message]) => message.type === "playbackTelemetry")?.[0];
+    expect(report).toMatchObject({ type: "playbackTelemetry", telemetry: {
+      playingVideoCount: event === "playing" ? 1 : 0,
+    } });
+  });
+});

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -444,6 +444,7 @@ export interface SchedulerState {
   managedWatchTabs?: Partial<Record<Platform, ManagedWatchTab>>;
   managedPageContextTabs?: Partial<Record<Platform, ManagedPageContextTab>>;
   manualWatch?: Partial<Record<Platform, ManualWatchState>>;
+  manualWatchTabs?: Partial<Record<Platform, Record<string, ManualWatchState>>>;
   // Platforms paused because the user manually closed their managed watch tab.
   // Cleared only by an explicit resume from the popup/CLI host.
   manualClosePause?: Partial<Record<Platform, ManualClosePauseState>>;


### PR DESCRIPTION
Manual watching now triggers prompt farming pause/resume checks when playback starts or stops, visibility changes, or a stream tab closes or navigates away. Previously, stopping manual watching could leave farming paused until the next periodic alarm.

Only supported Twitch and Kick channel routes with visible playback count as manual watching. Settings, inventory, directories, clips, and VOD routes are excluded. Persisted per-tab activity keeps farming paused while another manual stream remains active, and channel switching preserves the pause while fresh telemetry arrives. Closing an extension-managed farming tab still requires explicit user resume.

Closes #538

## Validation

- `pnpm verify` — script tests, workspace typechecks, extension/CLI/site tests, Astro site build, and Chromium/Firefox extension builds.
- Regression coverage for playback stop/visibility, settings and inventory exclusions, unsupported URLs, multiple tabs, controller recreation, channel switching, and disabled manual-watch pausing.
- Independent code review completed with no remaining important findings.

Validation uses deterministic mocked browser/playback signals; live Twitch/Kick browser behavior has not been manually exercised.
