### PR TITLE
fix(store): drop rating and install-count claims from listing screenshots

### DIFF
--- a/packages/extension/tests/i18n.test.ts
+++ b/packages/extension/tests/i18n.test.ts
@@ -206,8 +206,6 @@ describe("i18n", () => {
       screenshotUpdatedDockerTitle: "Docker",
       screenshotUpdatedDockerSub: "Same engine. In a container.",
       screenshotUpdatedLicense: "Apache-2.0",
-      screenshotUpdatedRating: "4.9",
-      screenshotUpdatedUsers: "1,000+ users",
     };
     const catalog = readCatalog("en");
     for (const [key, message] of Object.entries(english)) {
@@ -223,6 +221,10 @@ describe("i18n", () => {
       "screenshotActivityHeadline",
       "screenshotActivitySubcopy",
       "screenshotUpdatedReviews",
+      // Removed: the Chrome Web Store forbids listing assets that mimic an
+      // extension's rating, install count or other store standing.
+      "screenshotUpdatedRating",
+      "screenshotUpdatedUsers",
     ]) {
       expect(catalog[stale], stale).toBeUndefined();
     }
@@ -260,7 +262,6 @@ describe("i18n", () => {
       "screenshotUpdatedHeadlessTitle",
       "screenshotUpdatedDockerTitle",
       "screenshotUpdatedLicense",
-      "screenshotUpdatedRating",
     ]);
 
     for (const locale of localeCodes().filter((entry) => entry !== "en")) {

--- a/packages/extension/tests/storeScreenshot.test.tsx
+++ b/packages/extension/tests/storeScreenshot.test.tsx
@@ -167,9 +167,13 @@ describe("store screenshot cameras", () => {
   it("fills updated with a text runtime board and no popup", async () => {
     const container = await mountShot("updated", "LIVE_POPUP");
     expect(container.textContent).toContain("Featureful. Always updated.");
-    expect(container.textContent).toContain("4.9");
-    expect(container.textContent).toContain("1,000+ users");
+    // The Chrome Web Store forbids listing assets that mimic an extension's
+    // rating, install count or other store standing, so the board carries no
+    // rating, star row or user total.
+    expect(container.textContent).not.toContain("4.9");
+    expect(container.textContent).not.toContain("1,000+ users");
     expect(container.textContent).not.toContain("25 reviews");
+    expect(container.querySelectorAll(".lucide-star")).toHaveLength(0);
     expect(container.textContent).toContain("Chromium-based browsers");
     expect(container.textContent).toContain("Chrome Web Store listing. Same extension.");
     expect(container.textContent).toContain("CLI");

--- a/packages/locales/messages/ar.json
+++ b/packages/locales/messages/ar.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "أكثر من 1,000 مستخدم"
-  },
   "autoClaimReady": {
     "message": "الاستلام التلقائي جاهز"
   },

--- a/packages/locales/messages/de.json
+++ b/packages/locales/messages/de.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "über 1.000 Nutzer"
-  },
   "autoClaimReady": {
     "message": "Auto-Beanspruchen bereit"
   },

--- a/packages/locales/messages/en.json
+++ b/packages/locales/messages/en.json
@@ -953,12 +953,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "1,000+ users"
-  },
   "autoClaimReady": {
     "message": "Auto-claim ready"
   },

--- a/packages/locales/messages/es.json
+++ b/packages/locales/messages/es.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "más de 1.000 usuarios"
-  },
   "autoClaimReady": {
     "message": "Reclama automáticamente"
   },

--- a/packages/locales/messages/fr.json
+++ b/packages/locales/messages/fr.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "plus de 1 000 utilisateurs"
-  },
   "autoClaimReady": {
     "message": "Réclamation auto prête"
   },

--- a/packages/locales/messages/hi.json
+++ b/packages/locales/messages/hi.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "1,000+ उपयोगकर्ता"
-  },
   "autoClaimReady": {
     "message": "ऑटो-क्लेम तैयार"
   },

--- a/packages/locales/messages/it.json
+++ b/packages/locales/messages/it.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "oltre 1.000 utenti"
-  },
   "autoClaimReady": {
     "message": "Auto-riscatto pronto"
   },

--- a/packages/locales/messages/pt_BR.json
+++ b/packages/locales/messages/pt_BR.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "mais de 1.000 usuários"
-  },
   "autoClaimReady": {
     "message": "Auto-resgate pronto"
   },

--- a/packages/locales/messages/ru.json
+++ b/packages/locales/messages/ru.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "более 1 000 пользователей"
-  },
   "autoClaimReady": {
     "message": "Автополучение готово"
   },

--- a/packages/locales/messages/tr.json
+++ b/packages/locales/messages/tr.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "1.000+ kullanıcı"
-  },
   "autoClaimReady": {
     "message": "Otomatik alma aktif"
   },

--- a/packages/locales/messages/zh_CN.json
+++ b/packages/locales/messages/zh_CN.json
@@ -945,12 +945,6 @@
   "screenshotUpdatedLicense": {
     "message": "Apache-2.0"
   },
-  "screenshotUpdatedRating": {
-    "message": "4.9"
-  },
-  "screenshotUpdatedUsers": {
-    "message": "1,000+ 用户"
-  },
   "autoClaimReady": {
     "message": "自动领取就绪"
   },

--- a/packages/popup-ui/src/marketing.tsx
+++ b/packages/popup-ui/src/marketing.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { AppWindow, Box, SquareTerminal, Star, type LucideIcon } from "lucide-react";
+import { AppWindow, Box, SquareTerminal, type LucideIcon } from "lucide-react";
 import type { SupportedLocale } from "@lurkloot/shared/models";
 import { DEFAULT_LOCALE, isRtlLocale, translateFromCatalogs, type MessageCatalog } from "@lurkloot/shared/i18n";
 import { loadCatalog } from "@lurkloot/locales";
@@ -133,16 +133,6 @@ function GithubMark({ size = 26 }: { size?: number }): React.ReactElement {
     <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor" aria-hidden>
       <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.39 1.24-3.23-.12-.31-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.24 2.87.12 3.18.77.84 1.24 1.92 1.24 3.23 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 24 12.5C24 5.87 18.63.5 12 .5Z" />
     </svg>
-  );
-}
-
-function StarRow(): React.ReactElement {
-  return (
-    <div className="mt-4 flex items-center justify-center gap-1.5 text-[#c4a7ff]" aria-hidden>
-      {Array.from({ length: 5 }, (_, index) => (
-        <Star key={index} size={28} fill="currentColor" strokeWidth={0} />
-      ))}
-    </div>
   );
 }
 
@@ -314,59 +304,47 @@ export function StoreScreenshot({
               translate={translate}
             />
           </div>
-          <div
-            data-updated-board
-            className="absolute end-[7%] top-[9%] z-10 flex h-[600px] w-[400px] flex-col justify-between overflow-hidden rounded-3xl border border-white/8 bg-[#0c0c10]/80 px-8 py-9"
-          >
-            <div className="flex flex-col items-center text-center">
-              <div className="font-display text-[80px] font-bold leading-none tracking-tight text-[#ecedf5]">
-                {translate("screenshotUpdatedRating")}
-              </div>
-              <StarRow />
-              <p className="mt-5 text-[20px] leading-snug text-[#9c9db4]">
-                {translate("screenshotUpdatedUsers")}
-              </p>
-            </div>
-            <div>
-              <div className="mb-7 h-px bg-white/10" />
-              <div className="flex flex-col gap-5">
-                <RuntimeRow
-                  title={translate("screenshotUpdatedBrowsersTitle")}
-                  sub={translate("screenshotUpdatedBrowsersSub")}
-                  marks={(
-                    <RuntimeIcon accent="#c4a7ff">
-                      <LucideMark icon={AppWindow} />
-                    </RuntimeIcon>
-                  )}
-                />
-                <RuntimeRow
-                  title={translate("screenshotUpdatedHeadlessTitle")}
-                  sub={translate("screenshotUpdatedHeadlessSub")}
-                  marks={(
-                    <RuntimeIcon accent="#b7ff6a">
-                      <LucideMark icon={SquareTerminal} />
-                    </RuntimeIcon>
-                  )}
-                />
-                <RuntimeRow
-                  title={translate("screenshotUpdatedDockerTitle")}
-                  sub={translate("screenshotUpdatedDockerSub")}
-                  marks={(
-                    <RuntimeIcon accent="#9c9db4">
-                      <LucideMark icon={Box} />
-                    </RuntimeIcon>
-                  )}
-                />
-                <RuntimeRow
-                  title={translate("githubAttributionShort")}
-                  sub={`${translate("screenshotUpdatedEyebrow")} · ${translate("screenshotUpdatedLicense")}`}
-                  marks={(
-                    <RuntimeIcon accent="#ecedf5">
-                      <GithubMark />
-                    </RuntimeIcon>
-                  )}
-                />
-              </div>
+          <div className="absolute end-[7%] top-[9%] z-10 flex h-[600px] items-center">
+            <div
+              data-updated-board
+              className="flex w-[400px] flex-col gap-9 overflow-hidden rounded-3xl border border-white/8 bg-[#0c0c10]/80 px-8 py-10"
+            >
+              <RuntimeRow
+                title={translate("screenshotUpdatedBrowsersTitle")}
+                sub={translate("screenshotUpdatedBrowsersSub")}
+                marks={(
+                  <RuntimeIcon accent="#c4a7ff">
+                    <LucideMark icon={AppWindow} />
+                  </RuntimeIcon>
+                )}
+              />
+              <RuntimeRow
+                title={translate("screenshotUpdatedHeadlessTitle")}
+                sub={translate("screenshotUpdatedHeadlessSub")}
+                marks={(
+                  <RuntimeIcon accent="#b7ff6a">
+                    <LucideMark icon={SquareTerminal} />
+                  </RuntimeIcon>
+                )}
+              />
+              <RuntimeRow
+                title={translate("screenshotUpdatedDockerTitle")}
+                sub={translate("screenshotUpdatedDockerSub")}
+                marks={(
+                  <RuntimeIcon accent="#9c9db4">
+                    <LucideMark icon={Box} />
+                  </RuntimeIcon>
+                )}
+              />
+              <RuntimeRow
+                title={translate("githubAttributionShort")}
+                sub={`${translate("screenshotUpdatedEyebrow")} · ${translate("screenshotUpdatedLicense")}`}
+                marks={(
+                  <RuntimeIcon accent="#ecedf5">
+                    <GithubMark />
+                  </RuntimeIcon>
+                )}
+              />
             </div>
           </div>
         </>


### PR DESCRIPTION
## Summary

The Chrome Web Store rejected the 1.13.0 submission under **Ensuring Responsible Marketing and Monetization — Impersonation and Intellectual Property** (violation reference `Red Nickel`, routing ID `FZSL`), citing "mentioned 5star ratings in screenshots".

The offending asset is the fifth store screenshot (`05-updated`), whose right-hand board showed a **4.9** figure, a five-star row and **1,000+ users** — metadata that mimics the extension's rating, performance and current status on the store.

## Changes

- Remove the rating / star row / user-count stat block from the `updated` screenshot layout in `packages/popup-ui/src/marketing.tsx`, along with the `StarRow` component and its `Star` import.
- Delete `screenshotUpdatedRating` and `screenshotUpdatedUsers` from all 11 locale catalogs.
- Rebuild the board so it hugs its four runtime rows (Chromium / CLI / Docker / GitHub) and is vertically centred in the same band, instead of leaving a gutted box with a divider above nothing.
- Update `i18n.test.ts` (both keys move to the stale-key list) and `storeScreenshot.test.tsx` (asserts the board carries no rating, user total or star icons).

No user-facing behaviour changes — `marketing.tsx` renders only in screenshot mode and is inert in the shipped popup. No version bump needed.

## Testing

- `pnpm typecheck` — all 7 packages pass.
- `pnpm test` — 2074 tests pass across 89 files.
- `pnpm screenshot:store` — regenerated all 55 images; visually reviewed `en`, `de`, `ru`, `hi` and `ar` (RTL) for `05-updated`, all within the layout band.
- Swept the remaining store assets for the policy's keyword list (`recommended`, `premium`, `free`, `#1`, `new`): screenshots 01–04, both promo tiles, `docs/store-descriptions.md` and `docs/store-readiness.md` are clean.
- Verified the new star assertion is non-vacuous — lucide-react emits `lucide-<name>` classes in this test harness.

## Follow-up (not in this PR)

The dashboard listing still carries the rejected images. After merge, run `pnpm screenshot:store:sync` to replace all 55 screenshots, then resubmit.

https://claude.ai/code/session_01N4xhWMdyJg3vVP4x3ogjZ2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Redesigned the updated store screenshot layout with four vertically stacked runtime information rows.
  - Removed the displayed 4.9 rating, 1,000+ user count, review count, and star icons.
  - Removed these rating and user-count messages from supported translations.
- **Tests**
  - Updated screenshot and localization checks to verify that rating, review, and user-count details are no longer displayed or available in translated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->